### PR TITLE
fix: create .git/hooks directory if it doesn't exist

### DIFF
--- a/cmd/roborev/main.go
+++ b/cmd/roborev/main.go
@@ -260,6 +260,12 @@ func initCmd() *cobra.Command {
 # RoboRev post-commit hook - auto-reviews every commit
 roborev enqueue --sha HEAD 2>/dev/null &
 `
+			// Ensure hooks directory exists
+			hooksDir := filepath.Join(root, ".git", "hooks")
+			if err := os.MkdirAll(hooksDir, 0755); err != nil {
+				return fmt.Errorf("create hooks directory: %w", err)
+			}
+
 			// Check for existing hook
 			if existing, err := os.ReadFile(hookPath); err == nil {
 				if !strings.Contains(string(existing), "roborev") {
@@ -704,6 +710,12 @@ func installHookCmd() *cobra.Command {
 			// Check if hook already exists
 			if _, err := os.Stat(hookPath); err == nil && !force {
 				return fmt.Errorf("hook already exists at %s (use --force to overwrite)", hookPath)
+			}
+
+			// Ensure hooks directory exists
+			hooksDir := filepath.Join(root, ".git", "hooks")
+			if err := os.MkdirAll(hooksDir, 0755); err != nil {
+				return fmt.Errorf("create hooks directory: %w", err)
 			}
 
 			hookContent := `#!/bin/sh


### PR DESCRIPTION
## Problem

`roborev init` fails when the `.git/hooks` directory doesn't exist:

```
Error: install hook: open /path/to/repo/.git/hooks/post-commit: no such file or directory
```

This happens in repositories where the hooks directory has been removed or was never created.

## Solution

Added `os.MkdirAll` to create the `.git/hooks` directory before attempting to write the post-commit hook file.

## Changes

- **`cmd/roborev/main.go`**: Added hooks directory creation in both `initCmd()` and `installHookCmd()`
- **`cmd/roborev/main_test.go`**: Added comprehensive test `TestInitCmdCreatesHooksDirectory` that:
  - Creates a git repo without a hooks directory
  - Verifies `roborev init` succeeds
  - Confirms the hooks directory and post-commit hook are created
  - Validates hook is executable

## Testing

All existing tests pass, and the new test confirms the fix:

```bash
go test ./cmd/roborev/...
# ok  	github.com/wesm/roborev/cmd/roborev	3.617s
```

The fix follows TDD methodology:
1. ✅ Wrote failing test first
2. ✅ Implemented minimal fix
3. ✅ Verified test passes