### PR TITLE
Refactors post-commit hook generation to eliminate code duplication, improve security, and ensure truly silent operation.

### DIFF
--- a/cmd/roborev/main.go
+++ b/cmd/roborev/main.go
@@ -980,20 +980,20 @@ func shortRef(ref string) string {
 }
 
 // generateHookContent creates the post-commit hook script content.
-// It prefers PATH lookup for upgrades, falls back to baked path if not found.
+// It prefers the baked absolute path for security, falls back to PATH if missing.
 func generateHookContent() string {
-	// Get current roborev path as fallback
+	// Get current roborev absolute path
 	roborevPath, err := exec.LookPath("roborev")
 	if err != nil {
 		roborevPath = "roborev"
 	}
 
-	// Prefer PATH lookup (for upgrades), fall back to baked path
+	// Prefer baked path (security), fall back to PATH only if baked is missing
 	return fmt.Sprintf(`#!/bin/sh
 # RoboRev post-commit hook - auto-reviews every commit
-ROBOREV=$(command -v roborev 2>/dev/null)
-if [ -z "$ROBOREV" ] || [ ! -x "$ROBOREV" ]; then
-    ROBOREV=%q
+ROBOREV=%q
+if [ ! -x "$ROBOREV" ]; then
+    ROBOREV=$(command -v roborev 2>/dev/null) || exit 0
     [ ! -x "$ROBOREV" ] && exit 0
 fi
 "$ROBOREV" enqueue --quiet 2>/dev/null &


### PR DESCRIPTION
Follow on work from code review

## Changes
- **Factor out `generateHookContent()` helper** - Hook script generation was duplicated in `init` and `install-hook` commands, risking drift. Now uses a single shared function.
- **Security: prefer baked path over PATH lookup** - Hook now uses the absolute path baked at install time first, only falling back to `command -v roborev` if the baked binary is missing. Prevents PATH injection attacks from repo-local or malicious binaries.
- **Add stderr redirect for silence** - Hook now redirects stderr (`2>/dev/null`) so errors from `roborev enqueue --quiet` don't leak to the terminal.
- **Add comprehensive tests** - `TestGenerateHookContent` verifies:
	- Shebang and RoboRev comment present
	- Baked path assignment comes before PATH fallback (security)
	- Enqueue line has `--quiet`, `2>/dev/null`, and `&` on same line
	- Baked path is properly quoted
## Hook before/after
**Before:**

```sh
#!/bin/sh
# RoboRev post-commit hook - auto-reviews every commit
roborev enqueue --quiet &
```

After:

```
#!/bin/sh
# RoboRev post-commit hook - auto-reviews every commit
ROBOREV="/path/to/roborev"
if [ ! -x "$ROBOREV" ]; then
		ROBOREV=$(command -v roborev 2>/dev/null) || exit 0
		[ ! -x "$ROBOREV" ] && exit 0
fi
"$ROBOREV" enqueue --quiet 2>/dev/null &
```

Test plan
- go test ./... passes
- Run roborev install-hook --force and verify hook content
- Make a commit and verify no output appears
- Test with baked path removed (should fall back to PATH)