### PR TITLE
Add ROBOREV_DATA_DIR env var to override data directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ CLI (roborev) → HTTP API → Daemon (roborevd) → Worker Pool → Agents
 - **Workers**: Pool of 4 (configurable) parallel review workers
 - **Storage**: SQLite at `~/.roborev/reviews.db` with WAL mode
 - **Config**: Global at `~/.roborev/config.toml`, per-repo at `.roborev.toml`
+- **Data dir**: Set `ROBOREV_DATA_DIR` env var to override `~/.roborev`
 
 ## Key Files
 

--- a/cmd/roborev/main.go
+++ b/cmd/roborev/main.go
@@ -224,13 +224,12 @@ func initCmd() *cobra.Command {
 			}
 
 			// 2. Create config directory and default config
-			home, _ := os.UserHomeDir()
-			configDir := filepath.Join(home, ".roborev")
+			configDir := config.DataDir()
 			if err := os.MkdirAll(configDir, 0755); err != nil {
 				return fmt.Errorf("create config dir: %w", err)
 			}
 
-			configPath := filepath.Join(configDir, "config.toml")
+			configPath := config.GlobalConfigPath()
 			if _, err := os.Stat(configPath); os.IsNotExist(err) {
 				cfg := config.DefaultConfig()
 				if agent != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,10 +41,19 @@ func DefaultConfig() *Config {
 	}
 }
 
+// DataDir returns the roborev data directory.
+// Uses ROBOREV_DATA_DIR env var if set, otherwise ~/.roborev
+func DataDir() string {
+	if dir := os.Getenv("ROBOREV_DATA_DIR"); dir != "" {
+		return dir
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".roborev")
+}
+
 // GlobalConfigPath returns the path to the global config file
 func GlobalConfigPath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".roborev", "config.toml")
+	return filepath.Join(DataDir(), "config.toml")
 }
 
 // LoadGlobal loads the global configuration from the default path

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -21,6 +21,61 @@ func TestDefaultConfig(t *testing.T) {
 	}
 }
 
+func TestDataDir(t *testing.T) {
+	t.Run("default uses home directory", func(t *testing.T) {
+		// Clear env var to test default
+		origEnv := os.Getenv("ROBOREV_DATA_DIR")
+		os.Unsetenv("ROBOREV_DATA_DIR")
+		defer func() {
+			if origEnv != "" {
+				os.Setenv("ROBOREV_DATA_DIR", origEnv)
+			}
+		}()
+
+		dir := DataDir()
+		home, _ := os.UserHomeDir()
+		expected := filepath.Join(home, ".roborev")
+		if dir != expected {
+			t.Errorf("Expected %s, got %s", expected, dir)
+		}
+	})
+
+	t.Run("env var overrides default", func(t *testing.T) {
+		origEnv := os.Getenv("ROBOREV_DATA_DIR")
+		os.Setenv("ROBOREV_DATA_DIR", "/custom/data/dir")
+		defer func() {
+			if origEnv != "" {
+				os.Setenv("ROBOREV_DATA_DIR", origEnv)
+			} else {
+				os.Unsetenv("ROBOREV_DATA_DIR")
+			}
+		}()
+
+		dir := DataDir()
+		if dir != "/custom/data/dir" {
+			t.Errorf("Expected /custom/data/dir, got %s", dir)
+		}
+	})
+
+	t.Run("GlobalConfigPath uses DataDir", func(t *testing.T) {
+		origEnv := os.Getenv("ROBOREV_DATA_DIR")
+		os.Setenv("ROBOREV_DATA_DIR", "/tmp/roborev-test")
+		defer func() {
+			if origEnv != "" {
+				os.Setenv("ROBOREV_DATA_DIR", origEnv)
+			} else {
+				os.Unsetenv("ROBOREV_DATA_DIR")
+			}
+		}()
+
+		path := GlobalConfigPath()
+		expected := "/tmp/roborev-test/config.toml"
+		if path != expected {
+			t.Errorf("Expected %s, got %s", expected, path)
+		}
+	})
+}
+
 func TestResolveAgent(t *testing.T) {
 	cfg := DefaultConfig()
 	tmpDir := t.TempDir()

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/wesm/roborev/internal/config"
 )
 
 // RuntimeInfo stores daemon runtime state
@@ -20,8 +22,7 @@ type RuntimeInfo struct {
 
 // RuntimePath returns the path to the runtime info file
 func RuntimePath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".roborev", "daemon.json")
+	return filepath.Join(config.DataDir(), "daemon.json")
 }
 
 // WriteRuntime saves the daemon runtime info

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/wesm/roborev/internal/config"
 	_ "modernc.org/sqlite"
 )
 
@@ -75,8 +76,7 @@ type DB struct {
 
 // DefaultDBPath returns the default database path
 func DefaultDBPath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".roborev", "reviews.db")
+	return filepath.Join(config.DataDir(), "reviews.db")
 }
 
 // Open opens or creates the database at the given path

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/wesm/roborev/internal/config"
 	"github.com/wesm/roborev/internal/version"
 )
 
@@ -243,8 +244,7 @@ func RestartDaemon() error {
 
 // GetCacheDir returns the roborev cache directory
 func GetCacheDir() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".roborev")
+	return config.DataDir()
 }
 
 func fetchLatestRelease() (*Release, error) {


### PR DESCRIPTION
Allows specifying an alternative data directory instead of ~/.roborev. Useful for testing, running multiple instances, or custom deployments.

Changes:
- Add config.DataDir() that checks ROBOREV_DATA_DIR first
- Update GlobalConfigPath, DefaultDBPath, RuntimePath, GetCacheDir
- Update init command to use config.DataDir()
- Add tests for DataDir with and without env var
- Document in CLAUDE.md