### PR TITLE
Include full commit message body in review prompts

### DIFF
--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -128,7 +128,11 @@ func (b *Builder) buildSinglePrompt(repoPath, sha string, repoID int64, contextC
 	sb.WriteString("## Current Commit\n\n")
 	sb.WriteString(fmt.Sprintf("**Commit:** %s\n", shortSHA))
 	sb.WriteString(fmt.Sprintf("**Author:** %s\n", info.Author))
-	sb.WriteString(fmt.Sprintf("**Subject:** %s\n\n", info.Subject))
+	sb.WriteString(fmt.Sprintf("**Subject:** %s\n", info.Subject))
+	if info.Body != "" {
+		sb.WriteString(fmt.Sprintf("\n**Message:**\n%s\n", info.Body))
+	}
+	sb.WriteString("\n")
 
 	// Get and include the diff
 	diff, err := git.GetDiff(repoPath, sha)


### PR DESCRIPTION
Previously only the subject line was included, causing reviewers to lack context about why changes were made deliberately. Now includes the full commit message body when present.

Uses ASCII record separator (0x1e) as field delimiter to handle pipes and other special characters in commit messages.