### PR TITLE
Strip markdown formatting in verdict parsing

### DIFF
--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -15,6 +15,8 @@ func ParseVerdict(output string) string {
 		// Normalize curly apostrophes to straight apostrophes (LLMs sometimes use these)
 		trimmed = strings.ReplaceAll(trimmed, "\u2018", "'") // left single quote
 		trimmed = strings.ReplaceAll(trimmed, "\u2019", "'") // right single quote
+		// Strip markdown formatting (bold, italic, headers)
+		trimmed = stripMarkdown(trimmed)
 		// Strip leading list markers (bullets, numbers, etc.)
 		trimmed = stripListMarker(trimmed)
 
@@ -34,6 +36,23 @@ func ParseVerdict(output string) string {
 		}
 	}
 	return "F"
+}
+
+// stripMarkdown removes common markdown formatting from a line
+func stripMarkdown(s string) string {
+	// Strip leading markdown headers (##, ###, etc.)
+	for strings.HasPrefix(s, "#") {
+		s = strings.TrimPrefix(s, "#")
+	}
+	s = strings.TrimSpace(s)
+
+	// Strip bold/italic markers (**, __, *, _)
+	// Handle ** and __ first (bold), then * and _ (italic)
+	s = strings.ReplaceAll(s, "**", "")
+	s = strings.ReplaceAll(s, "__", "")
+	// Don't strip single * or _ as they might be intentional (e.g., bullet points handled separately)
+
+	return strings.TrimSpace(s)
 }
 
 // stripListMarker removes leading bullet/number markers from a line

--- a/internal/storage/verdict_test.go
+++ b/internal/storage/verdict_test.go
@@ -84,6 +84,32 @@ func TestParseVerdict(t *testing.T) {
 			output: "100. No issues found.",
 			want:   "P",
 		},
+		// Markdown formatting
+		{
+			name:   "bold no issues found",
+			output: "**No issues found.**",
+			want:   "P",
+		},
+		{
+			name:   "bold no issues in sentence",
+			output: "**No issues found.** The code looks good.",
+			want:   "P",
+		},
+		{
+			name:   "markdown header no issues",
+			output: "## No issues found",
+			want:   "P",
+		},
+		{
+			name:   "markdown h3 no issues",
+			output: "### No issues found.",
+			want:   "P",
+		},
+		{
+			name:   "underscore bold no issues",
+			output: "__No issues found.__",
+			want:   "P",
+		},
 		{
 			name:   "no tests failed is pass",
 			output: "No issues found; no tests failed.",


### PR DESCRIPTION
## Summary
- Add `stripMarkdown()` function to remove bold (`**`), underscore bold (`__`), and header markers (`##`, `###`, etc.) before checking for pass indicators
- Fixes false negatives when AI outputs `**No issues found.**` with markdown bold formatting

Fixes #70

## Test plan
- [x] Added test cases for bold, underscore bold, and header formatted "No issues found"
- [x] All existing verdict parsing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)