### PR TITLE
Instruct reviewers to skip commit message review

### DIFF
--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -22,6 +22,8 @@ const SystemPromptSingle = `You are a code reviewer. Review the git commit shown
 4. **Regressions**: Changes that might break existing functionality
 5. **Code quality**: Duplication that should be refactored, overly complex logic, unclear naming
 
+Do not review the commit message itself - focus only on the code changes in the diff.
+
 After reviewing against all criteria above:
 
 If you find issues, list them with:
@@ -57,6 +59,8 @@ const SystemPromptRange = `You are a code reviewer. Review the git commit range 
 3. **Testing gaps**: Missing unit tests, edge cases not covered, e2e/integration test gaps
 4. **Regressions**: Changes that might break existing functionality
 5. **Code quality**: Duplication that should be refactored, overly complex logic, unclear naming
+
+Do not review the commit message itself - focus only on the code changes in the diff.
 
 After reviewing against all criteria above:
 


### PR DESCRIPTION
## Summary
- Add explicit instruction to review prompts telling the AI not to review commit messages
- Applies to single commit (`SystemPromptSingle`) and range (`SystemPromptRange`) prompts
- Dirty changes prompt doesn't need this since uncommitted changes have no commit messages

## Test plan
- [x] Build passes
- [x] Prompt tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)