### PR TITLE
Fix TUI rendering artifacts on page up/down scrolling

### DIFF
--- a/cmd/roborev/refine.go
+++ b/cmd/roborev/refine.go
@@ -39,8 +39,9 @@ func refineCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "refine",
-		Short: "Automatically address failed code reviews",
+		Use:          "refine",
+		Short:        "Automatically address failed code reviews",
+		SilenceUsage: true,
 		Long: `Automatically address failed code reviews using an AI agent.
 
 This command runs an agentic loop that:

--- a/cmd/roborev/tui.go
+++ b/cmd/roborev/tui.go
@@ -1185,11 +1185,11 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.updateSelectedJobID()
 			} else if m.currentView == tuiViewReview {
 				m.reviewScroll = max(0, m.reviewScroll-pageSize)
+				return m, tea.ClearScreen
 			} else if m.currentView == tuiViewPrompt {
 				m.promptScroll = max(0, m.promptScroll-pageSize)
+				return m, tea.ClearScreen
 			}
-			// Force full screen clear on page navigation
-			return m, tea.ClearScreen
 
 		case "pgdown":
 			pageSize := max(1, m.height-10)
@@ -1212,11 +1212,11 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			} else if m.currentView == tuiViewReview {
 				m.reviewScroll += pageSize
+				return m, tea.ClearScreen
 			} else if m.currentView == tuiViewPrompt {
 				m.promptScroll += pageSize
+				return m, tea.ClearScreen
 			}
-			// Force full screen clear on page navigation
-			return m, tea.ClearScreen
 
 		case "enter":
 			if m.currentView == tuiViewQueue && len(m.jobs) > 0 && m.selectedIdx >= 0 && m.selectedIdx < len(m.jobs) {


### PR DESCRIPTION
## Summary

- Add `tea.ClearScreen` on pgup and pgdown to force full redraw
- Add `\x1b[J` (clear to end of screen) at end of all view renders
- Clamp scroll position to valid range in review and prompt views

## Problem

When scrolling through long content (prompts, reviews) with page up/down, ghost text from previous frames would sometimes remain on screen, causing visual artifacts like help text overlapping with content.

## Solution

Force Bubble Tea to do a full redraw on page navigation rather than relying on diff-based updates. Also ensure all views clear to end of screen to prevent any leftover content.

## Test plan
- [x] Page down through a long prompt - no artifacts
- [x] Page up through a long prompt - no artifacts
- [x] Scroll indicator updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)