### PR TITLE
Fix multi-byte character handling in TUI text input

### DIFF
--- a/cmd/roborev/tui.go
+++ b/cmd/roborev/tui.go
@@ -2524,6 +2524,8 @@ func (m tuiModel) renderRespondView() string {
 			if textLinesWritten >= maxTextLines {
 				break
 			}
+			// Expand tabs to spaces (4-space tabs) for consistent width calculation
+			line = strings.ReplaceAll(line, "\t", "    ")
 			// Truncate lines that are too long (use visual width for wide characters)
 			line = runewidth.Truncate(line, boxWidth-2, "")
 			// Pad based on visual width, not rune count


### PR DESCRIPTION
## Summary
- Fix backspace handling for multi-byte characters (emojis, CJK) in respond text and filter search inputs
- Fix line truncation to use visual width instead of byte/rune count
- Expand tabs to 4 spaces for consistent width calculation
- Add regression tests for all fixes

## Details

**Backspace bug (High severity)**
Previously, backspace used byte slicing (`text[:len(text)-1]`) which corrupted multi-byte characters. Now uses rune slicing.

**Line truncation (Medium severity)**  
Line truncation and padding now use `runewidth.Truncate()` and `runewidth.StringWidth()` to handle wide characters (CJK, emojis) that take 2 terminal cells.

**Tab handling (Low severity)**
Tabs are expanded to 4 spaces before width calculation to prevent border overflow.

## Test plan
- [x] `TestTUIFilterBackspaceMultiByte` - emoji backspace in filter search
- [x] `TestTUIRespondBackspaceMultiByte` - CJK backspace in respond text
- [x] `TestTUIRespondViewTruncationMultiByte` - visual width alignment
- [x] `TestTUIRespondViewTabExpansion` - tab expansion
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)