### PR TITLE
Add config hot-reload for daemon (#85)

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -35,7 +35,7 @@ func TestE2EEnqueueAndReview(t *testing.T) {
 
 	// Create a mock server
 	cfg := config.DefaultConfig()
-	server := daemon.NewServer(db, cfg)
+	server := daemon.NewServer(db, cfg, "")
 
 	// Create test HTTP server
 	mux := http.NewServeMux()

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
 
             src = ./.;
 
-            vendorHash = "sha256-cK2kLRu6riVReSflP//YaKOZc2VBCfAjVmKd4AsXdYQ=";
+            vendorHash = "sha256-OQI9CbvazUzdbHTuUbizVK5UMq1OEbi2OJ7sL4bKJ44=";
 
             subPackages = [ "cmd/roborev" ];
 

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/internal/daemon/config_watcher.go
+++ b/internal/daemon/config_watcher.go
@@ -1,0 +1,212 @@
+package daemon
+
+import (
+	"context"
+	"log"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/roborev-dev/roborev/internal/agent"
+	"github.com/roborev-dev/roborev/internal/config"
+)
+
+// ConfigGetter provides access to the current config
+type ConfigGetter interface {
+	Config() *config.Config
+}
+
+// StaticConfig wraps a config for use without hot-reloading (e.g., in tests)
+type StaticConfig struct {
+	cfg *config.Config
+}
+
+// NewStaticConfig creates a ConfigGetter that always returns the same config
+func NewStaticConfig(cfg *config.Config) *StaticConfig {
+	return &StaticConfig{cfg: cfg}
+}
+
+// Config returns the static config
+func (sc *StaticConfig) Config() *config.Config {
+	return sc.cfg
+}
+
+// ConfigWatcher watches config.toml for changes and reloads configuration.
+//
+// Hot-reloadable settings take effect immediately: default_agent, job_timeout,
+// allow_unsafe_agents, anthropic_api_key, review_context_count.
+//
+// Settings requiring restart: server_addr, max_workers, [sync] section.
+// These are read at startup and the running values are preserved even if the
+// config file changes. CLI flag overrides (--addr, --workers) only apply to
+// restart-required settings, so they remain in effect for the daemon's lifetime.
+// The config object may show file values after reload, but the actual running
+// server address and worker pool size are fixed at startup.
+type ConfigWatcher struct {
+	configPath     string
+	cfg            *config.Config
+	cfgMu          sync.RWMutex
+	broadcaster    Broadcaster
+	watcher        *fsnotify.Watcher
+	stopCh         chan struct{}
+	stopOnce       sync.Once
+	lastReloadedAt time.Time // Time of last successful config reload
+}
+
+// NewConfigWatcher creates a new config watcher
+func NewConfigWatcher(configPath string, cfg *config.Config, broadcaster Broadcaster) *ConfigWatcher {
+	return &ConfigWatcher{
+		configPath:  configPath,
+		cfg:         cfg,
+		broadcaster: broadcaster,
+		stopCh:      make(chan struct{}),
+	}
+}
+
+// Start begins watching the config file for changes
+func (cw *ConfigWatcher) Start(ctx context.Context) error {
+	// Skip watching if no config path provided (e.g., in tests)
+	if cw.configPath == "" {
+		return nil
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	cw.watcher = watcher
+
+	// Watch the directory containing the config file, not the file itself.
+	// This handles editors that do atomic writes (delete + create).
+	configDir := filepath.Dir(cw.configPath)
+	configFile := filepath.Base(cw.configPath)
+
+	if err := watcher.Add(configDir); err != nil {
+		watcher.Close()
+		return err
+	}
+
+	go cw.watchLoop(ctx, configFile)
+	return nil
+}
+
+// Stop stops the config watcher. Safe to call multiple times.
+func (cw *ConfigWatcher) Stop() {
+	cw.stopOnce.Do(func() {
+		close(cw.stopCh)
+		if cw.watcher != nil {
+			cw.watcher.Close()
+		}
+	})
+}
+
+// Config returns the current config with read lock
+func (cw *ConfigWatcher) Config() *config.Config {
+	cw.cfgMu.RLock()
+	defer cw.cfgMu.RUnlock()
+	return cw.cfg
+}
+
+// LastReloadedAt returns the time of the last successful config reload
+func (cw *ConfigWatcher) LastReloadedAt() time.Time {
+	cw.cfgMu.RLock()
+	defer cw.cfgMu.RUnlock()
+	return cw.lastReloadedAt
+}
+
+func (cw *ConfigWatcher) watchLoop(ctx context.Context, configFile string) {
+	// Debounce timer to handle rapid file changes
+	var debounceTimer *time.Timer
+	debounceDelay := 200 * time.Millisecond
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-cw.stopCh:
+			return
+		case event, ok := <-cw.watcher.Events:
+			if !ok {
+				return
+			}
+
+			// Only react to changes to our config file
+			if filepath.Base(event.Name) != configFile {
+				continue
+			}
+
+			// React to write, create, or rename events
+			// Rename is needed for editors that do atomic saves via rename (e.g., vim)
+			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename) == 0 {
+				continue
+			}
+
+			// Debounce: reset timer on each event
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			debounceTimer = time.AfterFunc(debounceDelay, func() {
+				cw.reloadConfig()
+			})
+
+		case err, ok := <-cw.watcher.Errors:
+			if !ok {
+				return
+			}
+			log.Printf("Config watcher error: %v", err)
+		}
+	}
+}
+
+func (cw *ConfigWatcher) reloadConfig() {
+	newCfg, err := config.LoadGlobalFrom(cw.configPath)
+	if err != nil {
+		log.Printf("Failed to reload config: %v", err)
+		return
+	}
+
+	cw.cfgMu.Lock()
+	oldCfg := cw.cfg
+	cw.cfg = newCfg
+	cw.lastReloadedAt = time.Now()
+	cw.cfgMu.Unlock()
+
+	// Update global agent settings
+	agent.SetAllowUnsafeAgents(newCfg.AllowUnsafeAgents != nil && *newCfg.AllowUnsafeAgents)
+	agent.SetAnthropicAPIKey(newCfg.AnthropicAPIKey)
+
+	// Log what changed (for debugging)
+	logConfigChanges(oldCfg, newCfg)
+
+	// Broadcast config reloaded event to notify connected clients
+	cw.broadcaster.Broadcast(Event{
+		Type: "config.reloaded",
+		TS:   time.Now(),
+	})
+
+	log.Printf("Config reloaded successfully")
+}
+
+func logConfigChanges(old, new *config.Config) {
+	if old.DefaultAgent != new.DefaultAgent {
+		log.Printf("Config change: default_agent %q -> %q", old.DefaultAgent, new.DefaultAgent)
+	}
+	if old.ReviewContextCount != new.ReviewContextCount {
+		log.Printf("Config change: review_context_count %d -> %d", old.ReviewContextCount, new.ReviewContextCount)
+	}
+	if old.JobTimeoutMinutes != new.JobTimeoutMinutes {
+		log.Printf("Config change: job_timeout_minutes %d -> %d", old.JobTimeoutMinutes, new.JobTimeoutMinutes)
+	}
+	oldUnsafe := old.AllowUnsafeAgents != nil && *old.AllowUnsafeAgents
+	newUnsafe := new.AllowUnsafeAgents != nil && *new.AllowUnsafeAgents
+	if oldUnsafe != newUnsafe {
+		log.Printf("Config change: allow_unsafe_agents %v -> %v", oldUnsafe, newUnsafe)
+	}
+	if old.MaxWorkers != new.MaxWorkers {
+		log.Printf("Config change: max_workers %d -> %d (requires daemon restart to take effect)", old.MaxWorkers, new.MaxWorkers)
+	}
+	if old.ServerAddr != new.ServerAddr {
+		log.Printf("Config change: server_addr %q -> %q (requires daemon restart to take effect)", old.ServerAddr, new.ServerAddr)
+	}
+}

--- a/internal/daemon/config_watcher_test.go
+++ b/internal/daemon/config_watcher_test.go
@@ -1,0 +1,341 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/roborev-dev/roborev/internal/config"
+)
+
+func TestStaticConfig(t *testing.T) {
+	cfg := &config.Config{
+		DefaultAgent: "test-agent",
+		MaxWorkers:   5,
+	}
+
+	sc := NewStaticConfig(cfg)
+
+	// Should always return the same config
+	if sc.Config() != cfg {
+		t.Error("StaticConfig.Config() should return the same config object")
+	}
+
+	// Call multiple times to verify consistency
+	for i := 0; i < 3; i++ {
+		if sc.Config().DefaultAgent != "test-agent" {
+			t.Errorf("StaticConfig.Config().DefaultAgent = %q, want %q", sc.Config().DefaultAgent, "test-agent")
+		}
+	}
+}
+
+func TestNewConfigWatcher(t *testing.T) {
+	cfg := &config.Config{
+		DefaultAgent: "initial-agent",
+		MaxWorkers:   3,
+	}
+	broadcaster := NewBroadcaster()
+
+	cw := NewConfigWatcher("/path/to/config.toml", cfg, broadcaster)
+
+	if cw.Config() != cfg {
+		t.Error("NewConfigWatcher should store the initial config")
+	}
+
+	if cw.configPath != "/path/to/config.toml" {
+		t.Errorf("configPath = %q, want %q", cw.configPath, "/path/to/config.toml")
+	}
+
+	// LastReloadedAt should be zero initially
+	if !cw.LastReloadedAt().IsZero() {
+		t.Error("LastReloadedAt should be zero initially")
+	}
+}
+
+func TestConfigWatcher_NoConfigPath(t *testing.T) {
+	cfg := &config.Config{DefaultAgent: "test"}
+	broadcaster := NewBroadcaster()
+
+	// When configPath is empty, Start should be a no-op
+	cw := NewConfigWatcher("", cfg, broadcaster)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := cw.Start(ctx)
+	if err != nil {
+		t.Errorf("Start with empty configPath should not error, got: %v", err)
+	}
+
+	// Stop should not panic
+	cw.Stop()
+}
+
+func TestConfigWatcher_ReloadOnFileChange(t *testing.T) {
+	// Create a temporary config file
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.toml")
+
+	// Write initial config
+	initialConfig := `default_agent = "initial-agent"
+max_workers = 2
+`
+	if err := os.WriteFile(configPath, []byte(initialConfig), 0644); err != nil {
+		t.Fatalf("Failed to write initial config: %v", err)
+	}
+
+	// Load initial config
+	cfg, err := config.LoadGlobalFrom(configPath)
+	if err != nil {
+		t.Fatalf("Failed to load initial config: %v", err)
+	}
+
+	// Create broadcaster and subscribe to events
+	broadcaster := NewBroadcaster()
+	_, eventCh := broadcaster.Subscribe("")
+
+	// Create and start config watcher
+	cw := NewConfigWatcher(configPath, cfg, broadcaster)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := cw.Start(ctx); err != nil {
+		t.Fatalf("Failed to start config watcher: %v", err)
+	}
+	defer cw.Stop()
+
+	// Verify initial state
+	if cw.Config().DefaultAgent != "initial-agent" {
+		t.Errorf("Initial DefaultAgent = %q, want %q", cw.Config().DefaultAgent, "initial-agent")
+	}
+	if !cw.LastReloadedAt().IsZero() {
+		t.Error("LastReloadedAt should be zero before reload")
+	}
+
+	// Update config file
+	updatedConfig := `default_agent = "updated-agent"
+max_workers = 4
+`
+	if err := os.WriteFile(configPath, []byte(updatedConfig), 0644); err != nil {
+		t.Fatalf("Failed to write updated config: %v", err)
+	}
+
+	// Wait for the config reload event (with timeout)
+	// The watcher has a 200ms debounce, so we need to wait a bit longer
+	timeout := time.After(2 * time.Second)
+	var eventReceived bool
+	for !eventReceived {
+		select {
+		case event := <-eventCh:
+			if event.Type == "config.reloaded" {
+				eventReceived = true
+			}
+		case <-timeout:
+			t.Fatal("Timeout waiting for config.reloaded event")
+		}
+	}
+
+	// Verify config was updated
+	if cw.Config().DefaultAgent != "updated-agent" {
+		t.Errorf("After reload, DefaultAgent = %q, want %q", cw.Config().DefaultAgent, "updated-agent")
+	}
+	if cw.Config().MaxWorkers != 4 {
+		t.Errorf("After reload, MaxWorkers = %d, want %d", cw.Config().MaxWorkers, 4)
+	}
+
+	// Verify LastReloadedAt was set
+	if cw.LastReloadedAt().IsZero() {
+		t.Error("LastReloadedAt should be set after reload")
+	}
+	if time.Since(cw.LastReloadedAt()) > 5*time.Second {
+		t.Error("LastReloadedAt should be recent")
+	}
+}
+
+func TestConfigWatcher_InvalidConfigDoesNotCrash(t *testing.T) {
+	// Create a temporary config file
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.toml")
+
+	// Write valid initial config
+	initialConfig := `default_agent = "test-agent"
+`
+	if err := os.WriteFile(configPath, []byte(initialConfig), 0644); err != nil {
+		t.Fatalf("Failed to write initial config: %v", err)
+	}
+
+	// Load initial config
+	cfg, err := config.LoadGlobalFrom(configPath)
+	if err != nil {
+		t.Fatalf("Failed to load initial config: %v", err)
+	}
+
+	// Create and start config watcher
+	broadcaster := NewBroadcaster()
+	cw := NewConfigWatcher(configPath, cfg, broadcaster)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := cw.Start(ctx); err != nil {
+		t.Fatalf("Failed to start config watcher: %v", err)
+	}
+	defer cw.Stop()
+
+	// Write invalid TOML - this should not crash the watcher
+	invalidConfig := `this is not valid toml [[[
+`
+	if err := os.WriteFile(configPath, []byte(invalidConfig), 0644); err != nil {
+		t.Fatalf("Failed to write invalid config: %v", err)
+	}
+
+	// Wait for debounce and reload attempt
+	time.Sleep(500 * time.Millisecond)
+
+	// Config should still be the original value
+	if cw.Config().DefaultAgent != "test-agent" {
+		t.Errorf("Config should not change on invalid TOML, DefaultAgent = %q", cw.Config().DefaultAgent)
+	}
+
+	// Watcher should still be working - fix the config
+	fixedConfig := `default_agent = "fixed-agent"
+`
+	if err := os.WriteFile(configPath, []byte(fixedConfig), 0644); err != nil {
+		t.Fatalf("Failed to write fixed config: %v", err)
+	}
+
+	// Wait for reload
+	time.Sleep(500 * time.Millisecond)
+
+	// Now config should be updated
+	if cw.Config().DefaultAgent != "fixed-agent" {
+		t.Errorf("After fix, DefaultAgent = %q, want %q", cw.Config().DefaultAgent, "fixed-agent")
+	}
+}
+
+func TestConfigGetter_Interface(t *testing.T) {
+	// Verify both StaticConfig and ConfigWatcher implement ConfigGetter
+	var _ ConfigGetter = (*StaticConfig)(nil)
+	var _ ConfigGetter = (*ConfigWatcher)(nil)
+}
+
+func TestConfigWatcher_HotReloadableSettingsTakeEffect(t *testing.T) {
+	// This test verifies that hot-reloadable settings actually take effect
+	// after a config file change
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.toml")
+
+	// Write initial config with specific hot-reloadable values
+	initialConfig := `default_agent = "initial-agent"
+review_context_count = 3
+job_timeout_minutes = 10
+`
+	if err := os.WriteFile(configPath, []byte(initialConfig), 0644); err != nil {
+		t.Fatalf("Failed to write initial config: %v", err)
+	}
+
+	cfg, err := config.LoadGlobalFrom(configPath)
+	if err != nil {
+		t.Fatalf("Failed to load initial config: %v", err)
+	}
+
+	broadcaster := NewBroadcaster()
+	_, eventCh := broadcaster.Subscribe("")
+
+	cw := NewConfigWatcher(configPath, cfg, broadcaster)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := cw.Start(ctx); err != nil {
+		t.Fatalf("Failed to start config watcher: %v", err)
+	}
+	defer cw.Stop()
+
+	// Verify initial values
+	if cw.Config().ReviewContextCount != 3 {
+		t.Errorf("Initial ReviewContextCount = %d, want 3", cw.Config().ReviewContextCount)
+	}
+	if cw.Config().JobTimeoutMinutes != 10 {
+		t.Errorf("Initial JobTimeoutMinutes = %d, want 10", cw.Config().JobTimeoutMinutes)
+	}
+	initialReloadTime := cw.LastReloadedAt()
+
+	// Update config with new hot-reloadable values
+	updatedConfig := `default_agent = "updated-agent"
+review_context_count = 7
+job_timeout_minutes = 30
+`
+	if err := os.WriteFile(configPath, []byte(updatedConfig), 0644); err != nil {
+		t.Fatalf("Failed to write updated config: %v", err)
+	}
+
+	// Wait for config.reloaded event
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case event := <-eventCh:
+			if event.Type == "config.reloaded" {
+				goto reloaded
+			}
+		case <-timeout:
+			t.Fatal("Timeout waiting for config.reloaded event")
+		}
+	}
+reloaded:
+
+	// Verify hot-reloadable settings took effect
+	if cw.Config().ReviewContextCount != 7 {
+		t.Errorf("After reload, ReviewContextCount = %d, want 7", cw.Config().ReviewContextCount)
+	}
+	if cw.Config().JobTimeoutMinutes != 30 {
+		t.Errorf("After reload, JobTimeoutMinutes = %d, want 30", cw.Config().JobTimeoutMinutes)
+	}
+	if cw.Config().DefaultAgent != "updated-agent" {
+		t.Errorf("After reload, DefaultAgent = %q, want %q", cw.Config().DefaultAgent, "updated-agent")
+	}
+
+	// Verify LastReloadedAt changed
+	if cw.LastReloadedAt().Equal(initialReloadTime) {
+		t.Error("LastReloadedAt should have changed after reload")
+	}
+	if cw.LastReloadedAt().IsZero() {
+		t.Error("LastReloadedAt should not be zero after reload")
+	}
+}
+
+func TestConfigWatcher_DoubleStopSafe(t *testing.T) {
+	cfg := &config.Config{DefaultAgent: "test"}
+	broadcaster := NewBroadcaster()
+
+	cw := NewConfigWatcher("", cfg, broadcaster)
+
+	// Multiple Stop() calls should not panic
+	cw.Stop()
+	cw.Stop()
+	cw.Stop()
+}
+
+func TestConfigWatcher_StopAfterStart(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.toml")
+
+	if err := os.WriteFile(configPath, []byte("default_agent = \"test\"\n"), 0644); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+
+	cfg, _ := config.LoadGlobalFrom(configPath)
+	broadcaster := NewBroadcaster()
+	cw := NewConfigWatcher(configPath, cfg, broadcaster)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := cw.Start(ctx); err != nil {
+		t.Fatalf("Failed to start: %v", err)
+	}
+
+	// Stop multiple times should not panic
+	cw.Stop()
+	cw.Stop()
+}

--- a/internal/daemon/health_test.go
+++ b/internal/daemon/health_test.go
@@ -21,7 +21,7 @@ func TestHealthEndpoint(t *testing.T) {
 
 	// Create server
 	cfg := config.DefaultConfig()
-	server := NewServer(db, cfg)
+	server := NewServer(db, cfg, "")
 	defer func() {
 		if server.errorLog != nil {
 			server.errorLog.Close()
@@ -85,7 +85,7 @@ func TestHealthEndpointWithErrors(t *testing.T) {
 
 	// Create server
 	cfg := config.DefaultConfig()
-	server := NewServer(db, cfg)
+	server := NewServer(db, cfg, "")
 	defer func() {
 		if server.errorLog != nil {
 			server.errorLog.Close()
@@ -143,7 +143,7 @@ func TestHealthEndpointMethodNotAllowed(t *testing.T) {
 
 	// Create server
 	cfg := config.DefaultConfig()
-	server := NewServer(db, cfg)
+	server := NewServer(db, cfg, "")
 	defer func() {
 		if server.errorLog != nil {
 			server.errorLog.Close()

--- a/internal/daemon/stream_integration_test.go
+++ b/internal/daemon/stream_integration_test.go
@@ -143,7 +143,7 @@ func TestStreamEventsMethodNotAllowed(t *testing.T) {
 	defer db.Close()
 
 	cfg := config.DefaultConfig()
-	server := NewServer(db, cfg)
+	server := NewServer(db, cfg, "")
 
 	req := httptest.NewRequest("POST", "/api/stream/events", nil)
 	rec := httptest.NewRecorder()
@@ -189,7 +189,7 @@ func TestBroadcasterIntegrationWithWorker(t *testing.T) {
 	}
 
 	// Create worker pool with our broadcaster
-	pool := NewWorkerPool(db, cfg, 1, broadcaster, nil)
+	pool := NewWorkerPool(db, NewStaticConfig(cfg), 1, broadcaster, nil)
 	pool.Start()
 	defer pool.Stop()
 

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -36,7 +36,7 @@ func TestWorkerPoolE2E(t *testing.T) {
 
 	// Create and start worker pool
 	broadcaster := NewBroadcaster()
-	pool := NewWorkerPool(db, cfg, 1, broadcaster, nil)
+	pool := NewWorkerPool(db, NewStaticConfig(cfg), 1, broadcaster, nil)
 	pool.Start()
 
 	// Wait for job to complete (with timeout)
@@ -92,7 +92,7 @@ func TestWorkerPoolConcurrency(t *testing.T) {
 	}
 
 	broadcaster := NewBroadcaster()
-	pool := NewWorkerPool(db, cfg, 4, broadcaster, nil)
+	pool := NewWorkerPool(db, NewStaticConfig(cfg), 4, broadcaster, nil)
 	pool.Start()
 
 	// Wait briefly and check active workers
@@ -125,7 +125,7 @@ func TestWorkerPoolCancelRunningJob(t *testing.T) {
 	}
 
 	broadcaster := NewBroadcaster()
-	pool := NewWorkerPool(db, cfg, 1, broadcaster, nil)
+	pool := NewWorkerPool(db, NewStaticConfig(cfg), 1, broadcaster, nil)
 	pool.Start()
 	defer pool.Stop()
 
@@ -179,7 +179,7 @@ func TestWorkerPoolPendingCancellation(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	broadcaster := NewBroadcaster()
-	pool := NewWorkerPool(db, cfg, 1, broadcaster, nil)
+	pool := NewWorkerPool(db, NewStaticConfig(cfg), 1, broadcaster, nil)
 
 	// Create a real job in 'running' state (simulating claimed but not yet registered)
 	repo, err := db.GetOrCreateRepo(tmpDir)
@@ -239,7 +239,7 @@ func TestWorkerPoolPendingCancellationAfterDBCancel(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	broadcaster := NewBroadcaster()
-	pool := NewWorkerPool(db, cfg, 1, broadcaster, nil)
+	pool := NewWorkerPool(db, NewStaticConfig(cfg), 1, broadcaster, nil)
 
 	// Create and claim a job (simulating worker claimed but not yet registered)
 	repo, err := db.GetOrCreateRepo(tmpDir)
@@ -308,7 +308,7 @@ func TestWorkerPoolCancelInvalidJob(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	broadcaster := NewBroadcaster()
-	pool := NewWorkerPool(db, cfg, 1, broadcaster, nil)
+	pool := NewWorkerPool(db, NewStaticConfig(cfg), 1, broadcaster, nil)
 
 	// CancelJob for non-existent job should return false
 	if pool.CancelJob(99999) {
@@ -330,7 +330,7 @@ func TestWorkerPoolCancelJobFinishedDuringWindow(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	broadcaster := NewBroadcaster()
-	pool := NewWorkerPool(db, cfg, 1, broadcaster, nil)
+	pool := NewWorkerPool(db, NewStaticConfig(cfg), 1, broadcaster, nil)
 
 	// Create and claim a job
 	repo, err := db.GetOrCreateRepo(tmpDir)
@@ -384,7 +384,7 @@ func TestWorkerPoolCancelJobRegisteredDuringCheck(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	broadcaster := NewBroadcaster()
-	pool := NewWorkerPool(db, cfg, 1, broadcaster, nil)
+	pool := NewWorkerPool(db, NewStaticConfig(cfg), 1, broadcaster, nil)
 
 	// Create and claim a job
 	repo, err := db.GetOrCreateRepo(tmpDir)
@@ -434,7 +434,7 @@ func TestWorkerPoolCancelJobConcurrentRegister(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	broadcaster := NewBroadcaster()
-	pool := NewWorkerPool(db, cfg, 1, broadcaster, nil)
+	pool := NewWorkerPool(db, NewStaticConfig(cfg), 1, broadcaster, nil)
 
 	repo, err := db.GetOrCreateRepo(tmpDir)
 	if err != nil {
@@ -487,7 +487,7 @@ func TestWorkerPoolCancelJobFinalCheckDeadlockSafe(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	broadcaster := NewBroadcaster()
-	pool := NewWorkerPool(db, cfg, 1, broadcaster, nil)
+	pool := NewWorkerPool(db, NewStaticConfig(cfg), 1, broadcaster, nil)
 
 	repo, err := db.GetOrCreateRepo(tmpDir)
 	if err != nil {

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -96,15 +96,16 @@ type Response struct {
 }
 
 type DaemonStatus struct {
-	Version       string `json:"version"`
-	QueuedJobs    int    `json:"queued_jobs"`
-	RunningJobs   int    `json:"running_jobs"`
-	CompletedJobs int    `json:"completed_jobs"`
-	FailedJobs    int    `json:"failed_jobs"`
-	CanceledJobs  int    `json:"canceled_jobs"`
-	ActiveWorkers int    `json:"active_workers"`
-	MaxWorkers    int    `json:"max_workers"`
-	MachineID     string `json:"machine_id,omitempty"` // Local machine ID for remote job detection
+	Version          string `json:"version"`
+	QueuedJobs       int    `json:"queued_jobs"`
+	RunningJobs      int    `json:"running_jobs"`
+	CompletedJobs    int    `json:"completed_jobs"`
+	FailedJobs       int    `json:"failed_jobs"`
+	CanceledJobs     int    `json:"canceled_jobs"`
+	ActiveWorkers    int    `json:"active_workers"`
+	MaxWorkers       int    `json:"max_workers"`
+	MachineID        string `json:"machine_id,omitempty"`         // Local machine ID for remote job detection
+	ConfigReloadedAt string `json:"config_reloaded_at,omitempty"` // Last config reload timestamp (RFC3339)
 }
 
 // HealthStatus represents the overall daemon health


### PR DESCRIPTION
## Summary

- Watch `~/.roborev/config.toml` for changes and automatically reload configuration without requiring a daemon restart
- Hot-reloadable settings: `default_agent`, `job_timeout`, `allow_unsafe_agents`, `anthropic_api_key`, `review_context_count`
- Settings requiring restart: `server_addr`, `max_workers`, `[sync]` section
- Show "Config reloaded" flash notification in TUI for 5 seconds when config changes are applied
- Add `config_reloaded_at` timestamp to `/api/status` endpoint

## Implementation Details

- Uses fsnotify for cross-platform file watching (Linux, macOS, Windows)
- Handles atomic saves via rename (vim and similar editors)
- `ConfigGetter` interface for thread-safe config access with snapshot-per-job to prevent mixed settings
- Resource cleanup on `Start()` failure
- `sync.Once` guard on `Stop()` to prevent double-close panic

## Test plan

- [x] `TestConfigWatcher_ReloadOnFileChange` - verifies config reload on file change
- [x] `TestConfigWatcher_HotReloadableSettingsTakeEffect` - verifies `review_context_count`, `job_timeout_minutes` update
- [x] `TestConfigWatcher_InvalidConfigDoesNotCrash` - verifies graceful handling of invalid TOML
- [x] `TestConfigWatcher_DoubleStopSafe` - verifies multiple Stop() calls don't panic
- [x] `TestTUIConfigReloadFlash` - verifies flash behavior on config reload
- [x] `TestHandleStatus` - verifies `config_reloaded_at` and `max_workers` in status

Closes #85

🤖 Generated with [Claude Code](https://claude.ai/code)