### PR TITLE
Add flash notifications for incomplete jobs in TUI

### DIFF
--- a/cmd/roborev/tui.go
+++ b/cmd/roborev/tui.go
@@ -1304,6 +1304,23 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.currentView = tuiViewReview
 					m.reviewScroll = 0
 					return m, nil
+				} else {
+					// Queued, running, or canceled - show flash notification
+					var status string
+					switch job.Status {
+					case storage.JobStatusQueued:
+						status = "queued"
+					case storage.JobStatusRunning:
+						status = "in progress"
+					case storage.JobStatusCanceled:
+						status = "canceled"
+					default:
+						status = string(job.Status)
+					}
+					m.flashMessage = fmt.Sprintf("Job #%d is %s — no review yet", job.ID, status)
+					m.flashExpiresAt = time.Now().Add(2 * time.Second)
+					m.flashView = tuiViewQueue
+					return m, nil
 				}
 			}
 
@@ -1500,6 +1517,23 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if job.Status == storage.JobStatusDone || job.Status == storage.JobStatusFailed {
 					// Need to fetch review first, then copy
 					return m, m.fetchReviewAndCopy(job.ID)
+				} else {
+					// Queued, running, or canceled - show flash notification
+					var status string
+					switch job.Status {
+					case storage.JobStatusQueued:
+						status = "queued"
+					case storage.JobStatusRunning:
+						status = "in progress"
+					case storage.JobStatusCanceled:
+						status = "canceled"
+					default:
+						status = string(job.Status)
+					}
+					m.flashMessage = fmt.Sprintf("Job #%d is %s — no review to copy", job.ID, status)
+					m.flashExpiresAt = time.Now().Add(2 * time.Second)
+					m.flashView = tuiViewQueue
+					return m, nil
 				}
 			}
 


### PR DESCRIPTION
## Summary
When pressing enter or y on queued, running, or canceled jobs, show a flash notification explaining that there's no review yet. This provides clear feedback instead of silently doing nothing.

Fixes #96

## Changes
- **enter** on incomplete job: "Job #X is queued/in progress/canceled — no review yet"
- **y** on incomplete job: "Job #X is queued/in progress/canceled — no review to copy"

Flash appears in the same location as "Copied to clipboard" and fades after 2 seconds.

## Test Plan
- [x] Build and run TUI
- [x] Press enter on a queued job → see flash
- [x] Press enter on a running job → see flash
- [x] Press y on a queued/running job → see flash
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)