### PR TITLE
Update flake.nix for v0.16.1

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         packages = {
           default = pkgs.buildGoModule {
             pname = "roborev";
-            version = "0.16.0";
+            version = "0.16.1";
 
             src = ./.;
 


### PR DESCRIPTION
Updates flake.nix version to 0.16.1 for the v0.16.1 release.