### PR TITLE
Include --force in dev build update notification

### DIFF
--- a/cmd/roborev/tui.go
+++ b/cmd/roborev/tui.go
@@ -2290,7 +2290,7 @@ func (m tuiModel) renderQueueView() string {
 		updateStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("226")).Bold(true)
 		var updateMsg string
 		if m.updateIsDevBuild {
-			updateMsg = fmt.Sprintf("Dev build - latest release: %s - run 'roborev update'", m.updateAvailable)
+			updateMsg = fmt.Sprintf("Dev build - latest release: %s - run 'roborev update --force'", m.updateAvailable)
 		} else {
 			updateMsg = fmt.Sprintf("Update available: %s - run 'roborev update'", m.updateAvailable)
 		}


### PR DESCRIPTION
## Summary
- The TUI notification for dev builds now shows the complete command `roborev update --force` instead of just `roborev update`
- Dev builds require `--force` to update to an official release, so the notification should reflect that

## Test plan
- [x] Run a dev build and verify the notification shows `run 'roborev update --force'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)