### PR TITLE
Update flake.nix for v0.16.3

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         packages = {
           default = pkgs.buildGoModule {
             pname = "roborev";
-            version = "0.16.2";
+            version = "0.16.3";
 
             src = ./.;
 


### PR DESCRIPTION
Updates flake.nix version to 0.16.3 for the v0.16.3 release.