### PR TITLE
Add Gemini-specific preamble for run tasks

### DIFF
--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -256,8 +256,13 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 	var reviewPrompt string
 	var err error
 	if job.GitRef == "prompt" && job.Prompt != "" {
-		// Custom prompt job - use pre-stored prompt directly
-		reviewPrompt = job.Prompt
+		// Custom prompt job - prepend agent-specific preamble if available
+		preamble := prompt.GetSystemPrompt(job.Agent, "run")
+		if preamble != "" {
+			reviewPrompt = preamble + "\n" + job.Prompt
+		} else {
+			reviewPrompt = job.Prompt
+		}
 	} else if job.DiffContent != nil {
 		// Dirty job - use pre-captured diff
 		reviewPrompt, err = wp.promptBuilder.BuildDirty(job.RepoPath, *job.DiffContent, job.RepoID, cfg.ReviewContextCount, job.Agent)

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -136,7 +136,7 @@ func (b *Builder) BuildDirty(repoPath, diff string, repoID int64, contextCount i
 	var sb strings.Builder
 
 	// Start with system prompt for dirty changes
-	sb.WriteString(getSystemPrompt(agentName, "dirty"))
+	sb.WriteString(GetSystemPrompt(agentName, "dirty"))
 	sb.WriteString("\n")
 
 	// Add project-specific guidelines if configured
@@ -195,7 +195,7 @@ func (b *Builder) buildSinglePrompt(repoPath, sha string, repoID int64, contextC
 	var sb strings.Builder
 
 	// Start with system prompt
-	sb.WriteString(getSystemPrompt(agentName, "review"))
+	sb.WriteString(GetSystemPrompt(agentName, "review"))
 	sb.WriteString("\n")
 
 	// Add project-specific guidelines if configured
@@ -272,7 +272,7 @@ func (b *Builder) buildRangePrompt(repoPath, rangeRef string, repoID int64, cont
 	var sb strings.Builder
 
 	// Start with system prompt for ranges
-	sb.WriteString(getSystemPrompt(agentName, "range"))
+	sb.WriteString(GetSystemPrompt(agentName, "range"))
 	sb.WriteString("\n")
 
 	// Add project-specific guidelines if configured
@@ -508,7 +508,7 @@ func (b *Builder) BuildAddressPrompt(repoPath string, review *storage.Review, pr
 	var sb strings.Builder
 
 	// System prompt
-	sb.WriteString(getSystemPrompt(review.Agent, "address"))
+	sb.WriteString(GetSystemPrompt(review.Agent, "address"))
 	sb.WriteString("\n")
 
 	// Add project-specific guidelines if configured

--- a/internal/prompt/templates.go
+++ b/internal/prompt/templates.go
@@ -9,10 +9,11 @@ import (
 //go:embed templates/*.tmpl
 var templateFS embed.FS
 
-// getSystemPrompt returns the system prompt for the specified agent and type.
+// GetSystemPrompt returns the system prompt for the specified agent and type.
 // If a specific template exists for the agent, it uses that.
 // Otherwise, it falls back to the default constant.
-func getSystemPrompt(agentName string, promptType string) string {
+// Supported prompt types: review, range, dirty, address, run
+func GetSystemPrompt(agentName string, promptType string) string {
 	// Normalize agent name
 	agentName = strings.ToLower(agentName)
 	if agentName == "claude" {

--- a/internal/prompt/templates/gemini_run.tmpl
+++ b/internal/prompt/templates/gemini_run.tmpl
@@ -1,0 +1,9 @@
+You are a helpful assistant working on a software project.
+
+Your goal is to be extremely concise and professional. Do NOT explain your process, list the steps you are taking, or provide unnecessary commentary. Just provide the results directly.
+
+Focus on:
+- Answering questions directly and accurately
+- Providing code examples when helpful
+- Being practical and actionable
+

--- a/internal/prompt/templates_test.go
+++ b/internal/prompt/templates_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestGeminiTemplateLoads(t *testing.T) {
-	result := getSystemPrompt("gemini", "review")
+	result := GetSystemPrompt("gemini", "review")
 	if result == SystemPromptSingle {
 		t.Error("Expected Gemini-specific template, got default SystemPromptSingle")
 	}
@@ -17,14 +17,24 @@ func TestGeminiTemplateLoads(t *testing.T) {
 
 func TestAgentTemplatesFallbackToReview(t *testing.T) {
 	// Range and dirty should use the same template as review
-	review := getSystemPrompt("gemini", "review")
-	rang := getSystemPrompt("gemini", "range")
-	dirty := getSystemPrompt("gemini", "dirty")
+	review := GetSystemPrompt("gemini", "review")
+	rang := GetSystemPrompt("gemini", "range")
+	dirty := GetSystemPrompt("gemini", "dirty")
 
 	if rang != review {
 		t.Error("Expected range to use same template as review")
 	}
 	if dirty != review {
 		t.Error("Expected dirty to use same template as review")
+	}
+}
+
+func TestGeminiRunTemplateLoads(t *testing.T) {
+	result := GetSystemPrompt("gemini", "run")
+	if result == "" {
+		t.Error("Expected Gemini run template to load")
+	}
+	if !strings.Contains(result, "Do NOT explain your process") {
+		t.Errorf("Expected Gemini run template content, got: %s", result[:min(100, len(result))])
 	}
 }


### PR DESCRIPTION
## Summary
- Gemini tends to be verbose and explain its process when running tasks, which clutters output
- Adds a `gemini_run.tmpl` template with the same professional/concise preamble used for reviews
- The worker now prepends agent-specific preambles to prompt jobs

## Changes
- Create `gemini_run.tmpl` template with concise instructions
- Export `GetSystemPrompt` for use by worker
- Update worker to prepend agent preamble to prompt jobs
- Add test for Gemini run template loading

## Test plan
- [x] Run `roborev run "explain this codebase" --agent gemini` and verify output is concise without inner monologue

🤖 Generated with [Claude Code](https://claude.com/claude-code)