### PR TITLE
Fix make install to never use go install

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ CLI (roborev) → HTTP API → Daemon (roborev daemon run) → Worker Pool → A
 ```bash
 go build ./...           # Build
 go test ./...            # Test
-go install ./cmd/...     # Install locally
+make install             # Install to ~/.local/bin
 roborev init             # Initialize in a repo
 roborev status           # Check daemon/queue
 ```

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,10 @@ build:
 	go build -ldflags="$(LDFLAGS)" -o bin/roborev ./cmd/roborev
 
 install:
-	@# Install to existing location if found, otherwise use go install default
-	@if [ -f "$(HOME)/.local/bin/roborev" ]; then \
-		echo "Installing to ~/.local/bin/roborev"; \
-		go build -ldflags="$(LDFLAGS)" -o "$(HOME)/.local/bin/roborev" ./cmd/roborev; \
-	else \
-		go install -ldflags="$(LDFLAGS)" ./cmd/roborev; \
-	fi
+	@# Install to ~/.local/bin for development (creates directory if needed)
+	@mkdir -p "$(HOME)/.local/bin"
+	go build -ldflags="$(LDFLAGS)" -o "$(HOME)/.local/bin/roborev" ./cmd/roborev
+	@echo "Installed to ~/.local/bin/roborev"
 
 clean:
 	rm -rf bin/


### PR DESCRIPTION
## Summary
- Always build to `~/.local/bin` instead of falling back to `go install`, which pollutes `~/go/bin` with development binaries that can conflict with production

## Test plan
- [x] Run `make install` - builds to ~/.local/bin/roborev

🤖 Generated with [Claude Code](https://claude.ai/code)