### PR TITLE
Improve TUI row selection styling

### DIFF
--- a/cmd/roborev/tui.go
+++ b/cmd/roborev/tui.go
@@ -46,8 +46,7 @@ var (
 			Foreground(lipgloss.AdaptiveColor{Light: "242", Dark: "246"}) // Gray
 
 	tuiSelectedStyle = lipgloss.NewStyle().
-				Bold(true).
-				Foreground(lipgloss.AdaptiveColor{Light: "127", Dark: "212"}) // Magenta/Pink
+				Background(lipgloss.AdaptiveColor{Light: "153", Dark: "24"}) // Light blue background
 
 	tuiQueuedStyle   = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "136", Dark: "226"}) // Yellow/Gold
 	tuiRunningStyle  = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "25", Dark: "33"})   // Blue
@@ -3123,7 +3122,13 @@ func (m tuiModel) renderQueueView() string {
 			selected := i == visibleSelectedIdx
 			line := m.renderJobLine(job, selected, idWidth, colWidths)
 			if selected {
-				line = tuiSelectedStyle.Render("> " + line)
+				// Pad line to full terminal width for background styling
+				lineWidth := lipgloss.Width(line)
+				paddedLine := "> " + line
+				if padding := m.width - lineWidth - 2; padding > 0 {
+					paddedLine += strings.Repeat(" ", padding)
+				}
+				line = tuiSelectedStyle.Render(paddedLine)
 			} else {
 				line = "  " + line
 			}


### PR DESCRIPTION
## Summary
- Replace bold pink text highlighting with a subtle light blue background cursor
- Extend the highlight full-width across the terminal for better visual clarity

I prefer this:

<img width="806" height="447" alt="image" src="https://github.com/user-attachments/assets/b60664b2-27f9-4bf1-93e5-8a5a707f8291" />

<img width="731" height="428" alt="image" src="https://github.com/user-attachments/assets/635992c9-677a-44fa-8c4b-62234b5663a5" />


## Test plan
- [x] Run `roborev tui` and verify the selected row shows a light blue background
- [x] Test on both light and dark terminals to confirm adaptive colors work

🤖 Generated with [Claude Code](https://claude.com/claude-code)