### PR TITLE
Support unbulleted severity labels in verdict detection

### DIFF
--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -159,41 +159,24 @@ func hasSeverityLabel(output string) bool {
 }
 
 // isLegendEntry checks if a line at index i appears to be part of a severity legend/rubric
-// by looking at preceding lines for legend indicators.
+// by looking at preceding lines for legend indicators. Scans up to 10 lines back,
+// skipping empty lines, severity lines, and description lines that may appear
+// between legend entries.
 func isLegendEntry(lines []string, i int) bool {
-	severities := []string{"critical", "high", "medium", "low"}
-
-	// Check previous lines for legend indicators
-	// Skip other severity lines (they might be part of the same legend)
 	for j := i - 1; j >= 0 && j >= i-10; j-- {
-		prev := strings.TrimSpace(strings.ToLower(lines[j]))
+		prev := strings.TrimSpace(lines[j])
 		if len(prev) == 0 {
 			continue
 		}
 
-		// Check for legend header patterns
-		if strings.HasSuffix(prev, ":") {
+		// Check for legend header patterns (ends with ":" and contains indicator word)
+		if strings.HasSuffix(prev, ":") || strings.HasSuffix(prev, "：") {
 			if strings.Contains(prev, "severity") || strings.Contains(prev, "level") ||
 				strings.Contains(prev, "legend") || strings.Contains(prev, "scale") ||
 				strings.Contains(prev, "rating") || strings.Contains(prev, "priority") {
 				return true
 			}
 		}
-
-		// Check if this line is also a severity label - if so, keep looking
-		isSeverityLine := false
-		for _, sev := range severities {
-			if strings.HasPrefix(prev, sev) {
-				isSeverityLine = true
-				break
-			}
-		}
-		if isSeverityLine {
-			continue
-		}
-
-		// Stop checking after first non-empty, non-severity line that isn't a header
-		break
 	}
 	return false
 }

--- a/internal/storage/verdict_test.go
+++ b/internal/storage/verdict_test.go
@@ -765,6 +765,11 @@ func TestParseVerdict(t *testing.T) {
 			want:   "P",
 		},
 		{
+			name:   "severity legend with descriptions not a finding",
+			output: "No issues found.\n\nSeverity levels:\nHigh - immediate action required.\n  These issues block release.\nMedium - should be addressed.",
+			want:   "P",
+		},
+		{
 			name:   "no issues found but with period",
 			output: "No issues found but.",
 			want:   "F",


### PR DESCRIPTION
## Summary

Lines starting directly with severity words (Critical/High/Medium/Low) followed by separators are now detected as findings, not just bulleted lines.

This fixes a regression from #153 where `Critical — Data loss possible.` on its own line would not be detected as a finding.

## Changes

- Simplified `hasSeverityLabel` to check both bulleted and unbulleted lines
- Added tests for unbulleted severity formats

## Test plan

- [x] `Critical — ...` without bullet is detected as Fail
- [x] `High: ...` without bullet is detected as Fail  
- [x] `- Medium — ...` with bullet still works
- [x] `high-level overview` in prose still passes
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)