### PR TITLE
feat: add Claude Code PostToolUse hook for review integration

### DIFF
--- a/internal/hooks/claude/roborev-post-commit/hook.sh
+++ b/internal/hooks/claude/roborev-post-commit/hook.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Claude Code PostToolUse hook for roborev integration
+# Triggers after git commit commands to remind the agent to check reviews
+
+set -euo pipefail
+INPUT=$(cat)
+
+# Only trigger on git commit (match command field specifically, not full JSON)
+echo "$INPUT" | jq -r '.tool_input.command // ""' | grep -q "git commit" || exit 0
+
+# Check prerequisites
+command -v roborev &>/dev/null || exit 0
+git rev-parse --git-dir &>/dev/null || exit 0
+roborev status &>/dev/null || exit 0
+
+COMMIT_SHA=$(git rev-parse HEAD)
+COMMIT_SHORT=$(git rev-parse --short HEAD)
+
+# stderr + exit 2 = Claude sees this message
+echo "**ROBOREV** — Review queued for ${COMMIT_SHORT}. Run \`sleep 25 && roborev show ${COMMIT_SHA}\`, note job ID, then \`roborev address <id>\`." >&2
+exit 2


### PR DESCRIPTION
Hi @wesm, as we discussed briefly in #151, there's currently no way for the main agent to know that a `roborev` review is happening in the background.

I had been using the `roborev` TUI, but I wanted to remove myself from the loop and make the agent aware - something close to a notification system. The Claude Code team hasn't released SDK support for this or a way to tap into their notification system (which seems to work for background tasks), so this is my attempt.

The hook at `internal/hooks/claude/roborev-post-commit/hook.sh` triggers after git commits, queues a review, and outputs a reminder for the agent to address findings.

A few tricks worth noting:

1. Hooks with exit code 0 don't pass context to the agent (useful for linting, not for our use case here). Exit code 2 passes the hook output to the main context. A bit of a magic number, but it works. (see https://code.claude.com/docs/en/hooks#simple:-exit-code)

2. Hook matchers can't use argument patterns like the permissions system can - `Bash(git commit*)` doesn't work, only `Bash`. So the hook fires on every Bash call and exits early (with 0) when it's not a git command. I raised [anthropics/claude-code#21540](https://github.com/anthropics/claude-code/issues/21540) about this limitation but I don't think it'll be addressed.

3. The pattern matches "git commit" anywhere in the command to catch chained commands like `git add && git commit`. Tradeoff: occasional false positives from heredocs or string arguments containing "git commit".

4. The hook output is kept lean to avoid polluting the agent's context.

Go code changes are still needed to embed and install it to `~/.claude/hooks/`.

## Question

How should installation work?

1. New command: `roborev hooks install`
2. Extend existing: `roborev skills install --hooks`
3. Something else?