### PR TITLE
Fail fast for task jobs with missing prompt

### DIFF
--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -291,6 +291,11 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 		} else {
 			reviewPrompt = job.Prompt
 		}
+	} else if job.IsTaskJob() {
+		// Task job with missing prompt - likely a daemon version mismatch where
+		// the prompt wasn't stored or loaded. Fail with a clear error instead of
+		// trying to git log on an analysis type name like "complexity".
+		err = fmt.Errorf("task job %d has no stored prompt (git_ref=%q); restart the daemon with 'roborev daemon restart'", job.ID, job.GitRef)
 	} else if job.DiffContent != nil {
 		// Dirty job - use pre-captured diff
 		reviewPrompt, err = wp.promptBuilder.BuildDirty(job.RepoPath, *job.DiffContent, job.RepoID, cfg.ReviewContextCount, job.Agent)


### PR DESCRIPTION
## Summary

- When a task job (analyze, run, custom) has no stored prompt, the worker now fails with a clear error message instead of falling through to `git log` on the analysis type name

## Background (fixes #194)

The reported error was:
```
Error: prompt failed: build prompt: get commit info: git log: exit status 128
```

This happened because `roborev analyze complexity file.go` stores the analysis type name ("complexity") in the `git_ref` field and the full prompt in the `prompt` column. The worker is supposed to detect task jobs via `IsTaskJob() && Prompt != ""` and use the stored prompt directly, skipping `git log`.

The most likely cause is a **daemon version mismatch**. Prior to v0.20.0, the worker recognized task jobs only when `git_ref == "prompt"` (the hardcoded literal). The `IsTaskJob()` function that handles arbitrary labels like "complexity" was introduced alongside the analyze command in v0.20.0. If a stale daemon process from an older version is still running (e.g., not killed by `ensureDaemon` due to a process management edge case), analyze jobs fall through to the normal commit path, which runs `git log "complexity"` and fails with exit status 128.

The reporter was on v0.23.1 with codex as the agent (not authenticated), so the jobs also failed in 0s. The codex auth issue is separate, but the confusing `git log` error is what this PR addresses.

## Fix

Added a defensive branch in the worker's prompt-building logic: if `IsTaskJob()` is true but `Prompt` is empty, fail immediately with an actionable error message suggesting `roborev daemon restart`, instead of falling through to `git log`.

## Test plan

- [x] `go test ./internal/daemon/ -run TestWorker -v` passes
- [x] `go test ./...` passes
- [ ] Verify that a task job with missing prompt produces the new error message instead of "git log: exit status 128"

🤖 Generated with [Claude Code](https://claude.com/claude-code)