### PR TITLE
Add `roborev list` command and `--json` flag to `show`

### DIFF
--- a/cmd/roborev/main.go
+++ b/cmd/roborev/main.go
@@ -1251,17 +1251,15 @@ Examples:
 
 			addr := getDaemonAddr()
 
-			// Auto-resolve repo and branch from cwd when not specified.
-			// Only auto-resolve branch when repo was also auto-resolved
-			// (or matches cwd), to avoid applying a cwd branch filter
-			// against an unrelated --repo.
+			// Auto-resolve repo from cwd when not specified.
 			if repoPath == "" {
 				if root, err := git.GetRepoRoot("."); err == nil {
 					repoPath = root
-					if branch == "" {
-						branch = git.GetCurrentBranch(root)
-					}
 				}
+			}
+			// Auto-resolve branch from the target repo when not specified.
+			if branch == "" && repoPath != "" {
+				branch = git.GetCurrentBranch(repoPath)
 			}
 
 			// Build query URL


### PR DESCRIPTION
## Summary

- Add new `roborev list` command for querying review jobs with filtering (`--branch`, `--repo`, `--status`, `--limit`) and `--json` output
- Add `--json` flag to existing `roborev show` command for machine-parseable review output
- `list --json` emits a bare JSON array for piping ergonomics (not a wrapper envelope)
- Auto-resolves repo and branch from the target repo (works correctly whether `--repo` is explicit or inferred from cwd)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (including 12 new tests)
- [x] New tests cover: tabular output, JSON output, `has_more` hint, empty results, HTTP error handling (both modes), query param passthrough, `--repo` to non-git path, `--repo` to valid git repo with branch auto-resolve, `show --json` output format, `show --json` skips header

🤖 Generated with [Claude Code](https://claude.com/claude-code)