### PR TITLE
Color-code Addressed column in TUI

### DIFF
--- a/cmd/roborev/tui.go
+++ b/cmd/roborev/tui.go
@@ -3345,9 +3345,17 @@ func (m tuiModel) renderJobLine(job storage.ReviewJob, selected bool, idWidth in
 	addr := ""
 	if job.Addressed != nil {
 		if *job.Addressed {
-			addr = "true"
+			if selected {
+				addr = "true"
+			} else {
+				addr = tuiAddressedStyle.Render("true")
+			}
 		} else {
-			addr = "false"
+			if selected {
+				addr = "false"
+			} else {
+				addr = tuiQueuedStyle.Render("false")
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Color-code the Addressed column values in the TUI job list table
- `true` renders in cyan (`tuiAddressedStyle`), matching the `[ADDRESSED]` badge in the review detail screen
- `false` renders in yellow (`tuiQueuedStyle`), signaling "needs attention" without alarm
- No color applied when the row is selected, consistent with Status and P/F columns

Closes #199

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Visual check in TUI: `true` is cyan, `false` is yellow, selected rows are unstyled

<img width="856" height="514" alt="image" src="https://github.com/user-attachments/assets/46f5a388-e91b-4e95-9b35-adf3dc8c9eae" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)