### PR TITLE
Document design constraint: daemon tasks must not modify the working tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,10 @@ Daemon writes runtime info to `~/.roborev/daemon.json`:
 
 CLI reads this to find the daemon. If port 7373 is busy, daemon auto-increments.
 
+## Design Constraints
+
+- **Daemon tasks must not modify the git working tree.** Background jobs (reviews, CI polling, synthesis) are read-only with respect to the user's repo checkout. They read source files and write results to the database only. CLI commands like `roborev fix` run synchronously in the foreground and may modify files, but nothing enqueued to the worker pool should touch the working tree. If we need background tasks that produce file changes in the future, they should operate in isolated git worktrees — that is a separate initiative.
+
 ## Style Preferences
 
 - Keep it simple, no over-engineering


### PR DESCRIPTION
## Summary
- Adds a "Design Constraints" section to CLAUDE.md codifying the rule that daemon/background tasks (reviews, CI polling, synthesis) must not modify the user's git working tree
- CLI commands like `roborev fix` may modify files synchronously, but nothing enqueued to the worker pool should touch the checkout
- Notes that isolated git worktrees are the future path if background file mutations are needed

Context: discussion in #216 about a design skill that would have enqueued background tasks writing PRD files to the working tree.

## Test plan
- [ ] Verify CLAUDE.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)