### PR TITLE
Fix review type consistency gaps before release

### DIFF
--- a/cmd/roborev/local_review_test.go
+++ b/cmd/roborev/local_review_test.go
@@ -268,5 +268,47 @@ func TestLocalReviewSkipsDaemon(t *testing.T) {
 	}
 }
 
+func TestReviewTypeValidation(t *testing.T) {
+	h := newReviewHarness(t)
+
+	t.Run("invalid type rejected by cobra", func(t *testing.T) {
+		cmd := reviewCmd()
+		cmd.SetArgs([]string{"--local", "--type", "bogus", "--agent", "test", "--reasoning", "fast", "--repo", h.Dir})
+
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("expected error for invalid review type")
+		}
+		if !strings.Contains(err.Error(), "invalid --type") {
+			t.Errorf("expected 'invalid --type' error, got: %v", err)
+		}
+	})
+
+	t.Run("security type accepted", func(t *testing.T) {
+		err := h.run(runOpts{Agent: "test", Reasoning: "fast", ReviewType: "security"})
+		if err != nil {
+			t.Fatalf("expected security type to be accepted, got: %v", err)
+		}
+	})
+
+	t.Run("design type accepted", func(t *testing.T) {
+		err := h.run(runOpts{Agent: "test", Reasoning: "fast", ReviewType: "design"})
+		if err != nil {
+			t.Fatalf("expected design type to be accepted, got: %v", err)
+		}
+	})
+
+	t.Run("empty type accepted as default", func(t *testing.T) {
+		err := h.run(runOpts{Agent: "test", Reasoning: "fast", ReviewType: ""})
+		if err != nil {
+			t.Fatalf("expected empty type to be accepted, got: %v", err)
+		}
+	})
+}
+
 // Ensure config package is used (for the linker)
 var _ = config.LoadGlobal

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,7 +106,7 @@ type CIConfig struct {
 	// Repos is the list of GitHub repos to poll in "owner/repo" format
 	Repos []string `toml:"repos"`
 
-	// ReviewTypes is the list of review types to run for each PR (e.g., ["security", "review"]).
+	// ReviewTypes is the list of review types to run for each PR (e.g., ["security", "default"]).
 	// Defaults to ["security"] if empty.
 	ReviewTypes []string `toml:"review_types"`
 

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -2693,6 +2693,65 @@ func TestHandleJobOutput_StreamingCompletedJob(t *testing.T) {
 }
 
 // TestHandleJobOutput_MissingJobID tests that missing job_id returns 400.
+func TestHandleEnqueueReviewTypeNormalization(t *testing.T) {
+	tests := []struct {
+		name         string
+		reviewType   string
+		wantCode     int
+		wantStored   string // expected ReviewType on response job
+		wantErrorMsg string // substring expected in error response
+	}{
+		{name: "empty defaults to default", reviewType: "", wantCode: http.StatusCreated, wantStored: "default"},
+		{name: "general alias normalized", reviewType: "general", wantCode: http.StatusCreated, wantStored: "default"},
+		{name: "review alias normalized", reviewType: "review", wantCode: http.StatusCreated, wantStored: "default"},
+		{name: "default stored as-is", reviewType: "default", wantCode: http.StatusCreated, wantStored: "default"},
+		{name: "security stored as-is", reviewType: "security", wantCode: http.StatusCreated, wantStored: "security"},
+		{name: "design stored as-is", reviewType: "design", wantCode: http.StatusCreated, wantStored: "design"},
+		{name: "invalid type rejected", reviewType: "bogus", wantCode: http.StatusBadRequest, wantErrorMsg: "invalid review_type"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, _, tmpDir := newTestServer(t)
+
+			repoDir := filepath.Join(tmpDir, "repo")
+			testutil.InitTestGitRepo(t, repoDir)
+			headSHA := testutil.GetHeadSHA(t, repoDir)
+
+			reqData := map[string]string{
+				"repo_path":   repoDir,
+				"git_ref":     headSHA,
+				"agent":       "test",
+				"review_type": tt.reviewType,
+			}
+			req := testutil.MakeJSONRequest(t, http.MethodPost, "/api/enqueue", reqData)
+			w := httptest.NewRecorder()
+
+			server.handleEnqueue(w, req)
+
+			if w.Code != tt.wantCode {
+				t.Fatalf("status=%d, want %d; body=%s", w.Code, tt.wantCode, w.Body.String())
+			}
+
+			if tt.wantErrorMsg != "" {
+				if !strings.Contains(w.Body.String(), tt.wantErrorMsg) {
+					t.Fatalf("expected error containing %q, got %s", tt.wantErrorMsg, w.Body.String())
+				}
+				return
+			}
+
+			// Decode the job from the response to verify ReviewType
+			var job storage.ReviewJob
+			if err := json.NewDecoder(w.Body).Decode(&job); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if job.ReviewType != tt.wantStored {
+				t.Errorf("ReviewType=%q, want %q", job.ReviewType, tt.wantStored)
+			}
+		})
+	}
+}
+
 func TestHandleEnqueueAgentAvailability(t *testing.T) {
 	// Shared read-only git repo created once (all subtests use different servers for DB isolation)
 	repoDir := filepath.Join(t.TempDir(), "repo")

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -481,14 +481,18 @@ func (b *Builder) getPreviousReviewContexts(repoPath, sha string, count int) ([]
 	return contexts, nil
 }
 
-// SystemPromptDesignReview is the base instruction for reviewing design documents
-const SystemPromptDesignReview = `You are a design reviewer. Review the design proposal shown below for:
+// SystemPromptDesignReview is the base instruction for reviewing design documents.
+// The input is a code diff (commit, range, or uncommitted changes) that is expected
+// to contain design artifacts such as PRDs, task lists, or architectural proposals.
+const SystemPromptDesignReview = `You are a design reviewer. The changes shown below are expected to contain design artifacts — PRDs, task lists, architectural proposals, or similar planning documents. Review them for:
 
 1. **Completeness**: Are goals, non-goals, success criteria, and edge cases defined?
 2. **Feasibility**: Are technical decisions grounded in the actual codebase?
 3. **Task scoping**: Are implementation stages small enough to review incrementally? Are dependencies ordered correctly?
 4. **Missing considerations**: Security, performance, backwards compatibility, error handling
 5. **Clarity**: Are decisions justified and understandable?
+
+If the changes do not appear to contain design documents, note this and review whatever design intent is evident from the code changes.
 
 After reviewing, provide:
 


### PR DESCRIPTION
## Summary

Addresses consistency and coverage gaps found by a design review of the `--type` flag feature (#217) before release.

- **CI poller canonicalization**: The daemon API normalized review type aliases (`"review"`, `"general"`) to canonical `"default"` before storing jobs, but the CI poller stored raw config values. This meant `review_types = ["review"]` produced jobs with `ReviewType="review"` instead of `"default"`, creating inconsistent data in the database. Now both paths canonicalize identically.
- **CI alias deduplication**: `review_types = ["default", "review", "general"]` would create three identical jobs since all are aliases for the default review. The CI poller now deduplicates after canonicalization.
- **Test coverage**: No tests existed for CLI `--type` validation, daemon API review_type normalization, or the CI design review happy path. Added four focused test functions covering these gaps.
- **Design prompt refinement**: The design-review system prompt said "review the design proposal" but receives commit diffs, not raw documents. Reworded to acknowledge the input shape and fall back gracefully when changes aren't design artifacts.
- **Comment fix**: Config comment still referenced `"review"` instead of `"default"`.

## Why now

These are consistency and correctness issues that would be confusing to debug after release — especially the CI canonicalization bug, which would cause `ReviewType` values in the database to differ depending on whether a job was enqueued via CLI/daemon or CI poller.

## Test plan

- [x] `go test ./...` — all pass
- [x] `TestHandleEnqueueReviewTypeNormalization` — 7 subtests: empty, general, review, default, security, design, invalid
- [x] `TestReviewTypeValidation` — CLI rejects invalid type, accepts security/design/empty
- [x] `TestCIPollerProcessPR_DesignReviewType` — design jobs enqueued correctly via CI
- [x] `TestCIPollerProcessPR_AliasDeduplication` — 3 aliases produce 1 job

🤖 Generated with [Claude Code](https://claude.com/claude-code)