### PR TITLE
Update flake.nix for v0.29.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         packages = {
           default = pkgs.buildGoModule {
             pname = "roborev";
-            version = "0.28.0";
+            version = "0.29.0";
 
             src = ./.;
 


### PR DESCRIPTION
Updates flake.nix version to 0.29.0 for the v0.29.0 release.