### PR TITLE
Fix cancel cursor + addressed stats in TUI

### DIFF
--- a/cmd/roborev/tui_helpers.go
+++ b/cmd/roborev/tui_helpers.go
@@ -35,6 +35,18 @@ func (m *tuiModel) mutateJob(id int64, fn func(*storage.ReviewJob)) bool {
 	return false
 }
 
+// applyStatsDelta adjusts jobStats for an addressed state change.
+// addressed=true means marking as addressed (+Addressed, -Unaddressed).
+func (m *tuiModel) applyStatsDelta(addressed bool) {
+	if addressed {
+		m.jobStats.Addressed++
+		m.jobStats.Unaddressed--
+	} else {
+		m.jobStats.Addressed--
+		m.jobStats.Unaddressed++
+	}
+}
+
 // setJobAddressed updates the addressed state for a job by ID.
 // Handles nil pointer by allocating if necessary.
 func (m *tuiModel) setJobAddressed(jobID int64, state bool) {


### PR DESCRIPTION
## Summary

- Cancel key (`x`) now adjusts cursor to next visible job when hide-addressed is active, preventing the cursor from landing on a hidden row (#265)
- Addressed toggle (`a`) now optimistically updates the status bar stats (addressed/unaddressed counts) immediately instead of waiting for the next poll cycle (#262)
- Both queue-view and review-view addressed paths update stats

## Test plan

- [x] Enable hide-addressed (`h`), cancel a running job (`x`) — cursor should move to next visible job
- [x] Toggle addressed (`a`) on a job — status bar counts should update immediately
- [x] Toggle addressed from review view (`a`) — status bar counts should update on return to queue

Fixes #262, fixes #265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)