### PR TITLE
Fix macOS CI flakiness caused by TUI test subprocess exhaustion

### DIFF
--- a/cmd/roborev/testmain_test.go
+++ b/cmd/roborev/testmain_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 )
 
-// TestMain isolates the entire test package from the real ~/.roborev directory.
-// Without this, newTuiModel (and anything else that calls config.LoadGlobal)
-// would read the developer's production config, making test outcomes dependent
-// on local machine state.
+// TestMain isolates the entire test package from the real ~/.roborev directory
+// and disables external I/O in newTuiModel (daemon detection, config loading,
+// git subprocess spawning). Without skipExternalIO, the 200+ tests that call
+// newTuiModel each spawn git subprocesses, exhausting macOS CI runner resources.
 func TestMain(m *testing.M) {
+	skipExternalIO = true
+
 	tmpDir, err := os.MkdirTemp("", "roborev-test-*")
 	if err != nil {
 		panic(err)

--- a/cmd/roborev/tui_test.go
+++ b/cmd/roborev/tui_test.go
@@ -540,6 +540,9 @@ func TestTUIJobsMsgAppendKeepsLoadingJobs(t *testing.T) {
 }
 
 func TestTUIHideAddressedDefaultFromConfig(t *testing.T) {
+	skipExternalIO = false
+	defer func() { skipExternalIO = true }()
+
 	tmpDir := t.TempDir()
 	t.Setenv("ROBOREV_DATA_DIR", tmpDir)
 
@@ -847,6 +850,9 @@ func TestTUIHideAddressedDisableRefetches(t *testing.T) {
 }
 
 func TestTUIHideAddressedMalformedConfigNotOverwritten(t *testing.T) {
+	skipExternalIO = false
+	defer func() { skipExternalIO = true }()
+
 	tmpDir := t.TempDir()
 	t.Setenv("ROBOREV_DATA_DIR", tmpDir)
 
@@ -885,6 +891,9 @@ func TestTUIHideAddressedMalformedConfigNotOverwritten(t *testing.T) {
 }
 
 func TestTUIHideAddressedValidConfigNotMutated(t *testing.T) {
+	skipExternalIO = false
+	defer func() { skipExternalIO = true }()
+
 	tmpDir := t.TempDir()
 	t.Setenv("ROBOREV_DATA_DIR", tmpDir)
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -75,9 +75,7 @@ func GetCommitInfo(repoPath, sha string) (*CommitInfo, error) {
 
 // GetCurrentBranch returns the current branch name, or empty string if detached HEAD
 func GetCurrentBranch(repoPath string) string {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
 	cmd.Dir = repoPath
 
 	out, err := cmd.Output()
@@ -230,9 +228,7 @@ func GetMainRepoRoot(path string) (string, error) {
 	// For regular repos: both return ".git" (or absolute path)
 	// For submodules: both return the same path (e.g., "../.git/modules/sub")
 	// For worktrees: --git-dir returns worktree-specific dir, --git-common-dir returns main repo's .git
-	ctx1, cancel1 := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel1()
-	gitDirCmd := exec.CommandContext(ctx1, "git", "rev-parse", "--git-dir")
+	gitDirCmd := exec.Command("git", "rev-parse", "--git-dir")
 	gitDirCmd.Dir = path
 	gitDirOut, err := gitDirCmd.Output()
 	if err != nil {
@@ -240,9 +236,7 @@ func GetMainRepoRoot(path string) (string, error) {
 	}
 	gitDir := strings.TrimSpace(string(gitDirOut))
 
-	ctx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel2()
-	commonDirCmd := exec.CommandContext(ctx2, "git", "rev-parse", "--git-common-dir")
+	commonDirCmd := exec.Command("git", "rev-parse", "--git-common-dir")
 	commonDirCmd.Dir = path
 	commonDirOut, err := commonDirCmd.Output()
 	if err != nil {


### PR DESCRIPTION
## Summary

- `newTuiModel` performs daemon file reads, config loading, and git subprocess spawning on every call
- 200+ TUI tests each call `newTuiModel`, creating hundreds of subprocess spawns and disk reads per test run
- On resource-constrained macOS CI runners (ARM64 VMs), this exhausts process resources — 187 orphan `roborev.test` processes, 10-minute timeouts on arbitrary tests
- The failure is flaky because it depends on runner load: some runs pass, others timeout on whichever test happens to be running when resources are exhausted
- Not reproducible locally (`go test -race` finishes in ~56s on a dev machine)

## Fix

Add `skipExternalIO` flag set by `TestMain` that skips all daemon/config/git I/O in `newTuiModel` during tests. Tests don't need real daemon detection, config loading, or git branch detection — they set model fields directly. The 3 tests that specifically validate config integration temporarily re-enable I/O.

Also reverts an earlier attempt that added `context.WithTimeout` to git subprocess calls, which treated a symptom (slow git commands) rather than the root cause (too many of them).

## Test plan

- [x] macOS CI passes (run 22075073968, ~69s)
- [x] All tests pass on Linux and Windows
- [x] Config integration tests still exercise real I/O

🤖 Generated with [Claude Code](https://claude.com/claude-code)