### PR TITLE
Fix remap race: skip running jobs whose prompt is already built

### DIFF
--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -1532,6 +1532,7 @@ func (db *DB) RemapJobGitRef(
 		UPDATE review_jobs
 		SET git_ref = ?, commit_id = ?, patch_id = ?, updated_at = ?
 		WHERE git_ref = ? AND repo_id = ?
+		AND status != 'running'
 		AND (patch_id IS NULL OR patch_id = '' OR patch_id = ?)
 	`, newSHA, newCommitID, nullString(patchID), now, oldSHA, repoID, patchID)
 	if err != nil {
@@ -1561,6 +1562,7 @@ func (db *DB) RemapJob(
 	err = tx.QueryRow(`
 		SELECT COUNT(*) FROM review_jobs
 		WHERE git_ref = ? AND repo_id = ?
+		AND status != 'running'
 		AND (patch_id IS NULL OR patch_id = '' OR patch_id = ?)
 	`, oldSHA, repoID, patchID).Scan(&matchCount)
 	if err != nil {
@@ -1595,6 +1597,7 @@ func (db *DB) RemapJob(
 		UPDATE review_jobs
 		SET git_ref = ?, commit_id = ?, patch_id = ?, updated_at = ?
 		WHERE git_ref = ? AND repo_id = ?
+		AND status != 'running'
 		AND (patch_id IS NULL OR patch_id = '' OR patch_id = ?)
 	`, newSHA, commitID, nullString(patchID), now,
 		oldSHA, repoID, patchID)


### PR DESCRIPTION
## Summary

- `RemapJobGitRef` and `RemapJob` now exclude jobs with `status='running'` from remap updates
- Fixes a race condition where amending a commit quickly after creation causes the TUI to show the new SHA while the review was actually done against the original SHA
- Running jobs keep their original `git_ref` since the worker has already built the prompt with that SHA
- No coverage is lost: the post-rewrite hook enqueues a fresh review for the amended commit

**Root cause:** When a commit is amended within seconds of creation, (1) the worker claims the original job and builds the prompt with the old SHA, (2) the post-rewrite hook fires `roborev remap` which updates the job's `git_ref` to the new SHA, (3) but the prompt was already built and the agent is already running against the old SHA. This creates a mismatch between `git_ref` (new) and the review content (old).

## Test plan

- [x] `TestRemapJobGitRef_RunningJob` updated to assert running jobs are skipped (was asserting they were remapped)
- [x] `TestRemapJobGitRef` — queued jobs still remapped correctly
- [x] `TestRemapTriggersResync` — done jobs still remapped correctly
- [x] Remap integration tests (`TestRemapAfterRebase`, `TestRemapAfterAmendMessageOnly`) pass (these use done jobs)
- [x] Full test suite passes, `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)