### PR TITLE
feat: add shell completion for analyze command types

### DIFF
--- a/cmd/roborev/analyze.go
+++ b/cmd/roborev/analyze.go
@@ -45,6 +45,18 @@ func analyzeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "analyze <type> <files...>",
 		Short: "Run built-in analysis on files",
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) == 0 {
+				// Complete analysis type names
+				var completions []string
+				for _, t := range analyze.AllTypes {
+					completions = append(completions, t.Name+"\t"+t.Description)
+				}
+				return completions, cobra.ShellCompDirectiveNoFileComp
+			}
+			// After the type, complete file paths
+			return nil, cobra.ShellCompDirectiveDefault
+		},
 		Long: `Run a built-in analysis type on one or more files.
 
 This command provides predefined analysis prompts for common code review


### PR DESCRIPTION
## Summary
- Adds a `ValidArgsFunction` to the `analyze` cobra command so that tab-completing the first positional argument suggests the 7 available analyzer types (`test-fixtures`, `duplication`, `refactor`, `complexity`, `api-design`, `dead-code`, `architecture`) with their descriptions
- After the analyzer type is selected, completion falls back to default file path completion

## Test plan
- [ ] Run `roborev analyze <TAB>` and verify all 7 analyzer types appear with descriptions
- [ ] Run `roborev analyze refactor <TAB>` and verify file path completion works
- [ ] Verify `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)