### PR TITLE
fix: prevent text file busy race in writeTempCommand

### DIFF
--- a/internal/agent/agent_test_helpers.go
+++ b/internal/agent/agent_test_helpers.go
@@ -57,8 +57,20 @@ func writeTempCommand(t *testing.T, script string) string {
 
 	tmpDir := t.TempDir()
 	path := filepath.Join(tmpDir, "cmd")
-	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+	if err != nil {
 		t.Fatalf("write temp command: %v", err)
+	}
+	if _, err := f.Write([]byte(script)); err != nil {
+		f.Close()
+		t.Fatalf("write temp command: %v", err)
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		t.Fatalf("write temp command sync: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("write temp command close: %v", err)
 	}
 	return path
 }


### PR DESCRIPTION
## Summary
- Fixes flaky `TestOpenCodeReviewNoOutput` that intermittently fails in CI (Ubuntu) with `fork/exec: text file busy`
- Replaces `os.WriteFile` with explicit `OpenFile` → `Write` → `Sync` → `Close` in `writeTempCommand` to ensure the kernel fully releases the file descriptor before exec
- Verified with 50 consecutive test runs — no failures

## Test plan
- [x] `go test -run TestOpenCodeReviewNoOutput -count=50 ./internal/agent/` passes
- [x] Full agent test suite passes (171 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)