### PR TITLE
fix: make --all-branches imply --unaddressed

### DIFF
--- a/cmd/roborev/fix.go
+++ b/cmd/roborev/fix.go
@@ -63,11 +63,11 @@ Examples:
 `,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if branch != "" && !unaddressed && !batch && !list {
-				return fmt.Errorf("--branch requires --unaddressed, --batch, or --list")
-			}
 			if allBranches && !unaddressed && !batch && !list {
 				unaddressed = true
+			}
+			if branch != "" && !unaddressed && !batch && !list {
+				return fmt.Errorf("--branch requires --unaddressed, --batch, or --list")
 			}
 			if allBranches && branch != "" {
 				return fmt.Errorf("--all-branches and --branch are mutually exclusive")


### PR DESCRIPTION
## Summary
- `roborev fix --all-branches` now implies `--unaddressed` instead of erroring, removing an unnecessary sharp edge
- Validation order fixed so `--all-branches --branch main` correctly returns the mutual-exclusion error
- Added positive test for `--all-branches` alone and updated existing flag-validation tests

Closes #344

## Test plan
- [x] `TestFixCmdFlagValidation` passes (all error cases)
- [x] `TestFixAllBranchesImpliesUnaddressed` passes (positive case with mock daemon)
- [x] Full `TestFix*` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)