### PR TITLE
Restyle TUI help bar with two-tone keys and aligned columns

### DIFF
--- a/cmd/roborev/tui.go
+++ b/cmd/roborev/tui.go
@@ -82,22 +82,28 @@ var (
 				Foreground(lipgloss.AdaptiveColor{Light: "248", Dark: "240"}) // Dimmer gray for descriptions
 )
 
+// helpItem is a single help-bar entry with a key label and description.
+type helpItem struct {
+	key  string
+	desc string
+}
+
 // reflowHelpRows redistributes items across rows so that when rendered
 // as an aligned table (columns sized to the widest cell), the result
-// fits within width. Each cell's visible width is its content minus 1
-// (colon removed to space) and non-first columns add 2 chars (▕ border
-// + padding). If width is <= 0, rows are returned unchanged.
-func reflowHelpRows(rows [][]string, width int) [][]string {
+// fits within width. Each cell's visible width is key + space + desc,
+// and non-first columns add 2 chars (▕ border + padding). If width is
+// <= 0, rows are returned unchanged.
+func reflowHelpRows(rows [][]helpItem, width int) [][]helpItem {
 	if width <= 0 {
 		return rows
 	}
 
-	// cellWidth returns the visible width of a help item after the colon
-	// is removed (": " becomes " ").
-	cellWidth := func(item string) int {
-		w := runewidth.StringWidth(item) - 1
-		if w < 0 {
-			return 0
+	// cellWidth returns the visible width of a help item (key + space + desc,
+	// or just key when desc is empty).
+	cellWidth := func(item helpItem) int {
+		w := runewidth.StringWidth(item.key)
+		if item.desc != "" {
+			w += 1 + runewidth.StringWidth(item.desc)
 		}
 		return w
 	}
@@ -114,7 +120,7 @@ func reflowHelpRows(rows [][]string, width int) [][]string {
 	// input row into sub-rows of at most ncols items, compute aligned
 	// column widths, and check if the total fits within width.
 	for ncols := maxItemsPerRow; ncols >= 1; ncols-- {
-		var candidate [][]string
+		var candidate [][]helpItem
 		for _, row := range rows {
 			for i := 0; i < len(row); i += ncols {
 				end := min(i+ncols, len(row))
@@ -147,19 +153,19 @@ func reflowHelpRows(rows [][]string, width int) [][]string {
 	}
 
 	// Fallback: one item per row.
-	var result [][]string
+	var result [][]helpItem
 	for _, row := range rows {
 		for _, item := range row {
-			result = append(result, []string{item})
+			result = append(result, []helpItem{item})
 		}
 	}
 	return result
 }
 
-// renderHelpTable renders "key: description" items as an aligned table.
-// Keys and descriptions are two-tone gray (colon removed), separated by a
-// thin ▕ border that is hidden for column 0 and trailing empty cells.
-func renderHelpTable(rows [][]string, width int) string {
+// renderHelpTable renders helpItem entries as an aligned table.
+// Keys and descriptions are two-tone gray, separated by a thin ▕ border
+// that is hidden for column 0 and trailing empty cells.
+func renderHelpTable(rows [][]helpItem, width int) string {
 	rows = reflowHelpRows(rows, width)
 	if len(rows) == 0 {
 		return ""
@@ -181,11 +187,14 @@ func renderHelpTable(rows [][]string, width int) string {
 		}
 	}
 
-	// Compute minimum visible width per column (without ": ").
+	// Compute minimum visible width per column.
 	colMinW := make([]int, maxCols)
 	for _, row := range rows {
 		for c, item := range row {
-			w := max(runewidth.StringWidth(item)-1, 0) // colon removed
+			w := runewidth.StringWidth(item.key)
+			if item.desc != "" {
+				w += 1 + runewidth.StringWidth(item.desc)
+			}
 			if w > colMinW[c] {
 				colMinW[c] = w
 			}
@@ -218,10 +227,10 @@ func renderHelpTable(rows [][]string, width int) string {
 		styled := make([]string, maxCols)
 		empty[ri] = make([]bool, maxCols)
 		for i, item := range row {
-			if key, desc, ok := strings.Cut(item, ": "); ok {
-				styled[i] = tuiHelpKeyStyle.Render(key) + " " + tuiHelpDescStyle.Render(desc)
+			if item.desc != "" {
+				styled[i] = tuiHelpKeyStyle.Render(item.key) + " " + tuiHelpDescStyle.Render(item.desc)
 			} else {
-				styled[i] = tuiHelpKeyStyle.Render(item)
+				styled[i] = tuiHelpKeyStyle.Render(item.key)
 			}
 		}
 		for i := len(row); i < maxCols; i++ {
@@ -1771,15 +1780,15 @@ func (m *tuiModel) logVisibleLines() int {
 }
 
 // logHelpRows returns the help row items for the log view.
-func (m *tuiModel) logHelpRows() [][]string {
-	helpRow := []string{
-		"↑/↓: scroll", "←/→: prev/next", "g: toggle top/bottom",
+func (m *tuiModel) logHelpRows() [][]helpItem {
+	helpRow := []helpItem{
+		{"↑/↓", "scroll"}, {"←/→", "prev/next"}, {"g", "toggle top/bottom"},
 	}
 	if m.logStreaming {
-		helpRow = append(helpRow, "x: cancel")
+		helpRow = append(helpRow, helpItem{"x", "cancel"})
 	}
-	helpRow = append(helpRow, "esc/q: back")
-	return [][]string{helpRow}
+	helpRow = append(helpRow, helpItem{"esc/q", "back"})
+	return [][]helpItem{helpRow}
 }
 
 // normalizeSelectionIfHidden adjusts selectedIdx/selectedJobID if the current
@@ -2064,19 +2073,19 @@ func (m tuiModel) getVisibleJobs() []storage.ReviewJob {
 
 // queueHelpRows returns queue help table rows, omitting
 // "f: filter" when both repo and branch filters are locked.
-func (m tuiModel) queueHelpRows() [][]string {
-	row1 := []string{
-		"x: cancel", "r: rerun", "l: log", "p: prompt",
-		"c: comment", "y: copy", "m: commit msg", "F: fix",
+func (m tuiModel) queueHelpRows() [][]helpItem {
+	row1 := []helpItem{
+		{"x", "cancel"}, {"r", "rerun"}, {"l", "log"}, {"p", "prompt"},
+		{"c", "comment"}, {"y", "copy"}, {"m", "commit msg"}, {"F", "fix"},
 	}
-	row2 := []string{
-		"↑/↓: navigate", "↵: review", "a: addressed",
+	row2 := []helpItem{
+		{"↑/↓", "navigate"}, {"↵", "review"}, {"a", "addressed"},
 	}
 	if !m.lockedRepoFilter || !m.lockedBranchFilter {
-		row2 = append(row2, "f: filter")
+		row2 = append(row2, helpItem{"f", "filter"})
 	}
-	row2 = append(row2, "h: hide", "T: tasks", "?: help", "q: quit")
-	return [][]string{row1, row2}
+	row2 = append(row2, helpItem{"h", "hide"}, helpItem{"T", "tasks"}, helpItem{"?", "help"}, helpItem{"q", "quit"})
+	return [][]helpItem{row1, row2}
 }
 
 // queueHelpLines computes how many terminal lines the queue help
@@ -3208,9 +3217,9 @@ func (m tuiModel) renderReviewView() string {
 	}
 
 	// Help table rows
-	reviewHelpRows := [][]string{
-		{"p: prompt", "c: comment", "m: commit msg", "a: addressed", "y: copy", "F: fix"},
-		{"↑/↓: scroll", "←/→: prev/next", "?: commands", "esc: back"},
+	reviewHelpRows := [][]helpItem{
+		{{"p", "prompt"}, {"c", "comment"}, {"m", "commit msg"}, {"a", "addressed"}, {"y", "copy"}, {"F", "fix"}},
+		{{"↑/↓", "scroll"}, {"←/→", "prev/next"}, {"?", "commands"}, {"esc", "back"}},
 	}
 	helpLines := len(reflowHelpRows(reviewHelpRows, m.width))
 
@@ -3380,8 +3389,8 @@ func (m tuiModel) renderPromptView() string {
 	}
 
 	// Reserve: title + command(0-1) + scroll indicator(1) + help(N) + margin(1)
-	promptHelpRows := [][]string{
-		{"↑/↓: scroll", "←/→: prev/next", "p: toggle prompt/review", "?: commands", "esc: back"},
+	promptHelpRows := [][]helpItem{
+		{{"↑/↓", "scroll"}, {"←/→", "prev/next"}, {"p", "toggle prompt/review"}, {"?", "commands"}, {"esc", "back"}},
 	}
 	promptHelpLines := len(reflowHelpRows(promptHelpRows, m.width))
 	visibleLines := max(m.height-(2+promptHelpLines)-headerLines, 1)
@@ -3458,8 +3467,8 @@ func (m tuiModel) renderFilterView() string {
 	flatList := m.filterFlatList
 
 	// Calculate visible rows
-	filterHelpRows := [][]string{
-		{"up/down: navigate", "right/left: expand/collapse", "↵: select", "esc: cancel", "type to search"},
+	filterHelpRows := [][]helpItem{
+		{{"↑/↓", "navigate"}, {"→/←", "expand/collapse"}, {"↵", "select"}, {"esc", "cancel"}, {"type to search", ""}},
 	}
 	filterHelpLines := len(reflowHelpRows(filterHelpRows, m.width))
 	// Reserve: title(1) + blank(1) + search(1) + blank(1) + scroll-info(1) + blank(1) + help(N)
@@ -3612,8 +3621,8 @@ func (m tuiModel) renderRespondView() string {
 		linesWritten++
 	}
 
-	b.WriteString(renderHelpTable([][]string{
-		{"↵: submit", "esc: cancel"},
+	b.WriteString(renderHelpTable([][]helpItem{
+		{{"↵", "submit"}, {"esc", "cancel"}},
 	}, m.width))
 	b.WriteString("\x1b[K")
 	b.WriteString("\x1b[J") // Clear to end of screen to prevent artifacts
@@ -3694,8 +3703,8 @@ func (m tuiModel) renderCommitMsgView() string {
 	}
 	b.WriteString("\x1b[K\n") // Clear scroll indicator line
 
-	b.WriteString(renderHelpTable([][]string{
-		{"up/down: scroll", "esc/q: back"},
+	b.WriteString(renderHelpTable([][]helpItem{
+		{{"↑/↓", "scroll"}, {"esc/q", "back"}},
 	}, m.width))
 	b.WriteString("\x1b[K") // Clear help line
 	b.WriteString("\x1b[J") // Clear to end of screen to prevent artifacts
@@ -3954,8 +3963,8 @@ func (m tuiModel) renderHelpView() string {
 		linesWritten++
 	}
 
-	b.WriteString(renderHelpTable([][]string{
-		{"↑/↓: scroll", "esc/q/?: close"},
+	b.WriteString(renderHelpTable([][]helpItem{
+		{{"↑/↓", "scroll"}, {"esc/q/?", "close"}},
 	}, m.width))
 	b.WriteString("\x1b[K")
 	b.WriteString("\x1b[J") // Clear to end of screen
@@ -4055,8 +4064,8 @@ func (m tuiModel) renderTasksView() string {
 	if len(m.fixJobs) == 0 {
 		b.WriteString("\n  No fix tasks. Press F on a review to trigger a background fix.\n")
 		b.WriteString("\n")
-		b.WriteString(renderHelpTable([][]string{
-			{"T: back to queue", "F: fix review", "q: quit"},
+		b.WriteString(renderHelpTable([][]helpItem{
+			{{"T", "back to queue"}, {"F", "fix review"}, {"q", "quit"}},
 		}, m.width))
 		b.WriteString("\x1b[K\x1b[J")
 		return b.String()
@@ -4081,8 +4090,8 @@ func (m tuiModel) renderTasksView() string {
 	b.WriteString("\x1b[K\n")
 
 	// Render each fix job
-	tasksHelpRows := [][]string{
-		{"↵: view", "p: patch", "A: apply", "l: log", "x: cancel", "r: refresh", "?: help", "T/esc: back"},
+	tasksHelpRows := [][]helpItem{
+		{{"↵", "view"}, {"p", "patch"}, {"A", "apply"}, {"l", "log"}, {"x", "cancel"}, {"r", "refresh"}, {"?", "help"}, {"T/esc", "back"}},
 	}
 	tasksHelpLines := len(reflowHelpRows(tasksHelpRows, m.width))
 	visibleRows := m.height - (6 + tasksHelpLines) // title + header + separator + status + scroll + help(N)
@@ -4264,8 +4273,8 @@ func (m tuiModel) renderPatchView() string {
 		}
 	}
 
-	b.WriteString(renderHelpTable([][]string{
-		{"j/k/up/down: scroll", "esc: back to tasks"},
+	b.WriteString(renderHelpTable([][]helpItem{
+		{{"j/k/↑/↓", "scroll"}, {"esc", "back to tasks"}},
 	}, m.width))
 	b.WriteString("\x1b[K\x1b[J")
 	return b.String()

--- a/cmd/roborev/tui_filter_test.go
+++ b/cmd/roborev/tui_filter_test.go
@@ -761,7 +761,7 @@ func TestTUIFilterViewSmallTerminal(t *testing.T) {
 	})
 
 	t.Run("exactly reservedLines shows no items", func(t *testing.T) {
-		m.height = 8 // Exactly reservedLines (help wraps to 2 lines at width=80), visibleRows = 0
+		m.height = 7 // Exactly reservedLines (help fits in 1 line at width=80), visibleRows = 0
 		output := m.renderFilterView()
 
 		if !strings.Contains(output, "(terminal too small)") {
@@ -770,7 +770,7 @@ func TestTUIFilterViewSmallTerminal(t *testing.T) {
 	})
 
 	t.Run("one row available", func(t *testing.T) {
-		m.height = 9 // reservedLines + 1 = visibleRows of 1
+		m.height = 8 // reservedLines + 1 = visibleRows of 1
 		output := m.renderFilterView()
 
 		if strings.Contains(output, "(terminal too small)") {
@@ -787,7 +787,7 @@ func TestTUIFilterViewSmallTerminal(t *testing.T) {
 	})
 
 	t.Run("fits all items without scroll", func(t *testing.T) {
-		m.height = 15 // reservedLines(8) + 7 = visibleRows of 7, enough for 4 entries
+		m.height = 15 // reservedLines(7) + 8 = visibleRows of 8, enough for 4 entries
 		output := m.renderFilterView()
 
 		// Should show all items
@@ -831,7 +831,7 @@ func TestTUIFilterViewScrollWindow(t *testing.T) {
 		makeNode("repo-5", 1),
 	})
 	// Flat list: All + 5 repos = 6 entries
-	m.height = 11 // visibleRows = 3 (reservedLines=8 at width=80)
+	m.height = 10 // visibleRows = 3 (reservedLines=7 at width=80)
 
 	t.Run("scroll keeps selected item visible at top", func(t *testing.T) {
 		m.filterSelectedIdx = 0

--- a/cmd/roborev/tui_helpers_test.go
+++ b/cmd/roborev/tui_helpers_test.go
@@ -475,31 +475,31 @@ func TestReflowHelpRows(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		items    []string
+		items    []helpItem
 		width    int
 		wantRows int
 	}{
 		{
 			name:     "all fit in one row",
-			items:    []string{"a: one", "b: two"},
+			items:    []helpItem{{"a", "one"}, {"b", "two"}},
 			width:    80,
 			wantRows: 1,
 		},
 		{
 			name:     "split into two rows",
-			items:    []string{"a: one", "b: two", "c: three", "d: four"},
+			items:    []helpItem{{"a", "one"}, {"b", "two"}, {"c", "three"}, {"d", "four"}},
 			width:    28, // 4 cols aligned = 29 chars, won't fit in 28
 			wantRows: 2,
 		},
 		{
 			name:     "width zero returns unchanged",
-			items:    []string{"a: one", "b: two", "c: three"},
+			items:    []helpItem{{"a", "one"}, {"b", "two"}, {"c", "three"}},
 			width:    0,
 			wantRows: 1,
 		},
 		{
 			name:     "single wide item gets own row",
-			items:    []string{"very-long-item-label: description"},
+			items:    []helpItem{{"very-long-item-label", "description"}},
 			width:    20,
 			wantRows: 1,
 		},
@@ -507,7 +507,7 @@ func TestReflowHelpRows(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			rows := reflowHelpRows([][]string{tc.items}, tc.width)
+			rows := reflowHelpRows([][]helpItem{tc.items}, tc.width)
 			if len(rows) != tc.wantRows {
 				t.Errorf("got %d rows, want %d (items=%v, width=%d)",
 					len(rows), tc.wantRows, tc.items, tc.width)
@@ -520,20 +520,20 @@ func TestRenderHelpTableLinesWithinWidth(t *testing.T) {
 	t.Parallel()
 
 	// Real help row sets used by the TUI views.
-	helpSets := map[string][][]string{
+	helpSets := map[string][][]helpItem{
 		"queue": {
-			{"x: cancel", "r: rerun", "l: log", "p: prompt", "c: comment", "y: copy", "m: commit msg", "F: fix"},
-			{"↑/↓: navigate", "enter: review", "a: addressed", "f: filter", "h: hide", "T: tasks", "?: help", "q: quit"},
+			{{"x", "cancel"}, {"r", "rerun"}, {"l", "log"}, {"p", "prompt"}, {"c", "comment"}, {"y", "copy"}, {"m", "commit msg"}, {"F", "fix"}},
+			{{"↑/↓", "navigate"}, {"enter", "review"}, {"a", "addressed"}, {"f", "filter"}, {"h", "hide"}, {"T", "tasks"}, {"?", "help"}, {"q", "quit"}},
 		},
 		"review": {
-			{"p: prompt", "c: comment", "m: commit msg", "a: addressed", "y: copy", "F: fix"},
-			{"↑/↓: scroll", "←/→: prev/next", "?: commands", "esc: back"},
+			{{"p", "prompt"}, {"c", "comment"}, {"m", "commit msg"}, {"a", "addressed"}, {"y", "copy"}, {"F", "fix"}},
+			{{"↑/↓", "scroll"}, {"←/→", "prev/next"}, {"?", "commands"}, {"esc", "back"}},
 		},
 		"filter": {
-			{"up/down: navigate", "right/left: expand/collapse", "enter: select", "esc: cancel", "type to search"},
+			{{"↑/↓", "navigate"}, {"→/←", "expand/collapse"}, {"↵", "select"}, {"esc", "cancel"}, {"type to search", ""}},
 		},
 		"tasks": {
-			{"enter: view", "p: patch", "A: apply", "l: log", "x: cancel", "r: refresh", "?: help", "T/esc: back"},
+			{{"enter", "view"}, {"p", "patch"}, {"A", "apply"}, {"l", "log"}, {"x", "cancel"}, {"r", "refresh"}, {"?", "help"}, {"T/esc", "back"}},
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Remove colon separator between key and description, render keys in medium gray and descriptions in dimmer gray for visual hierarchy
- Replace `enter` with `↵` symbol in help labels
- Use `▕` (right one-eighth block) as thin column separator via per-cell lipgloss border, hidden for column 0 and trailing empty cells
- Switch from independent tables per row to a single aligned table so columns line up across rows
- Rewrite `reflowHelpRows` to account for aligned column widths when deciding how many items fit per row, preventing truncation

## Test plan
- [x] `go test ./...` passes (3382 tests)
- [ ] Visually verify help bar in queue view, review view, filter view, prompt view, and tasks view
- [ ] Verify reflow at narrow terminal widths (columns should wrap to additional rows without truncation)

<img width="763" height="599" alt="image" src="https://github.com/user-attachments/assets/8501d256-4f2b-443e-9bd8-ebb2c9135dd1" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)