### PR TITLE
Print right version when installed via "go install"

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -26,6 +26,11 @@ func getVersionFromVCS() string {
 		return "dev"
 	}
 
+	// Use module version when installed via `go install pkg@version`
+	if v := info.Main.Version; v != "" && v != "(devel)" {
+		return v
+	}
+
 	var revision string
 	var modified bool
 


### PR DESCRIPTION
Currently when install with `go install github.com/roborev-dev/roborev/cmd/roborev@latest`, running `roborev version` prints `dev`. This PR changes that to take version info from debug info.