### PR TITLE
fix: use ANTHROPIC_API_KEY for opencode agent in gh-action

### DIFF
--- a/cmd/roborev/ghaction.go
+++ b/cmd/roborev/ghaction.go
@@ -65,10 +65,19 @@ After generating the workflow, add repository secrets ` +
 			// List required secrets per agent
 			infos := ghaction.AgentSecrets(cfg.Agents)
 			for i, info := range infos {
-				fmt.Printf(
-					"  %d. Add a repository secret "+
-						"named %q (%s API key)\n",
-					i+1, info.SecretName, info.Name)
+				if info.Name == "opencode" {
+					fmt.Printf(
+						"  %d. Add a repository secret "+
+							"named %q (default for "+
+							"opencode; change if using "+
+							"a different provider)\n",
+						i+1, info.SecretName)
+				} else {
+					fmt.Printf(
+						"  %d. Add a repository secret "+
+							"named %q (%s API key)\n",
+						i+1, info.SecretName, info.Name)
+				}
 				fmt.Printf(
 					"     gh secret set %s\n",
 					info.SecretName)

--- a/internal/ghaction/ghaction.go
+++ b/internal/ghaction/ghaction.go
@@ -85,6 +85,8 @@ func AgentEnvVar(agentName string) string {
 	switch agentName {
 	case "claude-code":
 		return "ANTHROPIC_API_KEY"
+	case "opencode":
+		return "ANTHROPIC_API_KEY"
 	case "gemini":
 		return "GOOGLE_API_KEY"
 	case "copilot":
@@ -253,7 +255,13 @@ var workflowTemplate = `# roborev CI Review
 #
 # Required setup:
 {{- range .EnvEntries }}
+{{- if eq .Name "opencode" }}
+#   - Add a repository secret named "{{ .SecretName }}" (default for opencode).
+#     If you use a different model provider, replace with the appropriate key
+#     (e.g., OPENAI_API_KEY, GOOGLE_API_KEY) and update the env block below.
+{{- else }}
 #   - Add a repository secret named "{{ .SecretName }}" with your {{ .Name }} API key
+{{- end }}
 {{- end }}
 #
 # Review behavior (types, reasoning, severity) is configured in


### PR DESCRIPTION
## Summary

- OpenCode is a multi-provider tool with no single API key. `AgentEnvVar()` previously fell through to the `default` case returning `OPENAI_API_KEY`, which was confusing and misleading.
- Default to `ANTHROPIC_API_KEY` for the opencode agent, matching [OpenCode's own GitHub Actions docs](https://opencode.ai/docs/github/).
- Add guidance in the generated workflow preamble and CLI next-steps output telling users to swap the secret if they use a different model provider (e.g., `OPENAI_API_KEY`, `GOOGLE_API_KEY`).

Closes #325

## Test plan

- [x] `TestAgentEnvVar/opencode` — verifies opencode maps to `ANTHROPIC_API_KEY`
- [x] `TestGenerate/opencode_uses_ANTHROPIC_API_KEY` — verifies workflow output contains `ANTHROPIC_API_KEY` and the "different model provider" guidance
- [x] `TestGenerate/dedupes_env_vars` — claude-code + opencode share a key, deduped to one entry
- [x] `TestAgentSecrets/codex_and_opencode_have_separate_keys` — codex and opencode no longer incorrectly dedupe
- [x] `TestGhActionCmd` — all CLI subtest variants pass
- [x] Full `go test -race ./internal/ghaction/... ./cmd/roborev/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)