### PR TITLE
Add multi-repo workspace support

### DIFF
--- a/cmd/roborev/list.go
+++ b/cmd/roborev/list.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -75,12 +76,22 @@ Examples:
 				branch = git.GetCurrentBranch(localRepoPath)
 			}
 
+			// Workspace mode: not in a git repo and no --repo specified
+			var repoPrefix string
+			if repoPath == "" && localRepoPath == "" {
+				if abs, err := filepath.Abs("."); err == nil {
+					repoPrefix = abs
+				}
+			}
+
 			// Build query URL
 			params := url.Values{}
-			if repoPath != "" {
+			if repoPrefix != "" {
+				params.Set("repo_prefix", repoPrefix)
+			} else if repoPath != "" {
 				params.Set("repo", repoPath)
 			}
-			if branch != "" {
+			if branch != "" && repoPrefix == "" {
 				params.Set("branch", branch)
 				params.Set("branch_include_empty", "true")
 			}

--- a/cmd/roborev/review.go
+++ b/cmd/roborev/review.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 
 	"github.com/roborev-dev/roborev/internal/agent"
 	"github.com/roborev-dev/roborev/internal/config"
@@ -79,6 +81,14 @@ Examples:
 			if err != nil {
 				if quiet {
 					return nil // Not a repo - silent exit for hooks
+				}
+				// Scan for child git repos to give a helpful hint
+				if children := findChildGitRepos(repoPath); len(children) > 0 {
+					msg := "not in a git repository; use --repo to specify one:"
+					for _, name := range children {
+						msg += "\n  roborev review --repo " + name
+					}
+					return fmt.Errorf("%s", msg)
 				}
 				return fmt.Errorf("not a git repository: %w", err)
 			}
@@ -410,4 +420,23 @@ func runLocalReview(cmd *cobra.Command, repoPath, gitRef, diffContent, agentName
 		fmt.Fprintln(out) // Final newline
 	}
 	return nil
+}
+
+// findChildGitRepos returns the names of immediate child directories that are git repos.
+func findChildGitRepos(dir string) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var repos []string
+	for _, e := range entries {
+		if !e.IsDir() || e.Name()[0] == '.' {
+			continue
+		}
+		gitDir := filepath.Join(dir, e.Name(), ".git")
+		if info, err := os.Stat(gitDir); err == nil && info.IsDir() {
+			repos = append(repos, e.Name())
+		}
+	}
+	return repos
 }

--- a/cmd/roborev/show.go
+++ b/cmd/roborev/show.go
@@ -54,10 +54,12 @@ Examples:
 				}
 				// Default to HEAD
 				sha := "HEAD"
-				if root, err := git.GetRepoRoot("."); err == nil {
-					if resolved, err := git.ResolveSHA(root, sha); err == nil {
-						sha = resolved
-					}
+				root, rootErr := git.GetRepoRoot(".")
+				if rootErr != nil {
+					return fmt.Errorf("not in a git repository; use a job ID instead (e.g., roborev show 42)")
+				}
+				if resolved, err := git.ResolveSHA(root, sha); err == nil {
+					sha = resolved
 				}
 				queryURL = addr + "/api/review?sha=" + sha
 				displayRef = git.ShortSHA(sha)

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -815,6 +815,7 @@ func (s *Server) handleListJobs(w http.ResponseWriter, r *http.Request) {
 	status := r.URL.Query().Get("status")
 	repo := r.URL.Query().Get("repo")
 	gitRef := r.URL.Query().Get("git_ref")
+	repoPrefix := r.URL.Query().Get("repo_prefix")
 
 	// Parse limit from query, default to 50, 0 means no limit
 	// Clamp to valid range: 0 (unlimited) or 1-10000
@@ -870,6 +871,9 @@ func (s *Server) handleListJobs(w http.ResponseWriter, r *http.Request) {
 	if exJobType := r.URL.Query().Get("exclude_job_type"); exJobType != "" {
 		listOpts = append(listOpts, storage.WithExcludeJobType(exJobType))
 	}
+	if repoPrefix != "" && repo == "" {
+		listOpts = append(listOpts, storage.WithRepoPrefix(repoPrefix))
+	}
 
 	jobs, err := s.db.ListJobs(status, repo, fetchLimit, offset, listOpts...)
 	if err != nil {
@@ -892,6 +896,9 @@ func (s *Server) handleListJobs(w http.ResponseWriter, r *http.Request) {
 		} else {
 			statsOpts = append(statsOpts, storage.WithBranch(branch))
 		}
+	}
+	if repoPrefix != "" && repo == "" {
+		statsOpts = append(statsOpts, storage.WithRepoPrefix(repoPrefix))
 	}
 	stats, statsErr := s.db.CountJobStats(repo, statsOpts...)
 	if statsErr != nil {
@@ -918,7 +925,11 @@ func (s *Server) handleListRepos(w http.ResponseWriter, r *http.Request) {
 	var totalCount int
 	var err error
 
-	if branch != "" {
+	prefix := r.URL.Query().Get("prefix")
+
+	if prefix != "" {
+		repos, totalCount, err = s.db.ListReposWithReviewCountsByPrefix(prefix)
+	} else if branch != "" {
 		repos, totalCount, err = s.db.ListReposWithReviewCountsByBranch(branch)
 	} else {
 		repos, totalCount, err = s.db.ListReposWithReviewCounts()

--- a/internal/daemon/server_jobs_test.go
+++ b/internal/daemon/server_jobs_test.go
@@ -1301,3 +1301,71 @@ func TestHandleListJobsJobTypeFilter(t *testing.T) {
 		}
 	})
 }
+
+func TestHandleListJobsRepoPrefixFilter(t *testing.T) {
+	server, db, tmpDir := newTestServer(t)
+
+	// Create repos under a "workspace" parent and one outside it
+	workspace := filepath.Join(tmpDir, "workspace")
+	seedRepoWithJobs(t, db, filepath.Join(workspace, "repo-a"), 3, "repoA")
+	seedRepoWithJobs(t, db, filepath.Join(workspace, "repo-b"), 2, "repoB")
+	seedRepoWithJobs(t, db, filepath.Join(tmpDir, "outside-repo"), 1, "outside")
+
+	t.Run("repo_prefix returns only child repos", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/jobs?repo_prefix="+url.QueryEscape(workspace), nil)
+		w := httptest.NewRecorder()
+		server.handleListJobs(w, req)
+		testutil.AssertStatusCode(t, w, http.StatusOK)
+
+		var resp struct {
+			Jobs  []storage.ReviewJob `json:"jobs"`
+			Stats storage.JobStats    `json:"stats"`
+		}
+		testutil.DecodeJSON(t, w, &resp)
+
+		if len(resp.Jobs) != 5 {
+			t.Errorf("Expected 5 jobs under workspace prefix, got %d", len(resp.Jobs))
+		}
+		for _, j := range resp.Jobs {
+			if !strings.HasPrefix(j.RepoPath, workspace+"/") {
+				t.Errorf("Job repo_path %q does not start with workspace prefix", j.RepoPath)
+			}
+		}
+	})
+
+	t.Run("repo_prefix does not match parent directory itself", func(t *testing.T) {
+		// A repo AT the workspace path shouldn't match (must be a child)
+		seedRepoWithJobs(t, db, workspace, 1, "exact")
+		req := httptest.NewRequest(http.MethodGet, "/api/jobs?repo_prefix="+url.QueryEscape(workspace), nil)
+		w := httptest.NewRecorder()
+		server.handleListJobs(w, req)
+		testutil.AssertStatusCode(t, w, http.StatusOK)
+
+		var resp struct {
+			Jobs []storage.ReviewJob `json:"jobs"`
+		}
+		testutil.DecodeJSON(t, w, &resp)
+
+		// Should still be 5 (not 6) - the exact workspace path match is excluded
+		if len(resp.Jobs) != 5 {
+			t.Errorf("Expected 5 jobs (excluding exact path match), got %d", len(resp.Jobs))
+		}
+	})
+
+	t.Run("repo param takes precedence over repo_prefix", func(t *testing.T) {
+		exactRepo := filepath.Join(workspace, "repo-a")
+		req := httptest.NewRequest(http.MethodGet, "/api/jobs?repo="+url.QueryEscape(exactRepo)+"&repo_prefix="+url.QueryEscape(workspace), nil)
+		w := httptest.NewRecorder()
+		server.handleListJobs(w, req)
+		testutil.AssertStatusCode(t, w, http.StatusOK)
+
+		var resp struct {
+			Jobs []storage.ReviewJob `json:"jobs"`
+		}
+		testutil.DecodeJSON(t, w, &resp)
+
+		if len(resp.Jobs) != 3 {
+			t.Errorf("Expected 3 jobs for exact repo (repo takes precedence), got %d", len(resp.Jobs))
+		}
+	})
+}

--- a/internal/daemon/server_repos_test.go
+++ b/internal/daemon/server_repos_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -150,6 +151,50 @@ func TestHandleListReposWithBranchFilter(t *testing.T) {
 		testutil.DecodeJSON(t, w, &response)
 		if response.TotalCount != 0 {
 			t.Errorf("Expected total_count 0 for nonexistent branch, got %d", response.TotalCount)
+		}
+	})
+}
+
+func TestHandleListReposWithPrefixFilter(t *testing.T) {
+	server, db, tmpDir := newTestServer(t)
+
+	// Create repos under a "workspace" parent and one outside it
+	workspace := filepath.Join(tmpDir, "workspace")
+	seedRepoWithJobs(t, db, filepath.Join(workspace, "repo1"), 3, "repo1")
+	seedRepoWithJobs(t, db, filepath.Join(workspace, "repo2"), 2, "repo2")
+	seedRepoWithJobs(t, db, filepath.Join(tmpDir, "other-repo"), 1, "other")
+
+	type reposResponse struct {
+		Repos      []struct{ Name string } `json:"repos"`
+		TotalCount int                     `json:"total_count"`
+	}
+
+	t.Run("prefix returns only child repos", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/repos?prefix="+url.QueryEscape(workspace), nil)
+		w := httptest.NewRecorder()
+		server.handleListRepos(w, req)
+		testutil.AssertStatusCode(t, w, http.StatusOK)
+
+		var response reposResponse
+		testutil.DecodeJSON(t, w, &response)
+		if len(response.Repos) != 2 {
+			t.Errorf("Expected 2 repos under workspace, got %d", len(response.Repos))
+		}
+		if response.TotalCount != 5 {
+			t.Errorf("Expected total_count 5, got %d", response.TotalCount)
+		}
+	})
+
+	t.Run("prefix excludes non-matching repos", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/repos?prefix="+url.QueryEscape(filepath.Join(tmpDir, "nonexistent")), nil)
+		w := httptest.NewRecorder()
+		server.handleListRepos(w, req)
+		testutil.AssertStatusCode(t, w, http.StatusOK)
+
+		var response reposResponse
+		testutil.DecodeJSON(t, w, &response)
+		if len(response.Repos) != 0 {
+			t.Errorf("Expected 0 repos for nonexistent prefix, got %d", len(response.Repos))
 		}
 	})
 }

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -1340,6 +1340,7 @@ type listJobsOptions struct {
 	closed             *bool
 	jobType            string
 	excludeJobType     string
+	repoPrefix         string
 }
 
 // WithGitRef filters jobs by git ref.
@@ -1376,6 +1377,19 @@ func WithExcludeJobType(jobType string) ListJobsOption {
 	return func(o *listJobsOptions) { o.excludeJobType = jobType }
 }
 
+// WithRepoPrefix filters jobs to repos whose root_path starts with the given prefix.
+func WithRepoPrefix(prefix string) ListJobsOption {
+	return func(o *listJobsOptions) { o.repoPrefix = escapeLike(prefix) }
+}
+
+// escapeLike escapes SQL LIKE wildcards (% and _) in a literal string.
+func escapeLike(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "%", "\\%")
+	s = strings.ReplaceAll(s, "_", "\\_")
+	return s
+}
+
 // ListJobs returns jobs with optional status, repo, branch, and closed filters.
 func (db *DB) ListJobs(statusFilter string, repoFilter string, limit, offset int, opts ...ListJobsOption) ([]ReviewJob, error) {
 	query := `
@@ -1403,6 +1417,10 @@ func (db *DB) ListJobs(statusFilter string, repoFilter string, limit, offset int
 	var o listJobsOptions
 	for _, opt := range opts {
 		opt(&o)
+	}
+	if repoFilter == "" && o.repoPrefix != "" {
+		conditions = append(conditions, "r.root_path LIKE ? || '/%' ESCAPE '\\'")
+		args = append(args, o.repoPrefix)
 	}
 	if o.gitRef != "" {
 		conditions = append(conditions, "j.git_ref = ?")
@@ -1570,6 +1588,10 @@ func (db *DB) CountJobStats(repoFilter string, opts ...ListJobsOption) (JobStats
 	var o listJobsOptions
 	for _, opt := range opts {
 		opt(&o)
+	}
+	if repoFilter == "" && o.repoPrefix != "" {
+		conditions = append(conditions, "r.root_path LIKE ? || '/%' ESCAPE '\\'")
+		args = append(args, o.repoPrefix)
 	}
 	if o.branch != "" {
 		if o.branchIncludeEmpty {

--- a/internal/storage/repos.go
+++ b/internal/storage/repos.go
@@ -139,6 +139,35 @@ func (db *DB) ListReposWithReviewCounts() ([]RepoWithCount, int, error) {
 	return repos, totalCount, rows.Err()
 }
 
+// ListReposWithReviewCountsByPrefix returns repos whose root_path starts with the given prefix, with their job counts
+func (db *DB) ListReposWithReviewCountsByPrefix(prefix string) ([]RepoWithCount, int, error) {
+	escaped := escapeLike(prefix)
+	rows, err := db.Query(`
+		SELECT r.name, r.root_path, COUNT(rj.id) as job_count
+		FROM repos r
+		LEFT JOIN review_jobs rj ON rj.repo_id = r.id
+		WHERE r.root_path LIKE ? || '/%' ESCAPE '\'
+		GROUP BY r.id, r.name, r.root_path
+		ORDER BY r.name
+	`, escaped)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var repos []RepoWithCount
+	totalCount := 0
+	for rows.Next() {
+		var rc RepoWithCount
+		if err := rows.Scan(&rc.Name, &rc.RootPath, &rc.Count); err != nil {
+			return nil, 0, err
+		}
+		repos = append(repos, rc)
+		totalCount += rc.Count
+	}
+	return repos, totalCount, rows.Err()
+}
+
 // ListReposWithReviewCountsByBranch returns repos filtered by branch with their job counts
 // If branch is empty, returns all repos. Use "(none)" to filter for jobs without a branch.
 func (db *DB) ListReposWithReviewCountsByBranch(branch string) ([]RepoWithCount, int, error) {


### PR DESCRIPTION
## Summary

When you run roborev from a parent directory that contains multiple repos (like a
monorepo workspace), things break because there's no `.git` directory. This fixes
that by detecting the workspace scenario and adapting each command:

- `list` shows jobs across all child repos instead of erroring out
- `show` tells you to use a job ID instead of a confusing git error
- `review` scans for child repos and shows you the `--repo` options

No new flags or config — it just works based on context.

## Details

- New `repo_prefix` query param on `/api/jobs` and `prefix` on `/api/repos` for
  filtering by parent directory path
- LIKE wildcards in paths are escaped so underscores/percents in directory names
  don't cause weird matches
- Tests cover prefix filtering, precedence over `repo` param, and edge cases

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] Manual test from workspace parent: `list`, `show`, `review` all behave correctly
- [x] Manual test from inside a child repo: no behavior change