### PR TITLE
Skip throttle for pushes that supersede in-progress reviews

### DIFF
--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -305,6 +305,24 @@ func (p *CIPoller) processPR(ctx context.Context, ghRepo string, pr ghPR, cfg *c
 		return nil
 	}
 
+	// Cancel any in-progress batches for this PR at an older HEAD SHA.
+	// When a PR gets a new push, work on the old HEAD is wasted.
+	// This runs before the throttle check so superseding pushes are
+	// never delayed by the batch they're replacing.
+	if canceledIDs, err := p.db.CancelSupersededBatches(ghRepo, pr.Number, pr.HeadRefOid); err != nil {
+		log.Printf("CI poller: error canceling superseded batches for %s#%d: %v", ghRepo, pr.Number, err)
+	} else if len(canceledIDs) > 0 {
+		headShort := gitpkg.ShortSHA(pr.HeadRefOid)
+		log.Printf("CI poller: canceled %d superseded jobs for %s#%d (new HEAD=%s)",
+			len(canceledIDs), ghRepo, pr.Number, headShort)
+		// Also kill running worker processes so they stop consuming compute.
+		if p.jobCancelFn != nil {
+			for _, jid := range canceledIDs {
+				p.jobCancelFn(jid)
+			}
+		}
+	}
+
 	// Throttle: skip if this PR was reviewed recently (any SHA).
 	// Bypass users are never throttled.
 	throttle := cfg.CI.ResolvedThrottleInterval()
@@ -443,24 +461,6 @@ func (p *CIPoller) processPR(ctx context.Context, ghRepo string, pr ghPR, cfg *c
 	}
 	if _, err = config.ValidateReviewTypes(rtList); err != nil {
 		return err
-	}
-
-	// Cancel any in-progress batches for this PR at an older HEAD SHA.
-	// When a PR gets a new push, work on the old HEAD is wasted.
-	// This runs before the empty-matrix guard so superseded work is
-	// always cleaned up, even when config changes remove all reviews.
-	if canceledIDs, err := p.db.CancelSupersededBatches(ghRepo, pr.Number, pr.HeadRefOid); err != nil {
-		log.Printf("CI poller: error canceling superseded batches for %s#%d: %v", ghRepo, pr.Number, err)
-	} else if len(canceledIDs) > 0 {
-		headShort := gitpkg.ShortSHA(pr.HeadRefOid)
-		log.Printf("CI poller: canceled %d superseded jobs for %s#%d (new HEAD=%s)",
-			len(canceledIDs), ghRepo, pr.Number, headShort)
-		// Also kill running worker processes so they stop consuming compute.
-		if p.jobCancelFn != nil {
-			for _, jid := range canceledIDs {
-				p.jobCancelFn(jid)
-			}
-		}
 	}
 
 	if len(matrix) == 0 {

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -2421,8 +2421,8 @@ func TestCIPollerProcessPR_ThrottlesRecentPR(t *testing.T) {
 		t.Fatal("expected batch for first push")
 	}
 
-	// Second push within throttle window — should be
-	// deferred
+	// Second push within throttle window — supersedes
+	// the unsynthesized first batch, so NOT throttled.
 	*captured = nil
 	err = h.Poller.processPR(
 		context.Background(), "acme/api",
@@ -2437,6 +2437,102 @@ func TestCIPollerProcessPR_ThrottlesRecentPR(t *testing.T) {
 
 	hasBatch, err = h.DB.HasCIBatch(
 		"acme/api", 70, "second-sha",
+	)
+	if err != nil {
+		t.Fatalf("HasCIBatch: %v", err)
+	}
+	if !hasBatch {
+		t.Fatal(
+			"expected batch for second push (supersedes in-progress first)")
+	}
+
+	// First-sha batch should be canceled (deleted).
+	hasBatch, err = h.DB.HasCIBatch(
+		"acme/api", 70, "first-sha",
+	)
+	if err != nil {
+		t.Fatalf("HasCIBatch first-sha: %v", err)
+	}
+	if hasBatch {
+		t.Fatal(
+			"expected first-sha batch to be canceled")
+	}
+
+	// No "Review deferred" status should have been set.
+	for _, sc := range *captured {
+		if strings.Contains(sc.Desc, "Review deferred") {
+			t.Errorf(
+				"unexpected deferred status: %+v", sc)
+		}
+	}
+}
+
+func TestCIPollerProcessPR_ThrottlesAfterCompletedReview(t *testing.T) {
+	h := newCIPollerHarness(t, "git@github.com:acme/api.git")
+	h.Cfg.CI.ReviewTypes = []string{"security"}
+	h.Cfg.CI.Agents = []string{"codex"}
+	h.Cfg.CI.ThrottleInterval = "1h"
+	h.Poller = NewCIPoller(
+		h.DB, NewStaticConfig(h.Cfg), nil,
+	)
+	h.stubProcessPRGit()
+	h.Poller.mergeBaseFn = func(_, _, _ string) (string, error) {
+		return "base-sha", nil
+	}
+
+	// First push — reviewed normally
+	err := h.Poller.processPR(
+		context.Background(), "acme/api",
+		ghPR{
+			Number:      71,
+			HeadRefOid:  "first-sha",
+			BaseRefName: "main",
+		}, h.Cfg)
+	if err != nil {
+		t.Fatalf("first processPR: %v", err)
+	}
+
+	hasBatch, err := h.DB.HasCIBatch(
+		"acme/api", 71, "first-sha",
+	)
+	if err != nil {
+		t.Fatalf("HasCIBatch: %v", err)
+	}
+	if !hasBatch {
+		t.Fatal("expected batch for first push")
+	}
+
+	// Mark first batch as synthesized + finalized (completed review).
+	// Re-call CreateCIBatch (INSERT OR IGNORE) to retrieve the existing batch.
+	batch, _, err := h.DB.CreateCIBatch(
+		"acme/api", 71, "first-sha", 0,
+	)
+	if err != nil {
+		t.Fatalf("CreateCIBatch lookup: %v", err)
+	}
+	if _, err := h.DB.ClaimBatchForSynthesis(batch.ID); err != nil {
+		t.Fatalf("ClaimBatchForSynthesis: %v", err)
+	}
+	if err := h.DB.FinalizeBatch(batch.ID); err != nil {
+		t.Fatalf("FinalizeBatch: %v", err)
+	}
+
+	// Second push within throttle window — should be throttled
+	// because the first batch is synthesized (completed).
+	captured := h.CaptureCommitStatuses()
+	err = h.Poller.processPR(
+		context.Background(), "acme/api",
+		ghPR{
+			Number:      71,
+			HeadRefOid:  "second-sha",
+			BaseRefName: "main",
+		}, h.Cfg)
+	if err != nil {
+		t.Fatalf("second processPR: %v", err)
+	}
+
+	hasBatch, err = h.DB.HasCIBatch(
+		"acme/api", 71, "second-sha",
 	)
 	if err != nil {
 		t.Fatalf("HasCIBatch: %v", err)


### PR DESCRIPTION
## Summary

- Move `CancelSupersededBatches` before the throttle check in `processPR` so that new pushes to a PR with an in-progress (unsynthesized) review are never delayed by the batch they're replacing
- Completed (synthesized) reviews still contribute to throttle as before
- Update existing throttle test to reflect new behavior; add new test for throttle-after-completed-review

Close #410 

🤖 Generated with [Claude Code](https://claude.com/claude-code)