### PR TITLE
feat: excluded commit patterns

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -537,18 +537,19 @@ type RepoCIConfig struct {
 
 // RepoConfig holds per-repo overrides
 type RepoConfig struct {
-	Agent              string   `toml:"agent"`
-	Model              string   `toml:"model"` // Model for agents (format varies by agent)
-	BackupAgent        string   `toml:"backup_agent"`
-	BackupModel        string   `toml:"backup_model"`
-	ReviewContextCount int      `toml:"review_context_count"`
-	ReviewGuidelines   string   `toml:"review_guidelines"`
-	JobTimeoutMinutes  int      `toml:"job_timeout_minutes"`
-	ExcludedBranches   []string `toml:"excluded_branches"`
-	DisplayName        string   `toml:"display_name"`
-	ReviewReasoning    string   `toml:"review_reasoning"` // Reasoning level for reviews: thorough, standard, fast
-	RefineReasoning    string   `toml:"refine_reasoning"` // Reasoning level for refine: thorough, standard, fast
-	FixReasoning       string   `toml:"fix_reasoning"`    // Reasoning level for fix: thorough, standard, fast
+	Agent                  string   `toml:"agent"`
+	Model                  string   `toml:"model"` // Model for agents (format varies by agent)
+	BackupAgent            string   `toml:"backup_agent"`
+	BackupModel            string   `toml:"backup_model"`
+	ReviewContextCount     int      `toml:"review_context_count"`
+	ReviewGuidelines       string   `toml:"review_guidelines"`
+	JobTimeoutMinutes      int      `toml:"job_timeout_minutes"`
+	ExcludedBranches       []string `toml:"excluded_branches"`
+	ExcludedCommitPatterns []string `toml:"excluded_commit_patterns"`
+	DisplayName            string   `toml:"display_name"`
+	ReviewReasoning        string   `toml:"review_reasoning"` // Reasoning level for reviews: thorough, standard, fast
+	RefineReasoning        string   `toml:"refine_reasoning"` // Reasoning level for refine: thorough, standard, fast
+	FixReasoning           string   `toml:"fix_reasoning"`    // Reasoning level for fix: thorough, standard, fast
 
 	// CI-specific overrides (used by CI poller for this repo)
 	CI RepoCIConfig `toml:"ci"`
@@ -806,6 +807,22 @@ func IsBranchExcluded(repoPath, branch string) bool {
 	}
 
 	return slices.Contains(repoCfg.ExcludedBranches, branch)
+}
+
+// IsCommitMessageExcluded checks if a commit should be excluded from reviews
+// based on substring patterns configured in the repo's .roborev.toml.
+func IsCommitMessageExcluded(repoPath, message string) bool {
+	repoCfg, err := LoadRepoConfig(repoPath)
+	if err != nil || repoCfg == nil {
+		return false
+	}
+	lower := strings.ToLower(message)
+	for _, pattern := range repoCfg.ExcludedCommitPatterns {
+		if pattern != "" && strings.Contains(lower, strings.ToLower(pattern)) {
+			return true
+		}
+	}
+	return false
 }
 
 // GetDisplayName returns the display name for a repo, or empty if not set

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -391,6 +391,73 @@ func TestIsBranchExcluded(t *testing.T) {
 	}
 }
 
+func TestIsCommitMessageExcluded(t *testing.T) {
+	tests := []struct {
+		name       string
+		repoConfig string
+		message    string
+		want       bool
+	}{
+		{
+			name:    "no config file",
+			message: "fix: update handler",
+			want:    false,
+		},
+		{
+			name:       "empty excluded_commit_patterns",
+			repoConfig: `agent = "codex"`,
+			message:    "fix: update handler",
+			want:       false,
+		},
+		{
+			name:       "message matches pattern",
+			repoConfig: `excluded_commit_patterns = ["[skip review]"]`,
+			message:    "wip: quick fix [skip review]",
+			want:       true,
+		},
+		{
+			name:       "message matches one of several patterns",
+			repoConfig: `excluded_commit_patterns = ["[skip review]", "[wip]", "[no review]"]`,
+			message:    "checkpoint [wip]",
+			want:       true,
+		},
+		{
+			name:       "message does not match",
+			repoConfig: `excluded_commit_patterns = ["[skip review]", "[wip]"]`,
+			message:    "feat: add new endpoint",
+			want:       false,
+		},
+		{
+			name:       "case insensitive match",
+			repoConfig: `excluded_commit_patterns = ["[Skip Review]"]`,
+			message:    "wip: quick fix [SKIP REVIEW]",
+			want:       true,
+		},
+		{
+			name:       "pattern in body not just subject",
+			repoConfig: `excluded_commit_patterns = ["[skip review]"]`,
+			message:    "feat: add feature\n\nsome details [skip review]",
+			want:       true,
+		},
+		{
+			name:       "empty pattern is ignored",
+			repoConfig: `excluded_commit_patterns = [""]`,
+			message:    "any commit message",
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := newTempRepo(t, tt.repoConfig)
+			got := IsCommitMessageExcluded(tmpDir, tt.message)
+			if got != tt.want {
+				t.Errorf("IsCommitMessageExcluded(%q) = %v, want %v", tt.message, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSyncConfigPostgresURLExpanded(t *testing.T) {
 	t.Run("empty URL returns empty", func(t *testing.T) {
 		cfg := SyncConfig{}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -739,6 +739,16 @@ func (s *Server) handleEnqueue(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// Check if commit message matches an excluded pattern
+		fullMessage := info.Subject + "\n" + info.Body
+		if config.IsCommitMessageExcluded(repoRoot, fullMessage) {
+			writeJSON(w, map[string]any{
+				"skipped": true,
+				"reason":  "commit message matches an excluded pattern",
+			})
+			return
+		}
+
 		// Get or create commit
 		commit, err := s.db.GetOrCreateCommit(repo.ID, sha, info.Author, info.Subject, info.Timestamp)
 		if err != nil {


### PR DESCRIPTION
## Summary

  - Add `excluded_commit_patterns` config option that allows skipping reviews for commits whose message contains any of the configured substrings (e.g., `[skip review]`,
  `[wip]`)
  - Matching is case-insensitive and checks the full commit message (subject + body)
  - Returns `{"skipped": true, ...}` when a commit matches an excluded pattern

Fixes #423 