### PR TITLE
Fix TUI Enter handling in embedded terminals

### DIFF
--- a/cmd/roborev/tui/handlers.go
+++ b/cmd/roborev/tui/handlers.go
@@ -74,6 +74,9 @@ func (m model) handleMouseMsg(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 
 // handleGlobalKey handles keys shared across queue, review, prompt, commit msg, and help views.
 func (m model) handleGlobalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if isSubmitKey(msg) {
+		return m.handleEnterKey()
+	}
 	switch msg.String() {
 	case "ctrl+c", "ctrl+d", "q":
 		return m.handleQuitKey()
@@ -91,8 +94,6 @@ func (m model) handleGlobalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handlePageUpKey()
 	case "pgdown":
 		return m.handlePageDownKey()
-	case "enter":
-		return m.handleEnterKey()
 	case "p":
 		return m.handlePromptKey()
 	case "a":

--- a/cmd/roborev/tui/handlers_modal.go
+++ b/cmd/roborev/tui/handlers_modal.go
@@ -346,25 +346,7 @@ func (m model) handleWorktreeConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 // handleTasksKey handles key input in the tasks view.
 func (m model) handleTasksKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case "ctrl+c", "ctrl+d", "q":
-		return m, tea.Quit
-	case "esc", "T":
-		m.currentView = viewQueue
-		return m, nil
-	case "o":
-		return m.handleColumnOptionsKey()
-	case "up", "k":
-		if m.fixSelectedIdx > 0 {
-			m.fixSelectedIdx--
-		}
-		return m, nil
-	case "down", "j":
-		if m.fixSelectedIdx < len(m.fixJobs)-1 {
-			m.fixSelectedIdx++
-		}
-		return m, nil
-	case "enter":
+	if isSubmitKey(msg) {
 		// View task: prompt for running, review for done/applied, log for failed
 		if len(m.fixJobs) > 0 && m.fixSelectedIdx < len(m.fixJobs) {
 			job := m.fixJobs[m.fixSelectedIdx]
@@ -391,6 +373,26 @@ func (m model) handleTasksKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			case job.Status == storage.JobStatusFailed:
 				return m.openLogView(job.ID, job.Status, viewTasks)
 			}
+		}
+		return m, nil
+	}
+
+	switch msg.String() {
+	case "ctrl+c", "ctrl+d", "q":
+		return m, tea.Quit
+	case "esc", "T":
+		m.currentView = viewQueue
+		return m, nil
+	case "o":
+		return m.handleColumnOptionsKey()
+	case "up", "k":
+		if m.fixSelectedIdx > 0 {
+			m.fixSelectedIdx--
+		}
+		return m, nil
+	case "down", "j":
+		if m.fixSelectedIdx < len(m.fixJobs)-1 {
+			m.fixSelectedIdx++
 		}
 		return m, nil
 	case "l", "t":

--- a/cmd/roborev/tui/helpers.go
+++ b/cmd/roborev/tui/helpers.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
 	gansi "github.com/charmbracelet/glamour/ansi"
 	"github.com/charmbracelet/glamour/styles"
@@ -22,6 +23,19 @@ const (
 
 // branchNone is the sentinel value for jobs with no branch information.
 const branchNone = "(none)"
+
+// Some embedded terminals forward Enter as LF (ctrl+j) instead of CR.
+// Only use this in non-text-entry flows where ctrl+j is not meaningful input.
+func isSubmitKey(msg tea.KeyMsg) bool {
+	switch msg.Type {
+	case tea.KeyEnter, tea.KeyCtrlJ:
+		return true
+	}
+	if len(msg.Runes) == 1 {
+		return msg.Runes[0] == '\r' || msg.Runes[0] == '\n'
+	}
+	return false
+}
 
 // setFlash sets a flash message with the given duration and view.
 func (m *model) setFlash(msg string, d time.Duration, v viewKind) {

--- a/cmd/roborev/tui/queue_test.go
+++ b/cmd/roborev/tui/queue_test.go
@@ -235,6 +235,25 @@ func TestTUIQueueMouseIgnoredOutsideQueueView(t *testing.T) {
 	}
 }
 
+func TestTUIQueueCtrlJFetchesReview(t *testing.T) {
+	m := newTuiModel("http://localhost")
+	m.currentView = tuiViewQueue
+	m.jobs = []storage.ReviewJob{
+		makeJob(1, withStatus(storage.JobStatusDone)),
+	}
+	m.selectedIdx = 0
+	m.selectedJobID = 1
+
+	m2, cmd := pressSpecial(m, tea.KeyCtrlJ)
+
+	if m2.reviewFromView != tuiViewQueue {
+		t.Fatalf("expected reviewFromView=%v, got %v", tuiViewQueue, m2.reviewFromView)
+	}
+	if cmd == nil {
+		t.Fatal("expected fetchReview command for ctrl+j activation")
+	}
+}
+
 func TestTUIQueueMouseWheelScrollsSelection(t *testing.T) {
 	m := newTuiModel("http://localhost")
 	m.currentView = tuiViewQueue
@@ -475,6 +494,27 @@ func TestTUITasksParentShortcutWithoutParentShowsFlash(t *testing.T) {
 	}
 	if m2.flashView != tuiViewTasks {
 		t.Fatalf("expected flashView=tuiViewTasks, got %v", m2.flashView)
+	}
+}
+
+func TestTUITasksCtrlJFetchesReview(t *testing.T) {
+	m := newTuiModel("http://localhost")
+	m.currentView = tuiViewTasks
+	m.fixJobs = []storage.ReviewJob{
+		{ID: 101, Status: storage.JobStatusDone},
+	}
+	m.fixSelectedIdx = 0
+
+	m2, cmd := pressSpecial(m, tea.KeyCtrlJ)
+
+	if m2.selectedJobID != 101 {
+		t.Fatalf("expected selectedJobID=101, got %d", m2.selectedJobID)
+	}
+	if m2.reviewFromView != tuiViewTasks {
+		t.Fatalf("expected reviewFromView=tuiViewTasks, got %v", m2.reviewFromView)
+	}
+	if cmd == nil {
+		t.Fatal("expected fetchReview command for ctrl+j activation")
 	}
 }
 


### PR DESCRIPTION
## Summary
- treat LF-style submit keys the same as Enter in non-text-entry TUI activation flows
- keep queue and tasks review activation working when embedded terminals emit ctrl+j for Enter
- add regression coverage for queue and tasks activation via ctrl+j

## Testing
- go test ./cmd/roborev/tui
- go vet ./cmd/roborev/tui