### PR TITLE
Remove accidental branch post-commit default

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -1,5 +1,4 @@
 review_agent = ""
-post_commit_review = "branch"
 review_guidelines = """
 The daemon and client evolve in lockstep; the daemon is restarted after
 updates. API changes do not require backward compatibility shims.


### PR DESCRIPTION
## Summary
- remove the repo-level `post_commit_review = "branch"` opt-in from `.roborev.toml`
- restore the default post-commit behavior for this repo to single-commit `HEAD` reviews

## Why
`roborev post-commit` only enables branch reviews when the repo config sets `post_commit_review = "branch"`.
That line was added to this repository in #455, which made post-commit hooks on this repo enqueue branch reviews even when the global `~/.roborev/config.toml` did not set anything.

## Testing
- not run (config-only change)