### PR TITLE
Move TUI mismatch warning into daemon status

### DIFF
--- a/cmd/roborev/tui/helpers.go
+++ b/cmd/roborev/tui/helpers.go
@@ -52,6 +52,19 @@ func (m *model) setWarningFlash(msg string, d time.Duration, v viewKind) {
 	m.flashWarning = true
 }
 
+func (m model) renderDaemonStatus() string {
+	daemonVersion := m.daemonVersion
+	if daemonVersion == "" {
+		daemonVersion = "?"
+	}
+
+	line := statusStyle.Render("Daemon: " + daemonVersion)
+	if m.versionMismatch {
+		line += " " + errorStyle.Render("[MISMATCH]")
+	}
+	return line
+}
+
 func (m model) renderFlash(view viewKind) string {
 	if m.flashMessage == "" || !time.Now().Before(m.flashExpiresAt) || m.flashView != view {
 		return ""

--- a/cmd/roborev/tui/render_queue.go
+++ b/cmd/roborev/tui/render_queue.go
@@ -138,7 +138,7 @@ func (m model) renderQueueView() string {
 	// In compact mode, show version mismatch inline since the status area is hidden
 	if compact && m.versionMismatch {
 		b.WriteString(" ")
-		b.WriteString(errorStyle.Render(fmt.Sprintf("MISMATCH: TUI %s != Daemon %s", version.Version, m.daemonVersion)))
+		b.WriteString(m.renderDaemonStatus())
 	}
 	b.WriteString("\x1b[K\n") // Clear to end of line
 
@@ -172,12 +172,12 @@ func (m model) renderQueueView() string {
 			closed = m.jobStats.Closed
 			open = m.jobStats.Open
 		}
+		b.WriteString(m.renderDaemonStatus())
 		if len(m.activeRepoFilter) > 0 || m.activeBranchFilter != "" {
-			statusLine = fmt.Sprintf("Daemon: %s | Completed: %d | Closed: %d | Open: %d",
-				m.daemonVersion, done, closed, open)
+			statusLine = fmt.Sprintf(" | Completed: %d | Closed: %d | Open: %d",
+				done, closed, open)
 		} else {
-			statusLine = fmt.Sprintf("Daemon: %s | Workers: %d/%d | Completed: %d | Closed: %d | Open: %d",
-				m.daemonVersion,
+			statusLine = fmt.Sprintf(" | Workers: %d/%d | Completed: %d | Closed: %d | Open: %d",
 				m.status.ActiveWorkers, m.status.MaxWorkers,
 				done, closed, open)
 		}
@@ -566,10 +566,7 @@ func (m model) renderQueueView() string {
 		b.WriteString("\x1b[K\n") // Clear scroll indicator line
 
 		// Status line: flash message (temporary)
-		// Version mismatch takes priority over flash messages (it's persistent and important)
-		if m.versionMismatch {
-			b.WriteString(errorStyle.Render(fmt.Sprintf("VERSION MISMATCH: TUI %s != Daemon %s - restart TUI or daemon", version.Version, m.daemonVersion)))
-		} else if flash := m.renderFlash(viewQueue); flash != "" {
+		if flash := m.renderFlash(viewQueue); flash != "" {
 			b.WriteString(flash)
 		}
 		b.WriteString("\x1b[K\n") // Clear to end of line

--- a/cmd/roborev/tui/render_review.go
+++ b/cmd/roborev/tui/render_review.go
@@ -8,7 +8,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	xansi "github.com/charmbracelet/x/ansi"
 	"github.com/mattn/go-runewidth"
-	"github.com/roborev-dev/roborev/internal/version"
 )
 
 func (m model) renderReviewView() string {
@@ -79,11 +78,15 @@ func (m model) renderReviewView() string {
 			b.WriteString("\x1b[K") // Clear to end of line
 		}
 		b.WriteString("\n")
+		b.WriteString(m.renderDaemonStatus())
+		b.WriteString("\x1b[K\n")
 	} else {
 		title = "Review"
 		titleLen = len(title)
 		b.WriteString(titleStyle.Render(title))
 		b.WriteString("\x1b[K\n") // Clear to end of line
+		b.WriteString(m.renderDaemonStatus())
+		b.WriteString("\x1b[K\n")
 	}
 
 	// Build content: review output + responses
@@ -138,8 +141,8 @@ func (m model) renderReviewView() string {
 		}
 	}
 
-	// headerHeight = title + location line + status line (1) + help + verdict/closed (0|1)
-	headerHeight := titleLines + locationLines + 1 + helpLines
+	// Reserve title, location, daemon status, footer status, help, and optional verdict.
+	headerHeight := titleLines + locationLines + 2 + helpLines
 	hasVerdict := review.Job != nil && review.Job.Verdict != nil && *review.Job.Verdict != "" && !review.Job.IsFixJob()
 	if hasVerdict || review.Closed {
 		headerHeight++ // Add 1 for verdict/closed line
@@ -236,10 +239,8 @@ func (m model) renderReviewView() string {
 		}
 	}
 
-	// Status line: version mismatch (persistent) takes priority, then flash message, then scroll indicator
-	if m.versionMismatch {
-		b.WriteString(errorStyle.Render(fmt.Sprintf("VERSION MISMATCH: TUI %s != Daemon %s - restart TUI or daemon", version.Version, m.daemonVersion)))
-	} else if flash := m.renderFlash(viewReview); flash != "" {
+	// Status line: flash message takes priority, then scroll indicator.
+	if flash := m.renderFlash(viewReview); flash != "" {
 		b.WriteString(flash)
 	} else if len(lines) > visibleLines {
 		scrollInfo := fmt.Sprintf("[%d-%d of %d lines]", start+1, end, len(lines))

--- a/cmd/roborev/tui/review_render_test.go
+++ b/cmd/roborev/tui/review_render_test.go
@@ -299,7 +299,7 @@ func TestTUIVisibleLinesCalculationTable(t *testing.T) {
 			jobRef:                   "abc1234",
 			jobAgent:                 "codex",
 			jobVerdict:               nil,
-			wantVisibleLines:         5, // height 10 - 5 non-content = 5
+			wantVisibleLines:         4, // height 10 - 6 non-content = 4
 			checkVisibleContentCount: true,
 		},
 		{
@@ -309,7 +309,7 @@ func TestTUIVisibleLinesCalculationTable(t *testing.T) {
 			jobRef:           "abc1234",
 			jobAgent:         "codex",
 			jobVerdict:       &verdictPass,
-			wantVisibleLines: 4, // height 10 - 6 non-content = 4
+			wantVisibleLines: 3, // height 10 - 7 non-content = 3
 		},
 		{
 			name:             "narrow terminal",
@@ -318,7 +318,7 @@ func TestTUIVisibleLinesCalculationTable(t *testing.T) {
 			jobRef:           "abc1234",
 			jobAgent:         "codex",
 			jobVerdict:       nil,
-			wantVisibleLines: 4, // height 10 - 6 non-content = 4
+			wantVisibleLines: 3, // height 10 - 7 non-content = 3
 		},
 		{
 			name:             "narrow terminal with verdict",
@@ -327,7 +327,7 @@ func TestTUIVisibleLinesCalculationTable(t *testing.T) {
 			jobRef:           "abc1234",
 			jobAgent:         "codex",
 			jobVerdict:       &verdictFail,
-			wantVisibleLines: 3, // height 10 - 7 non-content = 3
+			wantVisibleLines: 2, // height 10 - 8 non-content = 2
 			wantContains:     []string{"Verdict"},
 		},
 		{
@@ -341,7 +341,7 @@ func TestTUIVisibleLinesCalculationTable(t *testing.T) {
 			jobAgent:         "claude-code",
 			jobVerdict:       nil,
 			closed:           true,
-			wantVisibleLines: 3, // height 12 - 9 non-content = 3
+			wantVisibleLines: 2, // height 12 - 10 non-content = 2
 			wantContains:     []string{"very-long-repository-name-here", "feature/very-long-branch-name", "[CLOSED]"},
 		},
 	}

--- a/cmd/roborev/tui/tui_test.go
+++ b/cmd/roborev/tui/tui_test.go
@@ -594,15 +594,18 @@ func TestTUIVersionMismatchDetection(t *testing.T) {
 
 		output := m.View()
 
-		if !strings.Contains(output, "VERSION MISMATCH") {
-			t.Error("Expected queue view to show VERSION MISMATCH error")
+		if !strings.Contains(output, "Daemon: old-version") {
+			t.Error("Expected queue view to show daemon version")
 		}
-		if !strings.Contains(output, "old-version") {
-			t.Error("Expected error to show daemon version")
+		if !strings.Contains(output, "[MISMATCH]") {
+			t.Error("Expected queue view to show mismatch badge")
+		}
+		if strings.Contains(output, "VERSION MISMATCH") {
+			t.Error("Expected queue view to move mismatch warning out of footer")
 		}
 	})
 
-	t.Run("displays error banner in review view when mismatched", func(t *testing.T) {
+	t.Run("displays mismatch badge in review header when mismatched", func(t *testing.T) {
 		m := newModel(testServerAddr, withExternalIODisabled())
 		m.width = 100
 		m.height = 30
@@ -622,8 +625,43 @@ func TestTUIVersionMismatchDetection(t *testing.T) {
 
 		output := m.View()
 
-		if !strings.Contains(output, "VERSION MISMATCH") {
-			t.Error("Expected review view to show VERSION MISMATCH error")
+		if !strings.Contains(output, "Daemon: old-version") {
+			t.Error("Expected review view to show daemon version")
+		}
+		if !strings.Contains(output, "[MISMATCH]") {
+			t.Error("Expected review view to show mismatch badge")
+		}
+		if strings.Contains(output, "VERSION MISMATCH") {
+			t.Error("Expected review view to move mismatch warning out of footer")
+		}
+	})
+
+	t.Run("review flash still renders when mismatch is present", func(t *testing.T) {
+		m := newModel(testServerAddr, withExternalIODisabled())
+		m.width = 100
+		m.height = 30
+		m.currentView = viewReview
+		m.versionMismatch = true
+		m.daemonVersion = "old-version"
+		m.currentReview = &storage.Review{
+			ID:     1,
+			Output: "Test review",
+			Job: &storage.ReviewJob{
+				ID:       1,
+				GitRef:   "abc123",
+				RepoName: "test",
+				Agent:    "test",
+			},
+		}
+		m.setFlash("Saved", time.Minute, viewReview)
+
+		output := m.View()
+
+		if !strings.Contains(output, "Saved") {
+			t.Error("Expected review flash message to remain visible with mismatch badge")
+		}
+		if !strings.Contains(output, "[MISMATCH]") {
+			t.Error("Expected mismatch badge to still render alongside review header")
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- move the persistent version mismatch warning into the daemon status display
- show a red `[MISMATCH]` badge in queue and review headers instead of the transient footer row
- keep the footer status line available for flash messages and update viewport tests for the extra header line

## Testing
- go test ./cmd/roborev/tui
- go test ./...
- go vet ./...