### PR TITLE
Update flake.nix for v0.44.1

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         packages = {
           default = pkgs.buildGoModule {
             pname = "roborev";
-            version = "0.44.0";
+            version = "0.44.1";
 
             src = ./.;
 


### PR DESCRIPTION
Updates flake.nix version to 0.44.1 for the v0.44.1 release.