### PR TITLE
Hide daemon status from review view

### DIFF
--- a/cmd/roborev/tui/render_review.go
+++ b/cmd/roborev/tui/render_review.go
@@ -78,15 +78,11 @@ func (m model) renderReviewView() string {
 			b.WriteString("\x1b[K") // Clear to end of line
 		}
 		b.WriteString("\n")
-		b.WriteString(m.renderDaemonStatus())
-		b.WriteString("\x1b[K\n")
 	} else {
 		title = "Review"
 		titleLen = len(title)
 		b.WriteString(titleStyle.Render(title))
 		b.WriteString("\x1b[K\n") // Clear to end of line
-		b.WriteString(m.renderDaemonStatus())
-		b.WriteString("\x1b[K\n")
 	}
 
 	// Build content: review output + responses
@@ -141,8 +137,8 @@ func (m model) renderReviewView() string {
 		}
 	}
 
-	// Reserve title, location, daemon status, footer status, help, and optional verdict.
-	headerHeight := titleLines + locationLines + 2 + helpLines
+	// Reserve title, location, footer status, help, and optional verdict.
+	headerHeight := titleLines + locationLines + 1 + helpLines
 	hasVerdict := review.Job != nil && review.Job.Verdict != nil && *review.Job.Verdict != "" && !review.Job.IsFixJob()
 	if hasVerdict || review.Closed {
 		headerHeight++ // Add 1 for verdict/closed line

--- a/cmd/roborev/tui/review_render_test.go
+++ b/cmd/roborev/tui/review_render_test.go
@@ -66,6 +66,7 @@ func TestTUIRenderViews(t *testing.T) {
 				},
 			},
 			wantContains: []string{"on feature/test", "[CLOSED]", "myrepo", "abc1234"},
+			wantAbsent:   []string{"Daemon:"},
 		},
 		{
 			name: "review view with model",
@@ -83,6 +84,7 @@ func TestTUIRenderViews(t *testing.T) {
 				},
 			},
 			wantContains: []string{"(codex: o3)"},
+			wantAbsent:   []string{"Daemon:"},
 		},
 		{
 			name: "review view without model",
@@ -100,7 +102,7 @@ func TestTUIRenderViews(t *testing.T) {
 				},
 			},
 			wantContains: []string{"(codex)"},
-			wantAbsent:   []string{"(codex:"},
+			wantAbsent:   []string{"(codex:", "Daemon:"},
 		},
 		{
 			name: "prompt view with model",
@@ -150,7 +152,7 @@ func TestTUIRenderViews(t *testing.T) {
 				},
 			},
 			wantContains: []string{"abc123..def456"},
-			wantAbsent:   []string{" on "},
+			wantAbsent:   []string{" on ", "Daemon:"},
 		},
 		{
 			name: "review view no blank line without verdict",
@@ -167,6 +169,7 @@ func TestTUIRenderViews(t *testing.T) {
 				},
 			},
 			wantContains:              []string{"Review", "abc1234"},
+			wantAbsent:                []string{"Daemon:"},
 			checkContentStartsOnLine3: true,
 		},
 		{
@@ -184,6 +187,7 @@ func TestTUIRenderViews(t *testing.T) {
 				},
 			},
 			wantContains:              []string{"Review", "abc1234", "Verdict"},
+			wantAbsent:                []string{"Daemon:"},
 			checkContentStartsOnLine4: true,
 		},
 		{
@@ -202,6 +206,7 @@ func TestTUIRenderViews(t *testing.T) {
 				},
 			},
 			wantContains:              []string{"Review", "abc1234", "[CLOSED]"},
+			wantAbsent:                []string{"Daemon:"},
 			checkContentStartsOnLine4: true,
 			checkNoVerdictOnLine3:     true,
 		},
@@ -220,7 +225,7 @@ func TestTUIRenderViews(t *testing.T) {
 					Status:   storage.JobStatusFailed,
 				},
 			},
-			wantAbsent: []string{" on "},
+			wantAbsent: []string{" on ", "Daemon:"},
 		},
 	}
 
@@ -299,7 +304,7 @@ func TestTUIVisibleLinesCalculationTable(t *testing.T) {
 			jobRef:                   "abc1234",
 			jobAgent:                 "codex",
 			jobVerdict:               nil,
-			wantVisibleLines:         4, // height 10 - 6 non-content = 4
+			wantVisibleLines:         5, // height 10 - 5 non-content = 5
 			checkVisibleContentCount: true,
 		},
 		{
@@ -309,7 +314,7 @@ func TestTUIVisibleLinesCalculationTable(t *testing.T) {
 			jobRef:           "abc1234",
 			jobAgent:         "codex",
 			jobVerdict:       &verdictPass,
-			wantVisibleLines: 3, // height 10 - 7 non-content = 3
+			wantVisibleLines: 4, // height 10 - 6 non-content = 4
 		},
 		{
 			name:             "narrow terminal",
@@ -318,7 +323,7 @@ func TestTUIVisibleLinesCalculationTable(t *testing.T) {
 			jobRef:           "abc1234",
 			jobAgent:         "codex",
 			jobVerdict:       nil,
-			wantVisibleLines: 3, // height 10 - 7 non-content = 3
+			wantVisibleLines: 4, // height 10 - 6 non-content = 4
 		},
 		{
 			name:             "narrow terminal with verdict",
@@ -327,7 +332,7 @@ func TestTUIVisibleLinesCalculationTable(t *testing.T) {
 			jobRef:           "abc1234",
 			jobAgent:         "codex",
 			jobVerdict:       &verdictFail,
-			wantVisibleLines: 2, // height 10 - 8 non-content = 2
+			wantVisibleLines: 3, // height 10 - 7 non-content = 3
 			wantContains:     []string{"Verdict"},
 		},
 		{
@@ -341,7 +346,7 @@ func TestTUIVisibleLinesCalculationTable(t *testing.T) {
 			jobAgent:         "claude-code",
 			jobVerdict:       nil,
 			closed:           true,
-			wantVisibleLines: 2, // height 12 - 10 non-content = 2
+			wantVisibleLines: 3, // height 12 - 9 non-content = 3
 			wantContains:     []string{"very-long-repository-name-here", "feature/very-long-branch-name", "[CLOSED]"},
 		},
 	}

--- a/cmd/roborev/tui/tui_test.go
+++ b/cmd/roborev/tui/tui_test.go
@@ -605,7 +605,7 @@ func TestTUIVersionMismatchDetection(t *testing.T) {
 		}
 	})
 
-	t.Run("displays mismatch badge in review header when mismatched", func(t *testing.T) {
+	t.Run("does not display daemon status in review view when mismatched", func(t *testing.T) {
 		m := newModel(testServerAddr, withExternalIODisabled())
 		m.width = 100
 		m.height = 30
@@ -625,14 +625,11 @@ func TestTUIVersionMismatchDetection(t *testing.T) {
 
 		output := m.View()
 
-		if !strings.Contains(output, "Daemon: old-version") {
-			t.Error("Expected review view to show daemon version")
+		if strings.Contains(output, "Daemon: old-version") {
+			t.Error("Expected review view to omit daemon status")
 		}
-		if !strings.Contains(output, "[MISMATCH]") {
-			t.Error("Expected review view to show mismatch badge")
-		}
-		if strings.Contains(output, "VERSION MISMATCH") {
-			t.Error("Expected review view to move mismatch warning out of footer")
+		if strings.Contains(output, "[MISMATCH]") {
+			t.Error("Expected review view to omit mismatch badge")
 		}
 	})
 
@@ -658,10 +655,13 @@ func TestTUIVersionMismatchDetection(t *testing.T) {
 		output := m.View()
 
 		if !strings.Contains(output, "Saved") {
-			t.Error("Expected review flash message to remain visible with mismatch badge")
+			t.Error("Expected review flash message to remain visible")
 		}
-		if !strings.Contains(output, "[MISMATCH]") {
-			t.Error("Expected mismatch badge to still render alongside review header")
+		if strings.Contains(output, "Daemon: old-version") {
+			t.Error("Expected review view to omit daemon status even when flash is present")
+		}
+		if strings.Contains(output, "[MISMATCH]") {
+			t.Error("Expected review view to omit mismatch badge even when flash is present")
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- remove the daemon status line from the review detail header
- keep the queue view daemon status behavior unchanged
- update review rendering tests and visible-line expectations for the restored layout

## Testing
- go fmt ./...
- go vet ./...
- go test ./cmd/roborev/tui
- go test ./...