### PR TITLE
Include comments when copying a review

### DIFF
--- a/cmd/roborev/show.go
+++ b/cmd/roborev/show.go
@@ -132,6 +132,30 @@ Examples:
 				fmt.Println(review.Output)
 			}
 
+			// Fetch and display comments
+			commentsURL := addr + fmt.Sprintf(
+				"/api/comments?job_id=%d", review.JobID,
+			)
+			commentsResp, cErr := client.Get(commentsURL)
+			if cErr == nil {
+				defer commentsResp.Body.Close()
+				if commentsResp.StatusCode == http.StatusOK {
+					var result struct {
+						Responses []storage.Response `json:"responses"`
+					}
+					if json.NewDecoder(commentsResp.Body).Decode(&result) == nil &&
+						len(result.Responses) > 0 {
+						fmt.Println()
+						fmt.Println("--- Comments ---")
+						for _, r := range result.Responses {
+							ts := r.CreatedAt.Format("Jan 02 15:04")
+							fmt.Printf("\n[%s] %s:\n", ts, r.Responder)
+							fmt.Println(r.Response)
+						}
+					}
+				}
+			}
+
 			return nil
 		},
 	}

--- a/cmd/roborev/show_test.go
+++ b/cmd/roborev/show_test.go
@@ -5,8 +5,10 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/roborev-dev/roborev/internal/storage"
 )
@@ -210,4 +212,67 @@ func TestShowJSONOutput(t *testing.T) {
 			t.Errorf("--json should not contain separator, got: %s", output)
 		}
 	})
+}
+
+func TestShowIncludesComments(t *testing.T) {
+	repo := newTestGitRepo(t)
+	repo.CommitFile("file.txt", "content", "initial commit")
+
+	review := storage.Review{
+		ID: 1, JobID: 42, Output: "Found issues", Agent: "test",
+	}
+	responses := []storage.Response{
+		{
+			ID:        1,
+			Responder: "alice",
+			Response:  "This is expected",
+			CreatedAt: time.Date(2025, 6, 1, 10, 30, 0, 0, time.UTC),
+		},
+	}
+
+	daemonFromHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/review":
+			json.NewEncoder(w).Encode(review)
+		case "/api/comments":
+			json.NewEncoder(w).Encode(map[string]any{
+				"responses": responses,
+			})
+		}
+	}))
+
+	chdir(t, repo.Dir)
+	output := runShowCmd(t, "--job", "42")
+
+	if !strings.Contains(output, "Found issues") {
+		t.Errorf("expected review output, got: %s", output)
+	}
+	if !strings.Contains(output, "--- Comments ---") {
+		t.Errorf("expected comments separator, got: %s", output)
+	}
+	if !strings.Contains(output, "alice") {
+		t.Errorf("expected commenter name, got: %s", output)
+	}
+	if !strings.Contains(output, "This is expected") {
+		t.Errorf("expected comment text, got: %s", output)
+	}
+}
+
+func TestShowNoComments(t *testing.T) {
+	repo := newTestGitRepo(t)
+	repo.CommitFile("file.txt", "content", "initial commit")
+
+	mockReviewDaemon(t, storage.Review{
+		ID: 1, JobID: 42, Output: "LGTM", Agent: "test",
+	})
+
+	chdir(t, repo.Dir)
+	output := runShowCmd(t, "--job", "42")
+
+	if !strings.Contains(output, "LGTM") {
+		t.Errorf("expected review output, got: %s", output)
+	}
+	if strings.Contains(output, "Comments") {
+		t.Errorf("should not contain comments section when none exist, got: %s", output)
+	}
 }

--- a/cmd/roborev/tui/actions.go
+++ b/cmd/roborev/tui/actions.go
@@ -22,7 +22,10 @@ import (
 // server API calls (close, cancel, rerun, comment, fix, apply patch),
 // and git operations (commit, worktree management).
 
-func formatClipboardContent(review *storage.Review) string {
+func formatClipboardContent(
+	review *storage.Review,
+	responses []storage.Response,
+) string {
 	if review == nil || review.Output == "" {
 		return ""
 	}
@@ -54,12 +57,29 @@ func formatClipboardContent(review *storage.Review) string {
 		}
 	}
 
-	return header + review.Output
+	var b strings.Builder
+	b.WriteString(header)
+	b.WriteString(review.Output)
+
+	if len(responses) > 0 {
+		b.WriteString("\n\n--- Comments ---\n")
+		for _, r := range responses {
+			timestamp := r.CreatedAt.Format("Jan 02 15:04")
+			fmt.Fprintf(&b, "\n[%s] %s:\n", timestamp, r.Responder)
+			b.WriteString(r.Response)
+			b.WriteString("\n")
+		}
+	}
+
+	return b.String()
 }
 
-func (m model) copyToClipboard(review *storage.Review) tea.Cmd {
+func (m model) copyToClipboard(
+	review *storage.Review,
+	responses []storage.Response,
+) tea.Cmd {
 	view := m.currentView // Capture view at trigger time
-	content := formatClipboardContent(review)
+	content := formatClipboardContent(review, responses)
 	return func() tea.Msg {
 		if content == "" {
 			return clipboardResultMsg{err: fmt.Errorf("no content to copy"), view: view}

--- a/cmd/roborev/tui/fetch.go
+++ b/cmd/roborev/tui/fetch.go
@@ -648,7 +648,9 @@ func (m model) fetchReviewAndCopy(jobID int64, job *storage.ReviewJob) tea.Cmd {
 			review.Job = job
 		}
 
-		content := formatClipboardContent(review)
+		responses := m.loadResponses(jobID, review)
+
+		content := formatClipboardContent(review, responses)
 		err = m.clipboard.WriteText(content)
 		return clipboardResultMsg{err: err, view: view}
 	}

--- a/cmd/roborev/tui/handlers_review.go
+++ b/cmd/roborev/tui/handlers_review.go
@@ -192,7 +192,7 @@ func (m model) handleCommentOpenKey() (tea.Model, tea.Cmd) {
 
 func (m model) handleCopyKey() (tea.Model, tea.Cmd) {
 	if m.currentView == viewReview && m.currentReview != nil && m.currentReview.Output != "" {
-		return m, m.copyToClipboard(m.currentReview)
+		return m, m.copyToClipboard(m.currentReview, m.currentResponses)
 	} else if job, ok := m.selectedJob(); m.currentView == viewQueue && ok {
 		if job.Status == storage.JobStatusDone || job.Status == storage.JobStatusFailed {
 			jobCopy := *job

--- a/cmd/roborev/tui/review_clipboard_test.go
+++ b/cmd/roborev/tui/review_clipboard_test.go
@@ -1,11 +1,11 @@
 package tui
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/roborev-dev/roborev/internal/storage"
 )
@@ -155,23 +155,10 @@ func TestTUIYankFromQueueRequiresCompletedJob(t *testing.T) {
 func TestTUIFetchReviewAndCopySuccess(t *testing.T) {
 	mock := &mockClipboard{}
 
-	// Create test server that returns a review
-	_, m := mockServerModel(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/review" {
-			t.Errorf("Expected /api/review, got %s", r.URL.Path)
-		}
-		jobID := r.URL.Query().Get("job_id")
-		if jobID != "123" {
-			t.Errorf("Expected job_id=123, got %s", jobID)
-		}
-		review := storage.Review{
-			ID:     1,
-			JobID:  123,
-			Agent:  "test",
-			Output: "Review content for clipboard",
-		}
-		json.NewEncoder(w).Encode(review)
-	})
+	_, m := mockServerModel(t, mockReviewHandler(
+		storage.Review{ID: 1, JobID: 123, Agent: "test", Output: "Review content for clipboard"},
+		nil,
+	))
 	m.clipboard = mock
 
 	// Execute fetchReviewAndCopy
@@ -191,6 +178,48 @@ func TestTUIFetchReviewAndCopySuccess(t *testing.T) {
 	expectedContent := "Review #123\n\nReview content for clipboard"
 	if mock.lastText != expectedContent {
 		t.Errorf("Expected clipboard to contain review with header, got %q", mock.lastText)
+	}
+}
+
+func TestTUIFetchReviewAndCopyIncludesComments(t *testing.T) {
+	mock := &mockClipboard{}
+
+	responses := []storage.Response{
+		{
+			ID:        1,
+			Responder: "dev",
+			Response:  "This is expected behavior",
+			CreatedAt: time.Date(2025, 3, 10, 9, 0, 0, 0, time.UTC),
+		},
+	}
+	_, m := mockServerModel(t, mockReviewHandler(
+		storage.Review{ID: 1, JobID: 123, Agent: "test", Output: "Found an issue"},
+		responses,
+	))
+	m.clipboard = mock
+
+	cmd := m.fetchReviewAndCopy(123, nil)
+	msg := cmd()
+
+	result, ok := msg.(clipboardResultMsg)
+	if !ok {
+		t.Fatalf("Expected clipboardResultMsg, got %T", msg)
+	}
+	if result.err != nil {
+		t.Errorf("Expected no error, got %v", result.err)
+	}
+
+	if !strings.Contains(mock.lastText, "Found an issue") {
+		t.Error("Expected review output in clipboard")
+	}
+	if !strings.Contains(mock.lastText, "--- Comments ---") {
+		t.Error("Expected comments section in clipboard")
+	}
+	if !strings.Contains(mock.lastText, "[Mar 10 09:00] dev:") {
+		t.Error("Expected comment header in clipboard")
+	}
+	if !strings.Contains(mock.lastText, "This is expected behavior") {
+		t.Error("Expected comment body in clipboard")
 	}
 }
 
@@ -487,10 +516,77 @@ func TestFormatClipboardContent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := formatClipboardContent(tt.review)
+			got := formatClipboardContent(tt.review, nil)
 			if got != tt.expected {
 				t.Errorf("formatClipboardContent() = %q, want %q", got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestFormatClipboardContentWithResponses(t *testing.T) {
+	review := &storage.Review{
+		ID:     1,
+		JobID:  42,
+		Output: "Some findings here",
+	}
+	responses := []storage.Response{
+		{
+			ID:        1,
+			Responder: "alice",
+			Response:  "Known issue, ignoring",
+			CreatedAt: time.Date(2025, 3, 15, 14, 30, 0, 0, time.UTC),
+		},
+		{
+			ID:        2,
+			Responder: "bob",
+			Response:  "Fixed in next commit",
+			CreatedAt: time.Date(2025, 3, 15, 15, 0, 0, 0, time.UTC),
+		},
+	}
+
+	got := formatClipboardContent(review, responses)
+
+	// Should contain the review output
+	if !strings.Contains(got, "Some findings here") {
+		t.Errorf("Expected review output in result, got %q", got)
+	}
+
+	// Should contain the comments section
+	if !strings.Contains(got, "--- Comments ---") {
+		t.Errorf("Expected comments separator, got %q", got)
+	}
+
+	// Should contain each comment with timestamp and responder
+	if !strings.Contains(got, "[Mar 15 14:30] alice:") {
+		t.Errorf("Expected alice's comment header, got %q", got)
+	}
+	if !strings.Contains(got, "Known issue, ignoring") {
+		t.Errorf("Expected alice's comment body, got %q", got)
+	}
+	if !strings.Contains(got, "[Mar 15 15:00] bob:") {
+		t.Errorf("Expected bob's comment header, got %q", got)
+	}
+	if !strings.Contains(got, "Fixed in next commit") {
+		t.Errorf("Expected bob's comment body, got %q", got)
+	}
+}
+
+func TestFormatClipboardContentNoResponses(t *testing.T) {
+	review := &storage.Review{
+		ID:     1,
+		JobID:  42,
+		Output: "Review content",
+	}
+
+	withNil := formatClipboardContent(review, nil)
+	withEmpty := formatClipboardContent(review, []storage.Response{})
+
+	if withNil != withEmpty {
+		t.Errorf("nil and empty responses should produce same output")
+	}
+
+	if strings.Contains(withNil, "Comments") {
+		t.Error("Should not contain comments section with no responses")
 	}
 }


### PR DESCRIPTION
## Summary

- `formatClipboardContent()` and `copyToClipboard()` now accept responses and append them after the review output using the same `--- Comments ---` format as the TUI review view
- `fetchReviewAndCopy()` (queue-view copy) fetches comments via `loadResponses()` before formatting clipboard content
- `roborev show` fetches and displays comments after the review output
- Provides more context to the fix agent when pasting review output

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)