### PR TITLE
Document auto-written TOML config files

### DIFF
--- a/cmd/roborev/config_cmd.go
+++ b/cmd/roborev/config_cmd.go
@@ -5,11 +5,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"text/tabwriter"
 
-	"github.com/BurntSushi/toml"
 	"github.com/roborev-dev/roborev/internal/config"
 	"github.com/roborev-dev/roborev/internal/git"
 	"github.com/spf13/cobra"
@@ -384,27 +382,39 @@ func printKeyValues(kvs []config.KeyValue) {
 	}
 }
 
-// setConfigKey sets a key in a TOML file using raw map manipulation
-// to avoid writing default values for every field.
-// isGlobal determines which struct (Config vs RepoConfig) validates the key.
+// setConfigKey sets a key in a TOML config file.
 func setConfigKey(path, key, value string, isGlobal bool) error {
-	validationCfg, err := validateKeyForScope(key, value, isGlobal)
+	_, err := validateKeyForScope(key, value, isGlobal)
 	if err != nil {
 		return err
 	}
 
-	raw, err := loadRawConfig(path)
-	if err != nil {
-		return err
+	if isGlobal {
+		cfg, err := config.LoadGlobalFrom(path)
+		if err != nil {
+			return fmt.Errorf("parse %s: %w", path, err)
+		}
+		if err := config.SetConfigValue(cfg, key, value); err != nil {
+			return err
+		}
+		return config.SaveGlobalTo(path, cfg)
 	}
 
-	setRawMapKey(raw, key, coerceValue(validationCfg, key, value))
-
-	return atomicWriteConfig(path, raw, isGlobal)
+	repoDir := filepath.Dir(path)
+	repoCfg, err := config.LoadRepoConfig(repoDir)
+	if err != nil {
+		return fmt.Errorf("parse %s: %w", path, err)
+	}
+	if repoCfg == nil {
+		repoCfg = &config.RepoConfig{}
+	}
+	if err := config.SetConfigValue(repoCfg, key, value); err != nil {
+		return err
+	}
+	return config.SaveRepoConfigTo(path, repoCfg)
 }
 
-// validateKeyForScope validates a key against the appropriate config struct
-// and returns the populated struct for type coercion.
+// validateKeyForScope validates a key against the appropriate config scope.
 func validateKeyForScope(key, value string, isGlobal bool) (any, error) {
 	if isGlobal {
 		cfg := config.DefaultConfig()
@@ -427,72 +437,6 @@ func validateKeyForScope(key, value string, isGlobal bool) (any, error) {
 		return nil, err
 	}
 	return repoCfg, nil
-}
-
-// loadRawConfig loads an existing TOML file as a raw map, or returns
-// an empty map if the file doesn't exist.
-func loadRawConfig(path string) (map[string]any, error) {
-	raw := make(map[string]any)
-	if _, err := os.Stat(path); err == nil {
-		if _, err := toml.DecodeFile(path, &raw); err != nil {
-			return nil, fmt.Errorf("parse %s: %w", path, err)
-		}
-	}
-	return raw, nil
-}
-
-// atomicWriteConfig writes a config map to a TOML file atomically using
-// a temp file and rename. It creates parent directories as needed.
-func atomicWriteConfig(path string, raw map[string]any, isGlobal bool) error {
-	// Ensure directory exists. Use restrictive perms for the global config dir
-	// since it may contain secrets (API keys, DB credentials).
-	dirMode := os.FileMode(0755)
-	if isGlobal {
-		dirMode = 0700
-	}
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, dirMode); err != nil {
-		return err
-	}
-	// MkdirAll is a no-op for existing dirs. Tighten global config dir
-	// in case it was created with a permissive umask.
-	if isGlobal {
-		if err := os.Chmod(dir, dirMode); err != nil {
-			return err
-		}
-	}
-
-	// For global config, always enforce 0600 since it may contain secrets
-	// (API keys, DB credentials). Don't inherit existing permissions — the file
-	// may have been created manually with a permissive umask (0644).
-	// For repo config, preserve existing permissions (may be tracked in git).
-	var mode os.FileMode = 0644
-	if isGlobal {
-		mode = 0600
-	} else if info, err := os.Stat(path); err == nil {
-		mode = info.Mode()
-	}
-
-	f, err := os.CreateTemp(filepath.Dir(path), ".roborev-config-*.toml")
-	if err != nil {
-		return err
-	}
-	tmpPath := f.Name()
-	defer os.Remove(tmpPath)
-
-	if err := toml.NewEncoder(f).Encode(raw); err != nil {
-		f.Close()
-		return err
-	}
-	if err := f.Close(); err != nil {
-		return err
-	}
-
-	if err := os.Chmod(tmpPath, mode); err != nil {
-		return err
-	}
-
-	return os.Rename(tmpPath, path)
 }
 
 // setRawMapKey sets a value in a nested map using dot-separated keys.
@@ -524,48 +468,4 @@ func setRawMapKey(m map[string]any, key string, value any) {
 	}
 
 	current[parts[len(parts)-1]] = value
-}
-
-// coerceValue uses the typed config struct to determine the correct TOML type
-// for the given key's value.
-func coerceValue(validationCfg any, key, rawVal string) any {
-	v := reflect.ValueOf(validationCfg)
-	if v.Kind() == reflect.Ptr {
-		v = v.Elem()
-	}
-	field, err := config.FindFieldByTOMLKey(v, key)
-	if err != nil {
-		// Unreachable: key was already validated by SetConfigValue above.
-		// Fall back to raw string to avoid panicking on impossible paths.
-		return rawVal
-	}
-
-	switch field.Kind() {
-	case reflect.String:
-		return rawVal
-	case reflect.Bool:
-		return field.Bool()
-	case reflect.Int, reflect.Int64:
-		return field.Int()
-	case reflect.Slice:
-		if field.Type().Elem().Kind() == reflect.String {
-			result := make([]any, field.Len())
-			for i := 0; i < field.Len(); i++ {
-				result[i] = field.Index(i).String()
-			}
-			return result
-		}
-		return rawVal
-	case reflect.Ptr:
-		if field.IsNil() {
-			return rawVal
-		}
-		elem := field.Elem()
-		if elem.Kind() == reflect.Bool {
-			return elem.Bool()
-		}
-		return rawVal
-	default:
-		return rawVal
-	}
 }

--- a/cmd/roborev/config_cmd_test.go
+++ b/cmd/roborev/config_cmd_test.go
@@ -425,6 +425,30 @@ func TestSetConfigKeyRepoConfig(t *testing.T) {
 	assertConfigValue(t, path, "agent", "claude-code")
 }
 
+func TestSetConfigKeyRepoConfigWritesComments(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".roborev.toml")
+
+	if err := setConfigKey(path, "agent", "claude-code", false); err != nil {
+		t.Fatalf("setConfigKey repo: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	got := string(data)
+
+	for _, want := range []string{
+		"# Default agent for this repo when no workflow-specific agent is set.\n",
+		"agent = 'claude-code'",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("repo config missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestSetConfigKeyRepoConfigRejectsGlobalACPSettings(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".roborev.toml")
@@ -435,6 +459,30 @@ func TestSetConfigKeyRepoConfigRejectsGlobalACPSettings(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "is a global setting") {
 		t.Fatalf("expected global-setting error, got: %v", err)
+	}
+}
+
+func TestSetConfigKeyGlobalWritesComments(t *testing.T) {
+	path := setupConfigFile(t)
+
+	if err := setConfigKey(path, "default_agent", "codex", true); err != nil {
+		t.Fatalf("setConfigKey: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	got := string(data)
+
+	for _, want := range []string{
+		"# Default agent when no workflow-specific agent is set.\n",
+		"default_agent = 'codex'",
+		"# Hide closed reviews by default in the TUI queue.\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("global config missing %q:\n%s", want, got)
+		}
 	}
 }
 

--- a/cmd/roborev/hook_test.go
+++ b/cmd/roborev/hook_test.go
@@ -467,3 +467,40 @@ func TestInitNoDaemon(t *testing.T) {
 		})
 	}
 }
+
+func TestInitNoDaemonWithAgentCreatesCommentedRepoConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on Windows due to shell script stubs")
+	}
+
+	repo := initNoDaemonSetup(t)
+	setupMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	})
+
+	output := captureStdout(t, func() {
+		cmd := initCmd()
+		cmd.SetArgs([]string{"--no-daemon", "--agent", "codex"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "Created ") || !strings.Contains(output, ".roborev.toml") {
+		t.Fatalf("init output missing repo config creation message:\n%s", output)
+	}
+
+	data, err := os.ReadFile(filepath.Join(repo.Root, ".roborev.toml"))
+	if err != nil {
+		t.Fatalf("read repo config: %v", err)
+	}
+	got := string(data)
+	for _, want := range []string{
+		"# Default agent for this repo when no workflow-specific agent is set.\n",
+		"agent = 'codex'",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("repo config missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/cmd/roborev/init_cmd.go
+++ b/cmd/roborev/init_cmd.go
@@ -56,8 +56,8 @@ func initCmd() *cobra.Command {
 			repoConfigPath := filepath.Join(root, ".roborev.toml")
 			if agent != "" {
 				if _, err := os.Stat(repoConfigPath); os.IsNotExist(err) {
-					repoConfig := fmt.Sprintf("# roborev per-repo configuration\nagent = %q\n", agent)
-					if err := os.WriteFile(repoConfigPath, []byte(repoConfig), 0644); err != nil {
+					repoConfig := &config.RepoConfig{Agent: agent}
+					if err := config.SaveRepoConfigTo(repoConfigPath, repoConfig); err != nil {
 						return fmt.Errorf("create repo config: %w", err)
 					}
 					fmt.Printf("  Created %s\n", repoConfigPath)

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
 
             src = ./.;
 
-            vendorHash = "sha256-7meKrlC0b5N/TOrZJov/IQOs8FzhnNJ/3rnbDejtBKs=";
+            vendorHash = "sha256-HRVNiDpEoEFQZ7oMhGL+oAcqGdng4B14nTMebtBzufk=";
 
             subPackages = [ "cmd/roborev" ];
 

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-runewidth v0.0.20
 	github.com/muesli/termenv v0.16.0
+	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/sourcegraph/go-diff v0.7.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
+github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
+github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+	tomlv2 "github.com/pelletier/go-toml/v2"
 	"github.com/roborev-dev/roborev/internal/git"
 )
 
@@ -45,7 +46,7 @@ type HookConfig struct {
 }
 
 type AdvancedConfig struct {
-	TasksEnabled bool `toml:"tasks_enabled"` // Enables advanced TUI tasks workflow
+	TasksEnabled bool `toml:"tasks_enabled" comment:"Enable the advanced Tasks workflow in the TUI."` // Enables advanced TUI tasks workflow
 }
 
 // Config holds the daemon configuration
@@ -54,7 +55,7 @@ type Config struct {
 	MaxWorkers                 int    `toml:"max_workers"`
 	ReviewContextCount         int    `toml:"review_context_count"`
 	ReuseReviewSessionLookback int    `toml:"reuse_review_session_lookback"` // 0 means no candidate cap
-	DefaultAgent               string `toml:"default_agent"`
+	DefaultAgent               string `toml:"default_agent" comment:"Default agent when no workflow-specific agent is set."`
 	DefaultModel               string `toml:"default_model"` // Default model for agents (format varies by agent)
 	DefaultBackupAgent         string `toml:"default_backup_agent"`
 	DefaultBackupModel         string `toml:"default_backup_model"`
@@ -141,16 +142,16 @@ type Config struct {
 	DefaultMaxPromptSize int `toml:"default_max_prompt_size"` // Max prompt size in bytes before falling back to paths (default: 200KB)
 
 	// UI preferences
-	HideClosedByDefault    bool     `toml:"hide_closed_by_default"`
+	HideClosedByDefault    bool     `toml:"hide_closed_by_default" comment:"Hide closed reviews by default in the TUI queue."`
 	HideAddressedByDefault bool     `toml:"hide_addressed_by_default"` // deprecated: use hide_closed_by_default
-	AutoFilterRepo         bool     `toml:"auto_filter_repo"`
-	AutoFilterBranch       bool     `toml:"auto_filter_branch"`
-	MouseEnabled           bool     `toml:"mouse_enabled"`     // Enable mouse capture and mouse-driven TUI interactions
-	TabWidth               int      `toml:"tab_width"`         // Tab expansion width for TUI rendering (default: 2)
-	HiddenColumns          []string `toml:"hidden_columns"`    // Column names to hide in queue table (e.g. ["branch", "agent"])
-	ColumnBorders          bool     `toml:"column_borders"`    // Show ▕ separators between columns
-	ColumnOrder            []string `toml:"column_order"`      // Custom queue column display order
-	TaskColumnOrder        []string `toml:"task_column_order"` // Custom task column display order
+	AutoFilterRepo         bool     `toml:"auto_filter_repo" comment:"Automatically filter the TUI queue to the current repo."`
+	AutoFilterBranch       bool     `toml:"auto_filter_branch" comment:"Automatically filter the TUI queue to the current branch."`
+	MouseEnabled           bool     `toml:"mouse_enabled" comment:"Enable mouse support in the TUI."`          // Enable mouse capture and mouse-driven TUI interactions
+	TabWidth               int      `toml:"tab_width"`                                                         // Tab expansion width for TUI rendering (default: 2)
+	HiddenColumns          []string `toml:"hidden_columns" comment:"Queue columns to hide in the TUI."`        // Column names to hide in queue table (e.g. ["branch", "agent"])
+	ColumnBorders          bool     `toml:"column_borders" comment:"Show column borders in the TUI queue."`    // Show ▕ separators between columns
+	ColumnOrder            []string `toml:"column_order" comment:"Custom queue column order in the TUI."`      // Custom queue column display order
+	TaskColumnOrder        []string `toml:"task_column_order" comment:"Custom Tasks column order in the TUI."` // Custom task column display order
 
 	// Advanced feature flags
 	Advanced AdvancedConfig `toml:"advanced"`
@@ -527,44 +528,44 @@ func (c *SyncConfig) Validate() []string {
 // These override the global [ci] settings when reviewing this specific repo.
 type RepoCIConfig struct {
 	// Agents overrides the list of agents for CI reviews of this repo.
-	Agents []string `toml:"agents"`
+	Agents []string `toml:"agents" comment:"Override the agents used by CI for this repo."`
 
 	// ReviewTypes overrides the list of review types for CI reviews of this repo.
-	ReviewTypes []string `toml:"review_types"`
+	ReviewTypes []string `toml:"review_types" comment:"Override the review types used by CI for this repo."`
 
 	// Reviews maps agent names to review type lists. When set, replaces
 	// the ReviewTypes x Agents cross-product for this repo.
-	Reviews map[string][]string `toml:"reviews"`
+	Reviews map[string][]string `toml:"reviews" comment:"Explicit CI review matrix for this repo: agent name to review types."`
 
 	// Reasoning overrides the reasoning level for CI reviews (thorough, standard, fast).
-	Reasoning string `toml:"reasoning"`
+	Reasoning string `toml:"reasoning" comment:"Override the CI reasoning level for this repo: fast, standard, or thorough."`
 
 	// MinSeverity overrides the minimum severity filter for CI synthesis.
-	MinSeverity string `toml:"min_severity"`
+	MinSeverity string `toml:"min_severity" comment:"Override the minimum CI severity included in synthesized output."`
 
 	// UpsertComments overrides the global ci.upsert_comments setting.
 	// Use a pointer so we can distinguish "not set" from "explicitly false".
-	UpsertComments *bool `toml:"upsert_comments"`
+	UpsertComments *bool `toml:"upsert_comments" comment:"Override whether CI updates an existing PR comment instead of creating a new one."`
 }
 
 // RepoConfig holds per-repo overrides
 type RepoConfig struct {
-	Agent                      string   `toml:"agent"`
-	Model                      string   `toml:"model"` // Model for agents (format varies by agent)
-	BackupAgent                string   `toml:"backup_agent"`
-	BackupModel                string   `toml:"backup_model"`
-	ReviewContextCount         int      `toml:"review_context_count"`
-	ReviewGuidelines           string   `toml:"review_guidelines"`
-	JobTimeoutMinutes          int      `toml:"job_timeout_minutes"`
-	ExcludedBranches           []string `toml:"excluded_branches"`
-	ExcludedCommitPatterns     []string `toml:"excluded_commit_patterns"`
-	DisplayName                string   `toml:"display_name"`
-	ReviewReasoning            string   `toml:"review_reasoning"`              // Reasoning level for reviews: thorough, standard, fast
-	RefineReasoning            string   `toml:"refine_reasoning"`              // Reasoning level for refine: thorough, standard, fast
-	FixReasoning               string   `toml:"fix_reasoning"`                 // Reasoning level for fix: thorough, standard, fast
-	FixMinSeverity             string   `toml:"fix_min_severity"`              // Minimum severity for fix: critical, high, medium, low
-	RefineMinSeverity          string   `toml:"refine_min_severity"`           // Minimum severity for refine: critical, high, medium, low
-	PostCommitReview           string   `toml:"post_commit_review"`            // "commit" (default) or "branch"
+	Agent                      string   `toml:"agent" comment:"Default agent for this repo when no workflow-specific agent is set."`
+	Model                      string   `toml:"model" comment:"Default model for this repo when no workflow-specific model is set."` // Model for agents (format varies by agent)
+	BackupAgent                string   `toml:"backup_agent" comment:"Backup agent for this repo if the primary agent fails."`
+	BackupModel                string   `toml:"backup_model" comment:"Backup model for this repo if the primary model fails."`
+	ReviewContextCount         int      `toml:"review_context_count" comment:"Number of related reviews to include as context for this repo."`
+	ReviewGuidelines           string   `toml:"review_guidelines" comment:"Extra review instructions added to prompts for this repo."`
+	JobTimeoutMinutes          int      `toml:"job_timeout_minutes" comment:"Override the review job timeout in minutes for this repo."`
+	ExcludedBranches           []string `toml:"excluded_branches" comment:"Branches that should be skipped for automatic review in this repo."`
+	ExcludedCommitPatterns     []string `toml:"excluded_commit_patterns" comment:"Commit message substrings that should skip review for this repo."`
+	DisplayName                string   `toml:"display_name" comment:"Display name shown for this repo in the TUI and output."`
+	ReviewReasoning            string   `toml:"review_reasoning" comment:"Reasoning level for reviews in this repo: fast, standard, or thorough."`    // Reasoning level for reviews: thorough, standard, fast
+	RefineReasoning            string   `toml:"refine_reasoning" comment:"Reasoning level for refine in this repo: fast, standard, or thorough."`     // Reasoning level for refine: thorough, standard, fast
+	FixReasoning               string   `toml:"fix_reasoning" comment:"Reasoning level for fix in this repo: fast, standard, or thorough."`           // Reasoning level for fix: thorough, standard, fast
+	FixMinSeverity             string   `toml:"fix_min_severity" comment:"Minimum severity for fix in this repo: critical, high, medium, or low."`    // Minimum severity for fix: critical, high, medium, low
+	RefineMinSeverity          string   `toml:"refine_min_severity" comment:"Minimum severity for refine in this repo: critical, high, medium, low."` // Minimum severity for refine: critical, high, medium, low
+	PostCommitReview           string   `toml:"post_commit_review" comment:"Automatic post-commit review mode for this repo: commit or branch."`      // "commit" (default) or "branch"
 	ReuseReviewSession         *bool    `toml:"reuse_review_session"`
 	ReuseReviewSessionLookback int      `toml:"reuse_review_session_lookback"` // 0 means no candidate cap
 
@@ -572,66 +573,66 @@ type RepoConfig struct {
 	CI RepoCIConfig `toml:"ci"`
 
 	// Workflow-specific agent/model configuration
-	ReviewAgent           string `toml:"review_agent"`
-	ReviewAgentFast       string `toml:"review_agent_fast"`
-	ReviewAgentStandard   string `toml:"review_agent_standard"`
-	ReviewAgentThorough   string `toml:"review_agent_thorough"`
-	RefineAgent           string `toml:"refine_agent"`
-	RefineAgentFast       string `toml:"refine_agent_fast"`
-	RefineAgentStandard   string `toml:"refine_agent_standard"`
-	RefineAgentThorough   string `toml:"refine_agent_thorough"`
-	ReviewModel           string `toml:"review_model"`
-	ReviewModelFast       string `toml:"review_model_fast"`
-	ReviewModelStandard   string `toml:"review_model_standard"`
-	ReviewModelThorough   string `toml:"review_model_thorough"`
-	RefineModel           string `toml:"refine_model"`
-	RefineModelFast       string `toml:"refine_model_fast"`
-	RefineModelStandard   string `toml:"refine_model_standard"`
-	RefineModelThorough   string `toml:"refine_model_thorough"`
-	FixAgent              string `toml:"fix_agent"`
-	FixAgentFast          string `toml:"fix_agent_fast"`
-	FixAgentStandard      string `toml:"fix_agent_standard"`
-	FixAgentThorough      string `toml:"fix_agent_thorough"`
-	FixModel              string `toml:"fix_model"`
-	FixModelFast          string `toml:"fix_model_fast"`
-	FixModelStandard      string `toml:"fix_model_standard"`
-	FixModelThorough      string `toml:"fix_model_thorough"`
-	SecurityAgent         string `toml:"security_agent"`
-	SecurityAgentFast     string `toml:"security_agent_fast"`
-	SecurityAgentStandard string `toml:"security_agent_standard"`
-	SecurityAgentThorough string `toml:"security_agent_thorough"`
-	SecurityModel         string `toml:"security_model"`
-	SecurityModelFast     string `toml:"security_model_fast"`
-	SecurityModelStandard string `toml:"security_model_standard"`
-	SecurityModelThorough string `toml:"security_model_thorough"`
-	DesignAgent           string `toml:"design_agent"`
-	DesignAgentFast       string `toml:"design_agent_fast"`
-	DesignAgentStandard   string `toml:"design_agent_standard"`
-	DesignAgentThorough   string `toml:"design_agent_thorough"`
-	DesignModel           string `toml:"design_model"`
-	DesignModelFast       string `toml:"design_model_fast"`
-	DesignModelStandard   string `toml:"design_model_standard"`
-	DesignModelThorough   string `toml:"design_model_thorough"`
+	ReviewAgent           string `toml:"review_agent" comment:"Agent override for standard review in this repo."`
+	ReviewAgentFast       string `toml:"review_agent_fast" comment:"Agent override for fast review in this repo."`
+	ReviewAgentStandard   string `toml:"review_agent_standard" comment:"Agent override for standard review in this repo."`
+	ReviewAgentThorough   string `toml:"review_agent_thorough" comment:"Agent override for thorough review in this repo."`
+	RefineAgent           string `toml:"refine_agent" comment:"Agent override for refine in this repo."`
+	RefineAgentFast       string `toml:"refine_agent_fast" comment:"Agent override for fast refine in this repo."`
+	RefineAgentStandard   string `toml:"refine_agent_standard" comment:"Agent override for standard refine in this repo."`
+	RefineAgentThorough   string `toml:"refine_agent_thorough" comment:"Agent override for thorough refine in this repo."`
+	ReviewModel           string `toml:"review_model" comment:"Model override for standard review in this repo."`
+	ReviewModelFast       string `toml:"review_model_fast" comment:"Model override for fast review in this repo."`
+	ReviewModelStandard   string `toml:"review_model_standard" comment:"Model override for standard review in this repo."`
+	ReviewModelThorough   string `toml:"review_model_thorough" comment:"Model override for thorough review in this repo."`
+	RefineModel           string `toml:"refine_model" comment:"Model override for standard refine in this repo."`
+	RefineModelFast       string `toml:"refine_model_fast" comment:"Model override for fast refine in this repo."`
+	RefineModelStandard   string `toml:"refine_model_standard" comment:"Model override for standard refine in this repo."`
+	RefineModelThorough   string `toml:"refine_model_thorough" comment:"Model override for thorough refine in this repo."`
+	FixAgent              string `toml:"fix_agent" comment:"Agent override for fix in this repo."`
+	FixAgentFast          string `toml:"fix_agent_fast" comment:"Agent override for fast fix in this repo."`
+	FixAgentStandard      string `toml:"fix_agent_standard" comment:"Agent override for standard fix in this repo."`
+	FixAgentThorough      string `toml:"fix_agent_thorough" comment:"Agent override for thorough fix in this repo."`
+	FixModel              string `toml:"fix_model" comment:"Model override for standard fix in this repo."`
+	FixModelFast          string `toml:"fix_model_fast" comment:"Model override for fast fix in this repo."`
+	FixModelStandard      string `toml:"fix_model_standard" comment:"Model override for standard fix in this repo."`
+	FixModelThorough      string `toml:"fix_model_thorough" comment:"Model override for thorough fix in this repo."`
+	SecurityAgent         string `toml:"security_agent" comment:"Agent override for security review in this repo."`
+	SecurityAgentFast     string `toml:"security_agent_fast" comment:"Agent override for fast security review in this repo."`
+	SecurityAgentStandard string `toml:"security_agent_standard" comment:"Agent override for standard security review in this repo."`
+	SecurityAgentThorough string `toml:"security_agent_thorough" comment:"Agent override for thorough security review in this repo."`
+	SecurityModel         string `toml:"security_model" comment:"Model override for standard security review in this repo."`
+	SecurityModelFast     string `toml:"security_model_fast" comment:"Model override for fast security review in this repo."`
+	SecurityModelStandard string `toml:"security_model_standard" comment:"Model override for standard security review in this repo."`
+	SecurityModelThorough string `toml:"security_model_thorough" comment:"Model override for thorough security review in this repo."`
+	DesignAgent           string `toml:"design_agent" comment:"Agent override for design review in this repo."`
+	DesignAgentFast       string `toml:"design_agent_fast" comment:"Agent override for fast design review in this repo."`
+	DesignAgentStandard   string `toml:"design_agent_standard" comment:"Agent override for standard design review in this repo."`
+	DesignAgentThorough   string `toml:"design_agent_thorough" comment:"Agent override for thorough design review in this repo."`
+	DesignModel           string `toml:"design_model" comment:"Model override for standard design review in this repo."`
+	DesignModelFast       string `toml:"design_model_fast" comment:"Model override for fast design review in this repo."`
+	DesignModelStandard   string `toml:"design_model_standard" comment:"Model override for standard design review in this repo."`
+	DesignModelThorough   string `toml:"design_model_thorough" comment:"Model override for thorough design review in this repo."`
 
 	// Backup agents for failover
-	ReviewBackupAgent   string `toml:"review_backup_agent"`
-	RefineBackupAgent   string `toml:"refine_backup_agent"`
-	FixBackupAgent      string `toml:"fix_backup_agent"`
-	SecurityBackupAgent string `toml:"security_backup_agent"`
-	DesignBackupAgent   string `toml:"design_backup_agent"`
+	ReviewBackupAgent   string `toml:"review_backup_agent" comment:"Backup agent for review in this repo."`
+	RefineBackupAgent   string `toml:"refine_backup_agent" comment:"Backup agent for refine in this repo."`
+	FixBackupAgent      string `toml:"fix_backup_agent" comment:"Backup agent for fix in this repo."`
+	SecurityBackupAgent string `toml:"security_backup_agent" comment:"Backup agent for security review in this repo."`
+	DesignBackupAgent   string `toml:"design_backup_agent" comment:"Backup agent for design review in this repo."`
 
 	// Backup models for failover (used when failing over to backup agent)
-	ReviewBackupModel   string `toml:"review_backup_model"`
-	RefineBackupModel   string `toml:"refine_backup_model"`
-	FixBackupModel      string `toml:"fix_backup_model"`
-	SecurityBackupModel string `toml:"security_backup_model"`
-	DesignBackupModel   string `toml:"design_backup_model"`
+	ReviewBackupModel   string `toml:"review_backup_model" comment:"Backup model for review in this repo."`
+	RefineBackupModel   string `toml:"refine_backup_model" comment:"Backup model for refine in this repo."`
+	FixBackupModel      string `toml:"fix_backup_model" comment:"Backup model for fix in this repo."`
+	SecurityBackupModel string `toml:"security_backup_model" comment:"Backup model for security review in this repo."`
+	DesignBackupModel   string `toml:"design_backup_model" comment:"Backup model for design review in this repo."`
 
 	// Hooks configuration (per-repo)
 	Hooks []HookConfig `toml:"hooks"`
 
 	// Analysis settings
-	MaxPromptSize int `toml:"max_prompt_size"` // Max prompt size in bytes before falling back to paths (overrides global default)
+	MaxPromptSize int `toml:"max_prompt_size" comment:"Maximum prompt size for this repo before falling back to file paths."` // Max prompt size in bytes before falling back to paths (overrides global default)
 }
 
 // DefaultConfig returns the default configuration
@@ -1380,18 +1381,74 @@ func globalWorkflowField(g *Config, workflow, level string, isAgent bool) string
 
 // SaveGlobal saves the global configuration
 func SaveGlobal(cfg *Config) error {
-	path := GlobalConfigPath()
+	return SaveGlobalTo(GlobalConfigPath(), cfg)
+}
+
+// SaveGlobalTo saves the global configuration to a specific path.
+func SaveGlobalTo(path string, cfg *Config) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
 
-	f, err := os.Create(path)
+	data, err := tomlv2.Marshal(cfg)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 
-	return toml.NewEncoder(f).Encode(cfg)
+	f, err := os.CreateTemp(filepath.Dir(path), ".roborev-config-*.toml")
+	if err != nil {
+		return err
+	}
+	tmpPath := f.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpPath, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+// SaveRepoConfigTo saves a per-repo configuration to a specific path.
+func SaveRepoConfigTo(path string, cfg *RepoConfig) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+
+	data, err := tomlv2.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+
+	mode := os.FileMode(0644)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode()
+	}
+
+	f, err := os.CreateTemp(filepath.Dir(path), ".roborev-repo-config-*.toml")
+	if err != nil {
+		return err
+	}
+	tmpPath := f.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpPath, mode); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
 }
 
 // roborevIDPattern validates .roborev-id content.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2046,6 +2046,38 @@ func TestAdvancedTasksEnabledPersistence(t *testing.T) {
 	}
 }
 
+func TestSaveGlobalWritesDocumentedSettings(t *testing.T) {
+	testenv.SetDataDir(t)
+
+	cfg := DefaultConfig()
+	cfg.DefaultAgent = "claude-code"
+	cfg.HideClosedByDefault = true
+	cfg.MouseEnabled = false
+	cfg.Advanced.TasksEnabled = true
+
+	if err := SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal failed: %v", err)
+	}
+
+	data, err := os.ReadFile(GlobalConfigPath())
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	got := string(data)
+
+	for _, want := range []string{
+		"default_agent = 'claude-code'",
+		"# Hide closed reviews by default in the TUI queue.\nhide_closed_by_default = true",
+		"# Enable mouse support in the TUI.\nmouse_enabled = false",
+		"[advanced]\n# Enable the advanced Tasks workflow in the TUI.\ntasks_enabled = true",
+		"max_workers = 4",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("saved config missing documented setting %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestHideAddressedDeprecatedMigration(t *testing.T) {
 	testenv.SetDataDir(t)
 


### PR DESCRIPTION
## Summary
- switch global config writes to `go-toml/v2` so auto-written TOML can include inline comments
- route `roborev config set` global and local writes through typed save helpers so both `config.toml` and `.roborev.toml` get documented output
- update `roborev init --agent ...` to create a commented repo config scaffold and add regression coverage for the global, local, and init paths

## Test Plan
- go vet ./...
- go test ./...