### PR TITLE
Honor *_cmd config values for agent availability checks

### DIFF
--- a/internal/agent/acp.go
+++ b/internal/agent/acp.go
@@ -1591,7 +1591,22 @@ func GetAvailableWithConfig(preferred string, cfg *config.Config, backups ...str
 			}
 		}
 
-		// Finally fall back to normal auto-selection (with backups).
+		// ACP unavailable — try backup agents with config-aware
+		// availability so *_cmd overrides are honored.
+		if cfg != nil {
+			for _, b := range backups {
+				b = resolveAlias(b)
+				if b == "" {
+					continue
+				}
+				if _, ok := registry[b]; ok && isAvailableWithConfig(b, cfg) {
+					a, _ := Get(b)
+					return applyCommandOverrides(a, cfg), nil
+				}
+			}
+		}
+
+		// Finally fall back to normal auto-selection.
 		return GetAvailable("", backups...)
 	}
 

--- a/internal/agent/acp_test.go
+++ b/internal/agent/acp_test.go
@@ -1149,6 +1149,49 @@ func TestGetAvailableWithConfigPiCmd(t *testing.T) {
 	assert.Equal(t, filepath.Join(fakeBin, wrapper), ca.CommandName())
 }
 
+func TestGetAvailableWithConfigACPFallbackBackupUsesConfigCmd(t *testing.T) {
+	// Configured ACP alias is requested but ACP command is
+	// unavailable. The backup agent's default command is also
+	// unavailable, but its *_cmd override points to a real binary.
+	// The config-aware backup path should find it.
+	fakeBin := t.TempDir()
+	wrapper := "claude-wrapper"
+	if runtime.GOOS == "windows" {
+		wrapper += ".exe"
+	}
+	err := os.WriteFile(
+		filepath.Join(fakeBin, wrapper),
+		[]byte("#!/bin/sh\nexit 0\n"), 0o755,
+	)
+	require.NoError(t, err)
+	t.Setenv("PATH", fakeBin)
+
+	originalRegistry := registry
+	registry = map[string]Agent{
+		"claude-code": NewClaudeAgent(""),
+	}
+	t.Cleanup(func() { registry = originalRegistry })
+
+	cfg := &config.Config{
+		ACP: &config.ACPAgentConfig{
+			Name:    "my-acp",
+			Command: "nonexistent-acp-binary",
+		},
+		ClaudeCodeCmd: filepath.Join(fakeBin, wrapper),
+	}
+
+	resolved, err := GetAvailableWithConfig(
+		"my-acp", cfg, "claude-code",
+	)
+	require.NoError(t, err,
+		"backup should resolve via config cmd when ACP is unavailable")
+	assert.Equal(t, "claude-code", resolved.Name())
+
+	ca, ok := resolved.(CommandAgent)
+	require.True(t, ok)
+	assert.Equal(t, filepath.Join(fakeBin, wrapper), ca.CommandName())
+}
+
 func TestGetAvailableWithConfigEmptyPreferredBackupUsesConfigCmd(t *testing.T) {
 	// preferred="" with a backup agent whose default command isn't in
 	// PATH but whose configured command is. The backup should still


### PR DESCRIPTION
## Summary

- Extract the inline command override switch in `GetAvailableWithConfig` into a reusable `applyCommandOverrides` helper that clones an agent and sets the configured command path
- Add `isAvailableWithConfig` that checks agent availability using the configured command before falling back to the hardcoded default, so agents are found even when only the configured binary is in PATH
- `GetAvailableWithConfig` now checks the preferred agent and backup agents with config-aware availability before falling through to the `GetAvailable` fallback chain
- Add tests for `claude_code_cmd`, `codex_cmd`, `cursor_cmd`, and `pi_cmd` overrides, including the case where only the configured command is available

Fixes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)