### PR TITLE
Fix post-commit hook to use main repo root in git worktrees

### DIFF
--- a/cmd/roborev/postcommit_test.go
+++ b/cmd/roborev/postcommit_test.go
@@ -295,16 +295,20 @@ func TestPostCommitSendsLocalRepoPath(t *testing.T) {
 // end-to-end shell hook flow.
 func TestPostCommitSkipsEnqueueDuringRebase(t *testing.T) {
 	tests := []struct {
-		name string
-		dir  string // directory to create inside .git/
+		name     string
+		setup    func(t *testing.T) repoUnderTest
+		sentinel string // directory to create inside git dir
 	}{
-		{"rebase-merge", "rebase-merge"},
-		{"rebase-apply", "rebase-apply"},
+		{"plain repo/rebase-merge", setupPlainRepo, "rebase-merge"},
+		{"plain repo/rebase-apply", setupPlainRepo, "rebase-apply"},
+		{"worktree/rebase-merge", setupWorktreeRepo, "rebase-merge"},
+		{"worktree/rebase-apply", setupWorktreeRepo, "rebase-apply"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			repo, mux := setupTestEnvironment(t)
-			repo.CommitFile("file.txt", "content", "initial")
+			r := tt.setup(t)
+			mux := http.NewServeMux()
+			daemonFromHandler(t, mux)
 
 			mux.HandleFunc("/api/enqueue", func(
 				w http.ResponseWriter, r *http.Request,
@@ -313,12 +317,17 @@ func TestPostCommitSkipsEnqueueDuringRebase(t *testing.T) {
 				http.Error(w, "unexpected", http.StatusConflict)
 			})
 
-			// Simulate rebase state by creating the sentinel directory.
-			gitDir := filepath.Join(repo.Dir, ".git")
+			// Resolve the actual git dir (may differ from .git/ in
+			// linked worktrees where .git is a file).
+			gitDir := strings.TrimSpace(r.repo.Run(
+				"rev-parse", "--git-dir"))
+			if !filepath.IsAbs(gitDir) {
+				gitDir = filepath.Join(r.repo.Dir, gitDir)
+			}
 			require.NoError(t, os.MkdirAll(
-				filepath.Join(gitDir, tt.dir), 0755))
+				filepath.Join(gitDir, tt.sentinel), 0755))
 
-			_, _, err := executePostCommitCmd("--repo", repo.Dir)
+			_, _, err := executePostCommitCmd("--repo", r.repo.Dir)
 			require.NoError(t, err)
 		})
 	}


### PR DESCRIPTION
## Summary

- When the post-commit hook fires from a linked git worktree, `GetRepoRoot` returns the worktree path rather than the main repo root, causing the daemon to register the commit under a phantom repo entry
- Fix by using `GetMainRepoRoot` for the `RepoPath` sent to the daemon, while keeping `GetRepoRoot` (worktree-local path) for rebase detection and branch/ref resolution, since those states live in the worktree-specific git dir
- Adds table-driven tests covering both plain repo and worktree cases for `RepoPath` correctness and rebase suppression during in-progress rebases