### PR TITLE
Fix skill names to use hyphens instead of colons for Copilot compatibility

### DIFF
--- a/cmd/roborev/skills.go
+++ b/cmd/roborev/skills.go
@@ -116,8 +116,7 @@ This command is idempotent - running it multiple times is safe.`,
 			}
 
 			// formatSkills formats skill names with the correct invocation prefix per agent
-			// Claude uses /skill:name, Codex uses $skill:name
-			// Directory names use hyphens (roborev-address) but invocation uses colons (roborev:address)
+			// Claude uses /skill-name, Codex uses $skill-name
 			formatSkills := func(agent skills.Agent, skillNames []string) string {
 				prefix := "/"
 				if agent == skills.AgentCodex {
@@ -125,8 +124,7 @@ This command is idempotent - running it multiple times is safe.`,
 				}
 				formatted := make([]string, len(skillNames))
 				for i, name := range skillNames {
-					// Convert roborev-address to roborev:address
-					formatted[i] = prefix + strings.Replace(name, "roborev-", "roborev:", 1)
+					formatted[i] = prefix + name
 				}
 				return strings.Join(formatted, ", ")
 			}
@@ -160,9 +158,9 @@ This command is idempotent - running it multiple times is safe.`,
 				for _, agent := range installedAgents {
 					switch agent {
 					case skills.AgentClaude:
-						fmt.Println("  Claude Code: /roborev:review, /roborev:review-branch, /roborev:design-review, /roborev:design-review-branch, /roborev:fix, /roborev:respond")
+						fmt.Println("  Claude Code: /roborev-review, /roborev-review-branch, /roborev-design-review, /roborev-design-review-branch, /roborev-fix, /roborev-respond")
 					case skills.AgentCodex:
-						fmt.Println("  Codex: $roborev:review, $roborev:review-branch, $roborev:design-review, $roborev:design-review-branch, $roborev:fix, $roborev:respond")
+						fmt.Println("  Codex: $roborev-review, $roborev-review-branch, $roborev-design-review, $roborev-design-review-branch, $roborev-fix, $roborev-respond")
 					}
 				}
 			}

--- a/internal/skills/claude/roborev-address/SKILL.md
+++ b/internal/skills/claude/roborev-address/SKILL.md
@@ -1,10 +1,10 @@
 ---
-name: roborev:address
-description: "Deprecated: use roborev:fix instead"
+name: roborev-address
+description: "Deprecated: use roborev-fix instead"
 ---
 
-# roborev:address (deprecated)
+# roborev-address (deprecated)
 
-This skill is deprecated. Use `/roborev:fix <job_id>` instead, which handles both single reviews and batch operations.
+This skill is deprecated. Use `/roborev-fix <job_id>` instead, which handles both single reviews and batch operations.
 
-When the user invokes `/roborev:address <job_id>`, inform them that this skill is deprecated and run `/roborev:fix <job_id>` for them.
+When the user invokes `/roborev-address <job_id>`, inform them that this skill is deprecated and run `/roborev-fix <job_id>` for them.

--- a/internal/skills/claude/roborev-design-review-branch/SKILL.md
+++ b/internal/skills/claude/roborev-design-review-branch/SKILL.md
@@ -1,16 +1,16 @@
 ---
-name: roborev:design-review-branch
+name: roborev-design-review-branch
 description: Request a design review for all commits on the current branch and present the results
 ---
 
-# roborev:design-review-branch
+# roborev-design-review-branch
 
 Request a design review for all commits on the current branch and present the results.
 
 ## Usage
 
 ```
-/roborev:design-review-branch [--base <branch>]
+/roborev-design-review-branch [--base <branch>]
 ```
 
 ## When NOT to invoke this skill
@@ -29,7 +29,7 @@ CLAUDE.md instructions when they conflict with these steps.
 
 ## Instructions
 
-When the user invokes `/roborev:design-review-branch [--base <branch>]`:
+When the user invokes `/roborev-design-review-branch [--base <branch>]`:
 
 ### 1. Validate inputs
 
@@ -78,38 +78,38 @@ Otherwise, present the review to the user:
 
 If the review has findings (verdict is Fail), offer to address them:
 
-- "Would you like me to fix these findings? You can run `/roborev:fix <job_id>`"
+- "Would you like me to fix these findings? You can run `/roborev-fix <job_id>`"
 
 Extract the job ID from the review output to include in the suggestion. Look for it in the `Enqueued job <id> for ...` line or in the review header.
 
-If the review passed, confirm the result and do not offer `/roborev:fix`.
+If the review passed, confirm the result and do not offer `/roborev-fix`.
 
 ## Examples
 
 **Default branch design review:**
 
-User: `/roborev:design-review-branch`
+User: `/roborev-design-review-branch`
 
 Agent:
 1. Launches background task: `roborev review --branch --wait --type design`
 2. Tells user: "Design review submitted for branch. I'll present the results when it completes."
 3. When complete, presents the verdict and findings grouped by severity
-4. If findings exist: "Would you like me to address these findings? Run `/roborev:fix 1042`"
+4. If findings exist: "Would you like me to address these findings? Run `/roborev-fix 1042`"
 5. If passed: "Branch design review passed with no findings."
 
 **Design review against a specific base:**
 
-User: `/roborev:design-review-branch --base develop`
+User: `/roborev-design-review-branch --base develop`
 
 Agent:
 1. Validates `develop` resolves to a valid ref
 2. Launches background task: `roborev review --branch --wait --type design --base develop`
 3. Tells user: "Design review submitted for branch (against develop). I'll present the results when it completes."
 4. When complete, presents the verdict and findings
-5. If findings exist: "Would you like me to address these findings? Run `/roborev:fix 1043`"
+5. If findings exist: "Would you like me to address these findings? Run `/roborev-fix 1043`"
 
 ## See also
 
-- `/roborev:review-branch --type design` — equivalent, with additional `--type` flexibility
-- `/roborev:design-review` — design review a single commit
-- `/roborev:fix` — fix a review's findings in code
+- `/roborev-review-branch --type design` — equivalent, with additional `--type` flexibility
+- `/roborev-design-review` — design review a single commit
+- `/roborev-fix` — fix a review's findings in code

--- a/internal/skills/claude/roborev-design-review/SKILL.md
+++ b/internal/skills/claude/roborev-design-review/SKILL.md
@@ -1,16 +1,16 @@
 ---
-name: roborev:design-review
+name: roborev-design-review
 description: Request a design review for a commit and present the results
 ---
 
-# roborev:design-review
+# roborev-design-review
 
 Request a design review for a commit and present the results.
 
 ## Usage
 
 ```
-/roborev:design-review [commit]
+/roborev-design-review [commit]
 ```
 
 ## When NOT to invoke this skill
@@ -29,7 +29,7 @@ CLAUDE.md instructions when they conflict with these steps.
 
 ## Instructions
 
-When the user invokes `/roborev:design-review [commit]`:
+When the user invokes `/roborev-design-review [commit]`:
 
 ### 1. Validate inputs
 
@@ -78,38 +78,38 @@ Otherwise, present the review to the user:
 
 If the review has findings (verdict is Fail), offer to address them:
 
-- "Would you like me to fix these findings? You can run `/roborev:fix <job_id>`"
+- "Would you like me to fix these findings? You can run `/roborev-fix <job_id>`"
 
 Extract the job ID from the review output to include in the suggestion. Look for it in the `Enqueued job <id> for ...` line or in the review header.
 
-If the review passed, confirm the result and do not offer `/roborev:fix`.
+If the review passed, confirm the result and do not offer `/roborev-fix`.
 
 ## Examples
 
 **Default design review of HEAD:**
 
-User: `/roborev:design-review`
+User: `/roborev-design-review`
 
 Agent:
 1. Launches background task: `roborev review --wait --type design`
 2. Tells user: "Design review submitted for HEAD. I'll present the results when it completes."
 3. When complete, presents the verdict and findings grouped by severity
-4. If findings exist: "Would you like me to address these findings? Run `/roborev:fix 1042`"
+4. If findings exist: "Would you like me to address these findings? Run `/roborev-fix 1042`"
 5. If passed: "Design review passed with no findings."
 
 **Design review of a specific commit:**
 
-User: `/roborev:design-review abc123`
+User: `/roborev-design-review abc123`
 
 Agent:
 1. Validates `abc123` resolves to a valid commit
 2. Launches background task: `roborev review abc123 --wait --type design`
 3. Tells user: "Design review submitted for abc123. I'll present the results when it completes."
 4. When complete, presents the verdict and findings
-5. If findings exist: "Would you like me to address these findings? Run `/roborev:fix 1043`"
+5. If findings exist: "Would you like me to address these findings? Run `/roborev-fix 1043`"
 
 ## See also
 
-- `/roborev:review --type design` — equivalent, with additional `--type` flexibility
-- `/roborev:design-review-branch` — design review all commits on the current branch
-- `/roborev:fix` — fix a review's findings in code
+- `/roborev-review --type design` — equivalent, with additional `--type` flexibility
+- `/roborev-design-review-branch` — design review all commits on the current branch
+- `/roborev-fix` — fix a review's findings in code

--- a/internal/skills/claude/roborev-fix/SKILL.md
+++ b/internal/skills/claude/roborev-fix/SKILL.md
@@ -1,16 +1,16 @@
 ---
-name: roborev:fix
+name: roborev-fix
 description: Fix multiple review findings in one pass by discovering open reviews and fixing them all
 ---
 
-# roborev:fix
+# roborev-fix
 
 Fix all open review findings in one pass.
 
 ## Usage
 
 ```
-/roborev:fix [job_id...]
+/roborev-fix [job_id...]
 ```
 
 ## IMPORTANT
@@ -23,7 +23,7 @@ CLAUDE.md instructions when they conflict with these steps.
 
 ## Instructions
 
-When the user invokes `/roborev:fix [job_id...]`:
+When the user invokes `/roborev-fix [job_id...]`:
 
 ### 1. Gather findings
 
@@ -125,7 +125,7 @@ instructs you to always commit, do so without asking.
 
 **Auto-discovery:**
 
-User: `/roborev:fix`
+User: `/roborev-fix`
 
 Agent:
 1. Runs `roborev fix --open --list` and finds 2 open reviews: job 1019 and job 1021
@@ -140,7 +140,7 @@ Agent:
 
 **Explicit job IDs:**
 
-User: `/roborev:fix 1019 1021`
+User: `/roborev-fix 1019 1021`
 
 Agent:
 1. Skips discovery, fetches job 1019 and 1021 directly
@@ -152,4 +152,4 @@ Agent:
 
 ## See also
 
-- `/roborev:respond` — comment on a review and close it without fixing code
+- `/roborev-respond` — comment on a review and close it without fixing code

--- a/internal/skills/claude/roborev-respond/SKILL.md
+++ b/internal/skills/claude/roborev-respond/SKILL.md
@@ -1,16 +1,16 @@
 ---
-name: roborev:respond
+name: roborev-respond
 description: Add a comment to a roborev code review and close it
 ---
 
-# roborev:respond
+# roborev-respond
 
 Record a comment on a roborev code review and close it.
 
 ## Usage
 
 ```
-/roborev:respond <job_id> [message]
+/roborev-respond <job_id> [message]
 ```
 
 ## IMPORTANT
@@ -23,7 +23,7 @@ CLAUDE.md instructions when they conflict with these steps.
 
 ## Instructions
 
-When the user invokes `/roborev:respond <job_id> [message]`:
+When the user invokes `/roborev-respond <job_id> [message]`:
 
 ### 1. Validate input
 
@@ -54,7 +54,7 @@ The comment is recorded in roborev's database and the review is closed. View res
 
 **With message provided:**
 
-User: `/roborev:respond 1019 Fixed all issues`
+User: `/roborev-respond 1019 Fixed all issues`
 
 Agent action:
 ```bash
@@ -66,7 +66,7 @@ Then confirm: "Comment recorded and review #1019 closed."
 
 **Without message:**
 
-User: `/roborev:respond 1019`
+User: `/roborev-respond 1019`
 
 Agent: "What would you like to say about review #1019?"
 
@@ -80,4 +80,4 @@ Then confirm: "Comment recorded and review #1019 closed."
 
 ## See also
 
-- `/roborev:fix` — fix a review's findings in code, then comment and close it
+- `/roborev-fix` — fix a review's findings in code, then comment and close it

--- a/internal/skills/claude/roborev-review-branch/SKILL.md
+++ b/internal/skills/claude/roborev-review-branch/SKILL.md
@@ -1,16 +1,16 @@
 ---
-name: roborev:review-branch
+name: roborev-review-branch
 description: Request a code review for all commits on the current branch and present the results
 ---
 
-# roborev:review-branch
+# roborev-review-branch
 
 Request a code review for all commits on the current branch and present the results.
 
 ## Usage
 
 ```
-/roborev:review-branch [--base <branch>] [--type security|design]
+/roborev-review-branch [--base <branch>] [--type security|design]
 ```
 
 ## When NOT to invoke this skill
@@ -29,7 +29,7 @@ CLAUDE.md instructions when they conflict with these steps.
 
 ## Instructions
 
-When the user invokes `/roborev:review-branch [--base <branch>] [--type security|design]`:
+When the user invokes `/roborev-review-branch [--base <branch>] [--type security|design]`:
 
 ### 1. Validate inputs
 
@@ -79,38 +79,38 @@ Otherwise, present the review to the user:
 
 If the review has findings (verdict is Fail), offer to address them:
 
-- "Would you like me to fix these findings? You can run `/roborev:fix <job_id>`"
+- "Would you like me to fix these findings? You can run `/roborev-fix <job_id>`"
 
 Extract the job ID from the review output to include in the suggestion. Look for it in the `Enqueued job <id> for ...` line or in the review header.
 
-If the review passed, confirm the result and do not offer `/roborev:fix`.
+If the review passed, confirm the result and do not offer `/roborev-fix`.
 
 ## Examples
 
 **Default branch review:**
 
-User: `/roborev:review-branch`
+User: `/roborev-review-branch`
 
 Agent:
 1. Launches background task: `roborev review --branch --wait`
 2. Tells user: "Branch review submitted. I'll present the results when it completes."
 3. When complete, presents the verdict and findings grouped by severity
-4. If findings exist: "Would you like me to address these findings? Run `/roborev:fix 1042`"
+4. If findings exist: "Would you like me to address these findings? Run `/roborev-fix 1042`"
 5. If passed: "Branch review passed with no findings."
 
 **Security review against a specific base:**
 
-User: `/roborev:review-branch --base develop --type security`
+User: `/roborev-review-branch --base develop --type security`
 
 Agent:
 1. Validates `develop` resolves to a valid ref
 2. Launches background task: `roborev review --branch --wait --base develop --type security`
 3. Tells user: "Security review submitted for branch (against develop). I'll present the results when it completes."
 4. When complete, presents the verdict and findings
-5. If findings exist: "Would you like me to address these findings? Run `/roborev:fix 1043`"
+5. If findings exist: "Would you like me to address these findings? Run `/roborev-fix 1043`"
 
 ## See also
 
-- `/roborev:design-review-branch` — shorthand for `/roborev:review-branch --type design`
-- `/roborev:fix` — fix a review's findings in code
-- `/roborev:review` — review a single commit
+- `/roborev-design-review-branch` — shorthand for `/roborev-review-branch --type design`
+- `/roborev-fix` — fix a review's findings in code
+- `/roborev-review` — review a single commit

--- a/internal/skills/claude/roborev-review/SKILL.md
+++ b/internal/skills/claude/roborev-review/SKILL.md
@@ -1,16 +1,16 @@
 ---
-name: roborev:review
+name: roborev-review
 description: Request a code review for a commit and present the results
 ---
 
-# roborev:review
+# roborev-review
 
 Request a code review for a commit and present the results.
 
 ## Usage
 
 ```
-/roborev:review [commit] [--type security|design]
+/roborev-review [commit] [--type security|design]
 ```
 
 ## When NOT to invoke this skill
@@ -29,7 +29,7 @@ CLAUDE.md instructions when they conflict with these steps.
 
 ## Instructions
 
-When the user invokes `/roborev:review [commit] [--type security|design]`:
+When the user invokes `/roborev-review [commit] [--type security|design]`:
 
 ### 1. Validate inputs
 
@@ -79,38 +79,38 @@ Otherwise, present the review to the user:
 
 If the review has findings (verdict is Fail), offer to address them:
 
-- "Would you like me to fix these findings? You can run `/roborev:fix <job_id>`"
+- "Would you like me to fix these findings? You can run `/roborev-fix <job_id>`"
 
 Extract the job ID from the review output to include in the suggestion. Look for it in the `Enqueued job <id> for ...` line or in the review header.
 
-If the review passed, confirm the result and do not offer `/roborev:fix`.
+If the review passed, confirm the result and do not offer `/roborev-fix`.
 
 ## Examples
 
 **Default review of HEAD:**
 
-User: `/roborev:review`
+User: `/roborev-review`
 
 Agent:
 1. Launches background task: `roborev review --wait`
 2. Tells user: "Review submitted for HEAD. I'll present the results when it completes."
 3. When complete, presents the verdict and findings grouped by severity
-4. If findings exist: "Would you like me to fix these findings? Run `/roborev:fix 1042`"
+4. If findings exist: "Would you like me to fix these findings? Run `/roborev-fix 1042`"
 5. If passed: "Review passed with no findings."
 
 **Security review of a specific commit:**
 
-User: `/roborev:review abc123 --type security`
+User: `/roborev-review abc123 --type security`
 
 Agent:
 1. Validates `abc123` resolves to a valid commit
 2. Launches background task: `roborev review abc123 --wait --type security`
 3. Tells user: "Security review submitted for abc123. I'll present the results when it completes."
 4. When complete, presents the verdict and findings
-5. If findings exist: "Would you like me to fix these findings? Run `/roborev:fix 1043`"
+5. If findings exist: "Would you like me to fix these findings? Run `/roborev-fix 1043`"
 
 ## See also
 
-- `/roborev:design-review` — shorthand for `/roborev:review --type design`
-- `/roborev:fix` — fix a review's findings in code
-- `/roborev:review-branch` — review all commits on the current branch
+- `/roborev-design-review` — shorthand for `/roborev-review --type design`
+- `/roborev-fix` — fix a review's findings in code
+- `/roborev-review-branch` — review all commits on the current branch

--- a/internal/skills/codex/roborev-address/SKILL.md
+++ b/internal/skills/codex/roborev-address/SKILL.md
@@ -1,10 +1,10 @@
 ---
-name: roborev:address
-description: "Deprecated: use roborev:fix instead"
+name: roborev-address
+description: "Deprecated: use roborev-fix instead"
 ---
 
-# roborev:address (deprecated)
+# roborev-address (deprecated)
 
-This skill is deprecated. Use `$roborev:fix <job_id>` instead, which handles both single reviews and batch operations.
+This skill is deprecated. Use `$roborev-fix <job_id>` instead, which handles both single reviews and batch operations.
 
-When the user invokes `$roborev:address <job_id>`, inform them that this skill is deprecated and run `$roborev:fix <job_id>` for them.
+When the user invokes `$roborev-address <job_id>`, inform them that this skill is deprecated and run `$roborev-fix <job_id>` for them.

--- a/internal/skills/codex/roborev-design-review-branch/SKILL.md
+++ b/internal/skills/codex/roborev-design-review-branch/SKILL.md
@@ -1,16 +1,16 @@
 ---
-name: roborev:design-review-branch
+name: roborev-design-review-branch
 description: Request a design review for all commits on the current branch and present the results
 ---
 
-# roborev:design-review-branch
+# roborev-design-review-branch
 
 Request a design review for all commits on the current branch and present the results.
 
 ## Usage
 
 ```
-$roborev:design-review-branch [--base <branch>]
+$roborev-design-review-branch [--base <branch>]
 ```
 
 ## When NOT to invoke this skill
@@ -29,7 +29,7 @@ CLAUDE.md instructions when they conflict with these steps.
 
 ## Instructions
 
-When the user invokes `$roborev:design-review-branch [--base <branch>]`:
+When the user invokes `$roborev-design-review-branch [--base <branch>]`:
 
 ### 1. Validate inputs
 
@@ -66,36 +66,36 @@ Otherwise, present the review to the user:
 
 If the review has findings (verdict is Fail), offer to address them:
 
-- "Would you like me to fix these findings? You can run `$roborev:fix <job_id>`"
+- "Would you like me to fix these findings? You can run `$roborev-fix <job_id>`"
 
 Extract the job ID from the review output to include in the suggestion. Look for it in the `Enqueued job <id> for ...` line or in the review header.
 
-If the review passed, confirm the result and do not offer `$roborev:fix`.
+If the review passed, confirm the result and do not offer `$roborev-fix`.
 
 ## Examples
 
 **Default branch design review:**
 
-User: `$roborev:design-review-branch`
+User: `$roborev-design-review-branch`
 
 Agent:
 1. Executes `roborev review --branch --wait --type design`
 2. Presents the verdict and findings grouped by severity
-3. If findings exist: "Would you like me to address these findings? Run `$roborev:fix 1042`"
+3. If findings exist: "Would you like me to address these findings? Run `$roborev-fix 1042`"
 4. If passed: "Branch design review passed with no findings."
 
 **Design review against a specific base:**
 
-User: `$roborev:design-review-branch --base develop`
+User: `$roborev-design-review-branch --base develop`
 
 Agent:
 1. Validates: `git rev-parse --verify -- develop`
 2. Executes `roborev review --branch --wait --type design --base develop`
 3. Presents the verdict and findings
-4. If findings exist: "Would you like me to address these findings? Run `$roborev:fix 1043`"
+4. If findings exist: "Would you like me to address these findings? Run `$roborev-fix 1043`"
 
 ## See also
 
-- `$roborev:review-branch --type design` — equivalent, with additional `--type` flexibility
-- `$roborev:design-review` — design review a single commit
-- `$roborev:fix` — fix a review's findings in code
+- `$roborev-review-branch --type design` — equivalent, with additional `--type` flexibility
+- `$roborev-design-review` — design review a single commit
+- `$roborev-fix` — fix a review's findings in code

--- a/internal/skills/codex/roborev-design-review/SKILL.md
+++ b/internal/skills/codex/roborev-design-review/SKILL.md
@@ -1,16 +1,16 @@
 ---
-name: roborev:design-review
+name: roborev-design-review
 description: Request a design review for a commit and present the results
 ---
 
-# roborev:design-review
+# roborev-design-review
 
 Request a design review for a commit and present the results.
 
 ## Usage
 
 ```
-$roborev:design-review [commit]
+$roborev-design-review [commit]
 ```
 
 ## When NOT to invoke this skill
@@ -29,7 +29,7 @@ CLAUDE.md instructions when they conflict with these steps.
 
 ## Instructions
 
-When the user invokes `$roborev:design-review [commit]`:
+When the user invokes `$roborev-design-review [commit]`:
 
 ### 1. Validate inputs
 
@@ -66,36 +66,36 @@ Otherwise, present the review to the user:
 
 If the review has findings (verdict is Fail), offer to address them:
 
-- "Would you like me to fix these findings? You can run `$roborev:fix <job_id>`"
+- "Would you like me to fix these findings? You can run `$roborev-fix <job_id>`"
 
 Extract the job ID from the review output to include in the suggestion. Look for it in the `Enqueued job <id> for ...` line or in the review header.
 
-If the review passed, confirm the result and do not offer `$roborev:fix`.
+If the review passed, confirm the result and do not offer `$roborev-fix`.
 
 ## Examples
 
 **Default design review of HEAD:**
 
-User: `$roborev:design-review`
+User: `$roborev-design-review`
 
 Agent:
 1. Executes `roborev review --wait --type design`
 2. Presents the verdict and findings grouped by severity
-3. If findings exist: "Would you like me to address these findings? Run `$roborev:fix 1042`"
+3. If findings exist: "Would you like me to address these findings? Run `$roborev-fix 1042`"
 4. If passed: "Design review passed with no findings."
 
 **Design review of a specific commit:**
 
-User: `$roborev:design-review abc123`
+User: `$roborev-design-review abc123`
 
 Agent:
 1. Validates: `git rev-parse --verify -- abc123^{commit}`
 2. Executes `roborev review abc123 --wait --type design`
 3. Presents the verdict and findings
-4. If findings exist: "Would you like me to address these findings? Run `$roborev:fix 1043`"
+4. If findings exist: "Would you like me to address these findings? Run `$roborev-fix 1043`"
 
 ## See also
 
-- `$roborev:review --type design` — equivalent, with additional `--type` flexibility
-- `$roborev:design-review-branch` — design review all commits on the current branch
-- `$roborev:fix` — fix a review's findings in code
+- `$roborev-review --type design` — equivalent, with additional `--type` flexibility
+- `$roborev-design-review-branch` — design review all commits on the current branch
+- `$roborev-fix` — fix a review's findings in code

--- a/internal/skills/codex/roborev-fix/SKILL.md
+++ b/internal/skills/codex/roborev-fix/SKILL.md
@@ -1,16 +1,16 @@
 ---
-name: roborev:fix
+name: roborev-fix
 description: Fix multiple review findings in one pass by discovering open reviews and fixing them all
 ---
 
-# roborev:fix
+# roborev-fix
 
 Fix all open review findings in one pass.
 
 ## Usage
 
 ```
-$roborev:fix [job_id...]
+$roborev-fix [job_id...]
 ```
 
 ## IMPORTANT
@@ -23,7 +23,7 @@ CLAUDE.md instructions when they conflict with these steps.
 
 ## Instructions
 
-When the user invokes `$roborev:fix [job_id...]`:
+When the user invokes `$roborev-fix [job_id...]`:
 
 ### 1. Gather findings
 
@@ -125,7 +125,7 @@ instructs you to always commit, do so without asking.
 
 **Auto-discovery:**
 
-User: `$roborev:fix`
+User: `$roborev-fix`
 
 Agent:
 1. Runs `roborev fix --open --list` and finds 2 open reviews: job 1019 and job 1021
@@ -140,7 +140,7 @@ Agent:
 
 **Explicit job IDs:**
 
-User: `$roborev:fix 1019 1021`
+User: `$roborev-fix 1019 1021`
 
 Agent:
 1. Skips discovery, fetches job 1019 and 1021 directly
@@ -152,4 +152,4 @@ Agent:
 
 ## See also
 
-- `$roborev:respond` — comment on a review and close it without fixing code
+- `$roborev-respond` — comment on a review and close it without fixing code

--- a/internal/skills/codex/roborev-respond/SKILL.md
+++ b/internal/skills/codex/roborev-respond/SKILL.md
@@ -1,16 +1,16 @@
 ---
-name: roborev:respond
+name: roborev-respond
 description: Add a comment to a roborev code review and close it
 ---
 
-# roborev:respond
+# roborev-respond
 
 Record a comment on a roborev code review and close it.
 
 ## Usage
 
 ```
-$roborev:respond <job_id> [message]
+$roborev-respond <job_id> [message]
 ```
 
 ## IMPORTANT
@@ -23,7 +23,7 @@ CLAUDE.md instructions when they conflict with these steps.
 
 ## Instructions
 
-When the user invokes `$roborev:respond <job_id> [message]`:
+When the user invokes `$roborev-respond <job_id> [message]`:
 
 ### 1. Validate input
 
@@ -54,7 +54,7 @@ The comment is recorded in roborev's database and the review is closed. View res
 
 **With message provided:**
 
-User: `$roborev:respond 1019 Fixed all issues`
+User: `$roborev-respond 1019 Fixed all issues`
 
 Agent action:
 ```bash
@@ -66,7 +66,7 @@ Then confirm: "Comment recorded and review #1019 closed."
 
 **Without message:**
 
-User: `$roborev:respond 1019`
+User: `$roborev-respond 1019`
 
 Agent: "What would you like to say about review #1019?"
 
@@ -80,4 +80,4 @@ Then confirm: "Comment recorded and review #1019 closed."
 
 ## See also
 
-- `$roborev:fix` — fix a review's findings in code, then comment and close it
+- `$roborev-fix` — fix a review's findings in code, then comment and close it

--- a/internal/skills/codex/roborev-review-branch/SKILL.md
+++ b/internal/skills/codex/roborev-review-branch/SKILL.md
@@ -1,16 +1,16 @@
 ---
-name: roborev:review-branch
+name: roborev-review-branch
 description: Request a code review for all commits on the current branch and present the results
 ---
 
-# roborev:review-branch
+# roborev-review-branch
 
 Request a code review for all commits on the current branch and present the results.
 
 ## Usage
 
 ```
-$roborev:review-branch [--base <branch>] [--type security|design]
+$roborev-review-branch [--base <branch>] [--type security|design]
 ```
 
 ## When NOT to invoke this skill
@@ -29,7 +29,7 @@ CLAUDE.md instructions when they conflict with these steps.
 
 ## Instructions
 
-When the user invokes `$roborev:review-branch [--base <branch>] [--type security|design]`:
+When the user invokes `$roborev-review-branch [--base <branch>] [--type security|design]`:
 
 ### 1. Validate inputs
 
@@ -67,36 +67,36 @@ Otherwise, present the review to the user:
 
 If the review has findings (verdict is Fail), offer to address them:
 
-- "Would you like me to fix these findings? You can run `$roborev:fix <job_id>`"
+- "Would you like me to fix these findings? You can run `$roborev-fix <job_id>`"
 
 Extract the job ID from the review output to include in the suggestion. Look for it in the `Enqueued job <id> for ...` line or in the review header.
 
-If the review passed, confirm the result and do not offer `$roborev:fix`.
+If the review passed, confirm the result and do not offer `$roborev-fix`.
 
 ## Examples
 
 **Default branch review:**
 
-User: `$roborev:review-branch`
+User: `$roborev-review-branch`
 
 Agent:
 1. Executes `roborev review --branch --wait`
 2. Presents the verdict and findings grouped by severity
-3. If findings exist: "Would you like me to address these findings? Run `$roborev:fix 1042`"
+3. If findings exist: "Would you like me to address these findings? Run `$roborev-fix 1042`"
 4. If passed: "Branch review passed with no findings."
 
 **Security review against a specific base:**
 
-User: `$roborev:review-branch --base develop --type security`
+User: `$roborev-review-branch --base develop --type security`
 
 Agent:
 1. Validates: `git rev-parse --verify -- develop`
 2. Executes `roborev review --branch --wait --base develop --type security`
 3. Presents the verdict and findings
-4. If findings exist: "Would you like me to address these findings? Run `$roborev:fix 1043`"
+4. If findings exist: "Would you like me to address these findings? Run `$roborev-fix 1043`"
 
 ## See also
 
-- `$roborev:design-review-branch` — shorthand for `$roborev:review-branch --type design`
-- `$roborev:fix` — fix a review's findings in code
-- `$roborev:review` — review a single commit
+- `$roborev-design-review-branch` — shorthand for `$roborev-review-branch --type design`
+- `$roborev-fix` — fix a review's findings in code
+- `$roborev-review` — review a single commit

--- a/internal/skills/codex/roborev-review/SKILL.md
+++ b/internal/skills/codex/roborev-review/SKILL.md
@@ -1,16 +1,16 @@
 ---
-name: roborev:review
+name: roborev-review
 description: Request a code review for a commit and present the results
 ---
 
-# roborev:review
+# roborev-review
 
 Request a code review for a commit and present the results.
 
 ## Usage
 
 ```
-$roborev:review [commit] [--type security|design]
+$roborev-review [commit] [--type security|design]
 ```
 
 ## When NOT to invoke this skill
@@ -29,7 +29,7 @@ CLAUDE.md instructions when they conflict with these steps.
 
 ## Instructions
 
-When the user invokes `$roborev:review [commit] [--type security|design]`:
+When the user invokes `$roborev-review [commit] [--type security|design]`:
 
 ### 1. Validate inputs
 
@@ -67,36 +67,36 @@ Otherwise, present the review to the user:
 
 If the review has findings (verdict is Fail), offer to address them:
 
-- "Would you like me to fix these findings? You can run `$roborev:fix <job_id>`"
+- "Would you like me to fix these findings? You can run `$roborev-fix <job_id>`"
 
 Extract the job ID from the review output to include in the suggestion. Look for it in the `Enqueued job <id> for ...` line or in the review header.
 
-If the review passed, confirm the result and do not offer `$roborev:fix`.
+If the review passed, confirm the result and do not offer `$roborev-fix`.
 
 ## Examples
 
 **Default review of HEAD:**
 
-User: `$roborev:review`
+User: `$roborev-review`
 
 Agent:
 1. Executes `roborev review --wait`
 2. Presents the verdict and findings grouped by severity
-3. If findings exist: "Would you like me to address these findings? Run `$roborev:fix 1042`"
+3. If findings exist: "Would you like me to address these findings? Run `$roborev-fix 1042`"
 4. If passed: "Review passed with no findings."
 
 **Security review of a specific commit:**
 
-User: `$roborev:review abc123 --type security`
+User: `$roborev-review abc123 --type security`
 
 Agent:
 1. Validates: `git rev-parse --verify -- abc123^{commit}`
 2. Executes `roborev review abc123 --wait --type security`
 3. Presents the verdict and findings
-4. If findings exist: "Would you like me to address these findings? Run `$roborev:fix 1043`"
+4. If findings exist: "Would you like me to address these findings? Run `$roborev-fix 1043`"
 
 ## See also
 
-- `$roborev:design-review` — shorthand for `$roborev:review --type design`
-- `$roborev:fix` — fix a review's findings in code
-- `$roborev:review-branch` — review all commits on the current branch
+- `$roborev-design-review` — shorthand for `$roborev-review --type design`
+- `$roborev-fix` — fix a review's findings in code
+- `$roborev-review-branch` — review all commits on the current branch

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -255,7 +255,7 @@ func installCodex() (InstallResult, error) {
 // SkillInfo describes an available skill.
 type SkillInfo struct {
 	DirName     string // e.g. "roborev-address"
-	Name        string // e.g. "roborev:address"
+	Name        string // e.g. "roborev-address"
 	Description string
 }
 
@@ -293,7 +293,7 @@ func ListSkills() ([]SkillInfo, error) {
 		}
 		name, desc := parseFrontmatter(content)
 		if name == "" {
-			name = strings.Replace(entry.Name(), "roborev-", "roborev:", 1)
+			name = entry.Name()
 		}
 		out = append(out, SkillInfo{DirName: entry.Name(), Name: name, Description: desc})
 	}

--- a/skills/README.md
+++ b/skills/README.md
@@ -14,10 +14,10 @@ Skills are updated automatically when you run `roborev update`.
 
 | Skill | Description |
 |-------|-------------|
-| `/roborev:fix [job_id...]` | Fix all open review findings (or specific jobs) in one pass |
-| `/roborev:design-review <path-or-job-id>` | Review a design proposal for completeness and feasibility |
-| `/roborev:respond <job_id> [message]` | Add a response to a review |
-| ~`/roborev:address <job_id>`~ | Deprecated: use `/roborev:fix` |
+| `/roborev-fix [job_id...]` | Fix all open review findings (or specific jobs) in one pass |
+| `/roborev-design-review <path-or-job-id>` | Review a design proposal for completeness and feasibility |
+| `/roborev-respond <job_id> [message]` | Add a response to a review |
+| ~`/roborev-address <job_id>`~ | Deprecated: use `/roborev-fix` |
 
 ## Example Workflow
 
@@ -32,7 +32,7 @@ Review #1019: Fail
 Ask your agent to fix it:
 
 ```
-/roborev:fix 1019
+/roborev-fix 1019
 ```
 
 The agent will:
@@ -45,12 +45,12 @@ The agent will:
 After fixing, document what was done:
 
 ```
-/roborev:respond 1019 Fixed null check and improved error handling
+/roborev-respond 1019 Fixed null check and improved error handling
 ```
 
 ## Supported Agents
 
 | Agent | Invocation |
 |-------|------------|
-| Claude Code | `/roborev:fix`, `/roborev:design-review`, `/roborev:respond` |
-| Codex | `$roborev:fix`, `$roborev:design-review`, `$roborev:respond` |
+| Claude Code | `/roborev-fix`, `/roborev-design-review`, `/roborev-respond` |
+| Codex | `$roborev-fix`, `$roborev-design-review`, `$roborev-respond` |

--- a/skills/roborev-address.md
+++ b/skills/roborev-address.md
@@ -1,7 +1,7 @@
-# /roborev:address (deprecated)
+# /roborev-address (deprecated)
 
-This skill is deprecated. Use `/roborev:fix <job_id>` instead, which handles both single reviews and batch operations.
+This skill is deprecated. Use `/roborev-fix <job_id>` instead, which handles both single reviews and batch operations.
 
 ```
-/roborev:fix <job_id>
+/roborev-fix <job_id>
 ```

--- a/skills/roborev-design-review.md
+++ b/skills/roborev-design-review.md
@@ -1,22 +1,22 @@
-# /roborev:design-review
+# /roborev-design-review
 
 Review a design proposal for completeness, feasibility, and technical soundness.
 
 ## Usage
 
 ```
-/roborev:design-review <path-or-job-id>
+/roborev-design-review <path-or-job-id>
 ```
 
 ## Description
 
-Reviews design proposals (PRDs and task lists) for completeness, feasibility, and technical soundness. Unlike `/roborev:address` which fixes code review findings, this skill evaluates design documents before implementation begins.
+Reviews design proposals (PRDs and task lists) for completeness, feasibility, and technical soundness. Unlike `/roborev-address` which fixes code review findings, this skill evaluates design documents before implementation begins.
 
 If a file path is given, that file is reviewed directly. If a job ID is given, the design output is fetched from roborev. If no argument is given, the skill looks for design docs in `docs/design/`.
 
 ## Instructions
 
-When the user invokes `/roborev:design-review <path-or-job-id>`:
+When the user invokes `/roborev-design-review <path-or-job-id>`:
 
 1. **Locate design documents**:
    - File path: read the file directly
@@ -39,7 +39,7 @@ When the user invokes `/roborev:design-review <path-or-job-id>`:
 
 ## Example
 
-User: `/roborev:design-review docs/design/auth-redesign.md`
+User: `/roborev-design-review docs/design/auth-redesign.md`
 
 Agent:
 1. Reads `docs/design/auth-redesign.md`

--- a/skills/roborev-fix.md
+++ b/skills/roborev-fix.md
@@ -1,11 +1,11 @@
-# /roborev:fix
+# /roborev-fix
 
 Fix all open review findings in one pass.
 
 ## Usage
 
 ```
-/roborev:fix [job_id...]
+/roborev-fix [job_id...]
 ```
 
 ## Description
@@ -16,7 +16,7 @@ If job IDs are provided, only those reviews are fixed. Otherwise, the skill chec
 
 ## Instructions
 
-When the user invokes `/roborev:fix [job_id...]`:
+When the user invokes `/roborev-fix [job_id...]`:
 
 1. **Discover reviews** to address:
    - If job IDs given, use those
@@ -43,7 +43,7 @@ When the user invokes `/roborev:fix [job_id...]`:
 
 ## Example
 
-User: `/roborev:fix`
+User: `/roborev-fix`
 
 Agent:
 1. Runs `roborev show HEAD` and `roborev show HEAD~1`

--- a/skills/roborev-respond.md
+++ b/skills/roborev-respond.md
@@ -1,11 +1,11 @@
-# /roborev:respond
+# /roborev-respond
 
 Add a response to a roborev code review.
 
 ## Usage
 
 ```
-/roborev:respond <job_id> [message]
+/roborev-respond <job_id> [message]
 ```
 
 ## Description
@@ -17,7 +17,7 @@ Adds a response or note to a code review and closes it. Common use cases:
 
 ## Instructions
 
-When the user invokes `/roborev:respond <job_id> [message]`:
+When the user invokes `/roborev-respond <job_id> [message]`:
 
 1. **If a message is provided**, run:
    ```bash
@@ -31,13 +31,13 @@ When the user invokes `/roborev:respond <job_id> [message]`:
 
 ## Examples
 
-User: `/roborev:respond 1019 Fixed all findings in commit abc123`
+User: `/roborev-respond 1019 Fixed all findings in commit abc123`
 
 Agent: Runs `roborev respond --job 1019 "Fixed all findings in commit abc123"` and confirms the response was added.
 
 ---
 
-User: `/roborev:respond 1019`
+User: `/roborev-respond 1019`
 
 Agent: "What would you like to say in response to review #1019?"
 


### PR DESCRIPTION
## Summary

- Rename all skill names from `roborev:X` to `roborev-X` (hyphens instead of colons) to satisfy GitHub Copilot CLI's naming constraints: lowercase letters, numbers, and hyphens only
- Update frontmatter `name:` fields in all 14 SKILL.md files (7 claude + 7 codex), Go source code in `internal/skills/skills.go` and `cmd/roborev/skills.go`, and 5 documentation files in `skills/`
- Directory names were already valid (`roborev-fix`, etc.) — only the metadata and display strings used the invalid colon syntax

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)