### PR TITLE
Add token usage telemetry to review jobs

### DIFF
--- a/internal/daemon/token_capture.go
+++ b/internal/daemon/token_capture.go
@@ -1,0 +1,107 @@
+package daemon
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"sync"
+)
+
+// tokenCaptureWriter intercepts JSONL output from agents to extract token
+// usage events. All bytes pass through to the destination writer unchanged.
+// Accumulated token counts are available via InputTokens/OutputTokens after
+// the agent finishes.
+type tokenCaptureWriter struct {
+	dst          io.Writer
+	mu           sync.Mutex
+	buf          bytes.Buffer
+	inputTokens  int64
+	outputTokens int64
+}
+
+func newTokenCaptureWriter(dst io.Writer) *tokenCaptureWriter {
+	return &tokenCaptureWriter{dst: dst}
+}
+
+func (w *tokenCaptureWriter) Write(p []byte) (int, error) {
+	n, err := w.dst.Write(p)
+	if n > 0 {
+		w.scanLines(p[:n])
+	}
+	return n, err
+}
+
+// Flush processes any remaining partial line in the buffer.
+func (w *tokenCaptureWriter) Flush() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.buf.Len() > 0 {
+		w.parseLine(w.buf.Bytes())
+		w.buf.Reset()
+	}
+}
+
+// InputTokens returns the accumulated input token count.
+func (w *tokenCaptureWriter) InputTokens() int64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.inputTokens
+}
+
+// OutputTokens returns the accumulated output token count.
+func (w *tokenCaptureWriter) OutputTokens() int64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.outputTokens
+}
+
+func (w *tokenCaptureWriter) scanLines(p []byte) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	_, _ = w.buf.Write(p)
+	for {
+		data := w.buf.Bytes()
+		idx := bytes.IndexByte(data, '\n')
+		if idx < 0 {
+			break
+		}
+		line := data[:idx]
+		w.buf.Next(idx + 1)
+		w.parseLine(line)
+	}
+}
+
+// tokenEvent is a lightweight struct for extracting token counts from
+// agent JSONL events. Covers codex (usage.input_tokens/output_tokens)
+// and gemini (stats.total_tokens).
+type tokenEvent struct {
+	Usage struct {
+		InputTokens  int64 `json:"input_tokens"`
+		OutputTokens int64 `json:"output_tokens"`
+	} `json:"usage"`
+	Stats struct {
+		TotalTokens int64 `json:"total_tokens"`
+	} `json:"stats"`
+}
+
+func (w *tokenCaptureWriter) parseLine(line []byte) {
+	line = bytes.TrimSpace(line)
+	if len(line) == 0 || line[0] != '{' {
+		return
+	}
+	var ev tokenEvent
+	if json.Unmarshal(line, &ev) != nil {
+		return
+	}
+	if ev.Usage.InputTokens > 0 {
+		w.inputTokens += ev.Usage.InputTokens
+	}
+	if ev.Usage.OutputTokens > 0 {
+		w.outputTokens += ev.Usage.OutputTokens
+	}
+	// Gemini emits total_tokens without input/output split
+	if ev.Stats.TotalTokens > 0 {
+		w.outputTokens += ev.Stats.TotalTokens
+	}
+}

--- a/internal/daemon/token_capture_test.go
+++ b/internal/daemon/token_capture_test.go
@@ -1,0 +1,124 @@
+package daemon
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenCaptureWriter_Passthrough(t *testing.T) {
+	var dst bytes.Buffer
+	w := newTokenCaptureWriter(&dst)
+
+	data := []byte("hello world\n")
+	n, err := w.Write(data)
+	require.NoError(t, err)
+	require.Equal(t, len(data), n)
+	require.Equal(t, "hello world\n", dst.String())
+}
+
+func TestTokenCaptureWriter_CodexTokens(t *testing.T) {
+	var dst bytes.Buffer
+	w := newTokenCaptureWriter(&dst)
+
+	// Simulate codex turn.completed events
+	lines := `{"type":"turn.started"}
+{"type":"message","content":"review output"}
+{"type":"turn.completed","usage":{"input_tokens":1000,"output_tokens":500}}
+{"type":"turn.started"}
+{"type":"turn.completed","usage":{"input_tokens":200,"output_tokens":100}}
+`
+	_, err := w.Write([]byte(lines))
+	require.NoError(t, err)
+
+	require.Equal(t, int64(1200), w.InputTokens())
+	require.Equal(t, int64(600), w.OutputTokens())
+	require.Equal(t, lines, dst.String())
+}
+
+func TestTokenCaptureWriter_GeminiTokens(t *testing.T) {
+	var dst bytes.Buffer
+	w := newTokenCaptureWriter(&dst)
+
+	lines := `{"type":"text","content":"review"}
+{"type":"result","status":"success","stats":{"total_tokens":1500}}
+`
+	_, err := w.Write([]byte(lines))
+	require.NoError(t, err)
+
+	require.Equal(t, int64(0), w.InputTokens())
+	require.Equal(t, int64(1500), w.OutputTokens())
+}
+
+func TestTokenCaptureWriter_NoTokens(t *testing.T) {
+	var dst bytes.Buffer
+	w := newTokenCaptureWriter(&dst)
+
+	lines := `plain text output
+more output
+`
+	_, err := w.Write([]byte(lines))
+	require.NoError(t, err)
+
+	require.Equal(t, int64(0), w.InputTokens())
+	require.Equal(t, int64(0), w.OutputTokens())
+}
+
+func TestTokenCaptureWriter_PartialLines(t *testing.T) {
+	var dst bytes.Buffer
+	w := newTokenCaptureWriter(&dst)
+
+	// Write partial line across two writes
+	_, err := w.Write([]byte(`{"type":"turn.completed","usage":{"input_to`))
+	require.NoError(t, err)
+	_, err = w.Write([]byte(`kens":300,"output_tokens":150}}` + "\n"))
+	require.NoError(t, err)
+
+	require.Equal(t, int64(300), w.InputTokens())
+	require.Equal(t, int64(150), w.OutputTokens())
+}
+
+func TestTokenCaptureWriter_FlushPartialLine(t *testing.T) {
+	var dst bytes.Buffer
+	w := newTokenCaptureWriter(&dst)
+
+	// Write without trailing newline
+	_, err := w.Write([]byte(`{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":50}}`))
+	require.NoError(t, err)
+
+	// Before flush, no tokens captured
+	require.Equal(t, int64(0), w.InputTokens())
+
+	w.Flush()
+	require.Equal(t, int64(100), w.InputTokens())
+	require.Equal(t, int64(50), w.OutputTokens())
+}
+
+func TestTokenCaptureWriter_InvalidJSON(t *testing.T) {
+	var dst bytes.Buffer
+	w := newTokenCaptureWriter(&dst)
+
+	lines := `{invalid json}
+{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":50}}
+`
+	_, err := w.Write([]byte(lines))
+	require.NoError(t, err)
+
+	require.Equal(t, int64(100), w.InputTokens())
+	require.Equal(t, int64(50), w.OutputTokens())
+}
+
+func TestTokenCaptureWriter_MixedCodexGemini(t *testing.T) {
+	var dst bytes.Buffer
+	w := newTokenCaptureWriter(&dst)
+
+	lines := `{"type":"turn.completed","usage":{"input_tokens":500,"output_tokens":200}}
+{"type":"result","stats":{"total_tokens":1000}}
+`
+	_, err := w.Write([]byte(lines))
+	require.NoError(t, err)
+
+	require.Equal(t, int64(500), w.InputTokens())
+	require.Equal(t, int64(1200), w.OutputTokens())
+}

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -445,7 +445,8 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 		}
 	}()
 	agentOutput := io.MultiWriter(jobLog, outputWriter)
-	sessionWriter := newSessionCaptureWriter(agentOutput, func(sessionID string) {
+	tokenCapture := newTokenCaptureWriter(agentOutput)
+	sessionWriter := newSessionCaptureWriter(tokenCapture, func(sessionID string) {
 		if err := wp.db.SaveJobSessionID(job.ID, workerID, sessionID); err != nil {
 			log.Printf("[%s] Error saving session ID for job %d: %v", workerID, job.ID, err)
 		}
@@ -549,6 +550,14 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 	} else if err := wp.db.CompleteJob(job.ID, agentName, reviewPrompt, output); err != nil {
 		log.Printf("[%s] Error storing review: %v", workerID, err)
 		return
+	}
+
+	// Save token usage if the agent reported any
+	tokenCapture.Flush()
+	if in, out := tokenCapture.InputTokens(), tokenCapture.OutputTokens(); in > 0 || out > 0 {
+		if err := wp.db.SaveJobTokens(job.ID, in, out); err != nil {
+			log.Printf("[%s] Warning: save tokens for job %d: %v", workerID, job.ID, err)
+		}
 	}
 
 	// For compact jobs, verify the job actually completed (not

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -695,6 +695,22 @@ func (db *DB) migrate() error {
 		}
 	}
 
+	// Migration: add token usage columns to review_jobs if missing
+	err = db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('review_jobs') WHERE name = 'input_tokens'`).Scan(&count)
+	if err != nil {
+		return fmt.Errorf("check input_tokens column: %w", err)
+	}
+	if count == 0 {
+		_, err = db.Exec(`ALTER TABLE review_jobs ADD COLUMN input_tokens INTEGER`)
+		if err != nil {
+			return fmt.Errorf("add input_tokens column: %w", err)
+		}
+		_, err = db.Exec(`ALTER TABLE review_jobs ADD COLUMN output_tokens INTEGER`)
+		if err != nil {
+			return fmt.Errorf("add output_tokens column: %w", err)
+		}
+	}
+
 	// Run sync-related migrations
 	if err := db.migrateSyncColumns(); err != nil {
 		return err

--- a/internal/storage/db_job_test.go
+++ b/internal/storage/db_job_test.go
@@ -1407,3 +1407,96 @@ func TestSaveJobSessionID_StaleWorkerIgnored(t *testing.T) {
 			j.SessionID)
 	}
 }
+
+func TestSaveJobTokens(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	_, _, job := createJobChain(t, db, "/tmp/test-repo", "token-test")
+	claimJob(t, db, "worker-1")
+
+	t.Run("skipped when job is not done", func(t *testing.T) {
+		if err := db.SaveJobTokens(job.ID, 1000, 500); err != nil {
+			t.Fatalf("SaveJobTokens: %v", err)
+		}
+		j, err := db.GetJobByID(job.ID)
+		if err != nil {
+			t.Fatalf("GetJobByID: %v", err)
+		}
+		if j.InputTokens != nil || j.OutputTokens != nil {
+			t.Fatalf("tokens should be nil for running job, got in=%v out=%v", j.InputTokens, j.OutputTokens)
+		}
+	})
+
+	if err := db.CompleteJob(job.ID, "test", "prompt", "No issues found."); err != nil {
+		t.Fatalf("CompleteJob: %v", err)
+	}
+
+	t.Run("persisted when job is done", func(t *testing.T) {
+		if err := db.SaveJobTokens(job.ID, 1000, 500); err != nil {
+			t.Fatalf("SaveJobTokens: %v", err)
+		}
+		j, err := db.GetJobByID(job.ID)
+		if err != nil {
+			t.Fatalf("GetJobByID: %v", err)
+		}
+		if j.InputTokens == nil || *j.InputTokens != 1000 {
+			t.Fatalf("input_tokens = %v, want 1000", j.InputTokens)
+		}
+		if j.OutputTokens == nil || *j.OutputTokens != 500 {
+			t.Fatalf("output_tokens = %v, want 500", j.OutputTokens)
+		}
+	})
+
+	t.Run("round-trips through ListJobs", func(t *testing.T) {
+		jobs, err := db.ListJobs("done", "", 10, 0)
+		if err != nil {
+			t.Fatalf("ListJobs: %v", err)
+		}
+		if len(jobs) != 1 {
+			t.Fatalf("got %d jobs, want 1", len(jobs))
+		}
+		if jobs[0].InputTokens == nil || *jobs[0].InputTokens != 1000 {
+			t.Fatalf("ListJobs input_tokens = %v, want 1000", jobs[0].InputTokens)
+		}
+		if jobs[0].OutputTokens == nil || *jobs[0].OutputTokens != 500 {
+			t.Fatalf("ListJobs output_tokens = %v, want 500", jobs[0].OutputTokens)
+		}
+	})
+
+	t.Run("skipped for zero tokens", func(t *testing.T) {
+		_, _, job2 := createJobChain(t, db, "/tmp/test-repo2", "token-zero")
+		claimJob(t, db, "worker-2")
+		if err := db.CompleteJob(job2.ID, "test", "prompt", "No issues found."); err != nil {
+			t.Fatalf("CompleteJob: %v", err)
+		}
+		if err := db.SaveJobTokens(job2.ID, 0, 0); err != nil {
+			t.Fatalf("SaveJobTokens: %v", err)
+		}
+		j, err := db.GetJobByID(job2.ID)
+		if err != nil {
+			t.Fatalf("GetJobByID: %v", err)
+		}
+		if j.InputTokens != nil || j.OutputTokens != nil {
+			t.Fatalf("tokens should be nil for zero values, got in=%v out=%v", j.InputTokens, j.OutputTokens)
+		}
+	})
+
+	t.Run("skipped for canceled job", func(t *testing.T) {
+		_, _, job3 := createJobChain(t, db, "/tmp/test-repo3", "token-cancel")
+		claimJob(t, db, "worker-3")
+		if err := db.CancelJob(job3.ID); err != nil {
+			t.Fatalf("CancelJob: %v", err)
+		}
+		if err := db.SaveJobTokens(job3.ID, 2000, 1000); err != nil {
+			t.Fatalf("SaveJobTokens: %v", err)
+		}
+		j, err := db.GetJobByID(job3.ID)
+		if err != nil {
+			t.Fatalf("GetJobByID: %v", err)
+		}
+		if j.InputTokens != nil || j.OutputTokens != nil {
+			t.Fatalf("tokens should be nil for canceled job, got in=%v out=%v", j.InputTokens, j.OutputTokens)
+		}
+	})
+}

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -568,6 +568,22 @@ func (db *DB) SaveJobPatch(jobID int64, patch string) error {
 	return err
 }
 
+// SaveJobTokens stores token usage counts for a completed job.
+// Only updates when at least one value is positive and the job is
+// in 'done' status (guards against canceled/retried races).
+// Also bumps updated_at so the sync layer re-pushes the row.
+func (db *DB) SaveJobTokens(jobID int64, inputTokens, outputTokens int64) error {
+	if inputTokens <= 0 && outputTokens <= 0 {
+		return nil
+	}
+	now := time.Now().Format(time.RFC3339)
+	_, err := db.Exec(`
+		UPDATE review_jobs SET input_tokens = ?, output_tokens = ?, updated_at = ?
+		WHERE id = ? AND status = 'done'
+	`, inputTokens, outputTokens, now, jobID)
+	return err
+}
+
 // CompleteFixJob atomically marks a fix job as done, stores the review,
 // and persists the patch in a single transaction. This prevents invalid
 // states where a patch is written but the job isn't done, or vice versa.
@@ -1005,7 +1021,7 @@ func (db *DB) ListJobs(statusFilter string, repoFilter string, limit, offset int
 		       j.started_at, j.finished_at, j.worker_id, j.error, j.prompt, j.retry_count,
 		       COALESCE(j.agentic, 0), r.root_path, r.name, c.subject, rv.closed, rv.output,
 		       j.source_machine_id, j.uuid, j.model, j.job_type, j.review_type, j.patch_id,
-		       j.parent_job_id, j.provider
+		       j.parent_job_id, j.provider, j.input_tokens, j.output_tokens
 		FROM review_jobs j
 		JOIN repos r ON r.id = j.repo_id
 		LEFT JOIN commits c ON c.id = j.commit_id
@@ -1090,12 +1106,13 @@ func (db *DB) ListJobs(statusFilter string, repoFilter string, limit, offset int
 		var closed sql.NullInt64
 		var agentic int
 		var parentJobID sql.NullInt64
+		var inputTokens, outputTokens sql.NullInt64
 
 		err := rows.Scan(&j.ID, &j.RepoID, &commitID, &j.GitRef, &branch, &sessionID, &j.Agent, &j.Reasoning, &j.Status, &enqueuedAt,
 			&startedAt, &finishedAt, &workerID, &errMsg, &prompt, &j.RetryCount,
 			&agentic, &j.RepoPath, &j.RepoName, &commitSubject, &closed, &output,
 			&sourceMachineID, &jobUUID, &model, &jobTypeStr, &reviewTypeStr, &patchIDStr,
-			&parentJobID, &provider)
+			&parentJobID, &provider, &inputTokens, &outputTokens)
 		if err != nil {
 			return nil, err
 		}
@@ -1158,6 +1175,12 @@ func (db *DB) ListJobs(statusFilter string, repoFilter string, limit, offset int
 		}
 		if parentJobID.Valid {
 			j.ParentJobID = &parentJobID.Int64
+		}
+		if inputTokens.Valid {
+			j.InputTokens = &inputTokens.Int64
+		}
+		if outputTokens.Valid {
+			j.OutputTokens = &outputTokens.Int64
 		}
 		// Compute verdict only for non-task jobs (task jobs don't have PASS/FAIL verdicts)
 		// Task jobs (run, analyze, custom) are identified by having no commit_id and not being dirty
@@ -1236,11 +1259,12 @@ func (db *DB) GetJobByID(id int64) (*ReviewJob, error) {
 	var patch sql.NullString
 
 	var model, provider, branch, jobTypeStr, reviewTypeStr, patchIDStr sql.NullString
+	var inputTokens, outputTokens sql.NullInt64
 	err := db.QueryRow(`
 		SELECT j.id, j.repo_id, j.commit_id, j.git_ref, j.branch, j.session_id, j.agent, j.reasoning, j.status, j.enqueued_at,
 		       j.started_at, j.finished_at, j.worker_id, j.error, j.prompt, COALESCE(j.agentic, 0),
 		       r.root_path, r.name, c.subject, j.model, j.provider, j.job_type, j.review_type, j.patch_id,
-		       j.parent_job_id, j.patch
+		       j.parent_job_id, j.patch, j.input_tokens, j.output_tokens
 		FROM review_jobs j
 		JOIN repos r ON r.id = j.repo_id
 		LEFT JOIN commits c ON c.id = j.commit_id
@@ -1248,7 +1272,7 @@ func (db *DB) GetJobByID(id int64) (*ReviewJob, error) {
 	`, id).Scan(&j.ID, &j.RepoID, &commitID, &j.GitRef, &branch, &sessionID, &j.Agent, &j.Reasoning, &j.Status, &enqueuedAt,
 		&startedAt, &finishedAt, &workerID, &errMsg, &prompt, &agentic,
 		&j.RepoPath, &j.RepoName, &commitSubject, &model, &provider, &jobTypeStr, &reviewTypeStr, &patchIDStr,
-		&parentJobID, &patch)
+		&parentJobID, &patch, &inputTokens, &outputTokens)
 	if err != nil {
 		return nil, err
 	}
@@ -1304,6 +1328,12 @@ func (db *DB) GetJobByID(id int64) (*ReviewJob, error) {
 	}
 	if patch.Valid {
 		j.Patch = &patch.String
+	}
+	if inputTokens.Valid {
+		j.InputTokens = &inputTokens.Int64
+	}
+	if outputTokens.Valid {
+		j.OutputTokens = &outputTokens.Int64
 	}
 
 	return &j, nil

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -78,6 +78,10 @@ type ReviewJob struct {
 	UpdatedAt       *time.Time `json:"updated_at,omitempty"`        // Last modification time
 	SyncedAt        *time.Time `json:"synced_at,omitempty"`         // Last sync time
 
+	// Token usage (nullable — NULL means "not reported")
+	InputTokens  *int64 `json:"input_tokens,omitempty"`
+	OutputTokens *int64 `json:"output_tokens,omitempty"`
+
 	// Joined fields for convenience
 	RepoPath      string  `json:"repo_path,omitempty"`
 	RepoName      string  `json:"repo_name,omitempty"`

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -14,12 +14,12 @@ import (
 )
 
 // PostgreSQL schema version - increment when schema changes
-const pgSchemaVersion = 7
+const pgSchemaVersion = 8
 
 // pgSchemaName is the PostgreSQL schema used to isolate roborev tables
 const pgSchemaName = "roborev"
 
-//go:embed schemas/postgres_v7.sql
+//go:embed schemas/postgres_v8.sql
 var pgSchemaSQL string
 
 // pgSchemaStatements returns the individual DDL statements for schema creation.
@@ -276,6 +276,16 @@ func (p *PgPool) EnsureSchema(ctx context.Context) error {
 				return fmt.Errorf("migrate to v7 (add session_id column): %w", err)
 			}
 		}
+		if currentVersion < 8 {
+			_, err = p.pool.Exec(ctx, `ALTER TABLE review_jobs ADD COLUMN IF NOT EXISTS input_tokens BIGINT`)
+			if err != nil {
+				return fmt.Errorf("migrate to v8 (add input_tokens column): %w", err)
+			}
+			_, err = p.pool.Exec(ctx, `ALTER TABLE review_jobs ADD COLUMN IF NOT EXISTS output_tokens BIGINT`)
+			if err != nil {
+				return fmt.Errorf("migrate to v8 (add output_tokens column): %w", err)
+			}
+		}
 		// Update version
 		_, err = p.pool.Exec(ctx, `INSERT INTO schema_version (version) VALUES ($1) ON CONFLICT (version) DO NOTHING`, pgSchemaVersion)
 		if err != nil {
@@ -529,8 +539,9 @@ func (p *PgPool) UpsertJob(ctx context.Context, j SyncableJob, pgRepoID int64, p
 		INSERT INTO review_jobs (
 			uuid, repo_id, commit_id, git_ref, session_id, agent, model, reasoning, job_type, review_type, patch_id, status, agentic,
 			enqueued_at, started_at, finished_at, prompt, diff_content, error,
+			input_tokens, output_tokens,
 			source_machine_id, updated_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, NOW())
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, NOW())
 		ON CONFLICT (uuid) DO UPDATE SET
 			status = EXCLUDED.status,
 			finished_at = EXCLUDED.finished_at,
@@ -540,10 +551,12 @@ func (p *PgPool) UpsertJob(ctx context.Context, j SyncableJob, pgRepoID int64, p
 			session_id = COALESCE(EXCLUDED.session_id, review_jobs.session_id),
 			commit_id = EXCLUDED.commit_id,
 			patch_id = EXCLUDED.patch_id,
+			input_tokens = COALESCE(EXCLUDED.input_tokens, review_jobs.input_tokens),
+			output_tokens = COALESCE(EXCLUDED.output_tokens, review_jobs.output_tokens),
 			updated_at = NOW()
 	`, j.UUID, pgRepoID, pgCommitID, j.GitRef, nullString(j.SessionID), j.Agent, nullString(j.Model), nullString(j.Reasoning),
 		defaultStr(j.JobType, "review"), j.ReviewType, nullString(j.PatchID), j.Status, j.Agentic, j.EnqueuedAt, j.StartedAt, j.FinishedAt,
-		nullString(j.Prompt), j.DiffContent, nullString(j.Error), j.SourceMachineID)
+		nullString(j.Prompt), j.DiffContent, nullString(j.Error), j.InputTokens, j.OutputTokens, j.SourceMachineID)
 	return err
 }
 
@@ -598,6 +611,8 @@ type PulledJob struct {
 	Prompt          string
 	DiffContent     *string
 	Error           string
+	InputTokens     *int64
+	OutputTokens    *int64
 	SourceMachineID string
 	UpdatedAt       time.Time
 }
@@ -623,6 +638,7 @@ func (p *PgPool) PullJobs(ctx context.Context, excludeMachineID string, cursor s
 			j.git_ref, COALESCE(j.session_id, ''), j.agent, COALESCE(j.model, ''), COALESCE(j.reasoning, ''), COALESCE(j.job_type, 'review'), COALESCE(j.review_type, ''), COALESCE(j.patch_id, ''), j.status, j.agentic,
 			j.enqueued_at, j.started_at, j.finished_at,
 			COALESCE(j.prompt, ''), j.diff_content, COALESCE(j.error, ''),
+			j.input_tokens, j.output_tokens,
 			j.source_machine_id, j.updated_at, j.id
 		FROM review_jobs j
 		JOIN repos r ON j.repo_id = r.id
@@ -650,6 +666,7 @@ func (p *PgPool) PullJobs(ctx context.Context, excludeMachineID string, cursor s
 			&j.GitRef, &j.SessionID, &j.Agent, &j.Model, &j.Reasoning, &j.JobType, &j.ReviewType, &j.PatchID, &j.Status, &j.Agentic,
 			&j.EnqueuedAt, &j.StartedAt, &j.FinishedAt,
 			&j.Prompt, &diffContent, &j.Error,
+			&j.InputTokens, &j.OutputTokens,
 			&j.SourceMachineID, &j.UpdatedAt, &lastID,
 		)
 		if err != nil {
@@ -918,8 +935,9 @@ func (p *PgPool) BatchUpsertJobs(ctx context.Context, jobs []JobWithPgIDs) ([]bo
 			INSERT INTO review_jobs (
 				uuid, repo_id, commit_id, git_ref, session_id, agent, reasoning, job_type, review_type, patch_id, status, agentic,
 				enqueued_at, started_at, finished_at, prompt, diff_content, error,
+				input_tokens, output_tokens,
 				source_machine_id, updated_at
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, NOW())
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, NOW())
 			ON CONFLICT (uuid) DO UPDATE SET
 				status = EXCLUDED.status,
 				finished_at = EXCLUDED.finished_at,
@@ -928,10 +946,12 @@ func (p *PgPool) BatchUpsertJobs(ctx context.Context, jobs []JobWithPgIDs) ([]bo
 				session_id = COALESCE(EXCLUDED.session_id, review_jobs.session_id),
 				commit_id = EXCLUDED.commit_id,
 				patch_id = EXCLUDED.patch_id,
+				input_tokens = COALESCE(EXCLUDED.input_tokens, review_jobs.input_tokens),
+				output_tokens = COALESCE(EXCLUDED.output_tokens, review_jobs.output_tokens),
 				updated_at = NOW()
 		`, j.UUID, jw.PgRepoID, jw.PgCommitID, j.GitRef, nullString(j.SessionID), j.Agent, nullString(j.Reasoning),
 			defaultStr(j.JobType, "review"), j.ReviewType, nullString(j.PatchID), j.Status, j.Agentic, j.EnqueuedAt, j.StartedAt, j.FinishedAt,
-			nullString(j.Prompt), j.DiffContent, nullString(j.Error), j.SourceMachineID)
+			nullString(j.Prompt), j.DiffContent, nullString(j.Error), j.InputTokens, j.OutputTokens, j.SourceMachineID)
 	}
 
 	br := p.pool.SendBatch(ctx, batch)

--- a/internal/storage/schemas/postgres_v8.sql
+++ b/internal/storage/schemas/postgres_v8.sql
@@ -1,0 +1,102 @@
+-- PostgreSQL schema version 8
+-- Adds input_tokens and output_tokens columns to review_jobs for token usage telemetry.
+-- Note: Version is managed by EnsureSchema(), not this file.
+
+CREATE SCHEMA IF NOT EXISTS roborev;
+
+CREATE TABLE IF NOT EXISTS roborev.schema_version (
+  version INTEGER PRIMARY KEY,
+  applied_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.machines (
+  id SERIAL PRIMARY KEY,
+  machine_id UUID UNIQUE NOT NULL,
+  name TEXT,
+  last_seen_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.repos (
+  id SERIAL PRIMARY KEY,
+  identity TEXT UNIQUE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.commits (
+  id SERIAL PRIMARY KEY,
+  repo_id INTEGER REFERENCES roborev.repos(id),
+  sha TEXT NOT NULL,
+  author TEXT NOT NULL,
+  subject TEXT NOT NULL,
+  timestamp TIMESTAMP WITH TIME ZONE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  UNIQUE(repo_id, sha)
+);
+
+CREATE TABLE IF NOT EXISTS roborev.review_jobs (
+  id SERIAL PRIMARY KEY,
+  uuid UUID UNIQUE NOT NULL,
+  repo_id INTEGER NOT NULL REFERENCES roborev.repos(id),
+  commit_id INTEGER REFERENCES roborev.commits(id),
+  git_ref TEXT NOT NULL,
+  branch TEXT,
+  session_id TEXT,
+  agent TEXT NOT NULL,
+  model TEXT,
+  reasoning TEXT,
+  job_type TEXT NOT NULL DEFAULT 'review',
+  review_type TEXT NOT NULL DEFAULT '',
+  patch_id TEXT,
+  status TEXT NOT NULL CHECK(status IN ('done', 'failed', 'canceled')),
+  agentic BOOLEAN DEFAULT FALSE,
+  enqueued_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  started_at TIMESTAMP WITH TIME ZONE,
+  finished_at TIMESTAMP WITH TIME ZONE,
+  prompt TEXT,
+  diff_content TEXT,
+  error TEXT,
+  input_tokens BIGINT,
+  output_tokens BIGINT,
+  source_machine_id UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.reviews (
+  id SERIAL PRIMARY KEY,
+  uuid UUID UNIQUE NOT NULL,
+  job_uuid UUID NOT NULL REFERENCES roborev.review_jobs(uuid),
+  agent TEXT NOT NULL,
+  prompt TEXT NOT NULL,
+  output TEXT NOT NULL,
+  closed BOOLEAN NOT NULL DEFAULT FALSE,
+  updated_by_machine_id UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.responses (
+  id SERIAL PRIMARY KEY,
+  uuid UUID UNIQUE NOT NULL,
+  job_uuid UUID NOT NULL REFERENCES roborev.review_jobs(uuid),
+  responder TEXT NOT NULL,
+  response TEXT NOT NULL,
+  source_machine_id UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_review_jobs_source ON roborev.review_jobs(source_machine_id);
+CREATE INDEX IF NOT EXISTS idx_review_jobs_updated ON roborev.review_jobs(updated_at);
+-- Note: idx_review_jobs_branch, idx_review_jobs_job_type, and
+-- idx_review_jobs_patch_id are created by migration code, not here
+-- (to support upgrades from older versions where those columns
+-- don't exist yet).
+CREATE INDEX IF NOT EXISTS idx_reviews_job_uuid ON roborev.reviews(job_uuid);
+CREATE INDEX IF NOT EXISTS idx_reviews_updated ON roborev.reviews(updated_at);
+CREATE INDEX IF NOT EXISTS idx_responses_job_uuid ON roborev.responses(job_uuid);
+CREATE INDEX IF NOT EXISTS idx_responses_id ON roborev.responses(id);
+
+CREATE TABLE IF NOT EXISTS roborev.sync_metadata (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);

--- a/internal/storage/sync.go
+++ b/internal/storage/sync.go
@@ -285,6 +285,8 @@ type SyncableJob struct {
 	Prompt          string
 	DiffContent     *string
 	Error           string
+	InputTokens     *int64
+	OutputTokens    *int64
 	SourceMachineID string
 	UpdatedAt       time.Time
 }
@@ -299,6 +301,7 @@ func (db *DB) GetJobsToSync(machineID string, limit int) ([]SyncableJob, error) 
 			j.git_ref, COALESCE(j.session_id, ''), j.agent, COALESCE(j.model, ''), COALESCE(j.reasoning, ''), COALESCE(j.job_type, 'review'), COALESCE(j.review_type, ''), COALESCE(j.patch_id, ''), j.status, j.agentic,
 			j.enqueued_at, COALESCE(j.started_at, ''), COALESCE(j.finished_at, ''),
 			COALESCE(j.prompt, ''), j.diff_content, COALESCE(j.error, ''),
+			j.input_tokens, j.output_tokens,
 			j.source_machine_id, j.updated_at
 		FROM review_jobs j
 		JOIN repos r ON j.repo_id = r.id
@@ -334,6 +337,7 @@ func (db *DB) GetJobsToSync(machineID string, limit int) ([]SyncableJob, error) 
 			&j.GitRef, &j.SessionID, &j.Agent, &j.Model, &j.Reasoning, &j.JobType, &j.ReviewType, &j.PatchID, &j.Status, &j.Agentic,
 			&enqueuedAt, &startedAt, &finishedAt,
 			&j.Prompt, &diffContent, &j.Error,
+			&j.InputTokens, &j.OutputTokens,
 			&j.SourceMachineID, &updatedAt,
 		)
 		if err != nil {
@@ -577,8 +581,9 @@ func (db *DB) UpsertPulledJob(j PulledJob, repoID int64, commitID *int64) error 
 		INSERT INTO review_jobs (
 			uuid, repo_id, commit_id, git_ref, session_id, agent, model, reasoning, job_type, review_type, patch_id, status, agentic,
 			enqueued_at, started_at, finished_at, prompt, diff_content, error,
+			input_tokens, output_tokens,
 			source_machine_id, updated_at, synced_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(uuid) DO UPDATE SET
 			status = excluded.status,
 			finished_at = excluded.finished_at,
@@ -588,12 +593,15 @@ func (db *DB) UpsertPulledJob(j PulledJob, repoID int64, commitID *int64) error 
 			session_id = COALESCE(excluded.session_id, review_jobs.session_id),
 			commit_id = excluded.commit_id,
 			patch_id = excluded.patch_id,
+			input_tokens = COALESCE(excluded.input_tokens, review_jobs.input_tokens),
+			output_tokens = COALESCE(excluded.output_tokens, review_jobs.output_tokens),
 			updated_at = excluded.updated_at,
 			synced_at = ?
 	`, j.UUID, repoID, commitID, j.GitRef, nullStr(j.SessionID), j.Agent, nullStr(j.Model), j.Reasoning, j.JobType,
 		j.ReviewType, nullStr(j.PatchID), j.Status, j.Agentic, j.EnqueuedAt.Format(time.RFC3339),
 		nullTimeStr(j.StartedAt), nullTimeStr(j.FinishedAt),
 		nullStr(j.Prompt), j.DiffContent, nullStr(j.Error),
+		j.InputTokens, j.OutputTokens,
 		j.SourceMachineID, j.UpdatedAt.Format(time.RFC3339), now, now)
 	return err
 }


### PR DESCRIPTION
## Summary
- Capture input/output token counts from agent JSONL streams during review execution (#356)
- New `tokenCaptureWriter` intercepts the worker output chain, extracting token events from codex (`usage.input_tokens`/`output_tokens`) and gemini (`stats.total_tokens`) without changing the Agent interface or CompleteJob signature
- Add nullable `input_tokens`/`output_tokens` columns to `review_jobs` (SQLite migration + PostgreSQL v8 schema)
- `SaveJobTokens` guards on `status = 'done'` to prevent stale writes from canceled/retried workers, and bumps `updated_at` so the sync layer re-pushes token data to PostgreSQL
- Token fields flow through sync (push/pull) and API (`GET /api/jobs`) automatically via `ReviewJob` JSON serialization — `omitempty` keeps responses clean for pre-migration and non-reporting agents
- 13 new tests: 8 for token capture (codex, gemini, partial lines, passthrough, mixed, invalid JSON) and 5 for storage (status guard, cancel race, zero-value skip, ListJobs/GetJobByID round-trip)

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)