### PR TITLE
Update default Gemini model and add model-not-found fallback

### DIFF
--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -126,10 +126,9 @@ func (a *GeminiAgent) buildArgsWithModel(model string, agenticMode bool) []strin
 	}
 
 	if agenticMode {
-		args = append(args, "--yolo")
-		args = append(args, "--allowed-tools", "Edit,Write,Read,Glob,Grep,Bash,Shell")
+		args = append(args, "--approval-mode", "yolo")
 	} else {
-		args = append(args, "--allowed-tools", "Read,Glob,Grep")
+		args = append(args, "--approval-mode", "plan")
 	}
 	return args
 }

--- a/internal/agent/gemini_test.go
+++ b/internal/agent/gemini_test.go
@@ -44,20 +44,22 @@ func TestGeminiBuildArgs(t *testing.T) {
 			agentic: false,
 			wantArgPairs: map[string]string{
 				"--output-format": "stream-json",
-				"--allowed-tools": "Read,Glob,Grep",
+				"--approval-mode": "plan",
 			},
 			unwantedArgs: []string{
 				"--yolo",
-				"Edit", "Write", "Bash", "Shell",
+				"--allowed-tools",
 			},
 		},
 		{
-			name:      "AgenticMode",
-			agentic:   true,
-			wantFlags: []string{"--yolo"},
+			name:    "AgenticMode",
+			agentic: true,
 			wantArgPairs: map[string]string{
 				"--output-format": "stream-json",
-				"--allowed-tools": "Edit,Write,Read,Glob,Grep,Bash,Shell",
+				"--approval-mode": "yolo",
+			},
+			unwantedArgs: []string{
+				"--allowed-tools",
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- Update default Gemini model from `gemini-3.1-pro-preview` to `gemini-3.1-pro` now that it's promoted out of preview
- When the Gemini CLI fails with a model-not-found error, automatically retry without the `-m` flag to let the CLI use its own default model, making roborev resilient to Google renaming models
- Extract `runGemini` helper to support the retry without duplicating pipe/parse logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)