### PR TITLE
Add opencode_cmd config override for custom executable path

### DIFF
--- a/internal/agent/acp.go
+++ b/internal/agent/acp.go
@@ -1536,6 +1536,12 @@ func applyCommandOverrides(a Agent, cfg *config.Config) Agent {
 			clone.Command = cfg.PiCmd
 			return &clone
 		}
+	case *OpenCodeAgent:
+		if cfg.OpenCodeCmd != "" {
+			clone := *agent
+			clone.Command = cfg.OpenCodeCmd
+			return &clone
+		}
 	}
 	return a
 }

--- a/internal/agent/acp_test.go
+++ b/internal/agent/acp_test.go
@@ -1149,6 +1149,38 @@ func TestGetAvailableWithConfigPiCmd(t *testing.T) {
 	assert.Equal(t, filepath.Join(fakeBin, wrapper), ca.CommandName())
 }
 
+func TestGetAvailableWithConfigOpenCodeCmd(t *testing.T) {
+	fakeBin := t.TempDir()
+	wrapper := "custom-opencode"
+	if runtime.GOOS == "windows" {
+		wrapper += ".exe"
+	}
+	err := os.WriteFile(
+		filepath.Join(fakeBin, wrapper),
+		[]byte("#!/bin/sh\nexit 0\n"), 0o755,
+	)
+	require.NoError(t, err)
+	t.Setenv("PATH", fakeBin)
+
+	originalRegistry := registry
+	registry = map[string]Agent{
+		"opencode": NewOpenCodeAgent(""),
+	}
+	t.Cleanup(func() { registry = originalRegistry })
+
+	cfg := &config.Config{
+		OpenCodeCmd: filepath.Join(fakeBin, wrapper),
+	}
+
+	resolved, err := GetAvailableWithConfig("opencode", cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "opencode", resolved.Name())
+
+	ca, ok := resolved.(CommandAgent)
+	require.True(t, ok)
+	assert.Equal(t, filepath.Join(fakeBin, wrapper), ca.CommandName())
+}
+
 func TestGetAvailableWithConfigACPFallbackBackupUsesConfigCmd(t *testing.T) {
 	// Configured ACP alias is requested but ACP command is
 	// unavailable. The backup agent's default command is also

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -145,6 +145,7 @@ type Config struct {
 	ClaudeCodeCmd string `toml:"claude_code_cmd"`
 	CursorCmd     string `toml:"cursor_cmd"`
 	PiCmd         string `toml:"pi_cmd"`
+	OpenCodeCmd   string `toml:"opencode_cmd"`
 
 	// API keys (optional - agents use subscription auth by default)
 	AnthropicAPIKey string `toml:"anthropic_api_key" sensitive:"true"`
@@ -691,6 +692,7 @@ func DefaultConfig() *Config {
 		ClaudeCodeCmd:      "claude",
 		CursorCmd:          "agent",
 		PiCmd:              "pi",
+		OpenCodeCmd:        "opencode",
 		MouseEnabled:       true,
 	}
 	cfg.CI.ThrottleBypassUsers = []string{


### PR DESCRIPTION
## Summary

Add `opencode_cmd` config key so users can override the OpenCode executable path, matching the existing pattern for `codex_cmd`, `claude_code_cmd`, `cursor_cmd`, and `pi_cmd`.

This is the simplest unblocking approach (option 3) from #355, enabling users to point roborev at a wrapper script that passes `--agent` or other flags to opencode.

## Changes

- **`internal/config/config.go`** — Add `OpenCodeCmd` field to `Config` struct with `toml:"opencode_cmd"` tag; set default `"opencode"` in `DefaultConfig()`
- **`internal/agent/acp.go`** — Add `case *OpenCodeAgent:` branch in `applyCommandOverrides` to apply the config override
- **`internal/agent/acp_test.go`** — Add `TestGetAvailableWithConfigOpenCodeCmd` following the established test pattern

## How to test

```bash
go test ./internal/config/... ./internal/agent/...
```

The new test creates a fake binary, sets `opencode_cmd` in config, and verifies `GetAvailableWithConfig` resolves to the overridden path.

## Notes

- No changes needed in `keyval.go` or `config_cmd.go` — config keys are auto-discovered via reflection on `toml` struct tags
- No docs changes — existing `*_cmd` keys are not documented in-repo (README defers to roborev.io/configuration)

Closes #355 (option 3)