### PR TITLE
Add 1s display tick so TUI elapsed counter updates every second

### DIFF
--- a/cmd/roborev/tui/fetch.go
+++ b/cmd/roborev/tui/fetch.go
@@ -28,6 +28,12 @@ func (m model) tick() tea.Cmd {
 	})
 }
 
+func (m model) displayTick() tea.Cmd {
+	return tea.Tick(displayTickInterval, func(time.Time) tea.Msg {
+		return displayTickMsg{}
+	})
+}
+
 // tickInterval returns the appropriate polling interval based on queue activity.
 // Uses faster polling when jobs are running or pending, slower when idle.
 func (m model) tickInterval() time.Duration {

--- a/cmd/roborev/tui/tui.go
+++ b/cmd/roborev/tui/tui.go
@@ -25,10 +25,11 @@ import (
 	"github.com/roborev-dev/roborev/internal/streamfmt"
 )
 
-// Tick intervals for adaptive polling
+// Tick intervals for local redraws and adaptive polling.
 const (
-	tickIntervalActive = 2 * time.Second  // Poll frequently when jobs are running/pending
-	tickIntervalIdle   = 10 * time.Second // Poll less when queue is idle
+	displayTickInterval = 1 * time.Second  // Repaint only (elapsed counters, flash expiry)
+	tickIntervalActive  = 2 * time.Second  // Poll frequently when jobs are running/pending
+	tickIntervalIdle    = 10 * time.Second // Poll less when queue is idle
 )
 
 // TUI styles using AdaptiveColor for light/dark terminal support.
@@ -566,6 +567,7 @@ func newModel(serverAddr string, opts ...option) model {
 func (m model) Init() tea.Cmd {
 	return tea.Batch(
 		tea.WindowSize(), // request initial window size
+		m.displayTick(),
 		m.tick(),
 		m.fetchJobs(),
 		m.fetchStatus(),
@@ -712,6 +714,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		result, cmd = m.handleMouseMsg(msg)
 	case tea.WindowSizeMsg:
 		result, cmd = m.handleWindowSizeMsg(msg)
+	case displayTickMsg:
+		return m, m.displayTick()
 	case tickMsg:
 		result, cmd = m.handleTickMsg(msg)
 	case logTickMsg:

--- a/cmd/roborev/tui/tui_test.go
+++ b/cmd/roborev/tui/tui_test.go
@@ -330,6 +330,25 @@ func TestTUITickNoRefreshWhileLoadingJobs(t *testing.T) {
 	}
 }
 
+func TestTUIDisplayTickDoesNotTriggerRefresh(t *testing.T) {
+	m := newModel("http://localhost")
+	m.loadingJobs = false
+	m.loadingMore = false
+
+	updated, cmd := m.Update(displayTickMsg{})
+	m2 := updated.(model)
+
+	if m2.loadingJobs {
+		t.Error("display tick should not mark jobs as loading")
+	}
+	if m2.loadingMore {
+		t.Error("display tick should not start pagination loads")
+	}
+	if cmd == nil {
+		t.Error("display tick should reschedule itself")
+	}
+}
+
 func TestTUITickInterval(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/cmd/roborev/tui/types.go
+++ b/cmd/roborev/tui/types.go
@@ -115,6 +115,9 @@ type logOutputMsg struct {
 // logTickMsg triggers a refresh of the log output
 type logTickMsg struct{}
 
+// displayTickMsg triggers a local repaint without polling the daemon.
+type displayTickMsg struct{}
+
 type tickMsg time.Time
 type jobsMsg struct {
 	jobs    []storage.ReviewJob


### PR DESCRIPTION
## Summary
- The TUI elapsed counter only updated every 2 seconds because the display refresh was tied to the API polling interval (`tickIntervalActive = 2s`)
- Adds a separate 1-second display tick (`tuiDisplayTickMsg`) that triggers a repaint without any API calls
- API polling remains at 2s to avoid unnecessary daemon requests

## Test plan
- [x] `TestTUIDisplayTickDoesNotTriggerRefresh` verifies the display tick reschedules itself and does not trigger job/status fetches
- [x] Existing `TestTUITickInterval` and `TestTUITickNoRefreshWhileLoadingJobs` still pass
- [ ] Manual: run `roborev tui` with a running job and verify the elapsed counter ticks every second

🤖 Generated with [Claude Code](https://claude.com/claude-code)