### PR TITLE
Add .claude/worktrees to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ tmp/
 REPORT.md
 .zed
 .superset
+
+# Claude Code worktrees
+.claude/worktrees/


### PR DESCRIPTION
## Summary
- Add `.claude/worktrees/` to `.gitignore` to prevent Claude Code worktree directories from being tracked

## Test plan
- [x] Verify `.claude/worktrees/` directories are ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)