### PR TITLE
Fix --all-branches and --branch filtering from worktrees

### DIFF
--- a/cmd/roborev/fix.go
+++ b/cmd/roborev/fix.go
@@ -159,13 +159,16 @@ Examples:
 						}
 						effectiveBranch = git.GetCurrentBranch(repoRoot)
 					}
-					return runFixBatch(cmd, nil, effectiveBranch, newestFirst, opts)
+					return runFixBatch(cmd, nil, effectiveBranch, allBranches, branch != "", newestFirst, opts)
 				}
-				return runFixBatch(cmd, jobIDs, "", false, opts)
+				return runFixBatch(cmd, jobIDs, "", false, false, false, opts)
 			}
 
 			if len(args) == 0 {
-				// Default to current branch unless --branch or --all-branches is set
+				// Resolve branch for API query filtering.
+				// --branch X: use explicit branch
+				// --all-branches: empty string (no filter)
+				// default: current branch
 				effectiveBranch := branch
 				if !allBranches && effectiveBranch == "" {
 					workDir, err := os.Getwd()
@@ -178,7 +181,7 @@ Examples:
 					}
 					effectiveBranch = git.GetCurrentBranch(repoRoot)
 				}
-				return runFixOpen(cmd, effectiveBranch, newestFirst, opts)
+				return runFixOpen(cmd, effectiveBranch, allBranches, branch != "", newestFirst, opts)
 			}
 
 			// Parse job IDs
@@ -417,7 +420,19 @@ func runFixWithSeen(cmd *cobra.Command, jobIDs []int64, opts fixOptions, seen ma
 	return nil
 }
 
-func runFixOpen(cmd *cobra.Command, branch string, newestFirst bool, opts fixOptions) error {
+// runFixOpen discovers and fixes open jobs.
+//
+// branch is used for the API query filter (current branch, explicit
+// --branch, or "" for --all-branches). allBranches controls local
+// filtering: when true, filterReachableJobs is skipped entirely.
+// When false and the user passed --branch, the explicit branch is
+// forwarded as a branchOverride for branch-field matching. When false
+// and no --branch was passed, "" is used so filterReachableJobs falls
+// back to commit-graph reachability.
+//
+// explicitBranch should be true when the caller set --branch (as
+// opposed to auto-resolving the current branch).
+func runFixOpen(cmd *cobra.Command, branch string, allBranches, explicitBranch, newestFirst bool, opts fixOptions) error {
 	// Ensure daemon is running
 	if err := ensureDaemon(); err != nil {
 		return err
@@ -448,11 +463,17 @@ func runFixOpen(cmd *cobra.Command, branch string, newestFirst bool, opts fixOpt
 		if err != nil {
 			return err
 		}
-		// When listing a specific branch, filter by reachability/branch.
-		// When listing all branches (branch==""), skip filtering — the
-		// user explicitly asked for everything in this repo.
-		if branch != "" {
-			jobs = filterReachableJobs(worktreeRoot, branch, jobs)
+		// --all-branches: skip filtering, user wants everything.
+		// --branch X: pass branch so filterReachableJobs uses
+		// branch-field matching (cross-branch from worktree).
+		// Default: pass "" so filterReachableJobs uses commit-graph
+		// reachability for SHA/range refs.
+		if !allBranches {
+			filterBranch := ""
+			if explicitBranch {
+				filterBranch = branch
+			}
+			jobs = filterReachableJobs(worktreeRoot, filterBranch, jobs)
 		}
 
 		// Filter out jobs we've already processed
@@ -496,10 +517,11 @@ func runFixOpen(cmd *cobra.Command, branch string, newestFirst bool, opts fixOpt
 // graph; non-SHA refs (dirty, empty, task labels) fall back to
 // branch matching. branchOverride is the explicit --branch value
 // for non-mutating flows (e.g. --list); when set, all job types
-// use branch matching, so cross-branch listing works for SHA/range
-// jobs too. Mutating flows (fix, --batch) must pass "" so that
-// fixes are never applied to the wrong checkout. On git errors the
-// job is kept (fail open) to avoid silently dropping work.
+// use branch matching so cross-branch listing works for SHA/range
+// jobs too. Mutating flows (fix, --batch) pass "" so that
+// commit-graph reachability is checked. Callers that want all
+// branches (--all-branches) skip this function entirely. On git
+// errors the job is kept (fail open) to avoid silently dropping work.
 func filterReachableJobs(
 	worktreeRoot, branchOverride string,
 	jobs []storage.ReviewJob,
@@ -929,7 +951,7 @@ type batchEntry struct {
 
 // runFixBatch discovers jobs (or uses provided IDs), splits them into batches
 // respecting max prompt size, and runs each batch as a single agent invocation.
-func runFixBatch(cmd *cobra.Command, jobIDs []int64, branch string, newestFirst bool, opts fixOptions) error {
+func runFixBatch(cmd *cobra.Command, jobIDs []int64, branch string, allBranches, explicitBranch, newestFirst bool, opts fixOptions) error {
 	if err := ensureDaemon(); err != nil {
 		return err
 	}
@@ -958,8 +980,12 @@ func runFixBatch(cmd *cobra.Command, jobIDs []int64, branch string, newestFirst 
 		if queryErr != nil {
 			return queryErr
 		}
-		if branch != "" {
-			jobs = filterReachableJobs(repoRoot, branch, jobs)
+		if !allBranches {
+			filterBranch := ""
+			if explicitBranch {
+				filterBranch = branch
+			}
+			jobs = filterReachableJobs(repoRoot, filterBranch, jobs)
 		}
 		jobIDs = make([]int64, len(jobs))
 		for i, j := range jobs {

--- a/cmd/roborev/fix_test.go
+++ b/cmd/roborev/fix_test.go
@@ -749,7 +749,7 @@ func TestRunFixOpen(t *testing.T) {
 			Build()
 
 		out, err := runWithOutput(t, repo.Dir, func(cmd *cobra.Command) error {
-			return runFixOpen(cmd, "", false, fixOptions{agentName: "test"})
+			return runFixOpen(cmd, "", false, false, false, fixOptions{agentName: "test"})
 		})
 		require.NoError(t, err, "runFixOpen")
 		assert.Contains(t, out, "No open jobs found")
@@ -800,7 +800,7 @@ func TestRunFixOpen(t *testing.T) {
 			Build()
 
 		out, err := runWithOutput(t, repo.Dir, func(cmd *cobra.Command) error {
-			return runFixOpen(cmd, "", false, fixOptions{agentName: "test", reasoning: "fast"})
+			return runFixOpen(cmd, "", false, false, false, fixOptions{agentName: "test", reasoning: "fast"})
 		})
 		require.NoError(t, err, "runFixOpen")
 		assert.Contains(t, out, "Found 2 open job(s)")
@@ -823,7 +823,7 @@ func TestRunFixOpen(t *testing.T) {
 			Build()
 
 		_, err := runWithOutput(t, repo.Dir, func(cmd *cobra.Command) error {
-			return runFixOpen(cmd, "feature-branch", false, fixOptions{agentName: "test"})
+			return runFixOpen(cmd, "feature-branch", false, true, false, fixOptions{agentName: "test"})
 		})
 		require.NoError(t, err, "runFixOpen")
 		assert.Equal(t, "feature-branch", gotBranch)
@@ -838,7 +838,7 @@ func TestRunFixOpen(t *testing.T) {
 			Build()
 
 		_, err := runWithOutput(t, repo.Dir, func(cmd *cobra.Command) error {
-			return runFixOpen(cmd, "", false, fixOptions{agentName: "test"})
+			return runFixOpen(cmd, "", false, false, false, fixOptions{agentName: "test"})
 		})
 		require.Error(t, err, "expected error on server failure")
 		assert.Contains(t, err.Error(), "server error")
@@ -906,7 +906,7 @@ func TestRunFixOpen(t *testing.T) {
 			Build()
 
 		out, err := runWithOutput(t, repo.Dir, func(cmd *cobra.Command) error {
-			return runFixOpen(cmd, "", false, fixOptions{
+			return runFixOpen(cmd, "", true, false, false, fixOptions{
 				agentName: "test",
 				reasoning: "fast",
 			})
@@ -976,7 +976,7 @@ func TestRunFixOpen(t *testing.T) {
 			Build()
 
 		out, err := runWithOutput(t, repo.Dir, func(cmd *cobra.Command) error {
-			return runFixOpen(cmd, "target-branch", false, fixOptions{
+			return runFixOpen(cmd, "target-branch", false, true, false, fixOptions{
 				agentName: "test",
 				reasoning: "fast",
 			})
@@ -1042,7 +1042,7 @@ func TestRunFixOpenOrdering(t *testing.T) {
 		b.Build()
 
 		out, err := runWithOutput(t, repo.Dir, func(cmd *cobra.Command) error {
-			return runFixOpen(cmd, "", false, fixOptions{agentName: "test", reasoning: "fast"})
+			return runFixOpen(cmd, "", false, false, false, fixOptions{agentName: "test", reasoning: "fast"})
 		})
 		require.NoError(t, err)
 
@@ -1054,7 +1054,7 @@ func TestRunFixOpenOrdering(t *testing.T) {
 		b.Build()
 
 		out, err := runWithOutput(t, repo.Dir, func(cmd *cobra.Command) error {
-			return runFixOpen(cmd, "", true, fixOptions{agentName: "test", reasoning: "fast"})
+			return runFixOpen(cmd, "", false, false, true, fixOptions{agentName: "test", reasoning: "fast"})
 		})
 		require.NoError(t, err)
 
@@ -1120,7 +1120,7 @@ func TestRunFixOpenRequery(t *testing.T) {
 		Build()
 
 	out, err := runWithOutput(t, repo.Dir, func(cmd *cobra.Command) error {
-		return runFixOpen(cmd, "", false, fixOptions{agentName: "test", reasoning: "fast"})
+		return runFixOpen(cmd, "", false, false, false, fixOptions{agentName: "test", reasoning: "fast"})
 	})
 	require.NoError(t, err)
 
@@ -1214,7 +1214,7 @@ func TestRunFixOpenRecoversFromDaemonRestartOnRequery(t *testing.T) {
 		Build()
 
 	out, err := runWithOutput(t, repo.Dir, func(cmd *cobra.Command) error {
-		return runFixOpen(cmd, "", false, fixOptions{agentName: "test", reasoning: "fast"})
+		return runFixOpen(cmd, "", false, false, false, fixOptions{agentName: "test", reasoning: "fast"})
 	})
 	require.NoError(t, err)
 
@@ -1964,7 +1964,7 @@ func TestFixWorktreeRepoResolution(t *testing.T) {
 		var buf bytes.Buffer
 		cmd.SetOut(&buf)
 		opts := fixOptions{quiet: true}
-		if err := runFixOpen(cmd, "", false, opts); err != nil {
+		if err := runFixOpen(cmd, "", false, false, false, opts); err != nil {
 			require.NoError(t, err, "runFixOpen: %v")
 		}
 
@@ -1982,7 +1982,7 @@ func TestFixWorktreeRepoResolution(t *testing.T) {
 		cmd.SetOut(&buf)
 		opts := fixOptions{quiet: true}
 		// nil jobIDs triggers discovery via queryOpenJobs
-		if err := runFixBatch(cmd, nil, "", false, opts); err != nil {
+		if err := runFixBatch(cmd, nil, "", false, false, false, opts); err != nil {
 			require.NoError(t, err, "runFixBatch: %v")
 		}
 
@@ -2178,7 +2178,7 @@ func TestFixBatchSkipsPassVerdict(t *testing.T) {
 			cmd,
 			[]int64{10, 20},
 			"",
-			false,
+			false, false, false,
 			fixOptions{agentName: "test", reasoning: "fast"},
 		)
 	})
@@ -3020,12 +3020,13 @@ func TestRunFixOpenFiltersUnreachableJobs(t *testing.T) {
 		}).
 		Build()
 
-	// Pass the worktree's branch explicitly, matching what the CLI does
-	// when neither --all-branches nor --branch is set (effectiveBranch
-	// is resolved to the current branch before calling runFixOpen).
+	// Pass the worktree's branch for API query filtering, matching what
+	// the CLI does when neither --all-branches nor --branch is set
+	// (effectiveBranch is resolved to the current branch). allBranches
+	// is false, so filterReachableJobs uses commit-graph reachability.
 	_, runErr := runWithOutput(t, worktreeDir, func(cmd *cobra.Command) error {
 		return runFixOpen(
-			cmd, "wt-branch", false,
+			cmd, "wt-branch", false, false, false,
 			fixOptions{agentName: "test", reasoning: "fast"},
 		)
 	})


### PR DESCRIPTION
## Summary

- Fix `roborev fix --all-branches` and `--branch <name>` not discovering jobs from other branches when run from a git worktree — `filterReachableJobs` was called with an empty branch override, causing it to filter by the worktree's branch instead of the requested branch
- Deprecate `--open` and `--unaddressed` flags — open job discovery is now the default behavior when no positional job IDs are provided; both flags are hidden and silently ignored for backwards compatibility
- Thread `allBranches` and `explicitBranch` through `runFixOpen`/`runFixBatch` to distinguish three filtering modes: default (commit-graph reachability), `--branch X` (branch-field matching for cross-branch fixing), and `--all-branches` (skip filtering)
- Add tests for all-branches discovery, explicit branch filtering, and worktree reachability