### PR TITLE
Update flake.nix for v0.47.2

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         packages = {
           default = pkgs.buildGoModule {
             pname = "roborev";
-            version = "0.47.1";
+            version = "0.47.2";
 
             src = ./.;
 


### PR DESCRIPTION
Updates flake.nix version to 0.47.2 for the v0.47.2 release.