### PR TITLE
Check agentsview version before invoking token-use

### DIFF
--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -113,31 +113,34 @@ func ResetVersionCache() {
 }
 
 // resolveAgentsview checks whether agentsview is installed and new
-// enough. Caches positive results and definitive "too old" results
-// permanently. Transient failures (binary not found, timeout,
-// exec error, unparseable output) leave the cache unchecked so the
-// next call retries.
+// enough. The result is cached keyed to the resolved binary path,
+// so an upgrade, downgrade, or PATH change triggers a fresh probe.
+// Transient failures (binary not found, timeout, exec error,
+// unparseable output) leave the cache unchecked so the next call
+// retries.
 func resolveAgentsview(ctx context.Context) (string, bool) {
-	versionMu.Lock()
-	switch versionProbe {
-	case versionOK:
-		bin := cachedBin
-		versionMu.Unlock()
-		return bin, true
-	case versionTooOld:
-		versionMu.Unlock()
+	// LookPath is cheap (PATH scan, no exec) — always run it so we
+	// detect installs, upgrades, and PATH changes.
+	bin, err := exec.LookPath("agentsview")
+	if err != nil {
 		return "", false
+	}
+
+	versionMu.Lock()
+	if cachedBin == bin {
+		switch versionProbe {
+		case versionOK:
+			versionMu.Unlock()
+			return bin, true
+		case versionTooOld:
+			versionMu.Unlock()
+			return "", false
+		}
 	}
 	versionMu.Unlock()
 
-	// LookPath and exec run without holding the lock so concurrent
-	// callers are not blocked by the 5 s command timeout.
-	bin, err := exec.LookPath("agentsview")
-	if err != nil {
-		// Not installed — transient (could be installed later).
-		return "", false
-	}
-
+	// Exec runs without holding the lock so concurrent callers are
+	// not blocked by the 5 s command timeout.
 	cmdCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
@@ -145,7 +148,6 @@ func resolveAgentsview(ctx context.Context) (string, bool) {
 		cmdCtx, bin, "version",
 	).Output()
 	if err != nil {
-		// Exec/timeout error — don't cache, retry next time.
 		return "", false
 	}
 
@@ -155,11 +157,13 @@ func resolveAgentsview(ctx context.Context) (string, bool) {
 	defer versionMu.Unlock()
 
 	// Re-check: another goroutine may have updated the cache.
-	switch versionProbe {
-	case versionOK:
-		return cachedBin, true
-	case versionTooOld:
-		return "", false
+	if cachedBin == bin {
+		switch versionProbe {
+		case versionOK:
+			return bin, true
+		case versionTooOld:
+			return "", false
+		}
 	}
 
 	if supported {
@@ -168,10 +172,9 @@ func resolveAgentsview(ctx context.Context) (string, bool) {
 		return bin, true
 	}
 	if parsed {
-		// Parsed a version that is definitively too old.
 		versionProbe = versionTooOld
+		cachedBin = bin
 	}
-	// Unparseable output — don't cache, allow retry.
 	return "", false
 }
 

--- a/internal/tokens/tokens_test.go
+++ b/internal/tokens/tokens_test.go
@@ -239,6 +239,39 @@ echo "agentsview v0.15.0 (commit abc, built 2026-01-01)"
 	assert.False(t, ok, "too-old should be cached permanently")
 }
 
+func TestResolveAgentsviewInvalidatesCacheOnPathChange(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses shell scripts")
+	}
+
+	ResetVersionCache()
+	t.Cleanup(ResetVersionCache)
+
+	// First call: agentsview at dir1 is too old → cached.
+	dir1 := t.TempDir()
+	bin1 := filepath.Join(dir1, "agentsview")
+	script1 := "#!/bin/sh\necho 'agentsview v0.14.0 (commit abc)'\n"
+	require.NoError(t, os.WriteFile(bin1, []byte(script1), 0o755))
+
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", dir1+string(os.PathListSeparator)+origPath)
+
+	_, ok := resolveAgentsview(context.Background())
+	assert.False(t, ok)
+
+	// "Upgrade" by placing a new binary earlier in PATH.
+	dir2 := t.TempDir()
+	bin2 := filepath.Join(dir2, "agentsview")
+	script2 := "#!/bin/sh\necho 'agentsview v0.15.0 (commit def)'\n"
+	require.NoError(t, os.WriteFile(bin2, []byte(script2), 0o755))
+
+	t.Setenv("PATH", dir2+string(os.PathListSeparator)+origPath)
+
+	path, ok := resolveAgentsview(context.Background())
+	assert.True(t, ok, "new path should trigger re-probe")
+	assert.Equal(t, bin2, path)
+}
+
 func TestResolveAgentsviewRetriesAfterUnparseableOutput(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses shell scripts")


### PR DESCRIPTION
## Summary

- Gate `agentsview token-use` calls behind a version check (`agentsview version` >= 0.15.0) to prevent older installations from spawning a server/opening a browser
- Cache the version probe result per-process using a tri-state (`unchecked`/`ok`/`too_old`) so transient failures (missing binary, exec timeout) are retried on subsequent calls while definitive results are cached permanently
- Add tests for version parsing, old-version skipping, transient-failure retry, and permanent too-old caching

🤖 Generated with [Claude Code](https://claude.com/claude-code)