### PR TITLE
Refactor testutil git helpers

### DIFF
--- a/internal/daemon/remap_integration_test.go
+++ b/internal/daemon/remap_integration_test.go
@@ -20,7 +20,7 @@ import (
 type remapContext struct {
 	server  *Server
 	db      *storage.DB
-	repo    *testutil.GitHelper
+	repo    *testutil.TestRepo
 	oldSHA  string
 	patchID string
 	jobID   int64

--- a/internal/testutil/git.go
+++ b/internal/testutil/git.go
@@ -8,62 +8,223 @@ import (
 	"testing"
 )
 
-// GitHelper runs git commands in a repo directory.
-type GitHelper struct {
-	t            *testing.T
-	dir          string
+type testRepoOptions struct {
+	dir           string
+	initArgs      []string
+	configureUser bool
+	resolvePath   bool
+}
+
+// TestRepo encapsulates a temporary git repository for tests.
+type TestRepo struct {
+	Root         string
+	GitDir       string
+	HooksDir     string
+	HookPath     string
 	resolvedPath string
+	t            *testing.T
 }
 
-func (g *GitHelper) Run(args ...string) {
-	g.t.Helper()
+func newTestRepo(t *testing.T, opts testRepoOptions) *TestRepo {
+	t.Helper()
+
+	dir := opts.dir
+	if dir == "" {
+		dir = t.TempDir()
+	} else if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create repo dir %q: %v", dir, err)
+	}
+
+	repo := &TestRepo{
+		Root:     dir,
+		GitDir:   filepath.Join(dir, ".git"),
+		HooksDir: filepath.Join(dir, ".git", "hooks"),
+		HookPath: filepath.Join(dir, ".git", "hooks", "post-commit"),
+		t:        t,
+	}
+
+	if len(opts.initArgs) > 0 {
+		runGit(t, repo.Root, nil, opts.initArgs...)
+	}
+
+	if opts.configureUser {
+		repo.Config("user.email", GitUserEmail)
+		repo.Config("user.name", GitUserName)
+	}
+
+	if opts.resolvePath {
+		resolvedPath, err := filepath.EvalSymlinks(repo.Root)
+		if err != nil {
+			resolvedPath = repo.Root
+		}
+		repo.resolvedPath = resolvedPath
+	}
+
+	return repo
+}
+
+func runGit(t *testing.T, dir string, env []string, args ...string) string {
+	t.Helper()
+
 	cmd := exec.Command("git", args...)
-	cmd.Dir = g.dir
-	if out, err := cmd.CombinedOutput(); err != nil {
-		g.t.Fatalf("git %v: %s: %v", args, out, err)
+	cmd.Dir = dir
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
 	}
-}
 
-func (g *GitHelper) Path() string {
-	if g.resolvedPath != "" {
-		return g.resolvedPath
-	}
-	return g.dir
-}
-
-func (g *GitHelper) HeadSHA() string {
-	g.t.Helper()
-	cmd := exec.Command("git", "rev-parse", "HEAD")
-	cmd.Dir = g.dir
-	out, err := cmd.Output()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		g.t.Fatalf("git rev-parse HEAD: %v", err)
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
 	}
+
 	return strings.TrimSpace(string(out))
 }
 
-func (g *GitHelper) CommitFile(name, content, msg string) {
-	g.t.Helper()
-	if err := os.WriteFile(filepath.Join(g.dir, name), []byte(content), 0644); err != nil {
-		g.t.Fatal(err)
-	}
-	g.Run("add", name)
-	g.Run("commit", "-m", msg)
+func (r *TestRepo) runGitWithEnv(env []string, args ...string) string {
+	r.t.Helper()
+	return runGit(r.t, r.Root, env, args...)
 }
 
-func NewGitRepo(t *testing.T) *GitHelper {
+func (r *TestRepo) Run(args ...string) string {
+	r.t.Helper()
+	return r.runGitWithEnv(nil, args...)
+}
+
+// NewTestRepo creates a temporary git repository.
+func NewTestRepo(t *testing.T) *TestRepo {
 	t.Helper()
-	dir := t.TempDir()
+	return newTestRepo(t, testRepoOptions{
+		dir:      t.TempDir(),
+		initArgs: []string{"init"},
+	})
+}
 
-	// Resolve symlinks for macOS /var -> /private/var
-	resolvedPath, err := filepath.EvalSymlinks(dir)
-	if err != nil {
-		resolvedPath = dir
+// NewTestRepoWithCommit creates a temporary git repository with a file and
+// initial commit, suitable for tests that need a valid git history.
+func NewTestRepoWithCommit(t *testing.T) *TestRepo {
+	t.Helper()
+
+	repo := newTestRepo(t, testRepoOptions{
+		dir:           t.TempDir(),
+		initArgs:      []string{"init"},
+		configureUser: true,
+	})
+
+	repo.WriteFile("main.go", "package main\n\nfunc main() {\n\tprintln(\"hello\")\n}\n")
+	repo.RunGit("add", "main.go")
+	repo.RunGit("commit", "-m", "initial commit")
+
+	return repo
+}
+
+// InitTestRepo creates a standard test repository with an initial commit on the main branch.
+func InitTestRepo(t *testing.T) *TestRepo {
+	t.Helper()
+
+	repo := newTestRepo(t, testRepoOptions{
+		dir:           t.TempDir(),
+		initArgs:      []string{"init"},
+		configureUser: true,
+	})
+
+	repo.SymbolicRef("HEAD", "refs/heads/main")
+	repo.CommitFile("base.txt", "base", "base commit")
+
+	return repo
+}
+
+func (r *TestRepo) Path() string {
+	if r.resolvedPath != "" {
+		return r.resolvedPath
 	}
+	return r.Root
+}
 
-	g := &GitHelper{t: t, dir: dir, resolvedPath: resolvedPath}
-	g.Run("init", "-b", "main")
-	g.Run("config", "user.email", "test@test.com")
-	g.Run("config", "user.name", "Test")
-	return g
+func (r *TestRepo) HeadSHA() string {
+	r.t.Helper()
+	return r.RevParse("HEAD")
+}
+
+// RunGit runs a git command in the repo directory.
+func (r *TestRepo) RunGit(args ...string) {
+	r.t.Helper()
+	r.Run(args...)
+}
+
+// RevParse runs git rev-parse and returns the trimmed output.
+func (r *TestRepo) RevParse(args ...string) string {
+	r.t.Helper()
+	return r.Run(append([]string{"rev-parse"}, args...)...)
+}
+
+// WriteFile writes a file relative to the repo root, creating parent directories as needed.
+func (r *TestRepo) WriteFile(name, content string) {
+	r.t.Helper()
+
+	path := filepath.Join(r.Root, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		r.t.Fatalf("mkdir %q: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		r.t.Fatal(err)
+	}
+}
+
+// CommitFile writes a file, stages it, commits, and returns the new HEAD SHA.
+func (r *TestRepo) CommitFile(filename, content, msg string) string {
+	r.t.Helper()
+
+	r.WriteFile(filename, content)
+	r.RunGit("add", filename)
+	r.RunGit("commit", "-m", msg)
+	return r.HeadSHA()
+}
+
+// Config sets a git config value.
+func (r *TestRepo) Config(key, value string) {
+	r.t.Helper()
+	r.RunGit("config", key, value)
+}
+
+// Checkout runs git checkout.
+func (r *TestRepo) Checkout(args ...string) {
+	r.t.Helper()
+	allArgs := append([]string{"checkout"}, args...)
+	r.RunGit(allArgs...)
+}
+
+// SymbolicRef runs git symbolic-ref.
+func (r *TestRepo) SymbolicRef(ref, target string) {
+	r.t.Helper()
+	r.RunGit("symbolic-ref", ref, target)
+}
+
+func NewGitRepo(t *testing.T) *TestRepo {
+	t.Helper()
+	return newTestRepo(t, testRepoOptions{
+		dir:           t.TempDir(),
+		initArgs:      []string{"init", "-b", "main"},
+		configureUser: true,
+		resolvePath:   true,
+	})
+}
+
+// InitTestGitRepo initializes a git repository with a commit in the given directory.
+// Creates the directory if it doesn't exist, runs git init, configures user, creates
+// a test file, and makes an initial commit.
+func InitTestGitRepo(t *testing.T, dir string) {
+	t.Helper()
+
+	repo := newTestRepo(t, testRepoOptions{
+		dir:           dir,
+		initArgs:      []string{"init"},
+		configureUser: true,
+	})
+	repo.CommitFile("test.txt", "test content", "initial commit")
+}
+
+// GetHeadSHA returns the HEAD commit SHA for the git repo at dir.
+func GetHeadSHA(t *testing.T, dir string) string {
+	t.Helper()
+	return runGit(t, dir, nil, "rev-parse", "HEAD")
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -8,11 +8,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"slices"
-	"strings"
 	"testing"
 	"time"
 
@@ -23,132 +21,6 @@ const (
 	GitUserName  = "Test"
 	GitUserEmail = "test@test.com"
 )
-
-// TestRepo encapsulates a temporary git repository for tests.
-type TestRepo struct {
-	Root     string
-	GitDir   string
-	HooksDir string
-	HookPath string
-	t        *testing.T
-}
-
-// NewTestRepo creates a temporary git repository.
-func NewTestRepo(t *testing.T) *TestRepo {
-	t.Helper()
-	tmpDir := t.TempDir()
-
-	cmd := exec.Command("git", "init")
-	cmd.Dir = tmpDir
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git init failed: %v\n%s", err, out)
-	}
-
-	return &TestRepo{
-		Root:     tmpDir,
-		GitDir:   filepath.Join(tmpDir, ".git"),
-		HooksDir: filepath.Join(tmpDir, ".git", "hooks"),
-		HookPath: filepath.Join(tmpDir, ".git", "hooks", "post-commit"),
-		t:        t,
-	}
-}
-
-// NewTestRepoWithCommit creates a temporary git repository with a file and
-// initial commit, suitable for tests that need a valid git history.
-func NewTestRepoWithCommit(t *testing.T) *TestRepo {
-	t.Helper()
-	repo := NewTestRepo(t)
-
-	runGit := func(args ...string) {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = repo.Root
-		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME="+GitUserName,
-			"GIT_AUTHOR_EMAIL="+GitUserEmail,
-			"GIT_COMMITTER_NAME="+GitUserName,
-			"GIT_COMMITTER_EMAIL="+GitUserEmail,
-		)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v failed: %v\n%s", args, err, out)
-		}
-	}
-
-	runGit("config", "user.email", GitUserEmail)
-	runGit("config", "user.name", GitUserName)
-
-	if err := os.WriteFile(filepath.Join(repo.Root, "main.go"), []byte("package main\n\nfunc main() {\n\tprintln(\"hello\")\n}\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	runGit("add", "main.go")
-	runGit("commit", "-m", "initial commit")
-
-	return repo
-}
-
-// InitTestRepo creates a standard test repository with an initial commit on the main branch.
-func InitTestRepo(t *testing.T) *TestRepo {
-	t.Helper()
-	repo := NewTestRepo(t)
-	repo.RunGit("init")
-	repo.SymbolicRef("HEAD", "refs/heads/main")
-	repo.Config("user.email", GitUserEmail)
-	repo.Config("user.name", GitUserName)
-	repo.CommitFile("base.txt", "base", "base commit")
-	return repo
-}
-
-// RunGit runs a git command in the repo directory.
-func (r *TestRepo) RunGit(args ...string) {
-	r.t.Helper()
-	cmd := exec.Command("git", args...)
-	cmd.Dir = r.Root
-	if out, err := cmd.CombinedOutput(); err != nil {
-		r.t.Fatalf("git %v failed: %v\n%s", args, err, out)
-	}
-}
-
-// RevParse runs git rev-parse and returns the trimmed output.
-func (r *TestRepo) RevParse(args ...string) string {
-	r.t.Helper()
-	cmd := exec.Command("git", append([]string{"rev-parse"}, args...)...)
-	cmd.Dir = r.Root
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		r.t.Fatalf("git rev-parse %v failed: %v\n%s", args, err, out)
-	}
-	return strings.TrimSpace(string(out))
-}
-
-// CommitFile writes a file, stages it, commits, and returns the new HEAD SHA.
-func (r *TestRepo) CommitFile(filename, content, msg string) string {
-	r.t.Helper()
-	if err := os.WriteFile(filepath.Join(r.Root, filename), []byte(content), 0644); err != nil {
-		r.t.Fatal(err)
-	}
-	r.RunGit("add", filename)
-	r.RunGit("commit", "-m", msg)
-	return r.RevParse("HEAD")
-}
-
-// Config sets a git config value.
-func (r *TestRepo) Config(key, value string) {
-	r.t.Helper()
-	r.RunGit("config", key, value)
-}
-
-// Checkout runs git checkout.
-func (r *TestRepo) Checkout(args ...string) {
-	r.t.Helper()
-	allArgs := append([]string{"checkout"}, args...)
-	r.RunGit(allArgs...)
-}
-
-// SymbolicRef runs git symbolic-ref.
-func (r *TestRepo) SymbolicRef(ref, target string) {
-	r.t.Helper()
-	r.RunGit("symbolic-ref", ref, target)
-}
 
 // Chdir changes the working directory to the repo root and returns a
 // restore function. The caller should defer the returned function.
@@ -200,78 +72,75 @@ func (r *TestRepo) RemoveHooksDir() {
 	}
 }
 
-// MockExecutable creates a fake executable in PATH that exits with the given code.
-// Returns a cleanup function.
-func MockExecutable(t *testing.T, binName string, exitCode int) func() {
-	t.Helper()
-	tmpBin := t.TempDir()
-	var path string
-	var content []byte
+type pathMode int
 
-	if runtime.GOOS == "windows" {
-		path = filepath.Join(tmpBin, binName+".bat")
-		content = fmt.Appendf(nil, "@exit /b %d\r\n", exitCode)
-	} else {
-		path = filepath.Join(tmpBin, binName)
-		content = fmt.Appendf(nil, "#!/bin/sh\nexit %d\n", exitCode)
+const (
+	pathPrepend pathMode = iota
+	pathIsolate
+)
+
+func executableName(binName string) string {
+	if runtime.GOOS == "windows" && filepath.Ext(binName) == "" {
+		return binName + ".bat"
 	}
+	return binName
+}
 
+func mockScriptInPath(t *testing.T, binName, scriptContent string, mode pathMode) func() {
+	t.Helper()
+
+	tmpBin := t.TempDir()
+
+	path := filepath.Join(tmpBin, executableName(binName))
+	content := []byte(scriptContent)
 	if err := os.WriteFile(path, content, 0755); err != nil {
 		t.Fatal(err)
 	}
 
 	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", tmpBin+string(os.PathListSeparator)+origPath)
+	switch mode {
+	case pathIsolate:
+		os.Setenv("PATH", tmpBin)
+	default:
+		os.Setenv("PATH", tmpBin+string(os.PathListSeparator)+origPath)
+	}
 
 	return func() {
 		os.Setenv("PATH", origPath)
 	}
+}
+
+func mockExitCodeExecutable(t *testing.T, binName string, exitCode int, mode pathMode) func() {
+	t.Helper()
+
+	var scriptContent string
+	if runtime.GOOS == "windows" {
+		scriptContent = fmt.Sprintf("@exit /b %d\r\n", exitCode)
+	} else {
+		scriptContent = fmt.Sprintf("#!/bin/sh\nexit %d\n", exitCode)
+	}
+
+	return mockScriptInPath(t, binName, scriptContent, mode)
+}
+
+// MockExecutable creates a fake executable in PATH that exits with the given code.
+// Returns a cleanup function.
+func MockExecutable(t *testing.T, binName string, exitCode int) func() {
+	t.Helper()
+	return mockExitCodeExecutable(t, binName, exitCode, pathPrepend)
 }
 
 // MockExecutableIsolated creates a fake executable in a new directory and sets PATH to ONLY that directory.
 // Returns a cleanup function.
 func MockExecutableIsolated(t *testing.T, binName string, exitCode int) func() {
 	t.Helper()
-	tmpBin := t.TempDir()
-	var path string
-	var content []byte
-
-	if runtime.GOOS == "windows" {
-		path = filepath.Join(tmpBin, binName+".bat")
-		content = fmt.Appendf(nil, "@exit /b %d\r\n", exitCode)
-	} else {
-		path = filepath.Join(tmpBin, binName)
-		content = fmt.Appendf(nil, "#!/bin/sh\nexit %d\n", exitCode)
-	}
-
-	if err := os.WriteFile(path, content, 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", tmpBin)
-
-	return func() {
-		os.Setenv("PATH", origPath)
-	}
+	return mockExitCodeExecutable(t, binName, exitCode, pathIsolate)
 }
 
 // MockBinaryInPath creates a fake executable in PATH and returns a cleanup function.
 func MockBinaryInPath(t *testing.T, binName, scriptContent string) func() {
 	t.Helper()
-	tmpBin := t.TempDir()
-
-	path := filepath.Join(tmpBin, binName)
-	if err := os.WriteFile(path, []byte(scriptContent), 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", tmpBin+string(os.PathListSeparator)+origPath)
-
-	return func() {
-		os.Setenv("PATH", origPath)
-	}
+	return mockScriptInPath(t, binName, scriptContent, pathPrepend)
 }
 
 // OpenTestDB creates a test database in a temporary directory.
@@ -370,53 +239,6 @@ func CreateTestJobWithSHA(t *testing.T, db *storage.DB, repo *storage.Repo, sha,
 	}
 
 	return job
-}
-
-// InitTestGitRepo initializes a git repository with a commit in the given directory.
-// Creates the directory if it doesn't exist, runs git init, configures user, creates
-// a test file, and makes an initial commit.
-func InitTestGitRepo(t *testing.T, dir string) {
-	t.Helper()
-
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		t.Fatalf("Failed to create repo dir: %v", err)
-	}
-
-	cmds := [][]string{
-		{"git", "-C", dir, "init"},
-		{"git", "-C", dir, "config", "user.email", GitUserEmail},
-		{"git", "-C", dir, "config", "user.name", GitUserName},
-	}
-	for _, args := range cmds {
-		cmd := exec.Command(args[0], args[1:]...)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git command %v failed: %v\n%s", args, err, out)
-		}
-	}
-
-	testFile := filepath.Join(dir, "test.txt")
-	if err := os.WriteFile(testFile, []byte("test content"), 0644); err != nil {
-		t.Fatalf("Failed to create test file: %v", err)
-	}
-	addCmd := exec.Command("git", "-C", dir, "add", ".")
-	if out, err := addCmd.CombinedOutput(); err != nil {
-		t.Fatalf("git add failed: %v\n%s", err, out)
-	}
-	commitCmd := exec.Command("git", "-C", dir, "commit", "-m", "initial commit")
-	if out, err := commitCmd.CombinedOutput(); err != nil {
-		t.Fatalf("git commit failed: %v\n%s", err, out)
-	}
-}
-
-// GetHeadSHA returns the HEAD commit SHA for the git repo at dir.
-func GetHeadSHA(t *testing.T, dir string) string {
-	t.Helper()
-	cmd := exec.Command("git", "-C", dir, "rev-parse", "HEAD")
-	out, err := cmd.Output()
-	if err != nil {
-		t.Fatalf("git rev-parse HEAD failed: %v", err)
-	}
-	return strings.TrimSpace(string(out))
 }
 
 // MakeJSONRequest creates an HTTP request with the given body marshaled as JSON.

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -1,7 +1,9 @@
 package testutil
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,4 +35,37 @@ func TestMockExecutableIsolated(t *testing.T) {
 
 	_, err = exec.LookPath(baseline)
 	require.Error(t, err, "expected %q to be absent from isolated PATH", baseline)
+}
+
+func TestMockBinaryHelpersRestorePath(t *testing.T) {
+	origPath := os.Getenv("PATH")
+
+	cleanup := MockBinaryInPath(t, "test-script", "#!/bin/sh\nexit 0\n")
+
+	_, err := exec.LookPath("test-script")
+	require.NoError(t, err, "expected mocked binary in PATH")
+
+	cleanup()
+
+	require.Equal(t, origPath, os.Getenv("PATH"))
+}
+
+func TestCommitFileCreatesParentDirectories(t *testing.T) {
+	repo := InitTestRepo(t)
+
+	sha := repo.CommitFile(filepath.Join("nested", "dir", "file.txt"), "hello", "add nested file")
+
+	require.Equal(t, repo.HeadSHA(), sha)
+
+	content, err := os.ReadFile(filepath.Join(repo.Root, "nested", "dir", "file.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(content))
+}
+
+func TestNewGitRepoReturnsResolvedPath(t *testing.T) {
+	repo := NewGitRepo(t)
+
+	resolved, err := filepath.EvalSymlinks(repo.Root)
+	require.NoError(t, err)
+	require.Equal(t, resolved, repo.Path())
 }


### PR DESCRIPTION
## Summary
- unify internal/testutil repo creation and git execution around TestRepo
- preserve resolved-path behavior for remap integration tests and keep lightweight empty-repo setup semantics
- centralize PATH mocking helpers and add regression coverage for nested writes, PATH restore, and resolved paths

## Validation
- go fmt ./...
- go vet ./...
- go test ./...
- go test ./internal/daemon -run TestRemapAfterRebase -tags=integration
- go test ./internal/worktree -tags=integration -run "Test(CreateTempWorktree|CreateWorktree)"
- go test ./cmd/roborev -run "Test(UninstallHookCmd|InstallHookCmdCreatesHooksDirectory|InstallHookCmdCreatesPostRewriteHook|InitNoDaemon)"