### PR TITLE
Refactor skills installation/status around shared multi-agent catalog

### DIFF
--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -426,10 +427,5 @@ func fileExists(path string) bool {
 }
 
 func anyFileExists(paths []string) bool {
-	for _, p := range paths {
-		if fileExists(p) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(paths, fileExists)
 }

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -3,7 +3,6 @@ package skills
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -462,9 +461,9 @@ func TestDirNameEnumerationDoesNotReadContent(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, paths, 2)
 	for _, p := range paths {
-		assert.True(t, strings.Contains(p, filepath.Join(home, ".mock", "skills")),
+		assert.Contains(t, p, filepath.Join(home, ".mock", "skills"),
 			"path should be under agent skills dir: %s", p)
-		assert.True(t, strings.HasSuffix(p, "SKILL.md"),
+		assert.Contains(t, p, "SKILL.md",
 			"path should end with SKILL.md: %s", p)
 	}
 }


### PR DESCRIPTION
## Summary
- Replace per-agent install/update logic with a shared `supportedAgents` catalog and a unified `installAgent` flow.
- Add reusable helpers for agent path resolution, embedded skill loading, installed-skill detection, and legacy-skill cleanup.
- Update `ListSkills` to build metadata from a combined embedded catalog across agents instead of a Claude-only source.
- Refactor `Status` and `Update` to use shared catalog-driven logic, including legacy-only installs via `anyFileExists` checks.
- Rework skills tests to be agent-parameterized and dynamically derive expected skill names from `ListSkills`.

## Testing
- Not run (tests were not executed in this context).
- Verified by inspection that refactored tests cover install, idempotency, legacy cleanup, and update behavior for both Claude and Codex paths.