### PR TITLE
Refactor streamfmt Codex command tracking

### DIFF
--- a/internal/streamfmt/codex_tracker.go
+++ b/internal/streamfmt/codex_tracker.go
@@ -1,0 +1,177 @@
+package streamfmt
+
+import "strings"
+
+// codexCommandTracker pairs Codex started/completed command events so each
+// command is rendered once while tolerating mixed ID coverage.
+type codexCommandTracker struct {
+	renderedIDs  map[string]struct{}
+	startedByID  map[string]string
+	startedCount map[string]int
+	startedQueue map[string][]string
+}
+
+// Observe records a Codex command event and reports whether the normalized
+// command text should be rendered.
+func (t *codexCommandTracker) Observe(
+	eventType string, item codexItem,
+) (string, bool) {
+	if eventType != "item.started" && eventType != "item.completed" {
+		return "", false
+	}
+
+	id := strings.TrimSpace(item.ID)
+	cmd := strings.TrimSpace(item.Command)
+
+	if eventType == "item.started" {
+		if cmd == "" {
+			return "", false
+		}
+		if id != "" {
+			if t.wasRendered(id) {
+				return "", false
+			}
+			t.markRendered(id)
+			t.rememberStarted(id, cmd)
+		}
+		t.incrementStarted(cmd)
+		return cmd, true
+	}
+
+	if cmd == "" {
+		if id != "" {
+			t.clearStartedID(id)
+		}
+		return "", false
+	}
+
+	if id != "" {
+		if startedCmd, ok := t.clearStartedID(id); ok && startedCmd == cmd {
+			t.markRendered(id)
+			return "", false
+		}
+	}
+
+	if t.startedCount[cmd] > 0 {
+		t.decrementStarted(cmd)
+		if id == "" {
+			t.consumeStartedIDForCommand(cmd)
+		} else {
+			t.markRendered(id)
+		}
+		return "", false
+	}
+
+	if id != "" {
+		if t.wasRendered(id) {
+			return "", false
+		}
+		t.markRendered(id)
+	}
+
+	return cmd, true
+}
+
+func (t *codexCommandTracker) rememberStarted(id, cmd string) {
+	t.ensureMaps()
+	t.startedByID[id] = cmd
+	t.startedQueue[cmd] = append(t.startedQueue[cmd], id)
+}
+
+func (t *codexCommandTracker) incrementStarted(cmd string) {
+	if cmd == "" {
+		return
+	}
+	t.ensureMaps()
+	t.startedCount[cmd]++
+}
+
+func (t *codexCommandTracker) decrementStarted(cmd string) {
+	if cmd == "" {
+		return
+	}
+	count := t.startedCount[cmd]
+	if count <= 0 {
+		return
+	}
+	if count == 1 {
+		delete(t.startedCount, cmd)
+		return
+	}
+	t.startedCount[cmd] = count - 1
+}
+
+func (t *codexCommandTracker) clearStartedID(id string) (string, bool) {
+	if id == "" {
+		return "", false
+	}
+	cmd, ok := t.startedByID[id]
+	if !ok {
+		return "", false
+	}
+	t.decrementStarted(cmd)
+	t.removeStartedIDFromQueue(cmd, id)
+	delete(t.startedByID, id)
+	return cmd, true
+}
+
+func (t *codexCommandTracker) consumeStartedIDForCommand(cmd string) {
+	if cmd == "" {
+		return
+	}
+	ids := t.startedQueue[cmd]
+	if len(ids) == 0 {
+		return
+	}
+	consumed := ids[0]
+	if len(ids) == 1 {
+		delete(t.startedQueue, cmd)
+	} else {
+		t.startedQueue[cmd] = ids[1:]
+	}
+	delete(t.startedByID, consumed)
+}
+
+func (t *codexCommandTracker) removeStartedIDFromQueue(cmd, id string) {
+	ids := t.startedQueue[cmd]
+	for i, v := range ids {
+		if v == id {
+			t.startedQueue[cmd] = append(ids[:i], ids[i+1:]...)
+			if len(t.startedQueue[cmd]) == 0 {
+				delete(t.startedQueue, cmd)
+			}
+			return
+		}
+	}
+}
+
+func (t *codexCommandTracker) wasRendered(id string) bool {
+	if id == "" {
+		return false
+	}
+	_, seen := t.renderedIDs[id]
+	return seen
+}
+
+func (t *codexCommandTracker) markRendered(id string) {
+	if id == "" {
+		return
+	}
+	t.ensureMaps()
+	t.renderedIDs[id] = struct{}{}
+}
+
+func (t *codexCommandTracker) ensureMaps() {
+	if t.renderedIDs == nil {
+		t.renderedIDs = make(map[string]struct{})
+	}
+	if t.startedByID == nil {
+		t.startedByID = make(map[string]string)
+	}
+	if t.startedCount == nil {
+		t.startedCount = make(map[string]int)
+	}
+	if t.startedQueue == nil {
+		t.startedQueue = make(map[string][]string)
+	}
+}

--- a/internal/streamfmt/codex_tracker_test.go
+++ b/internal/streamfmt/codex_tracker_test.go
@@ -1,0 +1,202 @@
+package streamfmt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type codexTrackerExpectation struct {
+	name       string
+	eventType  string
+	item       codexItem
+	wantCmd    string
+	wantRender bool
+}
+
+func TestCodexCommandTracker(t *testing.T) {
+	tests := []struct {
+		name         string
+		observations []codexTrackerExpectation
+	}{
+		{
+			name: "StartedThenCompletedSameIDSuppressesCompletion",
+			observations: []codexTrackerExpectation{
+				{
+					name:       "started",
+					eventType:  "item.started",
+					item:       codexItem{ID: "cmd_1", Command: "bash -lc ls"},
+					wantCmd:    "bash -lc ls",
+					wantRender: true,
+				},
+				{
+					name:       "completed",
+					eventType:  "item.completed",
+					item:       codexItem{ID: "cmd_1", Command: "bash -lc ls"},
+					wantRender: false,
+				},
+			},
+		},
+		{
+			name: "CompletedWithoutStartedRenders",
+			observations: []codexTrackerExpectation{
+				{
+					name:       "completed",
+					eventType:  "item.completed",
+					item:       codexItem{ID: "cmd_2", Command: "bash -lc pwd"},
+					wantCmd:    "bash -lc pwd",
+					wantRender: true,
+				},
+			},
+		},
+		{
+			name: "MixedIDStartedWithoutIDCompletedWithIDSuppressesEcho",
+			observations: []codexTrackerExpectation{
+				{
+					name:       "started without id",
+					eventType:  "item.started",
+					item:       codexItem{Command: "bash -lc ls"},
+					wantCmd:    "bash -lc ls",
+					wantRender: true,
+				},
+				{
+					name:       "completed with id",
+					eventType:  "item.completed",
+					item:       codexItem{ID: "cmd_1", Command: "bash -lc ls"},
+					wantRender: false,
+				},
+			},
+		},
+		{
+			name: "MixedIDStartedWithIDCompletedWithoutIDSuppressesEcho",
+			observations: []codexTrackerExpectation{
+				{
+					name:       "started with id",
+					eventType:  "item.started",
+					item:       codexItem{ID: "cmd_1", Command: "bash -lc ls"},
+					wantCmd:    "bash -lc ls",
+					wantRender: true,
+				},
+				{
+					name:       "completed without id",
+					eventType:  "item.completed",
+					item:       codexItem{Command: "bash -lc ls"},
+					wantRender: false,
+				},
+			},
+		},
+		{
+			name: "CompletionWithoutCommandClearsStartedState",
+			observations: []codexTrackerExpectation{
+				{
+					name:       "started",
+					eventType:  "item.started",
+					item:       codexItem{ID: "cmd_1", Command: "bash -lc ls"},
+					wantCmd:    "bash -lc ls",
+					wantRender: true,
+				},
+				{
+					name:       "completed no command",
+					eventType:  "item.completed",
+					item:       codexItem{ID: "cmd_1"},
+					wantRender: false,
+				},
+				{
+					name:       "later completed",
+					eventType:  "item.completed",
+					item:       codexItem{ID: "cmd_2", Command: "bash -lc ls"},
+					wantCmd:    "bash -lc ls",
+					wantRender: true,
+				},
+			},
+		},
+		{
+			name: "CommandFallbackDoesNotLeaveStaleIDState",
+			observations: []codexTrackerExpectation{
+				{
+					name:       "started cmd 1",
+					eventType:  "item.started",
+					item:       codexItem{ID: "cmd_1", Command: "bash -lc ls"},
+					wantCmd:    "bash -lc ls",
+					wantRender: true,
+				},
+				{
+					name:       "command-only completion",
+					eventType:  "item.completed",
+					item:       codexItem{Command: "bash -lc ls"},
+					wantRender: false,
+				},
+				{
+					name:       "started cmd 2",
+					eventType:  "item.started",
+					item:       codexItem{ID: "cmd_2", Command: "bash -lc ls"},
+					wantCmd:    "bash -lc ls",
+					wantRender: true,
+				},
+				{
+					name:       "late completion for cmd 1",
+					eventType:  "item.completed",
+					item:       codexItem{ID: "cmd_1"},
+					wantRender: false,
+				},
+				{
+					name:       "completion for cmd 2",
+					eventType:  "item.completed",
+					item:       codexItem{Command: "bash -lc ls"},
+					wantRender: false,
+				},
+			},
+		},
+		{
+			name: "MultipleIDsPairInFIFOOrder",
+			observations: []codexTrackerExpectation{
+				{
+					name:       "started A",
+					eventType:  "item.started",
+					item:       codexItem{ID: "cmd_A", Command: "bash -lc ls"},
+					wantCmd:    "bash -lc ls",
+					wantRender: true,
+				},
+				{
+					name:       "started B",
+					eventType:  "item.started",
+					item:       codexItem{ID: "cmd_B", Command: "bash -lc ls"},
+					wantCmd:    "bash -lc ls",
+					wantRender: true,
+				},
+				{
+					name:       "first command-only completion",
+					eventType:  "item.completed",
+					item:       codexItem{Command: "bash -lc ls"},
+					wantRender: false,
+				},
+				{
+					name:       "completion for B",
+					eventType:  "item.completed",
+					item:       codexItem{ID: "cmd_B"},
+					wantRender: false,
+				},
+				{
+					name:       "second command-only completion",
+					eventType:  "item.completed",
+					item:       codexItem{Command: "bash -lc ls"},
+					wantCmd:    "bash -lc ls",
+					wantRender: true,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tracker codexCommandTracker
+			for _, obs := range tt.observations {
+				t.Run(obs.name, func(t *testing.T) {
+					gotCmd, gotRender := tracker.Observe(obs.eventType, obs.item)
+					assert.Equal(t, obs.wantCmd, gotCmd)
+					assert.Equal(t, obs.wantRender, gotRender)
+				})
+			}
+		})
+	}
+}

--- a/internal/streamfmt/render.go
+++ b/internal/streamfmt/render.go
@@ -263,13 +263,3 @@ func RenderMarkdownLines(
 	}
 	return lines
 }
-
-// renderMarkdownLines is the package-private alias used by Formatter.
-func renderMarkdownLines(
-	text string, wrapWidth, maxWidth int,
-	glamourStyle gansi.StyleConfig, tabWidth int,
-) []string {
-	return RenderMarkdownLines(
-		text, wrapWidth, maxWidth, glamourStyle, tabWidth,
-	)
-}

--- a/internal/streamfmt/streamfmt.go
+++ b/internal/streamfmt/streamfmt.go
@@ -60,15 +60,7 @@ type Formatter struct {
 
 	// Tracks opencode tool call IDs that have already been rendered.
 	opencodeRenderedToolIDs map[string]struct{}
-
-	// Tracks codex command_execution items that have already been rendered.
-	codexRenderedCommandIDs map[string]struct{}
-	// Track started command text to suppress duplicate completed echoes, including mixed-ID pairs.
-	codexStartedCommands map[string]int
-	// Track started command text by ID so completed events missing command can clear started state.
-	codexStartedCommandsByID map[string]string
-	// Track started IDs per command in FIFO order for deterministic pairing.
-	codexStartedIDsByCommand map[string][]string
+	codexCommands           codexCommandTracker
 }
 
 // New creates a Formatter that writes to w. When isTTY is true,
@@ -301,7 +293,11 @@ func (f *Formatter) processCodexItem(eventType string, item *codexItem) {
 		f.writeText(SanitizeControlKeepNewlines(item.Text))
 	case "command_execution":
 		cmd := strings.TrimSpace(sanitizeControl(item.Command))
-		if !f.shouldRenderCodexCommand(eventType, item, cmd) {
+		cmd, render := f.codexCommands.Observe(eventType, codexItem{
+			ID:      item.ID,
+			Command: cmd,
+		})
+		if !render {
 			return
 		}
 		if len(cmd) > 80 {
@@ -314,143 +310,6 @@ func (f *Formatter) processCodexItem(eventType string, item *codexItem) {
 		}
 		f.writeTool("Edit", "")
 	}
-}
-
-func (f *Formatter) shouldRenderCodexCommand(eventType string, item *codexItem, cmd string) bool {
-	if eventType != "item.started" && eventType != "item.completed" {
-		return false
-	}
-	id := strings.TrimSpace(item.ID)
-	if eventType == "item.started" {
-		if cmd == "" {
-			return false
-		}
-		if id != "" {
-			if f.codexRenderedCommandIDs == nil {
-				f.codexRenderedCommandIDs = make(map[string]struct{})
-			}
-			if _, seen := f.codexRenderedCommandIDs[id]; seen {
-				return false
-			}
-			f.codexRenderedCommandIDs[id] = struct{}{}
-			if f.codexStartedCommandsByID == nil {
-				f.codexStartedCommandsByID = make(map[string]string)
-			}
-			f.codexStartedCommandsByID[id] = cmd
-			if f.codexStartedIDsByCommand == nil {
-				f.codexStartedIDsByCommand = make(map[string][]string)
-			}
-			f.codexStartedIDsByCommand[cmd] = append(f.codexStartedIDsByCommand[cmd], id)
-		}
-		if f.codexStartedCommands == nil {
-			f.codexStartedCommands = make(map[string]int)
-		}
-		f.codexStartedCommands[cmd]++
-		return true
-	}
-
-	if cmd == "" {
-		if id != "" {
-			if startedCmd, ok := f.codexStartedCommandsByID[id]; ok {
-				f.decrementCodexStartedCommand(startedCmd)
-				f.removeCodexStartedIDFromQueue(startedCmd, id)
-				delete(f.codexStartedCommandsByID, id)
-			}
-		}
-		return false
-	}
-
-	if id != "" {
-		if startedCmd, ok := f.codexStartedCommandsByID[id]; ok {
-			f.decrementCodexStartedCommand(startedCmd)
-			f.removeCodexStartedIDFromQueue(startedCmd, id)
-			delete(f.codexStartedCommandsByID, id)
-			if startedCmd == cmd {
-				if f.codexRenderedCommandIDs == nil {
-					f.codexRenderedCommandIDs = make(map[string]struct{})
-				}
-				f.codexRenderedCommandIDs[id] = struct{}{}
-				return false
-			}
-		}
-	}
-
-	// Completed events should be suppressed when we've already rendered the paired
-	// started event for the same command text, even if ID presence changed.
-	if count := f.codexStartedCommands[cmd]; count > 0 {
-		f.decrementCodexStartedCommand(cmd)
-		if id == "" {
-			// Keep ID->command tracking in sync when a completion is matched by command only.
-			f.consumeCodexStartedCommandIDForCommand(cmd)
-		}
-		if id != "" {
-			if f.codexRenderedCommandIDs == nil {
-				f.codexRenderedCommandIDs = make(map[string]struct{})
-			}
-			f.codexRenderedCommandIDs[id] = struct{}{}
-		}
-		return false
-	}
-
-	if id != "" {
-		if f.codexRenderedCommandIDs == nil {
-			f.codexRenderedCommandIDs = make(map[string]struct{})
-		}
-		if _, seen := f.codexRenderedCommandIDs[id]; seen {
-			return false
-		}
-		f.codexRenderedCommandIDs[id] = struct{}{}
-		return true
-	}
-
-	return true
-}
-
-func (f *Formatter) consumeCodexStartedCommandIDForCommand(cmd string) {
-	if cmd == "" {
-		return
-	}
-	ids := f.codexStartedIDsByCommand[cmd]
-	if len(ids) == 0 {
-		return
-	}
-	// Pop the oldest ID (FIFO) for deterministic pairing.
-	consumed := ids[0]
-	if len(ids) == 1 {
-		delete(f.codexStartedIDsByCommand, cmd)
-	} else {
-		f.codexStartedIDsByCommand[cmd] = ids[1:]
-	}
-	delete(f.codexStartedCommandsByID, consumed)
-}
-
-// removeCodexStartedIDFromQueue removes a specific ID from the per-command FIFO.
-func (f *Formatter) removeCodexStartedIDFromQueue(cmd, id string) {
-	ids := f.codexStartedIDsByCommand[cmd]
-	for i, v := range ids {
-		if v == id {
-			f.codexStartedIDsByCommand[cmd] = append(ids[:i], ids[i+1:]...)
-			if len(f.codexStartedIDsByCommand[cmd]) == 0 {
-				delete(f.codexStartedIDsByCommand, cmd)
-			}
-			return
-		}
-	}
-}
-
-func (f *Formatter) decrementCodexStartedCommand(cmd string) {
-	if cmd == "" {
-		return
-	}
-	count := f.codexStartedCommands[cmd]
-	if count <= 0 {
-		return
-	}
-	if count == 1 {
-		delete(f.codexStartedCommands, cmd)
-		return
-	}
-	f.codexStartedCommands[cmd] = count - 1
 }
 
 func (f *Formatter) processOpenCodePart(
@@ -599,7 +458,7 @@ func (f *Formatter) writeText(text string) {
 		f.writef("%s\n", text)
 		return
 	}
-	lines := renderMarkdownLines(
+	lines := RenderMarkdownLines(
 		text, f.width, f.width, f.glamourStyle, 2,
 	)
 	for _, line := range lines {
@@ -663,7 +522,7 @@ func PrintMarkdownOrPlain(w io.Writer, text string) {
 	}
 	width := TerminalWidth(w)
 	style := GlamourStyle()
-	lines := renderMarkdownLines(text, width, width, style, 2)
+	lines := RenderMarkdownLines(text, width, width, style, 2)
 	for _, line := range lines {
 		fmt.Fprintln(w, line)
 	}

--- a/internal/streamfmt/streamfmt_test.go
+++ b/internal/streamfmt/streamfmt_test.go
@@ -711,7 +711,7 @@ func TestFormatter_OpenCode(t *testing.T) {
 	}
 }
 
-func TestFormatter_Codex_Scenarios(t *testing.T) {
+func TestFormatter_CodexRendering(t *testing.T) {
 	longCmd := "bash -lc " + strings.Repeat("x", 100)
 	tests := []streamTestCase{
 		{
@@ -788,62 +788,6 @@ func TestFormatter_Codex_Scenarios(t *testing.T) {
 			},
 		},
 		{
-			name: "Codex Command Completed Fallback",
-			events: []string{
-				`{"type":"item.started","item":{"id":"cmd_1","type":"command_execution"}}`,
-				`{"type":"item.completed","item":{"id":"cmd_1","type":"command_execution","command":"bash -lc ls"}}`,
-				`{"type":"item.completed","item":{"id":"cmd_2","type":"command_execution","command":"bash -lc pwd"}}`,
-			},
-			contains: []string{
-				"Bash   bash -lc ls",
-				"Bash   bash -lc pwd",
-			},
-			counts: map[string]int{
-				"Bash   bash -lc ls":  1,
-				"Bash   bash -lc pwd": 1,
-			},
-		},
-		{
-			name: "Codex Command Mixed ID Started Without ID Completed With ID",
-			events: []string{
-				`{"type":"item.started","item":{"type":"command_execution","command":"bash -lc ls"}}`,
-				`{"type":"item.completed","item":{"id":"cmd_1","type":"command_execution","command":"bash -lc ls"}}`,
-			},
-			contains: []string{"Bash   bash -lc ls"},
-			counts:   map[string]int{"Bash   bash -lc ls": 1},
-		},
-		{
-			name: "Codex Command Mixed ID Started With ID Completed Without ID",
-			events: []string{
-				`{"type":"item.started","item":{"id":"cmd_1","type":"command_execution","command":"bash -lc ls"}}`,
-				`{"type":"item.completed","item":{"type":"command_execution","command":"bash -lc ls"}}`,
-			},
-			contains: []string{"Bash   bash -lc ls"},
-			counts:   map[string]int{"Bash   bash -lc ls": 1},
-		},
-		{
-			name: "Codex Command Started With ID Completed Without Command Clears Counter",
-			events: []string{
-				`{"type":"item.started","item":{"id":"cmd_1","type":"command_execution","command":"bash -lc ls"}}`,
-				`{"type":"item.completed","item":{"id":"cmd_1","type":"command_execution"}}`,
-				`{"type":"item.completed","item":{"id":"cmd_2","type":"command_execution","command":"bash -lc ls"}}`,
-			},
-			contains: []string{"Bash   bash -lc ls"},
-			counts:   map[string]int{"Bash   bash -lc ls": 2},
-		},
-		{
-			name: "Codex Command Mixed ID Fallback Does Not Leave Stale ID",
-			events: []string{
-				`{"type":"item.started","item":{"id":"cmd_1","type":"command_execution","command":"bash -lc ls"}}`,
-				`{"type":"item.completed","item":{"type":"command_execution","command":"bash -lc ls"}}`,
-				`{"type":"item.started","item":{"id":"cmd_2","type":"command_execution","command":"bash -lc ls"}}`,
-				`{"type":"item.completed","item":{"id":"cmd_1","type":"command_execution"}}`,
-				`{"type":"item.completed","item":{"type":"command_execution","command":"bash -lc ls"}}`,
-			},
-			contains: []string{"Bash   bash -lc ls"},
-			counts:   map[string]int{"Bash   bash -lc ls": 2},
-		},
-		{
 			name: "Codex Reasoning Displayed",
 			events: []string{
 				`{"type":"item.completed","item":{"type":"reasoning","text":"**Reviewing error handling changes**"}}`,
@@ -857,17 +801,6 @@ func TestFormatter_Codex_Scenarios(t *testing.T) {
 				`{"type":"item.updated","item":{"type":"reasoning","text":"still thinking"}}`,
 			},
 			empty: true,
-		},
-		{
-			name: "Codex Multi ID Same Command Deterministic Pairing",
-			events: []string{
-				`{"type":"item.started","item":{"id":"cmd_A","type":"command_execution","command":"bash -lc ls"}}`,
-				`{"type":"item.started","item":{"id":"cmd_B","type":"command_execution","command":"bash -lc ls"}}`,
-				`{"type":"item.completed","item":{"type":"command_execution","command":"bash -lc ls"}}`,
-				`{"type":"item.completed","item":{"id":"cmd_B","type":"command_execution"}}`,
-				`{"type":"item.completed","item":{"type":"command_execution","command":"bash -lc ls"}}`,
-			},
-			counts: map[string]int{"Bash   bash -lc ls": 3},
 		},
 	}
 


### PR DESCRIPTION
## Summary
- extract Codex command pairing and dedup into a dedicated tracker
- add direct tracker tests and keep formatter-level Codex tests focused on rendering
- remove the redundant `renderMarkdownLines` alias and call `RenderMarkdownLines` directly

## Validation
- make lint
- go test ./internal/streamfmt
- go fmt ./...
- go test ./...
- go vet ./...