### PR TITLE
refactor(prompt): make prompt construction template-driven

### DIFF
--- a/internal/agent/claude_test.go
+++ b/internal/agent/claude_test.go
@@ -115,7 +115,7 @@ func TestParseModel(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			m, u, err := parseModel(tt.spec)
-			assert.NoError(err)
+			require.NoError(t, err)
 			assert.Equal(tt.wantModel, m)
 			assert.Equal(tt.wantBaseURL, u)
 		})
@@ -144,7 +144,7 @@ func TestParseModel(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			_, _, err := parseModel(tt.spec)
-			assert.Error(err)
+			require.Error(t, err)
 			assert.Contains(err.Error(), tt.errSubstr)
 		})
 	}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -34,109 +34,6 @@ IMPORTANT: You are being invoked by roborev to perform this review directly. Do 
 Return only the final review content. Do NOT include process narration, progress updates, or front matter such as "Reviewing the diff..." or "I'm checking...".
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.`
 
-// SystemPromptSingle is the base instruction for single commit reviews
-const SystemPromptSingle = `You are a code reviewer. Review the git commit shown below for:
-
-1. **Bugs**: Logic errors, off-by-one errors, null/undefined issues, race conditions
-2. **Security**: Injection vulnerabilities, auth issues, data exposure
-3. **Testing gaps**: Missing unit tests, edge cases not covered, e2e/integration test gaps
-4. **Regressions**: Changes that might break existing functionality
-5. **Code quality**: Duplication that should be refactored, overly complex logic, unclear naming
-
-Do not review the commit message itself - focus only on the code changes in the diff.
-
-After reviewing, provide:
-
-1. A brief summary of what the commit does
-2. Any issues found, listed with:
-   - Severity (high/medium/low)
-   - File and line reference where possible
-   - A brief explanation of the problem and suggested fix
-
-If you find no issues, state "No issues found." after the summary.`
-
-// SystemPromptDirty is the base instruction for reviewing uncommitted (dirty) changes
-const SystemPromptDirty = `You are a code reviewer. Review the following uncommitted changes for:
-
-1. **Bugs**: Logic errors, off-by-one errors, null/undefined issues, race conditions
-2. **Security**: Injection vulnerabilities, auth issues, data exposure
-3. **Testing gaps**: Missing unit tests, edge cases not covered, e2e/integration test gaps
-4. **Regressions**: Changes that might break existing functionality
-5. **Code quality**: Duplication that should be refactored, overly complex logic, unclear naming
-
-After reviewing, provide:
-
-1. A brief summary of what the changes do
-2. Any issues found, listed with:
-   - Severity (high/medium/low)
-   - File and line reference where possible
-   - A brief explanation of the problem and suggested fix
-
-If you find no issues, state "No issues found." after the summary.`
-
-// SystemPromptRange is the base instruction for commit range reviews
-const SystemPromptRange = `You are a code reviewer. Review the git commit range shown below for:
-
-1. **Bugs**: Logic errors, off-by-one errors, null/undefined issues, race conditions
-2. **Security**: Injection vulnerabilities, auth issues, data exposure
-3. **Testing gaps**: Missing unit tests, edge cases not covered, e2e/integration test gaps
-4. **Regressions**: Changes that might break existing functionality
-5. **Code quality**: Duplication that should be refactored, overly complex logic, unclear naming
-
-Do not review the commit message itself - focus only on the code changes in the diff.
-
-After reviewing, provide:
-
-1. A brief summary of what the commits do
-2. Any issues found, listed with:
-   - Severity (high/medium/low)
-   - File and line reference where possible
-   - A brief explanation of the problem and suggested fix
-
-If you find no issues, state "No issues found." after the summary.`
-
-// PreviousReviewsHeader introduces the previous reviews section
-const PreviousReviewsHeader = `
-## Previous Reviews
-
-The following are reviews of recent commits in this repository. Use them as context
-to understand ongoing work and to check if the current commit addresses previous feedback.
-
-**Important:** Reviews may include responses from developers. Pay attention to these responses -
-they may indicate known issues that should be ignored, explain why certain patterns exist,
-or provide context that affects how you should evaluate similar code in the current commit.
-`
-
-// ProjectGuidelinesHeader introduces the project-specific guidelines section
-const ProjectGuidelinesHeader = `
-## Project Guidelines
-
-The following are project-specific guidelines for this repository. Take these into account
-when reviewing the code - they may override or supplement the default review criteria.
-`
-
-// PreviousAttemptsForCommitHeader introduces previous review attempts for the same commit
-const PreviousAttemptsForCommitHeader = `
-## Previous Review Attempts
-
-This commit has been reviewed before. The following are previous review results and any
-responses from developers. Use this context to:
-- Avoid repeating issues that have been marked as known/acceptable
-- Check if previously identified issues are still present
-- Consider developer responses about why certain patterns exist
-`
-
-// InRangeReviewsHeader introduces per-commit reviews within a range review
-const InRangeReviewsHeader = `
-## Per-Commit Reviews in This Range
-
-The following commits in this range have already been individually reviewed.
-Issues found in earlier commits may have been fixed by later commits in the range.
-
-Do not re-raise issues identified below unless they persist in the final code.
-Focus on cross-commit interactions and problems not caught by per-commit reviews.
-`
-
 // ReviewContext holds a commit SHA and its associated review (if any) plus responses
 type ReviewContext struct {
 	SHA       string
@@ -240,13 +137,11 @@ func (b *Builder) BuildWithDiffFile(repoPath, gitRef string, repoID int64, conte
 // a diff snapshot file that was written during prompt construction.
 type SnapshotResult struct {
 	Prompt  string
-	Cleanup func() // nil when no snapshot was written
+	Cleanup func()
 }
 
 // BuildWithSnapshot builds a review prompt, automatically writing a
-// diff snapshot file when the diff is too large to inline. The caller
-// must call Cleanup (if non-nil) after the prompt is no longer needed.
-// excludes are applied to the snapshot diff.
+// diff snapshot file when the diff is too large to inline.
 func (b *Builder) BuildWithSnapshot(
 	repoPath, gitRef string, repoID int64,
 	contextCount int, agentName, reviewType, minSeverity string,
@@ -259,14 +154,9 @@ func (b *Builder) BuildWithSnapshot(
 	if !errors.Is(err, ErrDiffTruncatedNoFile) {
 		return SnapshotResult{Prompt: p}, err
 	}
-	// Diff too large — write a snapshot file and retry.
-	diffFile, cleanup, writeErr := WriteDiffSnapshot(
-		repoPath, gitRef, excludes,
-	)
+	diffFile, cleanup, writeErr := WriteDiffSnapshot(repoPath, gitRef, excludes)
 	if writeErr != nil {
-		return SnapshotResult{}, fmt.Errorf(
-			"write diff snapshot: %w", writeErr,
-		)
+		return SnapshotResult{}, fmt.Errorf("write diff snapshot: %w", writeErr)
 	}
 	p, err = b.BuildWithDiffFile(
 		repoPath, gitRef, repoID,
@@ -281,19 +171,15 @@ func (b *Builder) BuildWithSnapshot(
 
 // WriteDiffSnapshot writes the full diff for a git ref to a file in
 // the repo's git dir. Returns the file path and a cleanup function.
-func WriteDiffSnapshot(
-	repoPath, gitRef string, excludes []string,
-) (string, func(), error) {
-	var fullDiff string
-	var err error
+func WriteDiffSnapshot(repoPath, gitRef string, excludes []string) (string, func(), error) {
+	var (
+		fullDiff string
+		err      error
+	)
 	if git.IsRange(gitRef) {
-		fullDiff, err = git.GetRangeDiff(
-			repoPath, gitRef, excludes...,
-		)
+		fullDiff, err = git.GetRangeDiff(repoPath, gitRef, excludes...)
 	} else {
-		fullDiff, err = git.GetDiff(
-			repoPath, gitRef, excludes...,
-		)
+		fullDiff, err = git.GetDiff(repoPath, gitRef, excludes...)
 	}
 	if err != nil {
 		return "", nil, fmt.Errorf("capture diff: %w", err)
@@ -333,8 +219,6 @@ func (b *Builder) BuildDirtyWithSnapshot(
 	if err != nil {
 		return SnapshotResult{}, err
 	}
-	// If the diff was truncated and we have the full content, write
-	// a snapshot so the agent can read the complete diff.
 	if strings.Contains(p, "(Diff too large to include in full)") && len(diff) > 0 {
 		gitDir, dirErr := git.ResolveGitDir(repoPath)
 		if dirErr != nil {
@@ -354,13 +238,8 @@ func (b *Builder) BuildDirtyWithSnapshot(
 			}
 			return SnapshotResult{}, fmt.Errorf("dirty diff snapshot: %w", closeErr)
 		}
-		p += fmt.Sprintf(
-			"\nThe full diff is also available at: `%s`\n", diffFile,
-		)
-		return SnapshotResult{
-			Prompt:  p,
-			Cleanup: func() { os.Remove(diffFile) },
-		}, nil
+		p += fmt.Sprintf("\nThe full diff is also available at: `%s`\n", diffFile)
+		return SnapshotResult{Prompt: p, Cleanup: func() { os.Remove(diffFile) }}, nil
 	}
 	return SnapshotResult{Prompt: p}, nil
 }
@@ -377,16 +256,18 @@ func (b *Builder) BuildDirty(repoPath, diff string, repoID int64, contextCount i
 	if promptType == config.ReviewTypeDesign {
 		promptType = "design-review"
 	}
+	promptCap := b.resolveMaxPromptSize(repoPath)
 	requiredPrefix := GetSystemPrompt(agentName, promptType) + "\n"
 	if inst := config.SeverityInstruction(minSeverity); inst != "" {
 		requiredPrefix += inst + "\n"
 	}
+	requiredPrefix = hardCapPrompt(requiredPrefix, promptCap)
 
-	var optionalContext strings.Builder
+	optional := optionalSectionsView{}
 
 	// Add project-specific guidelines if configured
 	if repoCfg, err := config.LoadRepoConfig(repoPath); err == nil && repoCfg != nil {
-		b.writeProjectGuidelines(&optionalContext, repoCfg.ReviewGuidelines)
+		optional.ProjectGuidelines = buildProjectGuidelinesSectionView(repoCfg.ReviewGuidelines)
 	}
 
 	// Get previous reviews for context (use HEAD as reference point)
@@ -395,56 +276,138 @@ func (b *Builder) BuildDirty(repoPath, diff string, repoID int64, contextCount i
 		if err == nil {
 			contexts, err := b.getPreviousReviewContexts(repoPath, headSHA, contextCount)
 			if err == nil && len(contexts) > 0 {
-				b.writePreviousReviews(&optionalContext, contexts)
+				optional.PreviousReviews = orderedPreviousReviewViews(contexts)
 			}
 		}
 	}
 
-	currentRequired := "## Uncommitted Changes\n\n" +
-		"The following changes have not yet been committed.\n\n"
-
-	// Build diff section
-	var diffSection strings.Builder
-	diffSection.WriteString("### Diff\n\n")
-	diffSection.WriteString("```diff\n")
-	diffSection.WriteString(diff)
-	if !strings.HasSuffix(diff, "\n") {
-		diffSection.WriteString("\n")
+	bodyLimit := max(0, promptCap-len(requiredPrefix))
+	inlineDiff, err := renderInlineDiff(diff)
+	if err != nil {
+		return "", err
 	}
-	diffSection.WriteString("```\n")
-
-	// Trim optional context if it alone would exceed the prompt cap
-	promptCap := b.resolveMaxPromptSize(repoPath)
-	optCtx := optionalContext.String()
-	requiredLen := len(requiredPrefix) + len(currentRequired)
-	if requiredLen+len(optCtx) > promptCap {
-		optCtx = truncateUTF8(optCtx, max(0, promptCap-requiredLen))
+	view := dirtyPromptView{
+		Optional: optional,
+		Current: dirtyChangesSectionView{
+			Description: "The following changes have not yet been committed.",
+		},
+		Diff: diffSectionView{
+			Heading: "### Diff",
+			Body:    inlineDiff,
+		},
 	}
 
-	var sb strings.Builder
-	sb.WriteString(requiredPrefix)
-	sb.WriteString(optCtx)
-	sb.WriteString(currentRequired)
-
-	// Check if adding the diff would exceed max prompt size
-	if sb.Len()+diffSection.Len() > promptCap {
-		// For dirty changes, we can't tell them to "use git diff" because
-		// the working tree may have changed. Just truncate with a note.
-		sb.WriteString("### Diff\n\n")
-		sb.WriteString("(Diff too large to include in full)\n")
-		// Include truncated diff
-		maxDiffLen := promptCap - sb.Len() - 100 // Leave room for closing markers
-		if maxDiffLen > 1000 {
-			sb.WriteString("```diff\n")
-			sb.WriteString(truncateUTF8(diff, maxDiffLen))
-			sb.WriteString("\n... (truncated)\n")
-			sb.WriteString("```\n")
+	currentSection, err := renderDirtyChangesSection(view.Current)
+	if err != nil {
+		return "", err
+	}
+	fullDiffBlock, err := renderDiffBlock(view.Diff)
+	if err != nil {
+		return "", err
+	}
+	if len(currentSection)+len(fullDiffBlock) > bodyLimit {
+		fallbackOnly, err := renderDirtyTruncatedDiffFallback("")
+		if err != nil {
+			return "", err
 		}
-	} else {
-		sb.WriteString(diffSection.String())
+		fallbackBlock, err := renderDiffBlock(diffSectionView{Heading: "### Diff", Fallback: fallbackOnly})
+		if err != nil {
+			return "", err
+		}
+		maxDiffLen := bodyLimit - len(currentSection) - len(fallbackBlock)
+		view.Diff.Body = ""
+		sizingView := view
+		sizingBody, err := renderDirtyPrompt(sizingView)
+		if err != nil {
+			return "", err
+		}
+		for len(sizingBody) > bodyLimit && trimOptionalSections(&sizingView.Optional) {
+			sizingBody, err = renderDirtyPrompt(sizingView)
+			if err != nil {
+				return "", err
+			}
+		}
+		if maxDiffLen > 1000 {
+			emptyFallbackOptional := sizingView.Optional
+			sampleBody := "X\n"
+			sampleFallback, err := renderDirtyTruncatedDiffFallback(sampleBody)
+			if err != nil {
+				return "", err
+			}
+			wrapperOverhead := len(sampleFallback) - len(fallbackOnly) - len(sampleBody)
+			truncationSuffix := "\n... (truncated)\n"
+			availableContentLen := maxDiffLen - wrapperOverhead - len(truncationSuffix)
+			if availableContentLen > 0 {
+				truncatedContent := truncateUTF8(diff, availableContentLen)
+				for truncatedContent != "" {
+					truncatedBody := truncatedContent
+					if !strings.HasSuffix(truncatedBody, "\n") {
+						truncatedBody += "\n"
+					}
+					truncatedBody += "... (truncated)\n"
+					view.Diff.Fallback, err = renderDirtyTruncatedDiffFallback(truncatedBody)
+					if err != nil {
+						return "", err
+					}
+					sizingView.Diff = view.Diff
+					rendered, err := renderDirtyPrompt(sizingView)
+					if err != nil {
+						return "", err
+					}
+					if len(rendered) <= bodyLimit {
+						view.Optional = sizingView.Optional
+						break
+					}
+					if trimOptionalSections(&sizingView.Optional) {
+						continue
+					}
+					overflow := len(rendered) - bodyLimit
+					next := truncateUTF8(truncatedContent, max(0, len(truncatedContent)-overflow))
+					if next == truncatedContent {
+						next = truncateUTF8(truncatedContent, max(0, len(truncatedContent)-1))
+					}
+					truncatedContent = next
+				}
+				if truncatedContent == "" {
+					view.Diff.Fallback = fallbackOnly
+					view.Optional = emptyFallbackOptional
+				}
+			} else {
+				view.Diff.Fallback = fallbackOnly
+			}
+		} else {
+			view.Diff.Fallback = fallbackOnly
+		}
 	}
 
-	return hardCapPrompt(sb.String(), promptCap), nil
+	body, err := fitDirtyPrompt(bodyLimit, view)
+	if err != nil {
+		return "", err
+	}
+	return requiredPrefix + hardCapPrompt(body, bodyLimit), nil
+}
+
+func truncateUTF8(s string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len(s) <= maxBytes {
+		return s
+	}
+	for maxBytes > 0 && !utf8.RuneStart(s[maxBytes]) {
+		maxBytes--
+	}
+	return s[:maxBytes]
+}
+
+func hardCapPrompt(prompt string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	if len(prompt) <= limit {
+		return prompt
+	}
+	return truncateUTF8(prompt, limit)
 }
 
 // buildOpts groups optional parameters for buildSinglePrompt and
@@ -461,6 +424,19 @@ type buildOpts struct {
 	// minSeverity, when non-empty, injects a severity filter
 	// instruction into the system prompt.
 	minSeverity string
+}
+
+// diffFileFallbackVariants returns progressively shorter prompt
+// variants for oversized diffs. When filePath is non-empty, the
+// variants reference the file; otherwise they just note truncation.
+func diffFileFallbackVariants(heading, filePath string) []string {
+	if filePath == "" {
+		return []string{heading + "\n\n(Diff too large to include inline)\n"}
+	}
+	return []string{
+		fmt.Sprintf("%s\n\n(Diff too large to include inline)\n\nThe full diff has been written to a file for review.\nRead the diff from: `%s`\n\nReview the actual diff before writing findings.\n", heading, filePath),
+		fmt.Sprintf("%s\n\n(Diff too large to include inline)\nRead the diff from: `%s`\n", heading, filePath),
+	}
 }
 
 func writeLongestFitting(sb *strings.Builder, limit int, variants ...string) {
@@ -481,11 +457,7 @@ func writeLongestFitting(sb *strings.Builder, limit int, variants ...string) {
 	sb.WriteString(truncateUTF8(shortest, remaining))
 }
 
-func buildPromptPreservingCurrentSection(
-	requiredPrefix, optionalContext, currentRequired, currentOverflow string,
-	limit int,
-	variants ...string,
-) string {
+func buildPromptPreservingCurrentSection(requiredPrefix, optionalContext, currentRequired, currentOverflow string, limit int, variants ...string) string {
 	shortestLen := 0
 	if len(variants) > 0 {
 		shortestLen = len(variants[len(variants)-1])
@@ -514,51 +486,6 @@ func buildPromptPreservingCurrentSection(
 	return hardCapPrompt(sb.String(), limit)
 }
 
-func truncateUTF8(s string, maxBytes int) string {
-	if maxBytes <= 0 {
-		return ""
-	}
-	if len(s) <= maxBytes {
-		return s
-	}
-	for maxBytes > 0 && !utf8.RuneStart(s[maxBytes]) {
-		maxBytes--
-	}
-	return s[:maxBytes]
-}
-
-func hardCapPrompt(prompt string, limit int) string {
-	if limit <= 0 {
-		return ""
-	}
-	if len(prompt) <= limit {
-		return prompt
-	}
-	return truncateUTF8(prompt, limit)
-}
-
-// diffFileFallbackVariants returns progressively shorter prompt
-// variants for oversized diffs. When filePath is non-empty, the
-// variants reference the file; otherwise they just note truncation.
-func diffFileFallbackVariants(heading, filePath string) []string {
-	if filePath == "" {
-		return []string{
-			heading + "\n\n(Diff too large to include inline)\n",
-		}
-	}
-	return []string{
-		fmt.Sprintf("%s\n\n"+
-			"(Diff too large to include inline)\n\n"+
-			"The full diff has been written to a file for review.\n"+
-			"Read the diff from: `%s`\n\n"+
-			"Review the actual diff before writing findings.\n",
-			heading, filePath),
-		fmt.Sprintf("%s\n\n"+
-			"(Diff too large to include inline; read from `%s`)\n",
-			heading, filePath),
-	}
-}
-
 // buildSinglePrompt constructs a prompt for a single commit
 func (b *Builder) buildSinglePrompt(repoPath, sha string, repoID int64, contextCount int, agentName, reviewType string, opts buildOpts) (string, error) {
 	// Start with system prompt
@@ -569,30 +496,28 @@ func (b *Builder) buildSinglePrompt(repoPath, sha string, repoID int64, contextC
 	if promptType == config.ReviewTypeDesign {
 		promptType = "design-review"
 	}
+	promptCap := b.resolveMaxPromptSize(repoPath)
 	requiredPrefix := GetSystemPrompt(agentName, promptType) + "\n"
 	if inst := config.SeverityInstruction(opts.minSeverity); inst != "" {
 		requiredPrefix += inst + "\n"
 	}
+	requiredPrefix = hardCapPrompt(requiredPrefix, promptCap)
 
-	var optionalContext strings.Builder
-
-	// Add project-specific guidelines from default branch
-	b.writeProjectGuidelines(&optionalContext, LoadGuidelines(repoPath))
-	b.writeAdditionalContext(&optionalContext, opts.additionalContext)
+	optional := optionalSectionsView{
+		ProjectGuidelines: buildProjectGuidelinesSectionView(LoadGuidelines(repoPath)),
+		AdditionalContext: buildAdditionalContextSection(opts.additionalContext),
+	}
 
 	// Get previous reviews if requested
 	if contextCount > 0 && b.db != nil {
 		contexts, err := b.getPreviousReviewContexts(repoPath, sha, contextCount)
-		if err != nil {
-			// Log but don't fail - previous reviews are nice-to-have context
-			// Just continue without them
-		} else if len(contexts) > 0 {
-			b.writePreviousReviews(&optionalContext, contexts)
+		if err == nil && len(contexts) > 0 {
+			optional.PreviousReviews = orderedPreviousReviewViews(contexts)
 		}
 	}
 
 	// Include previous review attempts for this same commit (for re-reviews)
-	b.writePreviousAttemptsForGitRef(&optionalContext, sha)
+	optional.PreviousAttempts = previousAttemptViewsFromContexts(b.previousAttemptContexts(sha))
 
 	// Current commit section
 	shortSHA := git.ShortSHA(sha)
@@ -603,70 +528,74 @@ func (b *Builder) buildSinglePrompt(repoPath, sha string, repoID int64, contextC
 		return "", fmt.Errorf("get commit info: %w", err)
 	}
 
-	var currentRequired strings.Builder
-	currentRequired.WriteString("## Current Commit\n\n")
-	fmt.Fprintf(&currentRequired, "**Commit:** %s\n", shortSHA)
-	currentRequired.WriteString("\n")
-
-	var currentOverflow strings.Builder
-	fmt.Fprintf(&currentOverflow, "**Subject:** %s\n", info.Subject)
-	fmt.Fprintf(&currentOverflow, "**Author:** %s\n", info.Author)
-	currentOverflow.WriteString("\n")
-	if info.Body != "" {
-		fmt.Fprintf(&currentOverflow, "**Message:**\n%s\n\n", info.Body)
+	currentView := currentCommitSectionView{
+		Commit:  shortSHA,
+		Subject: info.Subject,
+		Author:  info.Author,
+		Message: info.Body,
+	}
+	currentRequired, err := renderCurrentCommitRequired(currentView)
+	if err != nil {
+		return "", err
+	}
+	currentOverflow, err := renderCurrentCommitOverflow(currentView)
+	if err != nil {
+		return "", err
+	}
+	emptyInlineDiff, err := renderInlineDiff("")
+	if err != nil {
+		return "", err
+	}
+	emptyDiffBlock, err := renderDiffBlock(diffSectionView{Heading: "### Diff", Body: emptyInlineDiff})
+	if err != nil {
+		return "", err
 	}
 
-	// Get and include the diff.
-	// Budget the diff from non-trimmable sections only; optional context
-	// is trimmed afterward to fit the remaining space.
 	excludes := b.resolveExcludes(repoPath, reviewType)
-	promptCap := b.resolveMaxPromptSize(repoPath)
-	diffWrap := len("### Diff\n\n```diff\n") + len("\n```\n") + 1
-	requiredLen := len(requiredPrefix) + currentRequired.Len() + currentOverflow.Len()
-	diffLimit := max(0, promptCap-requiredLen-diffWrap)
+	bodyLimit := max(0, promptCap-len(requiredPrefix))
+	diffLimit := max(0, bodyLimit-len(currentRequired)-len(currentOverflow)-len(emptyDiffBlock))
 	diff, truncated, err := git.GetDiffLimited(repoPath, sha, diffLimit, excludes...)
 	if err != nil {
 		return "", fmt.Errorf("get diff: %w", err)
 	}
+
+	diffView := diffSectionView{Heading: "### Diff"}
 	if truncated {
 		if opts.diffFilePath == "" && opts.requireDiffFile {
 			return "", ErrDiffTruncatedNoFile
 		}
-		fallback := diffFileFallbackVariants("### Diff", opts.diffFilePath)
+		optionalPrefix, err := renderOptionalSectionsPrefix(optional)
+		if err != nil {
+			return "", err
+		}
 		return buildPromptPreservingCurrentSection(
 			requiredPrefix,
-			optionalContext.String(),
-			currentRequired.String(),
-			currentOverflow.String(),
+			optionalPrefix,
+			currentRequired,
+			currentOverflow,
 			promptCap,
-			fallback...,
+			diffFileFallbackVariants("### Diff", opts.diffFilePath)...,
 		), nil
+	} else {
+		inlineDiff, err := renderInlineDiff(diff)
+		if err != nil {
+			return "", err
+		}
+		diffView.Body = inlineDiff
 	}
 
-	// Build diff section
-	var diffSection strings.Builder
-	diffSection.WriteString("### Diff\n\n")
-	diffSection.WriteString("```diff\n")
-	diffSection.WriteString(diff)
-	if !strings.HasSuffix(diff, "\n") {
-		diffSection.WriteString("\n")
+	body, err := fitSinglePrompt(
+		bodyLimit,
+		singlePromptView{
+			Optional: optional,
+			Current:  currentView,
+			Diff:     diffView,
+		},
+	)
+	if err != nil {
+		return "", err
 	}
-	diffSection.WriteString("```\n")
-
-	// Trim optional context to fit remaining budget after the diff
-	optCtx := optionalContext.String()
-	ctxBudget := promptCap - requiredLen - diffSection.Len()
-	if len(optCtx) > ctxBudget {
-		optCtx = truncateUTF8(optCtx, max(0, ctxBudget))
-	}
-
-	var sb strings.Builder
-	sb.WriteString(requiredPrefix)
-	sb.WriteString(optCtx)
-	sb.WriteString(currentRequired.String())
-	sb.WriteString(currentOverflow.String())
-	sb.WriteString(diffSection.String())
-	return sb.String(), nil
+	return requiredPrefix + body, nil
 }
 
 // buildRangePrompt constructs a prompt for a commit range
@@ -679,16 +608,17 @@ func (b *Builder) buildRangePrompt(repoPath, rangeRef string, repoID int64, cont
 	if promptType == config.ReviewTypeDesign {
 		promptType = "design-review"
 	}
+	promptCap := b.resolveMaxPromptSize(repoPath)
 	requiredPrefix := GetSystemPrompt(agentName, promptType) + "\n"
 	if inst := config.SeverityInstruction(opts.minSeverity); inst != "" {
 		requiredPrefix += inst + "\n"
 	}
+	requiredPrefix = hardCapPrompt(requiredPrefix, promptCap)
 
-	var optionalContext strings.Builder
-
-	// Add project-specific guidelines from default branch
-	b.writeProjectGuidelines(&optionalContext, LoadGuidelines(repoPath))
-	b.writeAdditionalContext(&optionalContext, opts.additionalContext)
+	optional := optionalSectionsView{
+		ProjectGuidelines: buildProjectGuidelinesSectionView(LoadGuidelines(repoPath)),
+		AdditionalContext: buildAdditionalContextSection(opts.additionalContext),
+	}
 
 	// Get previous reviews from before the range start
 	if contextCount > 0 && b.db != nil {
@@ -696,13 +626,13 @@ func (b *Builder) buildRangePrompt(repoPath, rangeRef string, repoID int64, cont
 		if err == nil {
 			contexts, err := b.getPreviousReviewContexts(repoPath, startSHA, contextCount)
 			if err == nil && len(contexts) > 0 {
-				b.writePreviousReviews(&optionalContext, contexts)
+				optional.PreviousReviews = orderedPreviousReviewViews(contexts)
 			}
 		}
 	}
 
 	// Include previous review attempts for this same range (for re-reviews)
-	b.writePreviousAttemptsForGitRef(&optionalContext, rangeRef)
+	optional.PreviousAttempts = previousAttemptViewsFromContexts(b.previousAttemptContexts(rangeRef))
 
 	// Get commits in range
 	commits, err := git.GetRangeCommits(repoPath, rangeRef)
@@ -710,132 +640,120 @@ func (b *Builder) buildRangePrompt(repoPath, rangeRef string, repoID int64, cont
 		return "", fmt.Errorf("get range commits: %w", err)
 	}
 
-	// Include per-commit reviews for commits in this range so the
-	// reviewer doesn't re-raise issues already found and addressed.
-	b.writeInRangeReviews(&optionalContext, commits)
+	optional.InRangeReviews = inRangeReviewViews(b.lookupReviewContexts(commits, true))
 
-	// Commit range section
-	var currentRequired strings.Builder
-	currentRequired.WriteString("## Commit Range\n\n")
-	fmt.Fprintf(&currentRequired, "Reviewing %d commits:\n\n", len(commits))
-
-	var currentOverflow strings.Builder
-	for _, sha := range commits {
-		info, err := git.GetCommitInfo(repoPath, sha)
-		shortSHA := git.ShortSHA(sha)
+	entries := make([]commitRangeEntryView, 0, len(commits))
+	for _, commitSHA := range commits {
+		short := git.ShortSHA(commitSHA)
+		info, err := git.GetCommitInfo(repoPath, commitSHA)
 		if err == nil {
-			fmt.Fprintf(&currentOverflow, "- %s %s\n", shortSHA, info.Subject)
-		} else {
-			fmt.Fprintf(&currentOverflow, "- %s\n", shortSHA)
+			entries = append(entries, commitRangeEntryView{Commit: short, Subject: info.Subject})
+			continue
 		}
+		entries = append(entries, commitRangeEntryView{Commit: short})
 	}
-	currentOverflow.WriteString("\n")
+	currentView := commitRangeSectionView{Count: len(commits), Entries: entries}
+	currentRequiredText, err := renderCommitRangeRequired(currentView)
+	if err != nil {
+		return "", err
+	}
+	currentOverflowText, err := renderCommitRangeOverflow(currentView)
+	if err != nil {
+		return "", err
+	}
+	emptyInlineDiff, err := renderInlineDiff("")
+	if err != nil {
+		return "", err
+	}
+	emptyDiffBlock, err := renderDiffBlock(diffSectionView{Heading: "### Combined Diff", Body: emptyInlineDiff})
+	if err != nil {
+		return "", err
+	}
 
-	// Get and include the combined diff for the range.
-	// Budget the diff from non-trimmable sections only; optional context
-	// is trimmed afterward to fit the remaining space.
 	excludes := b.resolveExcludes(repoPath, reviewType)
-	promptCap := b.resolveMaxPromptSize(repoPath)
-	diffWrap := len("### Combined Diff\n\n```diff\n") + len("\n```\n") + 1
-	requiredLen := len(requiredPrefix) + currentRequired.Len() + currentOverflow.Len()
-	diffLimit := max(0, promptCap-requiredLen-diffWrap)
+	bodyLimit := max(0, promptCap-len(requiredPrefix))
+	diffLimit := max(0, bodyLimit-len(currentRequiredText)-len(currentOverflowText)-len(emptyDiffBlock))
 	diff, truncated, err := git.GetRangeDiffLimited(repoPath, rangeRef, diffLimit, excludes...)
 	if err != nil {
 		return "", fmt.Errorf("get range diff: %w", err)
 	}
+
+	diffView := diffSectionView{Heading: "### Combined Diff"}
 	if truncated {
 		if opts.diffFilePath == "" && opts.requireDiffFile {
 			return "", ErrDiffTruncatedNoFile
 		}
-		fallback := diffFileFallbackVariants("### Combined Diff", opts.diffFilePath)
+		optionalPrefix, err := renderOptionalSectionsPrefix(optional)
+		if err != nil {
+			return "", err
+		}
 		return buildPromptPreservingCurrentSection(
 			requiredPrefix,
-			optionalContext.String(),
-			currentRequired.String(),
-			currentOverflow.String(),
+			optionalPrefix,
+			currentRequiredText,
+			currentOverflowText,
 			promptCap,
-			fallback...,
+			diffFileFallbackVariants("### Combined Diff", opts.diffFilePath)...,
 		), nil
+	} else {
+		inlineDiff, err := renderInlineDiff(diff)
+		if err != nil {
+			return "", err
+		}
+		diffView.Body = inlineDiff
 	}
 
-	// Build diff section
-	var diffSection strings.Builder
-	diffSection.WriteString("### Combined Diff\n\n")
-	diffSection.WriteString("```diff\n")
-	diffSection.WriteString(diff)
-	if !strings.HasSuffix(diff, "\n") {
-		diffSection.WriteString("\n")
+	body, err := fitRangePrompt(
+		bodyLimit,
+		rangePromptView{
+			Optional: optional,
+			Current:  currentView,
+			Diff:     diffView,
+		},
+	)
+	if err != nil {
+		return "", err
 	}
-	diffSection.WriteString("```\n")
-
-	// Trim optional context to fit remaining budget after the diff
-	optCtx := optionalContext.String()
-	ctxBudget := promptCap - requiredLen - diffSection.Len()
-	if len(optCtx) > ctxBudget {
-		optCtx = truncateUTF8(optCtx, max(0, ctxBudget))
-	}
-
-	var sb strings.Builder
-	sb.WriteString(requiredPrefix)
-	sb.WriteString(optCtx)
-	sb.WriteString(currentRequired.String())
-	sb.WriteString(currentOverflow.String())
-	sb.WriteString(diffSection.String())
-	return sb.String(), nil
+	return requiredPrefix + body, nil
 }
 
-// writePreviousReviews writes the previous reviews section to the builder
-func (b *Builder) writePreviousReviews(sb *strings.Builder, contexts []ReviewContext) {
-	sb.WriteString(PreviousReviewsHeader)
-	sb.WriteString("\n")
+func buildProjectGuidelinesSectionView(guidelines string) *markdownSectionView {
+	trimmed := strings.TrimSpace(guidelines)
+	if trimmed == "" {
+		return nil
+	}
+	return &markdownSectionView{
+		Heading: "## Project Guidelines",
+		Body:    trimmed,
+	}
+}
 
-	// Show in chronological order (oldest first) for narrative flow
+func buildAdditionalContextSection(additionalContext string) string {
+	trimmed := strings.TrimSpace(additionalContext)
+	if trimmed == "" {
+		return ""
+	}
+	return trimmed + "\n\n"
+}
+
+func orderedPreviousReviewViews(contexts []ReviewContext) []previousReviewView {
+	ordered := make([]ReviewContext, 0, len(contexts))
 	for i := len(contexts) - 1; i >= 0; i-- {
-		ctx := contexts[i]
-		shortSHA := git.ShortSHA(ctx.SHA)
-
-		fmt.Fprintf(sb, "--- Review for commit %s ---\n", shortSHA)
-		if ctx.Review != nil {
-			sb.WriteString(ctx.Review.Output)
-		} else {
-			sb.WriteString("No review available.")
-		}
-		sb.WriteString("\n")
-
-		// Include responses to this review
-		if len(ctx.Responses) > 0 {
-			sb.WriteString("\nComments on this review:\n")
-			for _, resp := range ctx.Responses {
-				fmt.Fprintf(sb, "- %s: %q\n", resp.Responder, resp.Response)
-			}
-		}
-		sb.WriteString("\n")
+		ordered = append(ordered, contexts[i])
 	}
-}
-
-// writeProjectGuidelines writes the project-specific guidelines section
-func (b *Builder) writeProjectGuidelines(sb *strings.Builder, guidelines string) {
-	if guidelines == "" {
-		return
-	}
-
-	sb.WriteString(ProjectGuidelinesHeader)
-	sb.WriteString("\n")
-	sb.WriteString(strings.TrimSpace(guidelines))
-	sb.WriteString("\n\n")
-}
-
-func (b *Builder) writeAdditionalContext(sb *strings.Builder, additionalContext string) {
-	if strings.TrimSpace(additionalContext) == "" {
-		return
-	}
-	sb.WriteString(strings.TrimSpace(additionalContext))
-	sb.WriteString("\n\n")
+	return previousReviewViews(ordered)
 }
 
 // LoadGuidelines loads review guidelines from the repo's default
 // branch, falling back to filesystem config when the default branch
 // has no .roborev.toml.
+func (b *Builder) writeProjectGuidelines(sb *strings.Builder, guidelines string) {
+	body, err := renderOptionalSectionsPrefix(optionalSectionsView{ProjectGuidelines: buildProjectGuidelinesSectionView(guidelines)})
+	if err == nil {
+		sb.WriteString(body)
+	}
+}
+
 func LoadGuidelines(repoPath string) string {
 	// Load review guidelines from the default branch (origin/main,
 	// origin/master, etc.). Branch-specific guidelines are intentionally
@@ -863,87 +781,34 @@ func LoadGuidelines(repoPath string) string {
 	return ""
 }
 
-// writePreviousAttemptsForGitRef writes previous review attempts for the same git ref (commit or range)
-func (b *Builder) writePreviousAttemptsForGitRef(sb *strings.Builder, gitRef string) {
+func (b *Builder) previousAttemptContexts(gitRef string) []reviewAttemptContext {
 	if b.db == nil {
-		return
+		return nil
 	}
 
 	reviews, err := b.db.GetAllReviewsForGitRef(gitRef)
 	if err != nil || len(reviews) == 0 {
-		return
+		return nil
 	}
 
-	sb.WriteString(PreviousAttemptsForCommitHeader)
-	sb.WriteString("\n")
-
-	for i, review := range reviews {
-		fmt.Fprintf(sb, "--- Review Attempt %d (%s, %s) ---\n",
-			i+1, review.Agent, review.CreatedAt.Format("2006-01-02 15:04"))
-		sb.WriteString(review.Output)
-		sb.WriteString("\n")
-
-		// Fetch and include comments for this review
+	attempts := make([]reviewAttemptContext, 0, len(reviews))
+	for _, review := range reviews {
+		attempt := reviewAttemptContext{Review: review}
 		if review.JobID > 0 {
 			responses, err := b.db.GetCommentsForJob(review.JobID)
-			if err == nil && len(responses) > 0 {
-				sb.WriteString("\nComments on this review:\n")
-				for _, resp := range responses {
-					fmt.Fprintf(sb, "- %s: %q\n", resp.Responder, resp.Response)
-				}
+			if err == nil {
+				attempt.Responses = responses
 			}
 		}
-		sb.WriteString("\n")
+		attempts = append(attempts, attempt)
 	}
+	return attempts
 }
 
-// writeInRangeReviews writes per-commit reviews for commits within a range.
-// This gives the range reviewer context about issues already found and
-// addressed, preventing duplicate findings.
-func (b *Builder) writeInRangeReviews(sb *strings.Builder, commits []string) {
-	if b.db == nil || len(commits) == 0 {
-		return
-	}
-
-	contexts := b.lookupReviewContexts(commits, true)
-	if len(contexts) == 0 {
-		return
-	}
-
-	sb.WriteString(InRangeReviewsHeader)
-	sb.WriteString("\n")
-
-	for _, ctx := range contexts {
-		shortSHA := git.ShortSHA(ctx.SHA)
-		verdict := storage.ParseVerdict(ctx.Review.Output)
-		verdictLabel := "unknown"
-		switch verdict {
-		case "P":
-			verdictLabel = "passed"
-		case "F":
-			verdictLabel = "failed"
-		}
-
-		fmt.Fprintf(sb, "--- Commit %s (%s, %s) ---\n",
-			shortSHA, ctx.Review.Agent, verdictLabel)
-		sb.WriteString(ctx.Review.Output)
-		sb.WriteString("\n")
-
-		if len(ctx.Responses) > 0 {
-			sb.WriteString("\nComments on this review:\n")
-			for _, resp := range ctx.Responses {
-				fmt.Fprintf(sb, "- %s: %q\n", resp.Responder, resp.Response)
-			}
-		}
-		sb.WriteString("\n")
-	}
-}
-
-// lookupReviewContexts fetches review contexts for the given SHAs.
-// When skipMissing is true, SHAs without reviews are omitted; when false,
-// they are included with Review == nil (used by writePreviousReviews to
-// show "No review available").
 func (b *Builder) lookupReviewContexts(shas []string, skipMissing bool) []ReviewContext {
+	if b.db == nil {
+		return nil
+	}
 	var contexts []ReviewContext
 	for _, sha := range shas {
 		review, err := b.db.GetReviewByCommitSHA(sha)
@@ -974,92 +839,13 @@ func (b *Builder) getPreviousReviewContexts(repoPath, sha string, count int) ([]
 	return b.lookupReviewContexts(parentSHAs, false), nil
 }
 
-// SystemPromptDesignReview is the base instruction for reviewing design documents.
-// The input is a code diff (commit, range, or uncommitted changes) that is expected
-// to contain design artifacts such as PRDs, task lists, or architectural proposals.
-const SystemPromptDesignReview = `You are a design reviewer. The changes shown below are expected to contain design artifacts — PRDs, task lists, architectural proposals, or similar planning documents. Review them for:
-
-1. **Completeness**: Are goals, non-goals, success criteria, and edge cases defined?
-2. **Feasibility**: Are technical decisions grounded in the actual codebase?
-3. **Task scoping**: Are implementation stages small enough to review incrementally? Are dependencies ordered correctly?
-4. **Missing considerations**: Security, performance, backwards compatibility, error handling
-5. **Clarity**: Are decisions justified and understandable?
-
-If the changes do not appear to contain design documents, note this and review whatever design intent is evident from the code changes.
-
-After reviewing, provide:
-
-1. A brief summary of what the design proposes
-2. PRD findings, listed with:
-   - Severity (high/medium/low)
-   - A brief explanation of the issue and suggested improvement
-3. Task list findings, listed with:
-   - Severity (high/medium/low)
-   - A brief explanation of the issue and suggested improvement
-4. Any missing considerations not covered by the design
-5. A verdict: Pass or Fail with brief justification
-
-If you find no issues, state "No issues found." after the summary.`
-
 // BuildSimple constructs a simpler prompt without database context
 func BuildSimple(repoPath, sha, agentName string) (string, error) {
 	b := &Builder{}
 	return b.Build(repoPath, sha, 0, 0, agentName, "", "")
 }
 
-// SystemPromptSecurity is the instruction for security-focused reviews
-const SystemPromptSecurity = `You are a security code reviewer. Analyze the code changes shown below with a security-first mindset. Focus on:
-
-1. **Injection vulnerabilities**: SQL injection, command injection, XSS, template injection, LDAP injection, header injection
-2. **Authentication & authorization**: Missing auth checks, privilege escalation, insecure session handling, broken access control
-3. **Credential exposure**: Hardcoded secrets, API keys, passwords, tokens in source code or logs
-4. **Path traversal**: Unsanitized file paths, directory traversal via user input, symlink attacks
-5. **Unsafe patterns**: Unsafe deserialization, insecure random number generation, missing input validation, buffer overflows
-6. **Dependency concerns**: Known vulnerable dependencies, typosquatting risks, pinning issues
-7. **CI/CD security**: Workflow injection via pull_request_target, script injection via untrusted inputs, excessive permissions
-8. **Data handling**: Sensitive data in logs, missing encryption, insecure data storage, PII exposure
-9. **Concurrency issues**: Race conditions leading to security bypasses, TOCTOU vulnerabilities
-10. **Error handling**: Information leakage via error messages, missing error checks on security-critical operations
-
-For each finding, provide:
-- Severity (critical/high/medium/low)
-- File and line reference
-- Description of the vulnerability
-- Suggested remediation
-
-If you find no security issues, state "No issues found." after the summary.
-Do not report code quality or style issues unless they have security implications.`
-
-// SystemPromptAddress is the instruction for addressing review findings
-const SystemPromptAddress = `You are a code assistant. Your task is to address the findings from a code review.
-
-Make the minimal changes necessary to address these findings:
-- Be pragmatic and simple - don't over-engineer
-- Focus on the specific issues mentioned
-- Don't refactor unrelated code
-- Don't add unnecessary abstractions or comments
-- Don't make cosmetic changes
-
-After making changes:
-1. Run the build command to verify the code compiles
-2. Run tests to verify nothing is broken
-3. Fix any build errors or test failures before finishing
-
-For Go projects, use: GOCACHE=/tmp/go-build go build ./... and GOCACHE=/tmp/go-build go test ./...
-(The GOCACHE override is needed for sandbox compatibility)
-
-IMPORTANT: Do NOT commit changes yourself. Just modify the files. The caller will handle committing.
-
-When finished, provide a brief summary in this format (this will be used in the commit message):
-
-Changes:
-- <first change>
-- <second change>
-...
-
-Keep the summary concise (under 10 bullet points). Put the most important changes first.`
-
-// PreviousAttemptsHeader introduces previous addressing attempts section
+// PreviousAttemptsHeader introduces previous addressing attempts section.
 const PreviousAttemptsHeader = `
 ## Previous Addressing Attempts
 
@@ -1097,8 +883,7 @@ func SplitResponses(responses []storage.Response) (toolAttempts, userComments []
 	return
 }
 
-// FormatToolAttempts renders automated tool responses (roborev-fix,
-// roborev-refine) into a prompt section. Returns empty string when empty.
+// FormatToolAttempts renders automated tool responses into a prompt section.
 func FormatToolAttempts(attempts []storage.Response) string {
 	if len(attempts) == 0 {
 		return ""
@@ -1107,8 +892,7 @@ func FormatToolAttempts(attempts []storage.Response) string {
 	sb.WriteString(PreviousAttemptsHeader)
 	sb.WriteString("\n")
 	for _, attempt := range attempts {
-		fmt.Fprintf(&sb, "--- Attempt by %s at %s ---\n",
-			attempt.Responder, attempt.CreatedAt.Format("2006-01-02 15:04"))
+		fmt.Fprintf(&sb, "--- Attempt by %s at %s ---\n", attempt.Responder, attempt.CreatedAt.Format("2006-01-02 15:04"))
 		sb.WriteString(attempt.Response)
 		sb.WriteString("\n\n")
 	}
@@ -1116,7 +900,6 @@ func FormatToolAttempts(attempts []storage.Response) string {
 }
 
 // FormatUserComments renders user-authored comments into a prompt section.
-// Returns empty string when there are no comments.
 func FormatUserComments(comments []storage.Response) string {
 	if len(comments) == 0 {
 		return ""
@@ -1124,8 +907,7 @@ func FormatUserComments(comments []storage.Response) string {
 	var sb strings.Builder
 	sb.WriteString(UserCommentsHeader)
 	for _, c := range comments {
-		fmt.Fprintf(&sb, "**%s** (%s):\n%s\n\n",
-			c.Responder, c.CreatedAt.Format("2006-01-02 15:04"), c.Response)
+		fmt.Fprintf(&sb, "**%s** (%s):\n%s\n\n", c.Responder, c.CreatedAt.Format("2006-01-02 15:04"), c.Response)
 	}
 	return sb.String()
 }
@@ -1134,52 +916,53 @@ func FormatUserComments(comments []storage.Response) string {
 // When minSeverity is non-empty, a severity filtering instruction is
 // injected before the findings section.
 func (b *Builder) BuildAddressPrompt(repoPath string, review *storage.Review, previousAttempts []storage.Response, minSeverity string) (string, error) {
-	var sb strings.Builder
+	view := addressPromptView{
+		SeverityFilter: config.SeverityInstruction(minSeverity),
+		ReviewFindings: review.Output,
+		JobID:          review.JobID,
+	}
 
-	// System prompt
-	sb.WriteString(GetSystemPrompt(review.Agent, "address"))
-	sb.WriteString("\n")
-
-	// Add project-specific guidelines if configured
 	if repoCfg, err := config.LoadRepoConfig(repoPath); err == nil && repoCfg != nil {
-		b.writeProjectGuidelines(&sb, repoCfg.ReviewGuidelines)
+		view.ProjectGuidelines = buildProjectGuidelinesSectionView(repoCfg.ReviewGuidelines)
 	}
 
-	// Split responses into tool attempts and user comments
-	toolAttempts, userComments := SplitResponses(previousAttempts)
-	sb.WriteString(FormatToolAttempts(toolAttempts))
-	sb.WriteString(FormatUserComments(userComments))
-
-	// Severity filter instruction (before findings)
-	if inst := config.SeverityInstruction(minSeverity); inst != "" {
-		sb.WriteString(inst)
-		sb.WriteString("\n")
-	}
-
-	// Review findings section
-	fmt.Fprintf(&sb, "## Review Findings to Address (Job %d)\n\n", review.JobID)
-	sb.WriteString(review.Output)
-	sb.WriteString("\n\n")
-
-	// Include the original diff for context if we have job info.
-	// Don't apply user exclude patterns — the diff should match
-	// what the original review saw so findings stay relevant.
-	// Built-in lockfile excludes still apply (hardcoded in GetDiff).
-	// Tradeoff: without user excludes the diff may be larger and
-	// trip the MaxPromptSize/2 guard, but that's a soft degradation
-	// vs hiding the exact file the findings reference.
-	if review.Job != nil && review.Job.GitRef != "" && review.Job.GitRef != "dirty" {
-		diff, err := git.GetDiff(repoPath, review.Job.GitRef)
-		if err == nil && len(diff) > 0 && len(diff) < MaxPromptSize/2 {
-			sb.WriteString("## Original Commit Diff (for context)\n\n")
-			sb.WriteString("```diff\n")
-			sb.WriteString(diff)
-			if !strings.HasSuffix(diff, "\n") {
-				sb.WriteString("\n")
+	if len(previousAttempts) > 0 {
+		toolAttempts, userComments := SplitResponses(previousAttempts)
+		if len(toolAttempts) > 0 {
+			view.ToolAttempts = make([]addressAttemptView, 0, len(toolAttempts))
+			for _, attempt := range toolAttempts {
+				when := ""
+				if !attempt.CreatedAt.IsZero() {
+					when = attempt.CreatedAt.Format("2006-01-02 15:04")
+				}
+				view.ToolAttempts = append(view.ToolAttempts, addressAttemptView{Responder: attempt.Responder, Response: attempt.Response, When: when})
 			}
-			sb.WriteString("```\n")
+		}
+		if len(userComments) > 0 {
+			view.UserComments = make([]addressAttemptView, 0, len(userComments))
+			for _, comment := range userComments {
+				when := ""
+				if !comment.CreatedAt.IsZero() {
+					when = comment.CreatedAt.Format("2006-01-02 15:04")
+				}
+				view.UserComments = append(view.UserComments, addressAttemptView{Responder: comment.Responder, Response: comment.Response, When: when})
+			}
 		}
 	}
 
-	return sb.String(), nil
+	if review.Job != nil && review.Job.GitRef != "" && review.Job.GitRef != "dirty" {
+		diff, err := git.GetDiff(repoPath, review.Job.GitRef)
+		if err == nil && len(diff) > 0 && len(diff) < MaxPromptSize/2 {
+			view.OriginalDiff = diff
+			if !strings.HasSuffix(view.OriginalDiff, "\n") {
+				view.OriginalDiff += "\n"
+			}
+		}
+	}
+
+	body, err := renderAddressPromptFromSections(view)
+	if err != nil {
+		return "", err
+	}
+	return GetSystemPrompt(review.Agent, "address") + "\n" + body, nil
 }

--- a/internal/prompt/prompt_body_templates.go
+++ b/internal/prompt/prompt_body_templates.go
@@ -1,0 +1,469 @@
+package prompt
+
+import (
+	"bytes"
+	"strconv"
+	"strings"
+	"text/template"
+
+	"github.com/roborev-dev/roborev/internal/git"
+	"github.com/roborev-dev/roborev/internal/storage"
+)
+
+type markdownSectionView struct {
+	Heading string
+	Body    string
+}
+
+type reviewCommentView struct {
+	Responder string
+	Response  string
+}
+
+type previousReviewView struct {
+	Commit    string
+	Output    string
+	Comments  []reviewCommentView
+	Available bool
+}
+
+type reviewAttemptView struct {
+	Label    string
+	Agent    string
+	When     string
+	Output   string
+	Comments []reviewCommentView
+}
+
+type optionalSectionsView struct {
+	ProjectGuidelines *markdownSectionView
+	AdditionalContext string
+	PreviousReviews   []previousReviewView
+	InRangeReviews    []inRangeReviewView
+	PreviousAttempts  []reviewAttemptView
+}
+
+type currentCommitSectionView struct {
+	Commit  string
+	Subject string
+	Author  string
+	Message string
+}
+
+type commitRangeEntryView struct {
+	Commit  string
+	Subject string
+}
+
+type commitRangeSectionView struct {
+	Count   int
+	Entries []commitRangeEntryView
+}
+
+type dirtyChangesSectionView struct {
+	Description string
+}
+
+type diffSectionView struct {
+	Heading  string
+	Body     string
+	Fallback string
+}
+
+type singlePromptView struct {
+	Optional optionalSectionsView
+	Current  currentCommitSectionView
+	Diff     diffSectionView
+}
+
+type rangePromptView struct {
+	Optional optionalSectionsView
+	Current  commitRangeSectionView
+	Diff     diffSectionView
+}
+
+type dirtyPromptView struct {
+	Optional optionalSectionsView
+	Current  dirtyChangesSectionView
+	Diff     diffSectionView
+}
+
+type inRangeReviewView struct {
+	Commit   string
+	Agent    string
+	Verdict  string
+	Output   string
+	Comments []reviewCommentView
+}
+
+type addressAttemptView struct {
+	Responder string
+	Response  string
+	When      string
+}
+
+type addressPromptView struct {
+	ProjectGuidelines *markdownSectionView
+	ToolAttempts      []addressAttemptView
+	UserComments      []addressAttemptView
+	SeverityFilter    string
+	ReviewFindings    string
+	OriginalDiff      string
+	JobID             int64
+}
+
+type reviewAttemptContext struct {
+	Review    storage.Review
+	Responses []storage.Response
+}
+
+type systemPromptView struct {
+	NoSkillsInstruction string
+	CurrentDate         string
+}
+
+type inlineDiffView struct {
+	Body string
+}
+
+type dirtyTruncatedDiffFallbackView struct {
+	Body string
+}
+
+var promptTemplates = template.Must(template.New("prompt-templates").ParseFS(
+	templateFS,
+	"templates/*.md.gotmpl",
+))
+
+func renderSinglePrompt(view singlePromptView) (string, error) {
+	return executePromptTemplate("assembled_single.md.gotmpl", view)
+}
+
+func renderRangePrompt(view rangePromptView) (string, error) {
+	return executePromptTemplate("assembled_range.md.gotmpl", view)
+}
+
+func renderDirtyPrompt(view dirtyPromptView) (string, error) {
+	return executePromptTemplate("assembled_dirty.md.gotmpl", view)
+}
+
+func renderAddressPrompt(view addressPromptView) (string, error) {
+	return executePromptTemplate("assembled_address.md.gotmpl", view)
+}
+
+func fitSinglePrompt(limit int, view singlePromptView) (string, error) {
+	body, err := renderSinglePrompt(view)
+	if err != nil {
+		return "", err
+	}
+	if len(body) <= limit {
+		return body, nil
+	}
+
+	for trimOptionalSections(&view.Optional) {
+		body, err = renderSinglePrompt(view)
+		if err != nil {
+			return "", err
+		}
+		if len(body) <= limit {
+			return body, nil
+		}
+	}
+
+	if view.Current.Message != "" {
+		view.Current.Message = ""
+		body, err = renderSinglePrompt(view)
+		if err != nil {
+			return "", err
+		}
+		if len(body) <= limit {
+			return body, nil
+		}
+	}
+
+	if view.Current.Author != "" {
+		view.Current.Author = ""
+		body, err = renderSinglePrompt(view)
+		if err != nil {
+			return "", err
+		}
+		if len(body) <= limit {
+			return body, nil
+		}
+	}
+
+	for len(body) > limit && view.Current.Subject != "" {
+		overflow := len(body) - limit
+		view.Current.Subject = truncateUTF8(view.Current.Subject, max(0, len(view.Current.Subject)-overflow))
+		body, err = renderSinglePrompt(view)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return hardCapPrompt(body, limit), nil
+}
+
+func fitRangePrompt(limit int, view rangePromptView) (string, error) {
+	_, body, err := trimRangePromptView(limit, view)
+	if err != nil {
+		return "", err
+	}
+	return hardCapPrompt(body, limit), nil
+}
+
+func cloneCommitRangeSectionView(view commitRangeSectionView) commitRangeSectionView {
+	cloned := view
+	if len(view.Entries) == 0 {
+		return cloned
+	}
+	cloned.Entries = append([]commitRangeEntryView(nil), view.Entries...)
+	return cloned
+}
+
+func trimRangePromptView(limit int, view rangePromptView) (rangePromptView, string, error) {
+	view.Current = cloneCommitRangeSectionView(view.Current)
+	body, err := renderRangePrompt(view)
+	if err != nil {
+		return rangePromptView{}, "", err
+	}
+	if len(body) <= limit {
+		return view, body, nil
+	}
+
+	for trimOptionalSections(&view.Optional) {
+		body, err = renderRangePrompt(view)
+		if err != nil {
+			return rangePromptView{}, "", err
+		}
+		if len(body) <= limit {
+			return view, body, nil
+		}
+	}
+
+	for i := len(view.Current.Entries) - 1; i >= 0 && len(body) > limit; i-- {
+		if view.Current.Entries[i].Subject == "" {
+			continue
+		}
+		view.Current.Entries[i].Subject = ""
+		body, err = renderRangePrompt(view)
+		if err != nil {
+			return rangePromptView{}, "", err
+		}
+	}
+
+	for len(view.Current.Entries) > 0 && len(body) > limit {
+		view.Current.Entries = view.Current.Entries[:len(view.Current.Entries)-1]
+		body, err = renderRangePrompt(view)
+		if err != nil {
+			return rangePromptView{}, "", err
+		}
+	}
+
+	return view, body, nil
+}
+
+func fitDirtyPrompt(limit int, view dirtyPromptView) (string, error) {
+	body, err := renderDirtyPrompt(view)
+	if err != nil {
+		return "", err
+	}
+	if len(body) <= limit {
+		return body, nil
+	}
+
+	for trimOptionalSections(&view.Optional) {
+		body, err = renderDirtyPrompt(view)
+		if err != nil {
+			return "", err
+		}
+		if len(body) <= limit {
+			return body, nil
+		}
+	}
+
+	return hardCapPrompt(body, limit), nil
+}
+
+func trimOptionalSections(view *optionalSectionsView) bool {
+	switch {
+	case len(view.PreviousAttempts) > 0:
+		view.PreviousAttempts = nil
+	case len(view.PreviousReviews) > 0:
+		view.PreviousReviews = nil
+	case view.AdditionalContext != "":
+		view.AdditionalContext = ""
+	case view.ProjectGuidelines != nil:
+		view.ProjectGuidelines = nil
+	default:
+		return false
+	}
+	return true
+}
+
+func renderSystemPrompt(name string, view systemPromptView) (string, error) {
+	return executePromptTemplate(name, view)
+}
+
+func renderAddressPromptFromSections(view addressPromptView) (string, error) {
+	return renderAddressPrompt(view)
+}
+
+func renderOptionalSectionsFromView(view optionalSectionsView) (string, error) {
+	body, err := executePromptTemplate("optional_sections", view)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(body), nil
+}
+
+func renderOptionalSectionsPrefix(view optionalSectionsView) (string, error) {
+	body, err := renderOptionalSectionsFromView(view)
+	if err != nil || body == "" {
+		return body, err
+	}
+	return body + "\n\n", nil
+}
+
+func renderCurrentCommitRequired(view currentCommitSectionView) (string, error) {
+	return executePromptTemplate("current_commit_required", view)
+}
+
+func renderCurrentCommitOverflow(view currentCommitSectionView) (string, error) {
+	return executePromptTemplate("current_commit_overflow", view)
+}
+
+func renderCommitRangeRequired(view commitRangeSectionView) (string, error) {
+	return executePromptTemplate("commit_range_required", view)
+}
+
+func renderCommitRangeOverflow(view commitRangeSectionView) (string, error) {
+	return executePromptTemplate("commit_range_overflow", view)
+}
+
+func renderDirtyChangesSection(view dirtyChangesSectionView) (string, error) {
+	return executePromptTemplate("dirty_changes", view)
+}
+
+func renderDiffBlock(view diffSectionView) (string, error) {
+	return executePromptTemplate("diff_block", view)
+}
+
+func renderInlineDiff(body string) (string, error) {
+	if body != "" && !strings.HasSuffix(body, "\n") {
+		body += "\n"
+	}
+	return executePromptTemplate("inline_diff", inlineDiffView{Body: body})
+}
+
+func renderDirtyTruncatedDiffFallback(body string) (string, error) {
+	if body != "" && !strings.HasSuffix(body, "\n") {
+		body += "\n"
+	}
+	return executePromptTemplate("dirty_truncated_diff_fallback", dirtyTruncatedDiffFallbackView{Body: body})
+}
+
+func previousReviewViews(contexts []ReviewContext) []previousReviewView {
+	views := make([]previousReviewView, 0, len(contexts))
+	for _, ctx := range contexts {
+		view := previousReviewView{Commit: git.ShortSHA(ctx.SHA)}
+		if ctx.Review != nil {
+			view.Available = true
+			view.Output = ctx.Review.Output
+		}
+		if len(ctx.Responses) > 0 {
+			view.Comments = make([]reviewCommentView, 0, len(ctx.Responses))
+			for _, resp := range ctx.Responses {
+				view.Comments = append(view.Comments, reviewCommentView{Responder: resp.Responder, Response: resp.Response})
+			}
+		}
+		views = append(views, view)
+	}
+	return views
+}
+
+func renderPreviousReviewsFromContexts(contexts []ReviewContext) (string, error) {
+	return renderOptionalSectionsFromView(optionalSectionsView{PreviousReviews: previousReviewViews(contexts)})
+}
+
+func inRangeReviewViews(contexts []ReviewContext) []inRangeReviewView {
+	views := make([]inRangeReviewView, 0, len(contexts))
+	for _, ctx := range contexts {
+		if ctx.Review == nil {
+			continue
+		}
+		verdict := storage.ParseVerdict(ctx.Review.Output)
+		verdictLabel := "unknown"
+		switch verdict {
+		case "P":
+			verdictLabel = "passed"
+		case "F":
+			verdictLabel = "failed"
+		}
+		view := inRangeReviewView{
+			Commit:  git.ShortSHA(ctx.SHA),
+			Agent:   ctx.Review.Agent,
+			Verdict: verdictLabel,
+			Output:  ctx.Review.Output,
+		}
+		if len(ctx.Responses) > 0 {
+			view.Comments = make([]reviewCommentView, 0, len(ctx.Responses))
+			for _, resp := range ctx.Responses {
+				view.Comments = append(view.Comments, reviewCommentView{Responder: resp.Responder, Response: resp.Response})
+			}
+		}
+		views = append(views, view)
+	}
+	return views
+}
+
+func reviewAttemptViews(reviews []storage.Review) []reviewAttemptView {
+	views := make([]reviewAttemptView, 0, len(reviews))
+	for i, review := range reviews {
+		when := ""
+		if !review.CreatedAt.IsZero() {
+			when = review.CreatedAt.Format("2006-01-02 15:04")
+		}
+		views = append(views, reviewAttemptView{
+			Label:  "Review Attempt " + strconv.Itoa(i+1),
+			Agent:  review.Agent,
+			When:   when,
+			Output: review.Output,
+		})
+	}
+	return views
+}
+
+func renderPreviousAttemptsFromReviews(reviews []storage.Review) (string, error) {
+	return renderOptionalSectionsFromView(optionalSectionsView{PreviousAttempts: reviewAttemptViews(reviews)})
+}
+
+func previousAttemptViewsFromContexts(attempts []reviewAttemptContext) []reviewAttemptView {
+	views := make([]reviewAttemptView, 0, len(attempts))
+	for i, attempt := range attempts {
+		view := reviewAttemptView{
+			Label:  "Review Attempt " + strconv.Itoa(i+1),
+			Agent:  attempt.Review.Agent,
+			Output: attempt.Review.Output,
+		}
+		if !attempt.Review.CreatedAt.IsZero() {
+			view.When = attempt.Review.CreatedAt.Format("2006-01-02 15:04")
+		}
+		if len(attempt.Responses) > 0 {
+			view.Comments = make([]reviewCommentView, 0, len(attempt.Responses))
+			for _, resp := range attempt.Responses {
+				view.Comments = append(view.Comments, reviewCommentView{Responder: resp.Responder, Response: resp.Response})
+			}
+		}
+		views = append(views, view)
+	}
+	return views
+}
+
+func executePromptTemplate(name string, view any) (string, error) {
+	var buf bytes.Buffer
+	if err := promptTemplates.ExecuteTemplate(&buf, name, view); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/internal/prompt/prompt_body_templates_test.go
+++ b/internal/prompt/prompt_body_templates_test.go
@@ -1,0 +1,409 @@
+package prompt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/roborev-dev/roborev/internal/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderSinglePromptBodyUsesNestedSections(t *testing.T) {
+	view := singlePromptView{
+		Optional: optionalSectionsView{
+			ProjectGuidelines: &markdownSectionView{
+				Heading: "## Project Guidelines",
+				Body:    "Prefer composition over inheritance.",
+			},
+			AdditionalContext: "## Pull Request Discussion\n\nNewest comment first.\n\n",
+		},
+		Current: currentCommitSectionView{
+			Commit:  "abc1234",
+			Subject: "template prompt rendering",
+			Author:  "Test User",
+		},
+		Diff: diffSectionView{
+			Heading: "### Diff",
+			Body:    "```diff\n+line\n```\n",
+		},
+	}
+
+	body, err := renderSinglePrompt(view)
+	require.NoError(t, err)
+
+	assert.Contains(t, body, "## Project Guidelines")
+	assert.Contains(t, body, "## Pull Request Discussion")
+	assert.Contains(t, body, "## Current Commit")
+	assert.Contains(t, body, "**Subject:** template prompt rendering")
+	assert.Contains(t, body, "### Diff")
+}
+
+func TestRenderRangePromptUsesNestedSections(t *testing.T) {
+	view := rangePromptView{
+		Optional: optionalSectionsView{
+			AdditionalContext: "## Pull Request Discussion\n\nNewest comment first.\n\n",
+		},
+		Current: commitRangeSectionView{
+			Entries: []commitRangeEntryView{{Commit: "abc1234", Subject: "first"}, {Commit: "def5678", Subject: "second"}},
+		},
+		Diff: diffSectionView{
+			Heading: "### Combined Diff",
+			Body:    "```diff\n+line\n```\n",
+		},
+	}
+
+	body, err := renderRangePrompt(view)
+	require.NoError(t, err)
+
+	assert.Contains(t, body, "## Pull Request Discussion")
+	assert.Contains(t, body, "## Commit Range")
+	assert.Contains(t, body, "- abc1234 first")
+	assert.Contains(t, body, "- def5678 second")
+	assert.Contains(t, body, "### Combined Diff")
+}
+
+func TestRenderCommitRangeSectionsFromTemplate(t *testing.T) {
+	required, err := renderCommitRangeRequired(commitRangeSectionView{
+		Entries: []commitRangeEntryView{{Commit: "abc1234", Subject: "first"}, {Commit: "def5678", Subject: "second"}},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, required, "## Commit Range")
+	assert.Contains(t, required, "Reviewing 2 commits:")
+
+	overflow, err := renderCommitRangeOverflow(commitRangeSectionView{
+		Entries: []commitRangeEntryView{{Commit: "abc1234", Subject: "first"}, {Commit: "def5678", Subject: "second"}},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, overflow, "- abc1234 first")
+	assert.Contains(t, overflow, "- def5678 second")
+}
+
+func TestRenderDirtyTruncatedDiffFallbackFromTemplate(t *testing.T) {
+	fallback, err := renderDirtyTruncatedDiffFallback("+line\n... (truncated)\n")
+	require.NoError(t, err)
+	assert.Contains(t, fallback, "(Diff too large to include in full)")
+	assert.Contains(t, fallback, "```diff")
+	assert.Contains(t, fallback, "+line")
+	assert.Contains(t, fallback, "... (truncated)")
+}
+
+func TestRenderDirtyPromptUsesNestedSections(t *testing.T) {
+	view := dirtyPromptView{
+		Optional: optionalSectionsView{
+			AdditionalContext: "## Pull Request Discussion\n\nNewest comment first.\n\n",
+		},
+		Current: dirtyChangesSectionView{
+			Description: "The following changes have not yet been committed.",
+		},
+		Diff: diffSectionView{
+			Heading: "### Diff",
+			Body:    "```diff\n+line\n```\n",
+		},
+	}
+
+	body, err := renderDirtyPrompt(view)
+	require.NoError(t, err)
+
+	assert.Contains(t, body, "## Pull Request Discussion")
+	assert.Contains(t, body, "## Uncommitted Changes")
+	assert.Contains(t, body, "The following changes have not yet been committed.")
+	assert.Contains(t, body, "### Diff")
+}
+
+func TestRenderAddressPromptUsesNestedSections(t *testing.T) {
+	view := addressPromptView{
+		ProjectGuidelines: &markdownSectionView{
+			Heading: "## Project Guidelines",
+			Body:    "Keep it simple.",
+		},
+		ToolAttempts:   []addressAttemptView{{Responder: "developer", Response: "Tried a narrow fix", When: "2026-04-04 12:00"}},
+		SeverityFilter: "Only address medium and higher findings.\n\n",
+		ReviewFindings: "- medium: do the thing",
+		OriginalDiff:   "diff --git a/a b/a\n+line\n",
+		JobID:          42,
+	}
+
+	body, err := renderAddressPrompt(view)
+	require.NoError(t, err)
+
+	assert.Contains(t, body, "## Project Guidelines")
+	assert.Contains(t, body, "## Previous Addressing Attempts")
+	assert.Contains(t, body, "## Review Findings to Address (Job 42)")
+	assert.Contains(t, body, "## Original Commit Diff (for context)")
+}
+
+func TestRenderSystemPromptUsesTemplateData(t *testing.T) {
+	body, err := renderSystemPrompt("default_review.md.gotmpl", systemPromptView{
+		NoSkillsInstruction: noSkillsInstruction,
+		CurrentDate:         "2030-06-15",
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, body, "You are a code reviewer")
+	assert.Contains(t, body, "Do NOT use any external skills")
+	assert.Contains(t, body, "Current date: 2030-06-15 (UTC)")
+}
+
+func TestRenderSinglePromptPreservesRawText(t *testing.T) {
+	view := singlePromptView{
+		Optional: optionalSectionsView{
+			ProjectGuidelines: &markdownSectionView{
+				Heading: "## Project Guidelines",
+				Body:    "context with <tag> & symbols > keep",
+			},
+		},
+		Current: currentCommitSectionView{
+			Commit:  "abc1234",
+			Subject: "required <input> && output > all",
+			Author:  "overflow uses <, >, and &",
+		},
+		Diff: diffSectionView{
+			Heading: "### Diff",
+			Body:    "```diff\n+ use <raw> & keep > unchanged\n```\n",
+		},
+	}
+
+	body, err := renderSinglePrompt(view)
+	require.NoError(t, err)
+	assert.Contains(t, body, "context with <tag> & symbols > keep")
+	assert.Contains(t, body, "required <input> && output > all")
+	assert.Contains(t, body, "overflow uses <, >, and &")
+	assert.Contains(t, body, "+ use <raw> & keep > unchanged")
+}
+
+func TestRenderSinglePromptUsesFallbackOverBody(t *testing.T) {
+	body, err := renderSinglePrompt(singlePromptView{
+		Current: currentCommitSectionView{Commit: "abc1234", Subject: "subject", Author: "author"},
+		Diff:    diffSectionView{Heading: "### Diff", Body: "body", Fallback: "fallback"},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, body, "fallback")
+	assert.NotContains(t, body, "body")
+}
+
+func TestRenderOptionalSectionsFromTypedData(t *testing.T) {
+	body, err := renderOptionalSectionsFromView(optionalSectionsView{
+		ProjectGuidelines: &markdownSectionView{
+			Heading: "## Project Guidelines",
+			Body:    "Prefer composition over inheritance.",
+		},
+		AdditionalContext: "## Pull Request Discussion\n\nNewest comment first.\n\n",
+		PreviousReviews: []previousReviewView{{
+			Commit:    "abc1234",
+			Available: true,
+			Output:    "Found a bug",
+			Comments:  []reviewCommentView{{Responder: "alice", Response: "Known issue"}},
+		}},
+		PreviousAttempts: []reviewAttemptView{{
+			Label:    "Review Attempt 1",
+			Agent:    "test",
+			When:     "2026-04-05 10:00",
+			Output:   "Still failing",
+			Comments: []reviewCommentView{{Responder: "bob", Response: "Will fix"}},
+		}},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, body, "## Project Guidelines")
+	assert.Contains(t, body, "These guidelines supplement the default review criteria")
+	assert.Contains(t, body, "## Pull Request Discussion")
+	assert.Contains(t, body, "## Previous Reviews")
+	assert.Contains(t, body, "Found a bug")
+	assert.Contains(t, body, "Known issue")
+	assert.Contains(t, body, "## Previous Review Attempts")
+	assert.Contains(t, body, "Review Attempt 1")
+	assert.Contains(t, body, "Will fix")
+}
+
+func TestRenderOptionalSectionsOmitsEmptySections(t *testing.T) {
+	body, err := renderOptionalSectionsFromView(optionalSectionsView{})
+	require.NoError(t, err)
+	assert.Empty(t, body)
+}
+
+func TestBuildAdditionalContextSectionTrimsAndFormats(t *testing.T) {
+	body := buildAdditionalContextSection("\n## Pull Request Discussion\n\nNewest comment first.\n")
+	assert.Equal(t, "## Pull Request Discussion\n\nNewest comment first.\n\n", body)
+}
+
+func TestBuildProjectGuidelinesSectionViewTrimsAndFormats(t *testing.T) {
+	section := buildProjectGuidelinesSectionView("\nPrefer composition over inheritance.\n")
+	require.NotNil(t, section)
+	assert.Equal(t, "## Project Guidelines", section.Heading)
+	assert.Equal(t, "Prefer composition over inheritance.", section.Body)
+}
+
+func TestPreviousReviewViewsPreserveChronologicalOrder(t *testing.T) {
+	views := previousReviewViews([]ReviewContext{
+		{SHA: "bbbbbbb", Review: &storage.Review{Output: "second"}},
+		{SHA: "aaaaaaa", Review: &storage.Review{Output: "first"}},
+	})
+	require.Len(t, views, 2)
+	assert.Equal(t, "bbbbbbb", views[0].Commit)
+	assert.Equal(t, "aaaaaaa", views[1].Commit)
+}
+
+func TestRenderPreviousReviewsFromContexts(t *testing.T) {
+	body, err := renderPreviousReviewsFromContexts([]ReviewContext{
+		{
+			SHA:    "abc1234",
+			Review: &storage.Review{Output: "Found a bug"},
+			Responses: []storage.Response{{
+				Responder: "alice",
+				Response:  "Known issue",
+			}},
+		},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, body, "## Previous Reviews")
+	assert.Contains(t, body, "Found a bug")
+	assert.Contains(t, body, "Known issue")
+}
+
+func TestReviewAttemptViewsPreserveOrderAndMetadata(t *testing.T) {
+	views := reviewAttemptViews([]storage.Review{{
+		Agent:     "test",
+		Output:    "first",
+		CreatedAt: mustParsePromptTestTime(t, "2026-04-05 10:00"),
+	}})
+	require.Len(t, views, 1)
+	assert.Equal(t, "Review Attempt 1", views[0].Label)
+	assert.Equal(t, "test", views[0].Agent)
+	assert.Equal(t, "2026-04-05 10:00", views[0].When)
+	assert.Equal(t, "first", views[0].Output)
+}
+
+func TestRenderPreviousAttemptsFromReviews(t *testing.T) {
+	body, err := renderPreviousAttemptsFromReviews([]storage.Review{{
+		Agent:     "test",
+		Output:    "first",
+		CreatedAt: mustParsePromptTestTime(t, "2026-04-05 10:00"),
+	}})
+	require.NoError(t, err)
+	assert.Contains(t, body, "## Previous Review Attempts")
+	assert.Contains(t, body, "Review Attempt 1")
+	assert.Contains(t, body, "first")
+}
+
+func mustParsePromptTestTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse("2006-01-02 15:04", value)
+	require.NoError(t, err)
+	return parsed
+}
+func TestRenderAddressPromptOmitsOptionalSectionsWhenEmpty(t *testing.T) {
+	body, err := renderAddressPrompt(addressPromptView{ReviewFindings: "finding", JobID: 1})
+	require.NoError(t, err)
+	assert.NotContains(t, body, "## Previous Addressing Attempts")
+	assert.NotContains(t, body, "## Original Commit Diff")
+}
+
+func TestFitSinglePromptTrimsOptionalSectionsBeforeCurrentMetadata(t *testing.T) {
+	view := singlePromptView{
+		Optional: optionalSectionsView{
+			AdditionalContext: strings.Repeat("g", 128),
+		},
+		Current: currentCommitSectionView{
+			Commit:  "abc1234",
+			Subject: "large change",
+			Author:  "Test User",
+		},
+		Diff: diffSectionView{
+			Heading:  "### Diff",
+			Fallback: "(Diff too large; for Codex run `git show abc1234 --` locally.)\n",
+		},
+	}
+	trimmed := view
+	trimmed.Optional = optionalSectionsView{}
+	trimmedBody, err := renderSinglePrompt(trimmed)
+	require.NoError(t, err)
+
+	body, err := fitSinglePrompt(len(trimmedBody), view)
+	require.NoError(t, err)
+	assert.Contains(t, body, "## Current Commit")
+	assert.Contains(t, body, "**Subject:** large change")
+	assert.NotContains(t, body, strings.Repeat("g", 128))
+}
+
+func TestFitRangePromptTrimsOptionalSectionsBeforeRangeMetadata(t *testing.T) {
+	view := rangePromptView{
+		Optional: optionalSectionsView{
+			AdditionalContext: strings.Repeat("g", 128),
+		},
+		Current: commitRangeSectionView{
+			Entries: []commitRangeEntryView{{Commit: "abc1234", Subject: "first change"}, {Commit: "def5678", Subject: "second change"}},
+		},
+		Diff: diffSectionView{
+			Heading:  "### Combined Diff",
+			Fallback: "(Diff too large; for Codex run `git diff abc1234..def5678 --` locally.)\n",
+		},
+	}
+	trimmed := view
+	trimmed.Optional = optionalSectionsView{}
+	trimmedBody, err := renderRangePrompt(trimmed)
+	require.NoError(t, err)
+
+	body, err := fitRangePrompt(len(trimmedBody), view)
+	require.NoError(t, err)
+	assert.Contains(t, body, "## Commit Range")
+	assert.Contains(t, body, "- abc1234 first change")
+	assert.NotContains(t, body, strings.Repeat("g", 128))
+}
+
+func TestFitRangePromptDropsTrailingEntriesBeforeCombinedDiff(t *testing.T) {
+	entries := make([]commitRangeEntryView, 0, 80)
+	for i := range 80 {
+		entries = append(entries, commitRangeEntryView{
+			Commit:  fmt.Sprintf("%07x", i),
+			Subject: "very large subject that should be removed before the combined diff is dropped",
+		})
+	}
+	view := rangePromptView{
+		Current: commitRangeSectionView{Count: 80, Entries: entries},
+		Diff: diffSectionView{
+			Heading:  "### Combined Diff",
+			Fallback: "(Diff too large; for Codex run `git diff base..head --` locally.)\n",
+		},
+	}
+	required, err := renderCommitRangeRequired(commitRangeSectionView{Count: 80, Entries: entries})
+	require.NoError(t, err)
+	diffBlock, err := renderDiffBlock(view.Diff)
+	require.NoError(t, err)
+	limit := len(required) + len(diffBlock) + (12 * len("- 0000000\n"))
+
+	body, err := fitRangePrompt(limit, view)
+	require.NoError(t, err)
+
+	assert.Contains(t, body, "Reviewing 80 commits:")
+	assert.Contains(t, body, "### Combined Diff")
+	assert.Contains(t, body, "git diff base..head")
+	assert.NotContains(t, body, "- 000004f",
+		"range fitting should trim trailing entries before hard-capping away the combined diff")
+}
+
+func TestFitDirtyPromptTrimsOptionalSectionsBeforeFallbackDiff(t *testing.T) {
+	view := dirtyPromptView{
+		Optional: optionalSectionsView{
+			AdditionalContext: strings.Repeat("g", 128),
+		},
+		Current: dirtyChangesSectionView{
+			Description: "The following changes have not yet been committed.",
+		},
+		Diff: diffSectionView{
+			Heading:  "### Diff",
+			Fallback: "(Diff too large to include in full)\n```diff\n+line\n... (truncated)\n```\n",
+		},
+	}
+	trimmed := view
+	trimmed.Optional = optionalSectionsView{}
+	trimmedBody, err := renderDirtyPrompt(trimmed)
+	require.NoError(t, err)
+
+	body, err := fitDirtyPrompt(len(trimmedBody), view)
+	require.NoError(t, err)
+	assert.Contains(t, body, "## Uncommitted Changes")
+	assert.Contains(t, body, "(Diff too large to include in full)")
+	assert.NotContains(t, body, strings.Repeat("g", 128))
+}

--- a/internal/prompt/templates.go
+++ b/internal/prompt/templates.go
@@ -7,12 +7,12 @@ import (
 	"time"
 )
 
-//go:embed templates/*.tmpl
+//go:embed templates/*.md.gotmpl
 var templateFS embed.FS
 
 // GetSystemPrompt returns the system prompt for the specified agent and type.
 // If a specific template exists for the agent, it uses that.
-// Otherwise, it falls back to the default constant.
+// Otherwise, it falls back to the default templates.
 // Supported prompt types: review, range, dirty, address, design-review, run, security
 func GetSystemPrompt(agentName string, promptType string) string {
 	return getSystemPrompt(agentName, promptType, time.Now)
@@ -26,49 +26,53 @@ func getSystemPrompt(agentName string, promptType string, now func() time.Time) 
 		agentName = "claude-code"
 	}
 
-	// For review operations (review, range, dirty), use {agent}_review.tmpl
+	// For review operations (review, range, dirty), use {agent}_review.md.gotmpl
 	// These are all code reviews, just with different input formats
-	// Security reviews use {agent}_security.tmpl
+	// Security reviews use {agent}_security.md.gotmpl
 	templateType := promptType
 	if promptType == "range" || promptType == "dirty" {
 		templateType = "review"
 	}
 
-	tmplName := fmt.Sprintf("templates/%s_%s.tmpl", agentName, templateType)
-	content, err := templateFS.ReadFile(tmplName)
-	if err == nil {
-		base := string(content)
-		if promptType != "run" {
-			base += noSkillsInstruction
+	tmplName := fmt.Sprintf("%s_%s.md.gotmpl", agentName, templateType)
+	if _, err := templateFS.ReadFile("templates/" + tmplName); err == nil {
+		body, err := renderSystemPrompt(tmplName, systemPromptView{
+			NoSkillsInstruction: noSkillsInstruction,
+			CurrentDate:         now().UTC().Format("2006-01-02"),
+		})
+		if err == nil {
+			return body
 		}
-		return appendDateLine(base, now)
 	}
 
-	// Fallback to default constants
-	var base string
+	// Fallback to default templates
+	var fallbackName string
 	switch promptType {
 	case "review":
-		base = SystemPromptSingle
+		fallbackName = "default_review.md.gotmpl"
 	case "dirty":
-		base = SystemPromptDirty
+		fallbackName = "default_dirty.md.gotmpl"
 	case "range":
-		base = SystemPromptRange
+		fallbackName = "default_range.md.gotmpl"
 	case "address":
-		base = SystemPromptAddress
+		fallbackName = "default_address.md.gotmpl"
 	case "security":
-		base = SystemPromptSecurity
+		fallbackName = "default_security.md.gotmpl"
 	case "design-review":
-		base = SystemPromptDesignReview
+		fallbackName = "default_design_review.md.gotmpl"
 	case "run":
 		// No default run preamble - return empty so raw prompts are used
 		return ""
 	default:
-		base = SystemPromptSingle
+		fallbackName = "default_review.md.gotmpl"
 	}
-	return appendDateLine(base+noSkillsInstruction, now)
-}
 
-// appendDateLine adds the current UTC date to a system prompt.
-func appendDateLine(prompt string, now func() time.Time) string {
-	return prompt + "\n\nCurrent date: " + now().UTC().Format("2006-01-02") + " (UTC)"
+	body, err := renderSystemPrompt(fallbackName, systemPromptView{
+		NoSkillsInstruction: noSkillsInstruction,
+		CurrentDate:         now().UTC().Format("2006-01-02"),
+	})
+	if err != nil {
+		return ""
+	}
+	return body
 }

--- a/internal/prompt/templates/assembled_address.md.gotmpl
+++ b/internal/prompt/templates/assembled_address.md.gotmpl
@@ -1,0 +1,1 @@
+{{template "project_guidelines" .}}{{template "address_tool_attempts" .}}{{template "address_user_comments" .}}{{template "address_findings" .}}

--- a/internal/prompt/templates/assembled_dirty.md.gotmpl
+++ b/internal/prompt/templates/assembled_dirty.md.gotmpl
@@ -1,0 +1,1 @@
+{{template "optional_sections" .Optional}}{{template "dirty_changes" .Current}}{{template "diff_block" .Diff}}

--- a/internal/prompt/templates/assembled_range.md.gotmpl
+++ b/internal/prompt/templates/assembled_range.md.gotmpl
@@ -1,0 +1,1 @@
+{{template "optional_sections" .Optional}}{{template "commit_range" .Current}}{{template "diff_block" .Diff}}

--- a/internal/prompt/templates/assembled_single.md.gotmpl
+++ b/internal/prompt/templates/assembled_single.md.gotmpl
@@ -1,0 +1,1 @@
+{{template "optional_sections" .Optional}}{{template "current_commit" .Current}}{{template "diff_block" .Diff}}

--- a/internal/prompt/templates/claude-code_review.md.gotmpl
+++ b/internal/prompt/templates/claude-code_review.md.gotmpl
@@ -3,7 +3,6 @@ You are a code reviewer. Review the code changes shown below.
 Return only the final review. Do NOT narrate your process, mention files you opened, or describe intermediate checks.
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
 Do NOT build the project, run the test suite, or execute the code while reviewing. Base your review on the diff and static analysis only.
-Do NOT search or read files outside the repository checkout, except for an explicitly provided diff file path for this review. Do not use tools like rg, find, or cat on unrelated paths outside the repo.
 
 ## Output Format
 
@@ -25,4 +24,6 @@ Do not include any front matter such as "Reviewing the diff..." or "I'm checking
 4. **Regressions**: Changes that might break existing functionality.
 5. **Code quality**: Duplication, overly complex logic, unclear naming.
 
-Do not review the commit message. Focus only on the code changes in the diff.
+Do not review the commit message. Focus only on the code changes in the diff.{{.NoSkillsInstruction}}
+
+Current date: {{.CurrentDate}} (UTC)

--- a/internal/prompt/templates/codex_review.md.gotmpl
+++ b/internal/prompt/templates/codex_review.md.gotmpl
@@ -3,6 +3,7 @@ You are a code reviewer. Review the code changes shown below.
 Return only the final review. Do NOT narrate your process, mention files you opened, or describe intermediate checks.
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
 Do NOT build the project, run the test suite, or execute the code while reviewing. Base your review on the diff and static analysis only.
+Do NOT search or read files outside the repository checkout, except for an explicitly provided diff file path for this review. Do not use tools like rg, find, or cat on unrelated paths outside the repo.
 
 ## Output Format
 
@@ -24,4 +25,6 @@ Do not include any front matter such as "Reviewing the diff..." or "I'm checking
 4. **Regressions**: Changes that might break existing functionality.
 5. **Code quality**: Duplication, overly complex logic, unclear naming.
 
-Do not review the commit message. Focus only on the code changes in the diff.
+Do not review the commit message. Focus only on the code changes in the diff.{{.NoSkillsInstruction}}
+
+Current date: {{.CurrentDate}} (UTC)

--- a/internal/prompt/templates/default_address.md.gotmpl
+++ b/internal/prompt/templates/default_address.md.gotmpl
@@ -1,0 +1,29 @@
+You are a code assistant. Your task is to address the findings from a code review.
+
+Make the minimal changes necessary to address these findings:
+- Be pragmatic and simple - don't over-engineer
+- Focus on the specific issues mentioned
+- Don't refactor unrelated code
+- Don't add unnecessary abstractions or comments
+- Don't make cosmetic changes
+
+After making changes:
+1. Run the build command to verify the code compiles
+2. Run tests to verify nothing is broken
+3. Fix any build errors or test failures before finishing
+
+For Go projects, use: GOCACHE=/tmp/go-build go build ./... and GOCACHE=/tmp/go-build go test ./...
+(The GOCACHE override is needed for sandbox compatibility)
+
+IMPORTANT: Do NOT commit changes yourself. Just modify the files. The caller will handle committing.
+
+When finished, provide a brief summary in this format (this will be used in the commit message):
+
+Changes:
+- <first change>
+- <second change>
+...
+
+Keep the summary concise (under 10 bullet points). Put the most important changes first.{{.NoSkillsInstruction}}
+
+Current date: {{.CurrentDate}} (UTC)

--- a/internal/prompt/templates/default_design_review.md.gotmpl
+++ b/internal/prompt/templates/default_design_review.md.gotmpl
@@ -1,0 +1,25 @@
+You are a design reviewer. The changes shown below are expected to contain design artifacts — PRDs, task lists, architectural proposals, or similar planning documents. Review them for:
+
+1. **Completeness**: Are goals, non-goals, success criteria, and edge cases defined?
+2. **Feasibility**: Are technical decisions grounded in the actual codebase?
+3. **Task scoping**: Are implementation stages small enough to review incrementally? Are dependencies ordered correctly?
+4. **Missing considerations**: Security, performance, backwards compatibility, error handling
+5. **Clarity**: Are decisions justified and understandable?
+
+If the changes do not appear to contain design documents, note this and review whatever design intent is evident from the code changes.
+
+After reviewing, provide:
+
+1. A brief summary of what the design proposes
+2. PRD findings, listed with:
+   - Severity (high/medium/low)
+   - A brief explanation of the issue and suggested improvement
+3. Task list findings, listed with:
+   - Severity (high/medium/low)
+   - A brief explanation of the issue and suggested improvement
+4. Any missing considerations not covered by the design
+5. A verdict: Pass or Fail with brief justification
+
+If you find no issues, state "No issues found." after the summary.{{.NoSkillsInstruction}}
+
+Current date: {{.CurrentDate}} (UTC)

--- a/internal/prompt/templates/default_dirty.md.gotmpl
+++ b/internal/prompt/templates/default_dirty.md.gotmpl
@@ -1,0 +1,19 @@
+You are a code reviewer. Review the following uncommitted changes for:
+
+1. **Bugs**: Logic errors, off-by-one errors, null/undefined issues, race conditions
+2. **Security**: Injection vulnerabilities, auth issues, data exposure
+3. **Testing gaps**: Missing unit tests, edge cases not covered, e2e/integration test gaps
+4. **Regressions**: Changes that might break existing functionality
+5. **Code quality**: Duplication that should be refactored, overly complex logic, unclear naming
+
+After reviewing, provide:
+
+1. A brief summary of what the changes do
+2. Any issues found, listed with:
+   - Severity (high/medium/low)
+   - File and line reference where possible
+   - A brief explanation of the problem and suggested fix
+
+If you find no issues, state "No issues found." after the summary.{{.NoSkillsInstruction}}
+
+Current date: {{.CurrentDate}} (UTC)

--- a/internal/prompt/templates/default_range.md.gotmpl
+++ b/internal/prompt/templates/default_range.md.gotmpl
@@ -1,0 +1,21 @@
+You are a code reviewer. Review the git commit range shown below for:
+
+1. **Bugs**: Logic errors, off-by-one errors, null/undefined issues, race conditions
+2. **Security**: Injection vulnerabilities, auth issues, data exposure
+3. **Testing gaps**: Missing unit tests, edge cases not covered, e2e/integration test gaps
+4. **Regressions**: Changes that might break existing functionality
+5. **Code quality**: Duplication that should be refactored, overly complex logic, unclear naming
+
+Do not review the commit message itself - focus only on the code changes in the diff.
+
+After reviewing, provide:
+
+1. A brief summary of what the commits do
+2. Any issues found, listed with:
+   - Severity (high/medium/low)
+   - File and line reference where possible
+   - A brief explanation of the problem and suggested fix
+
+If you find no issues, state "No issues found." after the summary.{{.NoSkillsInstruction}}
+
+Current date: {{.CurrentDate}} (UTC)

--- a/internal/prompt/templates/default_review.md.gotmpl
+++ b/internal/prompt/templates/default_review.md.gotmpl
@@ -1,0 +1,21 @@
+You are a code reviewer. Review the git commit shown below for:
+
+1. **Bugs**: Logic errors, off-by-one errors, null/undefined issues, race conditions
+2. **Security**: Injection vulnerabilities, auth issues, data exposure
+3. **Testing gaps**: Missing unit tests, edge cases not covered, e2e/integration test gaps
+4. **Regressions**: Changes that might break existing functionality
+5. **Code quality**: Duplication that should be refactored, overly complex logic, unclear naming
+
+Do not review the commit message itself - focus only on the code changes in the diff.
+
+After reviewing, provide:
+
+1. A brief summary of what the commit does
+2. Any issues found, listed with:
+   - Severity (high/medium/low)
+   - File and line reference where possible
+   - A brief explanation of the problem and suggested fix
+
+If you find no issues, state "No issues found." after the summary.{{.NoSkillsInstruction}}
+
+Current date: {{.CurrentDate}} (UTC)

--- a/internal/prompt/templates/default_security.md.gotmpl
+++ b/internal/prompt/templates/default_security.md.gotmpl
@@ -1,0 +1,23 @@
+You are a security code reviewer. Analyze the code changes shown below with a security-first mindset. Focus on:
+
+1. **Injection vulnerabilities**: SQL injection, command injection, XSS, template injection, LDAP injection, header injection
+2. **Authentication & authorization**: Missing auth checks, privilege escalation, insecure session handling, broken access control
+3. **Credential exposure**: Hardcoded secrets, API keys, passwords, tokens in source code or logs
+4. **Path traversal**: Unsanitized file paths, directory traversal via user input, symlink attacks
+5. **Unsafe patterns**: Unsafe deserialization, insecure random number generation, missing input validation, buffer overflows
+6. **Dependency concerns**: Known vulnerable dependencies, typosquatting risks, pinning issues
+7. **CI/CD security**: Workflow injection via pull_request_target, script injection via untrusted inputs, excessive permissions
+8. **Data handling**: Sensitive data in logs, missing encryption, insecure data storage, PII exposure
+9. **Concurrency issues**: Race conditions leading to security bypasses, TOCTOU vulnerabilities
+10. **Error handling**: Information leakage via error messages, missing error checks on security-critical operations
+
+For each finding, provide:
+- Severity (critical/high/medium/low)
+- File and line reference
+- Description of the vulnerability
+- Suggested remediation
+
+If you find no security issues, state "No issues found." after the summary.
+Do not report code quality or style issues unless they have security implications.{{.NoSkillsInstruction}}
+
+Current date: {{.CurrentDate}} (UTC)

--- a/internal/prompt/templates/gemini_review.md.gotmpl
+++ b/internal/prompt/templates/gemini_review.md.gotmpl
@@ -23,4 +23,6 @@ Do NOT build the project, run the test suite, or execute the code while reviewin
 4. **Regressions**: Changes that might break existing functionality.
 5. **Code quality**: Duplication, overly complex logic, unclear naming.
 
-Do not review the commit message. Focus ONLY on the code changes in the diff.
+Do not review the commit message. Focus ONLY on the code changes in the diff.{{.NoSkillsInstruction}}
+
+Current date: {{.CurrentDate}} (UTC)

--- a/internal/prompt/templates/gemini_run.md.gotmpl
+++ b/internal/prompt/templates/gemini_run.md.gotmpl
@@ -7,3 +7,5 @@ Focus on:
 - Providing code examples when helpful
 - Being practical and actionable
 
+Current date: {{.CurrentDate}} (UTC)
+

--- a/internal/prompt/templates/prompt_sections.md.gotmpl
+++ b/internal/prompt/templates/prompt_sections.md.gotmpl
@@ -1,0 +1,173 @@
+{{define "project_guidelines"}}{{with .ProjectGuidelines}}{{.Heading}}
+
+These guidelines supplement the default review criteria and may add repo-specific expectations or constraints.
+
+{{.Body}}
+
+{{end}}{{end}}
+{{define "additional_context"}}{{- .AdditionalContext -}}{{end}}
+{{define "review_comments"}}{{if .}}
+Comments on this review:
+{{range .}}- {{.Responder}}: {{printf "%q" .Response}}
+{{end}}{{end}}
+{{end}}
+{{define "previous_reviews"}}{{if .PreviousReviews}}## Previous Reviews
+
+The following are reviews of recent commits in this repository. Use them as context
+to understand ongoing work and to check if the current commit addresses previous feedback.
+
+**Important:** Reviews may include responses from developers. Pay attention to these responses -
+they may indicate known issues that should be ignored, explain why certain patterns exist,
+or provide context that affects how you should evaluate similar code in the current commit.
+
+{{range .PreviousReviews}}--- Review for commit {{.Commit}} ---
+{{if .Available}}{{.Output}}{{else}}No review available.{{end}}
+
+{{template "review_comments" .Comments}}
+{{end}}{{end}}
+{{end}}
+{{define "in_range_reviews"}}{{if .InRangeReviews}}## Per-Commit Reviews in This Range
+
+The following commits in this range have already been individually reviewed.
+Issues found in earlier commits may have been fixed by later commits in the range.
+
+Do not re-raise issues identified below unless they persist in the final code.
+Focus on cross-commit interactions and problems not caught by per-commit reviews.
+
+{{range .InRangeReviews}}--- Commit {{.Commit}} ({{.Agent}}, {{.Verdict}}) ---
+{{.Output}}
+
+{{template "review_comments" .Comments}}
+{{end}}{{end}}
+{{end}}
+{{define "previous_review_attempts"}}{{if .PreviousAttempts}}## Previous Review Attempts
+
+This commit has been reviewed before. The following are previous review results and any
+responses from developers. Use this context to:
+- Avoid repeating issues that have been marked as known/acceptable
+- Check if previously identified issues are still present
+- Consider developer responses about why certain patterns exist
+
+{{range .PreviousAttempts}}--- {{.Label}} ({{.Agent}}{{if .When}}, {{.When}}{{end}}) ---
+{{.Output}}
+
+{{template "review_comments" .Comments}}
+{{end}}{{end}}
+{{end}}
+{{define "optional_sections"}}{{template "project_guidelines" .}}{{template "additional_context" .}}{{template "previous_reviews" .}}{{template "in_range_reviews" .}}{{template "previous_review_attempts" .}}{{end}}
+{{define "current_commit_required"}}## Current Commit
+
+**Commit:** {{.Commit}}
+
+{{end}}
+{{define "current_commit_overflow"}}{{if .Subject}}**Subject:** {{.Subject}}
+{{end}}{{if .Author}}**Author:** {{.Author}}
+{{end}}
+{{if .Message}}**Message:**
+{{.Message}}
+
+{{end}}{{end}}
+{{define "current_commit"}}{{template "current_commit_required" .}}{{template "current_commit_overflow" .}}{{end}}
+{{define "commit_range_required"}}## Commit Range
+
+Reviewing {{if gt .Count 0}}{{.Count}}{{else}}{{len .Entries}}{{end}} commits:
+
+{{end}}
+{{define "commit_range_overflow"}}{{range .Entries}}- {{.Commit}}{{if .Subject}} {{.Subject}}{{end}}
+{{end}}
+{{end}}
+{{define "commit_range"}}{{template "commit_range_required" .}}{{template "commit_range_overflow" .}}{{end}}
+{{define "dirty_changes"}}## Uncommitted Changes
+
+{{if .Description}}{{.Description}}{{else}}The following changes have not yet been committed.{{end}}
+
+{{end}}
+{{define "diff_block"}}{{if .Heading}}{{.Heading}}{{else}}### Diff{{end}}
+
+{{if .Fallback}}{{.Fallback}}{{else}}{{.Body}}{{end}}{{end}}
+{{define "inline_diff"}}```diff
+{{.Body}}```
+{{end}}
+{{define "codex_commit_fallback_full"}}(Diff too large to include inline)
+
+For Codex in read-only review mode, inspect the commit locally with read-only git commands before writing findings. Do not claim the diff is inaccessible unless these commands fail.
+
+Use commands like:
+- `{{.StatCmd}}`
+- `{{.DiffCmd}}`
+- `{{.FilesCmd}}`
+- `{{.ShowPathCmd}}`
+
+Review the actual diff before writing findings.
+{{end}}
+{{define "codex_commit_fallback_medium"}}(Diff too large to include inline)
+
+For Codex in read-only review mode, inspect the commit locally before writing findings.
+- `{{.StatCmd}}`
+- `{{.DiffCmd}}`
+{{end}}
+{{define "codex_commit_fallback_short"}}(Diff too large to include inline)
+
+For Codex, inspect locally with `{{.DiffCmd}}`.
+{{end}}
+{{define "codex_commit_fallback_shortest"}}(Diff too large; for Codex run `{{.ShowPathCmd}}` locally.)
+{{end}}
+{{define "codex_range_fallback_full"}}(Diff too large to include inline)
+
+For Codex in read-only review mode, inspect the commit range locally with read-only git commands before writing findings. Do not claim the diff is inaccessible unless these commands fail.
+
+Use commands like:
+- `{{.LogCmd}}`
+- `{{.StatCmd}}`
+- `{{.DiffCmd}}`
+- `{{.FilesCmd}}`
+
+Review the actual diff before writing findings.
+{{end}}
+{{define "codex_range_fallback_medium"}}(Diff too large to include inline)
+
+For Codex in read-only review mode, inspect the commit range locally before writing findings.
+- `{{.StatCmd}}`
+- `{{.DiffCmd}}`
+{{end}}
+{{define "codex_range_fallback_short"}}(Diff too large to include inline)
+
+For Codex, inspect locally with `{{.DiffCmd}}`.
+{{end}}
+{{define "codex_range_fallback_shortest"}}(Diff too large; for Codex run `{{.ViewCmd}}` locally.)
+{{end}}
+{{define "generic_commit_fallback"}}(Diff too large to include - please review the commit directly)
+View with: {{.ViewCmd}}
+{{end}}
+{{define "generic_range_fallback"}}(Diff too large to include - please review the commits directly)
+View with: {{.ViewCmd}}
+{{end}}
+{{define "dirty_truncated_diff_fallback"}}(Diff too large to include in full)
+{{if .Body}}```diff
+{{.Body}}```
+{{end}}{{end}}
+{{define "address_tool_attempts"}}{{if .ToolAttempts}}## Previous Addressing Attempts
+
+{{range .ToolAttempts}}--- Attempt by {{.Responder}}{{if .When}} at {{.When}}{{end}} ---
+{{.Response}}
+
+{{end}}{{end}}{{end}}
+{{define "address_user_comments"}}{{if .UserComments}}## User Comments
+
+The following comments were left by the developer on this review.
+Take them into account when applying fixes — they may flag false
+positives, provide additional context, or request specific approaches.
+
+{{range .UserComments}}**{{.Responder}}**{{if .When}} ({{.When}}){{end}}:
+{{.Response}}
+
+{{end}}{{end}}{{end}}
+{{define "address_findings"}}{{if .SeverityFilter}}{{.SeverityFilter}}{{end}}## Review Findings to Address (Job {{.JobID}})
+
+{{.ReviewFindings}}
+
+{{if .OriginalDiff}}## Original Commit Diff (for context)
+
+```diff
+{{.OriginalDiff}}```
+{{end}}{{end}}

--- a/internal/prompt/templates_test.go
+++ b/internal/prompt/templates_test.go
@@ -2,11 +2,13 @@ package prompt
 
 import (
 	"fmt"
+	"io/fs"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type systemPromptTestCase struct {
@@ -16,7 +18,6 @@ type systemPromptTestCase struct {
 	wantContains    []string
 	wantNotContains []string
 	wantExact       string // if set, checks for exact match
-	wantNotDefault  bool   // if true, ensures it's not SystemPromptSingle (default)
 	wantEmpty       bool
 }
 
@@ -31,13 +32,6 @@ func (tc *systemPromptTestCase) assert(t *testing.T, got string) {
 
 	if tc.wantExact != "" && got != tc.wantExact {
 		assert.Equal(tc.wantExact, got, "got %q, want %q", got, tc.wantExact)
-	}
-
-	if tc.wantNotDefault {
-		// The default prompt (SystemPromptSingle) does NOT contain "Do NOT explain your process"
-		// but let's be safer.
-		// SystemPromptSingle is the fallback base.
-		assert.NotContains(got, SystemPromptSingle, "got default SystemPromptSingle, wanted specific template")
 	}
 
 	for _, substr := range tc.wantContains {
@@ -64,53 +58,46 @@ func TestGetSystemPrompt_Fallbacks(t *testing.T) {
 
 	tests := []systemPromptTestCase{
 		{
-			name:           "Codex Review",
-			agent:          "codex",
-			command:        "review",
-			wantContains:   []string{"## Review Findings", "Do not include any front matter", "Do NOT build the project, run the test suite, or execute the code while reviewing.", "finish all tool use before emitting the final review"},
-			wantNotDefault: true,
+			name:         "Codex Review",
+			agent:        "codex",
+			command:      "review",
+			wantContains: []string{"## Review Findings", "Do not include any front matter", "Do NOT build the project, run the test suite, or execute the code while reviewing.", "finish all tool use before emitting the final review"},
 		},
 		{
-			name:           "Claude Review",
-			agent:          "claude-code",
-			command:        "review",
-			wantContains:   []string{"## Review Findings", "Do not include any front matter", "Do NOT build the project, run the test suite, or execute the code while reviewing.", "finish all tool use before emitting the final review"},
-			wantNotDefault: true,
+			name:         "Claude Review",
+			agent:        "claude-code",
+			command:      "review",
+			wantContains: []string{"## Review Findings", "Do not include any front matter", "Do NOT build the project, run the test suite, or execute the code while reviewing.", "finish all tool use before emitting the final review"},
 		},
 		{
-			name:           "Gemini Review",
-			agent:          "gemini",
-			command:        "review",
-			wantContains:   []string{"Do NOT explain your process", "Do NOT build the project, run the test suite, or execute the code while reviewing.", "finish all tool use before emitting the final review"},
-			wantNotDefault: true,
+			name:         "Gemini Review",
+			agent:        "gemini",
+			command:      "review",
+			wantContains: []string{"Do NOT explain your process", "Do NOT build the project, run the test suite, or execute the code while reviewing.", "finish all tool use before emitting the final review"},
 		},
 		{
-			name:           "Codex Range (Review Fallback)",
-			agent:          "codex",
-			command:        "range",
-			wantExact:      codexReviewPrompt,
-			wantNotDefault: true,
+			name:      "Codex Range (Review Fallback)",
+			agent:     "codex",
+			command:   "range",
+			wantExact: codexReviewPrompt,
 		},
 		{
-			name:           "Claude Dirty (Review Fallback)",
-			agent:          "claude-code",
-			command:        "dirty",
-			wantExact:      claudeReviewPrompt,
-			wantNotDefault: true,
+			name:      "Claude Dirty (Review Fallback)",
+			agent:     "claude-code",
+			command:   "dirty",
+			wantExact: claudeReviewPrompt,
 		},
 		{
-			name:           "Gemini Range (Review Fallback)",
-			agent:          "gemini",
-			command:        "range",
-			wantExact:      geminiReviewPrompt,
-			wantNotDefault: true,
+			name:      "Gemini Range (Review Fallback)",
+			agent:     "gemini",
+			command:   "range",
+			wantExact: geminiReviewPrompt,
 		},
 		{
-			name:           "Gemini Dirty (Review Fallback)",
-			agent:          "gemini",
-			command:        "dirty",
-			wantExact:      geminiReviewPrompt,
-			wantNotDefault: true,
+			name:      "Gemini Dirty (Review Fallback)",
+			agent:     "gemini",
+			command:   "dirty",
+			wantExact: geminiReviewPrompt,
 		},
 	}
 
@@ -237,4 +224,48 @@ func TestGetSystemPrompt_Exported(t *testing.T) {
 	assert.Condition(func() bool {
 		return strings.Contains(got, beforeStr) || strings.Contains(got, afterStr)
 	}, "prompt missing expected date string. Looked for %q or %q", beforeStr, afterStr)
+}
+
+func TestGetSystemPrompt_DefaultFallbacksRenderFromTemplates(t *testing.T) {
+	fixedTime := time.Date(2030, 6, 15, 0, 0, 0, 0, time.UTC)
+	mockNow := func() time.Time { return fixedTime }
+
+	got := getSystemPrompt("unknown-agent", "security", mockNow)
+
+	assert.Contains(t, got, "You are a security code reviewer")
+	assert.Contains(t, got, "Do NOT use any external skills")
+	assert.Contains(t, got, "Current date: 2030-06-15 (UTC)")
+}
+
+func TestRenderSystemPrompt_AgentSpecificTemplates(t *testing.T) {
+	body, err := renderSystemPrompt("claude-code_review.md.gotmpl", systemPromptView{
+		NoSkillsInstruction: noSkillsInstruction,
+		CurrentDate:         "2030-06-15",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, body, "You are a code reviewer")
+}
+
+func TestRenderSystemPrompt_AllEmbeddedAgentSpecificTemplates(t *testing.T) {
+	matches, err := fs.Glob(templateFS, "templates/*.md.gotmpl")
+	require.NoError(t, err)
+
+	for _, match := range matches {
+		name := strings.TrimPrefix(match, "templates/")
+		if strings.HasPrefix(name, "default_") || strings.HasPrefix(name, "assembled_") || name == "prompt_sections.md.gotmpl" {
+			continue
+		}
+
+		t.Run(name, func(t *testing.T) {
+			tmpl := promptTemplates.Lookup(name)
+			require.NotNil(t, tmpl, "embedded agent-specific template should be parsed into the template set")
+
+			body, err := renderSystemPrompt(name, systemPromptView{
+				NoSkillsInstruction: noSkillsInstruction,
+				CurrentDate:         "2030-06-15",
+			})
+			require.NoError(t, err)
+			assert.NotEmpty(t, body)
+		})
+	}
 }


### PR DESCRIPTION
## Why
Prompt construction in `internal/prompt` had accumulated too much behavior in Go-side string assembly, which made the actual prompt structure hard to reason about, easy to regress during cleanup, and split across multiple sources of truth. This refactor moves the prompt format itself into templates so the rendered prompt shape is defined where it is authored, while preserving existing review behavior and fixing the regressions uncovered during the migration and subsequent `roborev` reviews.

## Summary
- make prompt construction template-driven end to end by moving assembled prompt bodies, prompt sections, and agent-specific system prompts onto embedded `.md.gotmpl` templates backed by typed view data
- preserve existing prompt behavior while fixing cleanup regressions in dirty and range prompt fitting, including truncated diff fallbacks, optional-context retention, and fallback selection quality
- resolve the accumulated `roborev` findings on `gotmpl` so the branch ends with no open review jobs

## Test Plan
- [x] go fmt ./...
- [x] go vet ./...
- [x] go test ./...