### PR TITLE
Prompt agents to read project instruction files during reviews

### DIFF
--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -34,7 +34,7 @@ IMPORTANT: You are being invoked by roborev to perform this review directly. Do 
 Return only the final review content. Do NOT include process narration, progress updates, or front matter such as "Reviewing the diff..." or "I'm checking...".
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
 
-Before reviewing the diff, read any project instruction files (CLAUDE.md, AGENTS.md) in the repository root and in the directories containing the changed files. These files contain project-specific guidelines that should inform your review. Respect and apply whatever conventions, standards, or review criteria they describe.`
+Before reviewing the diff, read any project instruction files (e.g., CLAUDE.md, AGENTS.md) in the repository root and in the directories containing the changed files. These files contain project-specific guidelines that should inform your review. Respect and apply whatever conventions, standards, or review criteria they describe.`
 
 // SystemPromptSingle is the base instruction for single commit reviews
 const SystemPromptSingle = `You are a code reviewer. Review the git commit shown below for:

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -32,7 +32,9 @@ const noSkillsInstruction = `
 IMPORTANT: You are being invoked by roborev to perform this review directly. Do NOT use any external skills, slash commands, or CLI tools (such as "roborev review") to delegate this task. Perform the review yourself by analyzing the diff provided below.
 
 Return only the final review content. Do NOT include process narration, progress updates, or front matter such as "Reviewing the diff..." or "I'm checking...".
-If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.`
+If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
+
+Before reviewing the diff, read any project instruction files (CLAUDE.md, AGENTS.md) in the repository root and in the directories containing the changed files. These files contain project-specific guidelines that should inform your review. Respect and apply whatever conventions, standards, or review criteria they describe.`
 
 // SystemPromptSingle is the base instruction for single commit reviews
 const SystemPromptSingle = `You are a code reviewer. Review the git commit shown below for:


### PR DESCRIPTION
## Summary

- Adds an instruction to the review prompt (`noSkillsInstruction`) telling agents to read project instruction files (e.g., CLAUDE.md, AGENTS.md) from the repo root and from directories containing changed files before reviewing.
- I've been seeing review agents clearly not following guidance from my CLAUDE.md files. In print mode (`-p`), agents focus on responding to the provided prompt and don't proactively explore the filesystem for instruction files the way they would in an interactive session. This is the simplest fix I could think of — just tell them to look. Open to other approaches if there's a better way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)