### PR TITLE
fix(opencode): render tool calls and drop stderr migration noise

### DIFF
--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -102,13 +102,18 @@ func (a *OpenCodeAgent) Review(
 	args := a.buildArgs()
 
 	runResult, runErr := runStreamingCLI(ctx, streamingCLISpec{
-		Name:         "opencode",
-		Command:      a.Command,
-		Args:         args,
-		Dir:          repoPath,
-		Stdin:        strings.NewReader(prompt),
-		Output:       output,
-		StreamStderr: true,
+		Name:    "opencode",
+		Command: a.Command,
+		Args:    args,
+		Dir:     repoPath,
+		Stdin:   strings.NewReader(prompt),
+		Output:  output,
+		// opencode prints sqlite-migration progress to stderr
+		// on every invocation, drowning the live log with
+		// noise. Skip stderr streaming; the full stderr is
+		// still captured by runStreamingCLI and surfaced via
+		// formatDetailedCLIWaitError on non-zero exit.
+		StreamStderr: false,
 		DrainStdout:  true,
 		Parse:        parseOpenCodeJSON,
 	})

--- a/internal/agent/opencode_test.go
+++ b/internal/agent/opencode_test.go
@@ -183,7 +183,7 @@ func TestOpenCodeReviewNoOutput(t *testing.T) {
 	assertEqual(t, result, "No review output generated")
 }
 
-func TestOpenCodeReviewStderrStreamedToOutput(t *testing.T) {
+func TestOpenCodeReviewStderrNotStreamedToOutput(t *testing.T) {
 	t.Parallel()
 	skipIfWindows(t)
 
@@ -196,7 +196,13 @@ func TestOpenCodeReviewStderrStreamedToOutput(t *testing.T) {
 		MockOpts: MockCLIOpts{
 			CaptureStdin: true,
 			StdoutLines:  stdoutLines,
-			StderrLines:  []string{"warning: something"},
+			StderrLines: []string{
+				"Performing one time database migration, may take a few minutes...",
+				"sqlite-migration:0",
+				"sqlite-migration:done",
+				"Database migration complete.",
+				"warning: something",
+			},
 		},
 		Prompt: "prompt",
 		Writer: &outputBuf,
@@ -205,9 +211,16 @@ func TestOpenCodeReviewStderrStreamedToOutput(t *testing.T) {
 
 	assertEqual(t, result, "Review done")
 
+	// opencode's stderr is intentionally suppressed from the live
+	// log because it is dominated by sqlite-migration noise. Real
+	// errors still surface via formatDetailedCLIWaitError on
+	// non-zero exit (covered by TestOpenCodeReviewPartialOnError).
 	outStr := outputBuf.String()
 	assertContains(t, outStr, `"type":"text"`)
-	assertContains(t, outStr, "warning: something")
+	assertNotContains(t, outStr, "sqlite-migration")
+	assertNotContains(t, outStr, "Performing one time database migration")
+	assertNotContains(t, outStr, "Database migration complete")
+	assertNotContains(t, outStr, "warning: something")
 }
 
 func TestOpenCodeReviewNilOutput(t *testing.T) {

--- a/internal/agent/opencode_test.go
+++ b/internal/agent/opencode_test.go
@@ -223,6 +223,36 @@ func TestOpenCodeReviewStderrNotStreamedToOutput(t *testing.T) {
 	assertNotContains(t, outStr, "warning: something")
 }
 
+func TestOpenCodeReviewStderrPreservedInError(t *testing.T) {
+	t.Parallel()
+	skipIfWindows(t)
+
+	// StreamStderr is disabled for opencode, so stderr does not
+	// appear in the live log on success. On non-zero exit the
+	// captured stderr must still reach the user via the returned
+	// error, otherwise failure diagnostics would be lost.
+	stdoutLines := []string{makeTextEvent("Partial review")}
+	stderrLines := []string{
+		"Performing one time database migration, may take a few minutes...",
+		"sqlite-migration:done",
+		"Error: authentication token expired",
+	}
+
+	_, _, _, err := executeReviewTest(t, reviewTestOpts{
+		MockOpts: MockCLIOpts{
+			CaptureStdin: true,
+			StdoutLines:  stdoutLines,
+			StderrLines:  stderrLines,
+			ExitCode:     1,
+		},
+		Prompt: "prompt",
+	})
+	require.Error(t, err)
+
+	msg := err.Error()
+	assertContains(t, msg, "Error: authentication token expired")
+}
+
 func TestOpenCodeReviewNilOutput(t *testing.T) {
 	t.Parallel()
 	skipIfWindows(t)

--- a/internal/streamfmt/streamfmt.go
+++ b/internal/streamfmt/streamfmt.go
@@ -274,22 +274,24 @@ func (f *Formatter) processLine(line string) {
 				f.writeText(text)
 			}
 		}
-	case "tool_use":
-		// Gemini format: top-level tool use
-		if ev.ToolName != "" {
+	case "item.started", "item.completed", "item.updated":
+		// Codex format: item events
+		f.processCodexItem(ev.Type, ev.Item)
+	case "text", "reasoning", "tool", "tool_use":
+		// Both Gemini and opencode use "tool_use", and opencode
+		// 1.4+ emits "tool_use" where earlier versions used
+		// "tool". Route by payload shape: an opencode event
+		// carries a nested "part" object; a Gemini tool_use
+		// carries top-level tool_name/parameters.
+		switch {
+		case ev.Part != nil:
+			f.processOpenCodePart(ev.Type, ev.Part)
+		case ev.Type == "tool_use" && ev.ToolName != "":
 			displayName := geminiToolNames[ev.ToolName]
 			if displayName == "" {
 				displayName = ev.ToolName
 			}
 			f.formatToolUse(displayName, ev.Parameters)
-		}
-	case "item.started", "item.completed", "item.updated":
-		// Codex format: item events
-		f.processCodexItem(ev.Type, ev.Item)
-	case "text", "reasoning", "tool":
-		// OpenCode format: event body nested under "part"
-		if ev.Part != nil {
-			f.processOpenCodePart(ev.Type, ev.Part)
 		}
 	case "step_start", "step_finish":
 		// OpenCode lifecycle events — suppress
@@ -357,7 +359,7 @@ func (f *Formatter) processOpenCodePart(
 				f.writeReasoning(text)
 			}
 		}
-	case "tool":
+	case "tool", "tool_use":
 		var tp opencodeToolPart
 		if json.Unmarshal(raw, &tp) != nil || tp.Tool == "" {
 			return

--- a/internal/streamfmt/streamfmt_test.go
+++ b/internal/streamfmt/streamfmt_test.go
@@ -707,6 +707,24 @@ func TestFormatter_OpenCode(t *testing.T) {
 			},
 			empty: true,
 		},
+		{
+			// opencode 1.4+ emits outer type "tool_use" while the
+			// nested part.type stays "tool". Ensure the renderer
+			// handles the newer event shape.
+			name: "ToolUseOuterType",
+			events: []string{
+				eventOpenCode("tool_use", openCodePart{
+					Type: "tool",
+					Tool: "Read",
+					ID:   "tc_newshape",
+					State: &openCodeState{
+						Status: "completed",
+						Input:  filePathInput("internal/agent/opencode.go"),
+					},
+				}),
+			},
+			contains: []string{"Read   internal/agent/opencode.go"},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

- streamfmt now renders opencode events whose outer type is `tool_use` (opencode 1.4+); earlier versions used `tool` and the renderer was silently dropping every tool call from the live job log on current opencode.
- The `tool_use` branch is shared with Gemini; routing is by payload shape (`part` object → opencode, top-level `tool_name` → Gemini).
- The opencode agent no longer streams stderr into the live log. opencode prints `sqlite-migration:*` progress and the `Performing one time database migration...` / `Database migration complete.` banners to stderr on every invocation; those lines were dominating the log for short reviews.
- Captured stderr still reaches the user on non-zero exit via `formatDetailedCLIWaitError`. A new test, `TestOpenCodeReviewStderrPreservedInError`, drives an exit-1 scenario and asserts the stderr content appears in the returned error.