### PR TITLE
fix: allow internal whitespace in severity threshold marker for Gemini agent

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1493,7 +1493,12 @@ func IsMarkerOnlyOutput(output string) bool {
 	// Strip a trailing period.
 	s = strings.TrimSpace(strings.TrimSuffix(s, "."))
 
-	return s == SeverityThresholdMarker
+	// Collapse any internal whitespace models might inject
+	sNoSpace := strings.ReplaceAll(s, " ", "")
+	sNoSpace = strings.ReplaceAll(sNoSpace, "\n", "")
+	sNoSpace = strings.ReplaceAll(sNoSpace, "\r", "")
+	sNoSpace = strings.ReplaceAll(sNoSpace, "\t", "")
+	return sNoSpace == SeverityThresholdMarker
 }
 
 // SeverityInstruction returns a prompt instruction telling the agent

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3345,6 +3345,8 @@ func TestIsMarkerOnlyOutput(t *testing.T) {
 		{"marker plus severity label", "SEVERITY_THRESHOLD_MET\n- High: critical bug", false},
 		{"different text only", "All good, no issues.", false},
 		{"marker substring inside another word", "PRESEVERITY_THRESHOLD_MET", false},
+		{"marker split by newline (gemini quirk)", "SEVERITY_THRESHOLD\n_MET", true},
+		{"marker split by double newline (gemini quirk)", "SEVERITY_THRESHOLD\n\n_MET", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes an issue where the Gemini model agent sometimes outputs the `SEVERITY_THRESHOLD_MET` marker with internal newlines (e.g., `SEVERITY_THRESHOLD\n_MET`), causing the `IsMarkerOnlyOutput` check to fail and incorrectly flag the review as a failure.

### Evidence
We tested this by feeding `SEVERITY_THRESHOLD\n_MET` and `SEVERITY_THRESHOLD\n\n_MET` to `IsMarkerOnlyOutput`. Previously it failed, but with the stripping of internal whitespace (`\n`, `\r`, `\t`, ` `) before the final string comparison, it passes correctly. We've added these cases to the test suite in `internal/config/config_test.go`.