### PR TITLE
fix(tui): allow j/k/q to be typed in filter search (#654)

### DIFF
--- a/cmd/roborev/tui/filter_queue_test.go
+++ b/cmd/roborev/tui/filter_queue_test.go
@@ -11,14 +11,14 @@ import (
 func TestTUIFilterNavigation(t *testing.T) {
 	cases := []struct {
 		startIdx    int
-		key         rune
+		key         tea.KeyType
 		expectedIdx int
 		description string
 	}{
-		{0, 'j', 1, "Navigate down from 0"},
-		{1, 'j', 2, "Navigate down from 1"},
-		{2, 'j', 2, "Navigate down at boundary"},
-		{2, 'k', 1, "Navigate up from 2"},
+		{0, tea.KeyDown, 1, "Navigate down from 0"},
+		{1, tea.KeyDown, 2, "Navigate down from 1"},
+		{2, tea.KeyDown, 2, "Navigate down at boundary"},
+		{2, tea.KeyUp, 1, "Navigate up from 2"},
 	}
 
 	for _, tc := range cases {
@@ -29,7 +29,7 @@ func TestTUIFilterNavigation(t *testing.T) {
 			})
 			m.filterSelectedIdx = tc.startIdx
 
-			m2, _ := pressKey(m, tc.key)
+			m2, _ := pressSpecial(m, tc.key)
 			assert.Equal(t, tc.expectedIdx, m2.filterSelectedIdx)
 		})
 	}
@@ -42,11 +42,11 @@ func TestTUIFilterNavigationSequential(t *testing.T) {
 		makeNode("repo-c", 1),
 	})
 
-	keys := []rune{'j', 'j', 'j', 'k'}
+	keys := []tea.KeyType{tea.KeyDown, tea.KeyDown, tea.KeyDown, tea.KeyUp}
 
 	m2 := m
 	for _, k := range keys {
-		m2, _ = pressKey(m2, k)
+		m2, _ = pressSpecial(m2, k)
 	}
 
 	assert.Equal(t, 2, m2.filterSelectedIdx)

--- a/cmd/roborev/tui/filter_search_test.go
+++ b/cmd/roborev/tui/filter_search_test.go
@@ -119,6 +119,28 @@ func TestTUIFilterTypingHAndL(t *testing.T) {
 	assert.Equal(t, "hl", m3.filterSearch)
 }
 
+// Regression test for issue #654: j, k, and q were swallowed by
+// vim-style navigation/quit shortcuts instead of being appended to
+// the search text.
+func TestTUIFilterTypingJKQ(t *testing.T) {
+	for _, r := range []rune{'j', 'k', 'q'} {
+		t.Run(string(r), func(t *testing.T) {
+			m := initFilterModel([]treeFilterNode{
+				makeNode("kubernetes", 3),
+				makeNode("jenkins", 2),
+				makeNode("queue-worker", 1),
+			})
+			m.filterSelectedIdx = 1
+
+			m2, _ := pressKey(m, r)
+			assert.Equal(t, string(r), m2.filterSearch,
+				"key %q should be appended to search", r)
+			assert.Equal(t, viewFilter, m2.currentView,
+				"key %q must not close the filter modal", r)
+		})
+	}
+}
+
 func TestTUIFilterSearchByRepoPath(t *testing.T) {
 	m := initFilterModel([]treeFilterNode{
 		{name: "backend", rootPaths: []string{"/path/to/backend-dev", "/path/to/backend-prod"}, count: 2},

--- a/cmd/roborev/tui/handlers_modal.go
+++ b/cmd/roborev/tui/handlers_modal.go
@@ -55,15 +55,15 @@ func (m model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "ctrl+c":
 		return m, tea.Quit
-	case "esc", "q":
+	case "esc":
 		m.currentView = viewQueue
 		m.filterSearch = ""
 		m.filterBranchMode = false
 		return m, nil
-	case "up", "k":
+	case "up":
 		m.filterNavigateUp()
 		return m, nil
-	case "down", "j":
+	case "down":
 		m.filterNavigateDown()
 		return m, nil
 	case "right":


### PR DESCRIPTION
## Summary

- The filter modal bound `j`/`k` to navigate up/down and `q` to close, which swallowed those characters before they could reach the search input (issue #654).
- Help text only advertises arrow keys and `esc`, so drop the vim-style aliases to match the documented UX.
- Added regression test for typing `j`/`k`/`q`; updated existing nav tests to use arrow keys.

Closes #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)