### PR TITLE
tui: fix clipboard over SSH using OSC52 escape sequences

### DIFF
--- a/cmd/roborev/tui/review_clipboard_test.go
+++ b/cmd/roborev/tui/review_clipboard_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"testing"
@@ -467,4 +468,74 @@ func TestFormatClipboardContentNoResponses(t *testing.T) {
 	assert.Equal(t, withEmpty, withNil, "nil and empty responses should produce same output")
 
 	assert.NotContains(t, withNil, "Comments")
+}
+
+func TestOSC52ClipboardWritesEscapeSequence(t *testing.T) {
+	var buf bytes.Buffer
+	cb := &osc52Clipboard{output: &buf}
+
+	err := cb.WriteText("hello clipboard")
+	require.NoError(t, err)
+
+	output := buf.String()
+	// OSC52 sequences begin with ESC ] 52 ; and end with BEL or ST
+	assert.Contains(t, output, "\x1b]52;")
+	// The base64-encoded content of "hello clipboard" is aGVsbG8gY2xpcGJvYXJk
+	assert.Contains(t, output, "aGVsbG8gY2xpcGJvYXJk")
+}
+
+func TestOSC52ClipboardEmptyText(t *testing.T) {
+	var buf bytes.Buffer
+	cb := &osc52Clipboard{output: &buf}
+
+	err := cb.WriteText("")
+	require.NoError(t, err)
+	// An empty string still produces a valid OSC52 sequence (clears clipboard)
+	assert.Contains(t, buf.String(), "\x1b]52;")
+}
+
+func TestNewClipboardReturnsOSC52OverSSH(t *testing.T) {
+	tests := []struct {
+		name    string
+		envVars map[string]string
+		wantOSC bool
+	}{
+		{
+			name:    "SSH_TTY set",
+			envVars: map[string]string{"SSH_TTY": "/dev/pts/0"},
+			wantOSC: true,
+		},
+		{
+			name:    "SSH_CLIENT set",
+			envVars: map[string]string{"SSH_CLIENT": "192.168.1.1 50000 22"},
+			wantOSC: true,
+		},
+		{
+			name:    "SSH_CONNECTION set",
+			envVars: map[string]string{"SSH_CONNECTION": "192.168.1.1 50000 10.0.0.1 22"},
+			wantOSC: true,
+		},
+		{
+			name:    "no SSH env vars",
+			envVars: map[string]string{},
+			wantOSC: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear SSH env vars before each sub-test
+			for _, key := range []string{"SSH_TTY", "SSH_CLIENT", "SSH_CONNECTION"} {
+				t.Setenv(key, "")
+			}
+			for k, v := range tt.envVars {
+				t.Setenv(k, v)
+			}
+
+			cb := newClipboard()
+			_, isOSC52 := cb.(*osc52Clipboard)
+			assert.Equal(t, tt.wantOSC, isOSC52,
+				"expected osc52Clipboard=%v for env %v", tt.wantOSC, tt.envVars)
+		})
+	}
 }

--- a/cmd/roborev/tui/tui.go
+++ b/cmd/roborev/tui/tui.go
@@ -447,6 +447,18 @@ func isConnectionError(err error) bool {
 	return errors.As(err, &netErr)
 }
 
+// newClipboard returns the appropriate ClipboardWriter for the current environment.
+// When running over SSH (detected via SSH_TTY, SSH_CLIENT, or SSH_CONNECTION env vars),
+// it returns an osc52Clipboard that writes clipboard data through OSC52 terminal escape
+// sequences — this works without X11 forwarding and is supported by all modern terminals.
+// Otherwise, it falls back to realClipboard which uses the local system clipboard tools.
+func newClipboard() ClipboardWriter {
+	if os.Getenv("SSH_TTY") != "" || os.Getenv("SSH_CLIENT") != "" || os.Getenv("SSH_CONNECTION") != "" {
+		return &osc52Clipboard{output: os.Stderr}
+	}
+	return &realClipboard{}
+}
+
 func newModel(ep daemon.DaemonEndpoint, opts ...option) model {
 	var opt options
 	for _, o := range opts {
@@ -584,7 +596,7 @@ func newModel(ep daemon.DaemonEndpoint, opts ...option) model {
 		branchNames:         make(map[int64]string),       // Cache derived branch names to avoid git calls on render
 		pendingClosed:       make(map[int64]pendingState), // Track pending closed changes (by job ID)
 		pendingReviewClosed: make(map[int64]pendingState), // Track pending closed changes (by review ID)
-		clipboard:           &realClipboard{},
+		clipboard:           newClipboard(),
 		mdCache:             newMarkdownCache(tabWidth),
 		tasksEnabled:        tasksEnabled,
 		mouseEnabled:        mouseEnabled,

--- a/cmd/roborev/tui/types.go
+++ b/cmd/roborev/tui/types.go
@@ -2,9 +2,11 @@ package tui
 
 import (
 	"errors"
+	"io"
 	"time"
 
 	"github.com/atotto/clipboard"
+	osc52 "github.com/aymanbagabas/go-osc52/v2"
 	"github.com/roborev-dev/roborev/internal/daemon"
 	"github.com/roborev-dev/roborev/internal/storage"
 	"github.com/roborev-dev/roborev/internal/streamfmt"
@@ -273,6 +275,18 @@ type realClipboard struct{}
 
 func (r *realClipboard) WriteText(text string) error {
 	return clipboard.WriteAll(text)
+}
+
+// osc52Clipboard implements ClipboardWriter using OSC52 terminal escape sequences.
+// It writes clipboard data through the terminal emulator, which makes it work
+// correctly over SSH without requiring X11 forwarding.
+type osc52Clipboard struct {
+	output io.Writer
+}
+
+func (c *osc52Clipboard) WriteText(text string) error {
+	_, err := osc52.New(text).WriteTo(c.output)
+	return err
 }
 
 // option func(*options) is a functional option for TUI.


### PR DESCRIPTION
## Problem

When `roborev tui` is used over an SSH connection, pressing `y` to copy a review shows "Copied to clipboard ✓" but the clipboard is empty on the local machine.

**Root cause:** `realClipboard.WriteText()` calls `xclip`/`xsel`/`wl-clipboard` on the *remote* machine. This only reaches the user's local clipboard if X11 forwarding is active. Terminals that don't forward X11 (e.g. Tabby's built-in SSH plugin) silently lose the data.

## Fix

Add an `osc52Clipboard` implementation that writes the [OSC52 terminal escape sequence](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Operating-System-Commands) (`\x1b]52;c;<base64>\x07`) to stderr. The sequence travels through the SSH pipe and is intercepted by the **local** terminal emulator, which sets the system clipboard directly — no X11 forwarding required.

`newClipboard()` auto-selects the implementation:
- **SSH session** (`SSH_TTY` / `SSH_CLIENT` / `SSH_CONNECTION` env var is set) → `osc52Clipboard`
- **Local session** → `realClipboard` (unchanged behaviour)

## Compatibility

OSC52 is supported by all modern terminals: Alacritty, Tabby (xterm.js), Kitty, WezTerm, iTerm2, Windows Terminal, and more.

## Changes

- `cmd/roborev/tui/types.go` — add `osc52Clipboard` struct; promote `go-osc52/v2` from indirect to direct dependency
- `cmd/roborev/tui/tui.go` — add `newClipboard()` factory with SSH detection; wire into `newModel`
- `cmd/roborev/tui/review_clipboard_test.go` — 5 new tests: OSC52 output format, empty string, SSH env var detection (SSH_TTY / SSH_CLIENT / SSH_CONNECTION / no-SSH)