### PR TITLE
Ignore Claude Code scheduled task files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ REPORT.md
 # Claude Code
 .claude/worktrees/
 .claude/settings.local.json
+.claude/scheduled_tasks.json
+.claude/scheduled_tasks.lock
 
 # Dolt database files (added by bd init)
 .dolt/


### PR DESCRIPTION
## Summary
- Add `.claude/scheduled_tasks.json` and `.claude/scheduled_tasks.lock` to `.gitignore` so the Claude Code harness's durable cron files don't get accidentally tracked.