### PR TITLE
fix: complete review type flag

### DIFF
--- a/cmd/roborev/completions.go
+++ b/cmd/roborev/completions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/roborev-dev/roborev/internal/agent"
+	"github.com/roborev-dev/roborev/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -24,5 +25,15 @@ func registerReasoningCompletion(cmd *cobra.Command) {
 		return agent.ReasoningLevels(), cobra.ShellCompDirectiveNoFileComp
 	}); err != nil {
 		panic(fmt.Sprintf("registering reasoning completion for %s: %v", cmd.Name(), err))
+	}
+}
+
+// registerReviewTypeCompletion registers shell completion for the --type flag.
+// Panics if the flag doesn't exist on the command (programming error).
+func registerReviewTypeCompletion(cmd *cobra.Command) {
+	if err := cmd.RegisterFlagCompletionFunc("type", func(_ *cobra.Command, _ []string, _ string) ([]cobra.Completion, cobra.ShellCompDirective) {
+		return []cobra.Completion{config.ReviewTypeSecurity, config.ReviewTypeDesign}, cobra.ShellCompDirectiveNoFileComp
+	}); err != nil {
+		panic(fmt.Sprintf("registering review type completion for %s: %v", cmd.Name(), err))
 	}
 }

--- a/cmd/roborev/completions_test.go
+++ b/cmd/roborev/completions_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReviewTypeFlagCompletion(t *testing.T) {
+	cmd := reviewCmd()
+
+	completion, ok := cmd.GetFlagCompletionFunc("type")
+	require.True(t, ok)
+
+	got, directive := completion(cmd, nil, "")
+
+	assert.ElementsMatch(t, []cobra.Completion{"security", "design"}, got)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+}

--- a/cmd/roborev/review.go
+++ b/cmd/roborev/review.go
@@ -386,6 +386,7 @@ Examples:
 	cmd.Flags().StringVar(&minSeverity, "min-severity", "", "minimum severity threshold: critical, high, medium, low")
 	registerAgentCompletion(cmd)
 	registerReasoningCompletion(cmd)
+	registerReviewTypeCompletion(cmd)
 
 	return cmd
 }


### PR DESCRIPTION
## Summary
- add shell completion for `roborev review --type`
- complete `security` and `design` without file fallback
- add regression coverage for review type flag completion

## Validation
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`