### PR TITLE
Fix detached-HEAD review discovery in roborev fix

### DIFF
--- a/cmd/roborev/fix.go
+++ b/cmd/roborev/fix.go
@@ -515,9 +515,17 @@ func filterReachableJobs(
 	if matchBranch == "" {
 		matchBranch = git.GetCurrentBranch(worktreeRoot)
 	}
+	var detachedRefs map[string]struct{}
+	if matchBranch == "" {
+		detachedRefs = detachedHeadReviewRefs(worktreeRoot)
+	}
 	var filtered []storage.ReviewJob
 	for _, j := range jobs {
 		if branchMatch(matchBranch, j.Branch) {
+			filtered = append(filtered, j)
+			continue
+		}
+		if len(detachedRefs) > 0 && jobMatchesDetachedRef(worktreeRoot, detachedRefs, j) {
 			filtered = append(filtered, j)
 		}
 	}
@@ -532,6 +540,43 @@ func branchMatch(matchBranch, jobBranch string) bool {
 		return false
 	}
 	return jobBranch == matchBranch
+}
+
+func detachedHeadReviewRefs(worktreeRoot string) map[string]struct{} {
+	head, err := git.ResolveSHA(worktreeRoot, "HEAD")
+	if err != nil {
+		return nil
+	}
+
+	refs := make(map[string]struct{})
+	for sha := head; sha != ""; {
+		refs[sha] = struct{}{}
+		if git.GetBranchName(worktreeRoot, sha) != "" {
+			break
+		}
+		parent, err := git.ResolveSHA(worktreeRoot, sha+"^")
+		if err != nil {
+			break
+		}
+		sha = parent
+	}
+	return refs
+}
+
+func jobMatchesDetachedRef(worktreeRoot string, refs map[string]struct{}, job storage.ReviewJob) bool {
+	if job.GitRef == "" || job.GitRef == "dirty" {
+		return false
+	}
+	ref := job.GitRef
+	if _, end, ok := git.ParseRange(ref); ok {
+		ref = end
+	}
+	sha, err := git.ResolveSHA(worktreeRoot, ref)
+	if err != nil {
+		return false
+	}
+	_, ok := refs[sha]
+	return ok
 }
 
 func queryOpenJobs(

--- a/cmd/roborev/fix.go
+++ b/cmd/roborev/fix.go
@@ -549,16 +549,23 @@ func detachedHeadReviewRefs(worktreeRoot string) map[string]struct{} {
 	}
 
 	refs := make(map[string]struct{})
-	for sha := head; sha != ""; {
+	seen := make(map[string]struct{})
+	stack := []string{head}
+	for len(stack) > 0 {
+		sha := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if _, ok := seen[sha]; ok {
+			continue
+		}
+		seen[sha] = struct{}{}
 		refs[sha] = struct{}{}
 		if git.GetBranchName(worktreeRoot, sha) != "" {
-			break
+			continue
 		}
-		parent, err := git.ResolveSHA(worktreeRoot, sha+"^")
-		if err != nil {
-			break
+		parents, err := git.GetCommitParents(worktreeRoot, sha)
+		if err == nil {
+			stack = append(stack, parents...)
 		}
-		sha = parent
 	}
 	return refs
 }

--- a/cmd/roborev/fix_test.go
+++ b/cmd/roborev/fix_test.go
@@ -3036,10 +3036,14 @@ func TestFilterReachableJobs(t *testing.T) {
 
 func TestFilterReachableJobsDetachedHead(t *testing.T) {
 	repo := newTestGitRepo(t)
-	sha := repo.CommitFile("a.txt", "a", "initial")
+	baseSHA := repo.CommitFile("a.txt", "a", "initial")
+	defaultBranch := strings.TrimSpace(
+		repo.Run("rev-parse", "--abbrev-ref", "HEAD"),
+	)
 
-	// Detach HEAD
-	repo.Run("checkout", "--detach", sha)
+	repo.Run("checkout", "--detach", baseSHA)
+	parentSHA := repo.CommitFile("b.txt", "b", "detached parent")
+	headSHA := repo.CommitFile("c.txt", "c", "detached head")
 
 	tests := []struct {
 		name    string
@@ -3047,23 +3051,33 @@ func TestFilterReachableJobsDetachedHead(t *testing.T) {
 		wantIDs []int64
 	}{
 		{
-			name: "no branch matches detached HEAD",
+			name: "detached head includes commits back to first branch commit",
 			jobs: []storage.ReviewJob{
-				{ID: 1, GitRef: sha},
+				{ID: 1, GitRef: headSHA},
+				{ID: 2, GitRef: parentSHA},
+				{ID: 3, GitRef: baseSHA, Branch: defaultBranch},
+			},
+			wantIDs: []int64{1, 2, 3},
+		},
+		{
+			name: "detached head includes range ending in detached commit",
+			jobs: []storage.ReviewJob{
+				{ID: 4, GitRef: baseSHA + "..HEAD"},
+			},
+			wantIDs: []int64{4},
+		},
+		{
+			name: "dirty refs stay excluded on detached HEAD",
+			jobs: []storage.ReviewJob{
+				{ID: 5, GitRef: "dirty", Branch: "some-branch"},
+				{ID: 6, GitRef: "dirty"},
 			},
 			wantIDs: nil,
 		},
 		{
-			name: "branch excluded on detached HEAD",
+			name: "unrelated refs are excluded on detached HEAD",
 			jobs: []storage.ReviewJob{
-				{ID: 2, GitRef: "dirty", Branch: "some-branch"},
-			},
-			wantIDs: nil,
-		},
-		{
-			name: "branchless excluded on detached HEAD",
-			jobs: []storage.ReviewJob{
-				{ID: 3, GitRef: "dirty"},
+				{ID: 7, GitRef: "does-not-resolve"},
 			},
 			wantIDs: nil,
 		},

--- a/cmd/roborev/fix_test.go
+++ b/cmd/roborev/fix_test.go
@@ -3095,6 +3095,29 @@ func TestFilterReachableJobsDetachedHead(t *testing.T) {
 	}
 }
 
+func TestFilterReachableJobsDetachedMergeHead(t *testing.T) {
+	repo := newTestGitRepo(t)
+	baseSHA := repo.CommitFile("base.txt", "base", "base")
+
+	repo.Run("checkout", "-b", "feature-side")
+	featureSHA := repo.CommitFile("feature.txt", "feature", "feature")
+
+	repo.Run("checkout", "--detach", baseSHA)
+	repo.Run("merge", "--no-ff", "feature-side", "-m", "detached merge")
+
+	jobs := []storage.ReviewJob{
+		{ID: 1, GitRef: featureSHA},
+		{ID: 2, GitRef: baseSHA + ".." + featureSHA},
+	}
+	got := filterReachableJobs(repo.Dir, "", jobs)
+
+	var gotIDs []int64
+	for _, j := range got {
+		gotIDs = append(gotIDs, j.ID)
+	}
+	assert.Equal(t, []int64{1, 2}, gotIDs)
+}
+
 func TestRunFixOpenFiltersUnreachableJobs(t *testing.T) {
 	repo, worktreeDir := setupWorktree(t)
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -490,6 +490,19 @@ func GetParentCommits(repoPath, sha string, count int) ([]string, error) {
 	return commits, nil
 }
 
+// GetCommitParents returns the direct parent commits for sha.
+func GetCommitParents(repoPath, sha string) ([]string, error) {
+	cmd := exec.Command("git", "show", "-s", "--format=%P", sha)
+	cmd.Dir = repoPath
+
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git show parents: %w", err)
+	}
+
+	return strings.Fields(string(out)), nil
+}
+
 // IsRange returns true if the ref is a range (contains "..")
 func IsRange(ref string) bool {
 	return strings.Contains(ref, "..")

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -514,6 +514,29 @@ func TestGetCommitInfo(t *testing.T) {
 	})
 }
 
+func TestGetCommitParents(t *testing.T) {
+	repo := NewTestRepo(t)
+	repo.CommitFile("base.txt", "base", "base")
+	baseSHA := repo.HeadSHA()
+	defaultBranch := repo.Run("rev-parse", "--abbrev-ref", "HEAD")
+
+	repo.Run("checkout", "-b", "feature")
+	repo.CommitFile("feature.txt", "feature", "feature")
+	featureSHA := repo.HeadSHA()
+
+	repo.Run("checkout", defaultBranch)
+	repo.Run("merge", "--no-ff", "feature", "-m", "merge feature")
+	mergeSHA := repo.HeadSHA()
+
+	parents, err := GetCommitParents(repo.Dir, mergeSHA)
+	require.NoError(t, err, "GetCommitParents failed")
+	assert.Equal(t, []string{baseSHA, featureSHA}, parents)
+
+	rootParents, err := GetCommitParents(repo.Dir, baseSHA)
+	require.NoError(t, err, "GetCommitParents root failed")
+	assert.Empty(t, rootParents)
+}
+
 func TestGetBranchName(t *testing.T) {
 	t.Run("valid commit on branch", func(t *testing.T) {
 		repo := NewTestRepoWithCommit(t)


### PR DESCRIPTION
## Summary
- Teach open-job filtering to fall back to detached commit refs when no branch is checked out, so `roborev fix` can still find reviews in detached HEAD state.
- Match jobs against the detached commit chain and range endpoints, while keeping `dirty` and unrelated refs excluded.
- Add regression coverage for detached HEAD discovery and the surrounding filtering cases.

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`