### PR TITLE
Fix repo rename TUI filtering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,7 +222,6 @@ When reviewing or fixing issues:
 4. **PUSH TO REMOTE** - This is MANDATORY:
    ```bash
    git pull --rebase
-   bd sync
    git push
    git status  # MUST show "up to date with origin"
    ```

--- a/cmd/roborev/repo.go
+++ b/cmd/roborev/repo.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/roborev-dev/roborev/internal/config"
 	"github.com/roborev-dev/roborev/internal/git"
 	"github.com/roborev-dev/roborev/internal/storage"
 	"github.com/spf13/cobra"
@@ -104,6 +105,7 @@ Subcommands:
   list    - List all repositories with their review counts
   show    - Show details about a specific repository
   rename  - Rename a repository's display name
+  move    - Update a repository's root path (after directory rename)
   delete  - Remove a repository from tracking
   merge   - Merge reviews from one repository into another
 `,
@@ -112,6 +114,7 @@ Subcommands:
 	cmd.AddCommand(repoListCmd())
 	cmd.AddCommand(repoShowCmd())
 	cmd.AddCommand(repoRenameCmd())
+	cmd.AddCommand(repoMoveCmd())
 	cmd.AddCommand(repoDeleteCmd())
 	cmd.AddCommand(repoMergeCmd())
 
@@ -239,8 +242,9 @@ NOTE: This is different from the display_name setting in .roborev.toml.
 The database name is set once when a repo is first tracked (from the
 directory name). Use this command to change it after the fact.
 
-When to use rename vs merge:
+When to use rename vs move vs merge:
   - Use RENAME when you have ONE repo entry and want a different name
+  - Use MOVE when you renamed/moved the directory on disk
   - Use MERGE when you have TWO repo entries that should be combined
     (e.g., after renaming a directory, you'll have both old and new entries)
 
@@ -288,9 +292,114 @@ Examples:
 			}
 
 			fmt.Printf("Renamed repository to %q\n", newName)
+
+			// If the renamed repo's stored root_path no longer exists on disk,
+			// hint the user about `repo move` so they know how to recover.
+			if repo, err := db.GetRepoByName(newName); err == nil {
+				if _, statErr := os.Stat(repo.RootPath); os.IsNotExist(statErr) {
+					fmt.Fprintf(os.Stderr,
+						"\nNote: %s no longer exists on disk.\n"+
+							"If the directory was moved, run:\n"+
+							"  roborev repo move %q <new-path>\n",
+						repo.RootPath, newName)
+				}
+			}
 			return nil
 		},
 	}
+}
+
+func repoMoveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "move <name-or-path> <new-path>",
+		Short: "Update a repository's root path",
+		Long: `Update the root_path stored for a repository in the roborev database.
+
+Use this when a repository's directory has been renamed or moved on disk.
+After moving, jobs continue to be associated with the same repo entry,
+so reviews remain visible.
+
+When to use move vs rename vs merge:
+  - Use MOVE when the directory was renamed/moved on disk
+  - Use RENAME to change the display name only
+  - Use MERGE when you have TWO repo entries that should be combined
+
+The first argument can be either:
+  - The current database name
+  - The current (or stale) repository path
+The second argument is the new path. "." resolves to the current
+directory's git repository root.
+
+Examples:
+  # After 'mv old-project new-project', update the database from inside the new directory
+  roborev repo move old-project .
+
+  # Specify an explicit new path
+  roborev repo move my-repo /Users/me/code/my-repo
+
+  # Identify the source by its old (now stale) path
+  roborev repo move /old/path /new/path
+`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			identifier := resolveRepoIdentifier(args[0])
+			newPathArg := args[1]
+
+			newPath, err := resolveMoveTargetPath(newPathArg)
+			if err != nil {
+				return err
+			}
+
+			dbPath := storage.DefaultDBPath()
+			if dbPath == "" {
+				return fmt.Errorf("cannot determine database path")
+			}
+
+			db, err := storage.Open(dbPath)
+			if err != nil {
+				return fmt.Errorf("open database: %w", err)
+			}
+			defer db.Close()
+
+			repo, err := db.FindRepo(identifier)
+			if err != nil {
+				return fmt.Errorf("repository not found: %s", identifier)
+			}
+
+			// Recompute identity for the new location. For repos with a git remote
+			// the identity stays stable; for local-only repos it changes to
+			// local://<new-path>.
+			newIdentity := config.ResolveRepoIdentity(newPath, nil)
+
+			if err := db.MoveRepo(repo.ID, newPath, newIdentity); err != nil {
+				if errors.Is(err, storage.ErrRepoPathConflict) {
+					return fmt.Errorf("another repository is already at %s; consider 'roborev repo merge' to combine them", newPath)
+				}
+				return fmt.Errorf("move repo: %w", err)
+			}
+
+			fmt.Printf("Moved repository %q to %s\n", repo.Name, newPath)
+			return nil
+		},
+	}
+}
+
+// resolveMoveTargetPath resolves the second argument to roborev repo move.
+// It accepts:
+//   - "." or relative paths starting with ./ or ../
+//   - absolute paths
+//   - bare identifiers (treated as relative to cwd)
+//
+// If the resolved path is inside a git repository, the repo root is returned.
+func resolveMoveTargetPath(p string) (string, error) {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", fmt.Errorf("resolve path: %w", err)
+	}
+	if root, err := git.GetRepoRoot(abs); err == nil && root != "" {
+		return filepath.ToSlash(root), nil
+	}
+	return filepath.ToSlash(abs), nil
 }
 
 func repoDeleteCmd() *cobra.Command {

--- a/cmd/roborev/repo.go
+++ b/cmd/roborev/repo.go
@@ -296,7 +296,7 @@ Examples:
 			// If the renamed repo's stored root_path no longer exists on disk,
 			// hint the user about `repo move` so they know how to recover.
 			if repo, err := db.GetRepoByName(newName); err == nil {
-				if _, statErr := os.Stat(repo.RootPath); os.IsNotExist(statErr) {
+				if _, statErr := os.Stat(repo.RootPath); errors.Is(statErr, os.ErrNotExist) {
 					fmt.Fprintf(os.Stderr,
 						"\nNote: %s no longer exists on disk.\n"+
 							"If the directory was moved, run:\n"+

--- a/cmd/roborev/tui/control_handlers.go
+++ b/cmd/roborev/tui/control_handlers.go
@@ -229,6 +229,7 @@ func (m model) handleCtrlSetFilter(
 	}
 
 	if params.Repo != nil {
+		m.autoRepoFilter = false
 		if *params.Repo == "" {
 			m.activeRepoFilter = nil
 			m.removeFilterFromStack(filterTypeRepo)
@@ -282,6 +283,7 @@ func (m model) handleCtrlClearFilter(
 	}
 
 	if params.Repo {
+		m.autoRepoFilter = false
 		m.activeRepoFilter = nil
 		m.removeFilterFromStack(filterTypeRepo)
 	}

--- a/cmd/roborev/tui/fetch.go
+++ b/cmd/roborev/tui/fetch.go
@@ -48,6 +48,7 @@ type repoListResult struct {
 	Repos []struct {
 		Name     string `json:"name"`
 		RootPath string `json:"root_path"`
+		Identity string `json:"identity"`
 		Count    int    `json:"count"`
 	} `json:"repos"`
 	TotalCount int `json:"total_count"`
@@ -326,14 +327,18 @@ func (m model) fetchRepoNames() tea.Cmd {
 		}
 
 		names := make(map[string][]string)
+		identities := make(map[string][]string)
 		for _, r := range result.Repos {
 			displayName := config.GetDisplayName(r.RootPath)
 			if displayName == "" {
 				displayName = r.Name
 			}
 			names[displayName] = append(names[displayName], r.RootPath)
+			if r.Identity != "" {
+				identities[r.Identity] = append(identities[r.Identity], r.RootPath)
+			}
 		}
-		return repoNamesMsg{names: names}
+		return repoNamesMsg{names: names, identities: identities}
 	}
 }
 
@@ -348,11 +353,15 @@ func (m model) fetchRepos() tea.Cmd {
 
 		// Aggregate repos by display name
 		displayNameMap := make(map[string]*repoFilterItem)
+		identities := make(map[string][]string)
 		var displayNameOrder []string // Preserve order for stable display
 		for _, r := range reposResult.Repos {
 			displayName := config.GetDisplayName(r.RootPath)
 			if displayName == "" {
 				displayName = r.Name
+			}
+			if r.Identity != "" {
+				identities[r.Identity] = append(identities[r.Identity], r.RootPath)
 			}
 			if item, ok := displayNameMap[displayName]; ok {
 				item.rootPaths = append(item.rootPaths, r.RootPath)
@@ -370,7 +379,7 @@ func (m model) fetchRepos() tea.Cmd {
 		for i, name := range displayNameOrder {
 			repos[i] = *displayNameMap[name]
 		}
-		return reposMsg{repos: repos, branchFiltered: filtered}
+		return reposMsg{repos: repos, identities: identities, branchFiltered: filtered}
 	}
 }
 

--- a/cmd/roborev/tui/filter.go
+++ b/cmd/roborev/tui/filter.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/roborev-dev/roborev/internal/config"
 	"github.com/roborev-dev/roborev/internal/storage"
 )
 
@@ -159,6 +160,68 @@ func (m model) repoMatchesFilter(repoPath string) bool {
 	return slices.Contains(m.activeRepoFilter, repoPath)
 }
 
+func (m model) displayNameForRootPaths(rootPaths []string) string {
+	for name, paths := range m.repoNames {
+		if rootPathsMatch(paths, rootPaths) {
+			return name
+		}
+	}
+	for _, node := range m.filterTree {
+		if rootPathsMatch(node.rootPaths, rootPaths) {
+			return node.name
+		}
+	}
+	if len(rootPaths) == 1 {
+		for _, job := range m.jobs {
+			if job.RepoPath == rootPaths[0] && job.RepoName != "" {
+				return job.RepoName
+			}
+		}
+	}
+	return ""
+}
+
+func (m model) repoFilterDisplayName() string {
+	if len(m.activeRepoFilter) == 0 {
+		return ""
+	}
+	if name := m.displayNameForRootPaths(m.activeRepoFilter); name != "" {
+		return name
+	}
+	if len(m.activeRepoFilter) == 1 {
+		return m.getDisplayName(
+			m.activeRepoFilter[0],
+			filepath.Base(m.activeRepoFilter[0]),
+		)
+	}
+	return strings.Join(m.activeRepoFilter, ", ")
+}
+
+func (m *model) reconcileAutoRepoFilter() bool {
+	if !m.autoRepoFilter || len(m.activeRepoFilter) != 1 ||
+		m.cwdRepoRoot == "" || m.activeRepoFilter[0] != m.cwdRepoRoot {
+		return false
+	}
+
+	displayName := config.GetDisplayName(m.cwdRepoRoot)
+	if displayName == "" {
+		displayName = filepath.Base(m.cwdRepoRoot)
+	}
+	rootPaths := m.repoNames[displayName]
+	if len(rootPaths) == 0 || rootPathsMatch(rootPaths, m.activeRepoFilter) {
+		return false
+	}
+
+	m.activeRepoFilter = copyStrings(rootPaths)
+	m.hasMore = false
+	m.selectedIdx = -1
+	m.selectedJobID = 0
+	m.fetchSeq++
+	m.queueColGen++
+	m.loadingJobs = true
+	return true
+}
+
 // isJobVisible checks if a job passes all active filters
 func (m model) isJobVisible(job storage.ReviewJob) bool {
 	if len(m.activeRepoFilter) > 0 && !m.repoMatchesFilter(job.RepoPath) {
@@ -219,6 +282,7 @@ func (m *model) popFilter() string {
 		switch ft {
 		case filterTypeRepo:
 			m.activeRepoFilter = nil
+			m.autoRepoFilter = false
 		case filterTypeBranch:
 			m.activeBranchFilter = ""
 		}

--- a/cmd/roborev/tui/filter.go
+++ b/cmd/roborev/tui/filter.go
@@ -161,8 +161,13 @@ func (m model) repoMatchesFilter(repoPath string) bool {
 }
 
 func (m model) displayNameForRootPaths(rootPaths []string) string {
-	for name, paths := range m.repoNames {
-		if rootPathsMatch(paths, rootPaths) {
+	names := make([]string, 0, len(m.repoNames))
+	for name := range m.repoNames {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if rootPathsMatch(m.repoNames[name], rootPaths) {
 			return name
 		}
 	}
@@ -209,7 +214,13 @@ func (m *model) reconcileAutoRepoFilter() bool {
 	}
 	rootPaths := m.repoNames[displayName]
 	if len(rootPaths) == 0 || rootPathsMatch(rootPaths, m.activeRepoFilter) {
-		return false
+		if m.cwdRepoIdentity == "" {
+			return false
+		}
+		rootPaths = m.repoIdentities[m.cwdRepoIdentity]
+		if len(rootPaths) == 0 || rootPathsMatch(rootPaths, m.activeRepoFilter) {
+			return false
+		}
 	}
 
 	m.activeRepoFilter = copyStrings(rootPaths)

--- a/cmd/roborev/tui/filter.go
+++ b/cmd/roborev/tui/filter.go
@@ -208,19 +208,19 @@ func (m *model) reconcileAutoRepoFilter() bool {
 		return false
 	}
 
-	displayName := config.GetDisplayName(m.cwdRepoRoot)
-	if displayName == "" {
-		displayName = filepath.Base(m.cwdRepoRoot)
-	}
-	rootPaths := m.repoNames[displayName]
-	if len(rootPaths) == 0 || rootPathsMatch(rootPaths, m.activeRepoFilter) {
-		if m.cwdRepoIdentity == "" {
-			return false
-		}
+	var rootPaths []string
+	if m.cwdRepoIdentity != "" {
 		rootPaths = m.repoIdentities[m.cwdRepoIdentity]
-		if len(rootPaths) == 0 || rootPathsMatch(rootPaths, m.activeRepoFilter) {
-			return false
+	}
+	if len(rootPaths) == 0 {
+		displayName := config.GetDisplayName(m.cwdRepoRoot)
+		if displayName == "" {
+			displayName = filepath.Base(m.cwdRepoRoot)
 		}
+		rootPaths = m.repoNames[displayName]
+	}
+	if len(rootPaths) == 0 || rootPathsMatch(rootPaths, m.activeRepoFilter) {
+		return false
 	}
 
 	m.activeRepoFilter = copyStrings(rootPaths)

--- a/cmd/roborev/tui/filter.go
+++ b/cmd/roborev/tui/filter.go
@@ -202,9 +202,34 @@ func (m model) repoFilterDisplayName() string {
 	return strings.Join(m.activeRepoFilter, ", ")
 }
 
+func (m model) repoRootTracked(rootPath string) bool {
+	if rootPath == "" {
+		return false
+	}
+	for _, rootPaths := range m.repoNames {
+		if slices.Contains(rootPaths, rootPath) {
+			return true
+		}
+	}
+	for _, rootPaths := range m.repoIdentities {
+		if slices.Contains(rootPaths, rootPath) {
+			return true
+		}
+	}
+	for _, node := range m.filterTree {
+		if slices.Contains(node.rootPaths, rootPath) {
+			return true
+		}
+	}
+	return false
+}
+
 func (m *model) reconcileAutoRepoFilter() bool {
 	if !m.autoRepoFilter || len(m.activeRepoFilter) != 1 ||
 		m.cwdRepoRoot == "" || m.activeRepoFilter[0] != m.cwdRepoRoot {
+		return false
+	}
+	if m.repoRootTracked(m.cwdRepoRoot) {
 		return false
 	}
 

--- a/cmd/roborev/tui/filter_queue_test.go
+++ b/cmd/roborev/tui/filter_queue_test.go
@@ -415,6 +415,23 @@ func TestTUIFilterNoCwdNoReorder(t *testing.T) {
 	assert.Equal(t, "repo-c", m2.filterTree[2].name)
 }
 
+func TestTUIAutoRepoFilterUsesRenamedRepoDisplayName(t *testing.T) {
+	oldRoot := "/workspace/vibekata"
+	newRoot := "/workspace/kata"
+	m := newModel(localhostEndpoint, withExternalIODisabled(), withAutoFilterRepo(newRoot))
+	m.currentView = viewQueue
+	m.loadingJobs = false
+
+	m2, cmd := updateModel(t, m, repoNamesMsg{
+		names: map[string][]string{
+			"kata": []string{oldRoot},
+		},
+	})
+
+	assert.Equal(t, []string{oldRoot}, m2.activeRepoFilter)
+	assert.NotNil(t, cmd)
+}
+
 func TestTUIBKeyNoOpOutsideQueue(t *testing.T) {
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.currentView = viewReview

--- a/cmd/roborev/tui/filter_queue_test.go
+++ b/cmd/roborev/tui/filter_queue_test.go
@@ -485,6 +485,33 @@ func TestTUIAutoRepoFilterPrefersIdentityOverDisplayName(t *testing.T) {
 	assert.NotNil(t, cmd)
 }
 
+func TestTUIAutoRepoFilterKeepsTrackedCloneWithSharedIdentity(t *testing.T) {
+	currentRoot := "/workspace/team-a/service"
+	otherRoot := "/workspace/team-b/service"
+	identity := "https://github.com/test/service.git"
+	m := newModel(
+		localhostEndpoint,
+		withExternalIODisabled(),
+		withAutoFilterRepo(currentRoot),
+		withCwdRepoIdentity(identity),
+	)
+	m.currentView = viewQueue
+	m.loadingJobs = false
+
+	m2, cmd := updateModel(t, m, repoNamesMsg{
+		names: map[string][]string{
+			"service": []string{currentRoot, otherRoot},
+		},
+		identities: map[string][]string{
+			identity: []string{currentRoot, otherRoot},
+		},
+	})
+
+	assert.Equal(t, []string{currentRoot}, m2.activeRepoFilter)
+	assert.Nil(t, cmd)
+	assert.False(t, m2.loadingJobs)
+}
+
 func TestTUIBKeyNoOpOutsideQueue(t *testing.T) {
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.currentView = viewReview

--- a/cmd/roborev/tui/filter_queue_test.go
+++ b/cmd/roborev/tui/filter_queue_test.go
@@ -416,15 +416,41 @@ func TestTUIFilterNoCwdNoReorder(t *testing.T) {
 }
 
 func TestTUIAutoRepoFilterUsesRenamedRepoDisplayName(t *testing.T) {
-	oldRoot := "/workspace/vibekata"
-	newRoot := "/workspace/kata"
+	oldRoot := "/workspace/old-service"
+	newRoot := "/workspace/new-service"
 	m := newModel(localhostEndpoint, withExternalIODisabled(), withAutoFilterRepo(newRoot))
 	m.currentView = viewQueue
 	m.loadingJobs = false
 
 	m2, cmd := updateModel(t, m, repoNamesMsg{
 		names: map[string][]string{
-			"kata": []string{oldRoot},
+			"new-service": []string{oldRoot},
+		},
+	})
+
+	assert.Equal(t, []string{oldRoot}, m2.activeRepoFilter)
+	assert.NotNil(t, cmd)
+}
+
+func TestTUIAutoRepoFilterFallsBackToIdentity(t *testing.T) {
+	oldRoot := "/workspace/old-service"
+	newRoot := "/workspace/cool-rebrand"
+	identity := "https://github.com/test/service.git"
+	m := newModel(
+		localhostEndpoint,
+		withExternalIODisabled(),
+		withAutoFilterRepo(newRoot),
+		withCwdRepoIdentity(identity),
+	)
+	m.currentView = viewQueue
+	m.loadingJobs = false
+
+	m2, cmd := updateModel(t, m, repoNamesMsg{
+		names: map[string][]string{
+			"old-service": []string{oldRoot},
+		},
+		identities: map[string][]string{
+			identity: []string{oldRoot},
 		},
 	})
 

--- a/cmd/roborev/tui/filter_queue_test.go
+++ b/cmd/roborev/tui/filter_queue_test.go
@@ -458,6 +458,33 @@ func TestTUIAutoRepoFilterFallsBackToIdentity(t *testing.T) {
 	assert.NotNil(t, cmd)
 }
 
+func TestTUIAutoRepoFilterPrefersIdentityOverDisplayName(t *testing.T) {
+	expectedRoot := "/workspace/team-a/service"
+	wrongRoot := "/workspace/team-b/service"
+	newRoot := "/workspace/team-c/service"
+	identity := "https://github.com/test/team-a-service.git"
+	m := newModel(
+		localhostEndpoint,
+		withExternalIODisabled(),
+		withAutoFilterRepo(newRoot),
+		withCwdRepoIdentity(identity),
+	)
+	m.currentView = viewQueue
+	m.loadingJobs = false
+
+	m2, cmd := updateModel(t, m, repoNamesMsg{
+		names: map[string][]string{
+			"service": []string{wrongRoot},
+		},
+		identities: map[string][]string{
+			identity: []string{expectedRoot},
+		},
+	})
+
+	assert.Equal(t, []string{expectedRoot}, m2.activeRepoFilter)
+	assert.NotNil(t, cmd)
+}
+
 func TestTUIBKeyNoOpOutsideQueue(t *testing.T) {
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.currentView = viewReview

--- a/cmd/roborev/tui/filter_stack_test.go
+++ b/cmd/roborev/tui/filter_stack_test.go
@@ -248,16 +248,16 @@ func TestTUIFilterStackTitleBarOrder(t *testing.T) {
 func TestTUIFilterStackTitleUsesRepoDisplayName(t *testing.T) {
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.currentView = viewQueue
-	m.activeRepoFilter = []string{"/workspace/vibekata"}
+	m.activeRepoFilter = []string{"/workspace/old-service"}
 	m.filterStack = []string{"repo"}
 	m.repoNames = map[string][]string{
-		"kata": []string{"/workspace/vibekata"},
+		"new-service": []string{"/workspace/old-service"},
 	}
 
 	output := m.View()
 
-	assert.Contains(t, output, "[f: kata]")
-	assert.NotContains(t, output, "[f: vibekata]")
+	assert.Contains(t, output, "[f: new-service]")
+	assert.NotContains(t, output, "[f: old-service]")
 }
 
 func TestTUIFilterStackReverseOrder(t *testing.T) {

--- a/cmd/roborev/tui/filter_stack_test.go
+++ b/cmd/roborev/tui/filter_stack_test.go
@@ -245,6 +245,21 @@ func TestTUIFilterStackTitleBarOrder(t *testing.T) {
 	assert.LessOrEqual(t, bIdx, fIdx)
 }
 
+func TestTUIFilterStackTitleUsesRepoDisplayName(t *testing.T) {
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.currentView = viewQueue
+	m.activeRepoFilter = []string{"/workspace/vibekata"}
+	m.filterStack = []string{"repo"}
+	m.repoNames = map[string][]string{
+		"kata": []string{"/workspace/vibekata"},
+	}
+
+	output := m.View()
+
+	assert.Contains(t, output, "[f: kata]")
+	assert.NotContains(t, output, "[f: vibekata]")
+}
+
 func TestTUIFilterStackReverseOrder(t *testing.T) {
 
 	m := newModel(localhostEndpoint, withExternalIODisabled())

--- a/cmd/roborev/tui/handlers_modal.go
+++ b/cmd/roborev/tui/handlers_modal.go
@@ -130,6 +130,7 @@ func (m model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			// "All" -- clear unlocked filters only
 			if !m.lockedRepoFilter {
 				m.activeRepoFilter = nil
+				m.autoRepoFilter = false
 				m.removeFilterFromStack(filterTypeRepo)
 			}
 			if !m.lockedBranchFilter {
@@ -141,6 +142,7 @@ func (m model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			node := m.filterTree[entry.repoIdx]
 			if !m.lockedRepoFilter {
 				m.activeRepoFilter = node.rootPaths
+				m.autoRepoFilter = false
 				m.pushFilter(filterTypeRepo)
 			}
 			if !m.lockedBranchFilter {
@@ -153,6 +155,7 @@ func (m model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			branch := node.children[entry.branchIdx]
 			if !m.lockedRepoFilter {
 				m.activeRepoFilter = node.rootPaths
+				m.autoRepoFilter = false
 				m.pushFilter(filterTypeRepo)
 			}
 			if !m.lockedBranchFilter {

--- a/cmd/roborev/tui/handlers_msg.go
+++ b/cmd/roborev/tui/handlers_msg.go
@@ -258,6 +258,9 @@ func (m model) handleRepoNamesMsg(
 ) (tea.Model, tea.Cmd) {
 	if msg.names != nil {
 		m.repoNames = msg.names
+		if m.reconcileAutoRepoFilter() {
+			return m, m.fetchJobs()
+		}
 	}
 	return m, nil
 }
@@ -267,6 +270,7 @@ func (m model) handleReposMsg(
 	msg reposMsg,
 ) (tea.Model, tea.Cmd) {
 	m.consecutiveErrors = 0
+	refetchJobs := false
 
 	// Refresh repoNames when the modal fetch was unfiltered (no
 	// branch constraint), so newly registered repos are picked up.
@@ -278,6 +282,7 @@ func (m model) handleReposMsg(
 			names[r.name] = r.rootPaths
 		}
 		m.repoNames = names
+		refetchJobs = m.reconcileAutoRepoFilter()
 	}
 
 	// Build filterTree from repos (all collapsed, no children)
@@ -341,14 +346,24 @@ func (m model) handleReposMsg(
 				break
 			}
 		}
-		return m, m.fetchBranchesForRepo(
+		branchCmd := m.fetchBranchesForRepo(
 			m.filterTree[targetIdx].rootPaths,
 			targetIdx, true, m.filterSearchSeq,
 		)
+		if refetchJobs {
+			return m, tea.Batch(m.fetchJobs(), branchCmd)
+		}
+		return m, branchCmd
 	}
 	// If user typed search before repos loaded, kick off fetches
 	if cmd := m.fetchUnloadedBranches(); cmd != nil {
+		if refetchJobs {
+			return m, tea.Batch(m.fetchJobs(), cmd)
+		}
 		return m, cmd
+	}
+	if refetchJobs {
+		return m, m.fetchJobs()
 	}
 	return m, nil
 }

--- a/cmd/roborev/tui/handlers_msg.go
+++ b/cmd/roborev/tui/handlers_msg.go
@@ -258,6 +258,7 @@ func (m model) handleRepoNamesMsg(
 ) (tea.Model, tea.Cmd) {
 	if msg.names != nil {
 		m.repoNames = msg.names
+		m.repoIdentities = msg.identities
 		if m.reconcileAutoRepoFilter() {
 			return m, m.fetchJobs()
 		}
@@ -282,6 +283,7 @@ func (m model) handleReposMsg(
 			names[r.name] = r.rootPaths
 		}
 		m.repoNames = names
+		m.repoIdentities = msg.identities
 		refetchJobs = m.reconcileAutoRepoFilter()
 	}
 

--- a/cmd/roborev/tui/render_queue.go
+++ b/cmd/roborev/tui/render_queue.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"fmt"
 	"maps"
-	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -128,7 +127,7 @@ func (m model) renderQueueView() string {
 		switch filterType {
 		case filterTypeRepo:
 			if len(m.activeRepoFilter) > 0 {
-				filterName := m.getDisplayName(m.activeRepoFilter[0], filepath.Base(m.activeRepoFilter[0]))
+				filterName := m.repoFilterDisplayName()
 				fmt.Fprintf(&title, " [f: %s]", filterName)
 			}
 		case filterTypeBranch:

--- a/cmd/roborev/tui/tui.go
+++ b/cmd/roborev/tui/tui.go
@@ -312,6 +312,7 @@ type model struct {
 
 	// Active filter (applied to queue view)
 	activeRepoFilter   []string // Empty = show all, otherwise repo root_paths to filter by
+	autoRepoFilter     bool     // true when activeRepoFilter came from auto_filter_repo
 	activeBranchFilter string   // Empty = show all, otherwise branch name to filter by
 	filterStack        []string // Order of applied filters: "repo", "branch" - for escape to pop in order
 	hideClosed         bool     // When true, hide jobs with closed reviews
@@ -537,6 +538,7 @@ func newModel(ep daemon.DaemonEndpoint, opts ...option) model {
 	// Determine active filters: CLI flags take priority over auto-filter config
 	var activeRepoFilter []string
 	var filterStack []string
+	var autoRepoFilterActive bool
 	var lockedRepo, lockedBranch bool
 
 	if opt.repoFilter != "" {
@@ -546,6 +548,7 @@ func newModel(ep daemon.DaemonEndpoint, opts ...option) model {
 	} else if autoFilterRepo && cwdRepoRoot != "" {
 		activeRepoFilter = []string{cwdRepoRoot}
 		filterStack = append(filterStack, filterTypeRepo)
+		autoRepoFilterActive = true
 	}
 
 	var activeBranchFilter string
@@ -590,6 +593,7 @@ func newModel(ep daemon.DaemonEndpoint, opts ...option) model {
 		loadingStatus:       true, // Init() calls fetchStatus, so mark as loading
 		hideClosed:          hideClosed,
 		activeRepoFilter:    activeRepoFilter,
+		autoRepoFilter:      autoRepoFilterActive,
 		activeBranchFilter:  activeBranchFilter,
 		filterStack:         filterStack,
 		lockedRepoFilter:    lockedRepo,

--- a/cmd/roborev/tui/tui.go
+++ b/cmd/roborev/tui/tui.go
@@ -323,7 +323,8 @@ type model struct {
 	// Repo name lookup (display name → root paths), populated from
 	// /api/repos at init. Used by control socket set-filter to resolve
 	// display names to the root paths that the daemon API expects.
-	repoNames map[string][]string
+	repoNames      map[string][]string
+	repoIdentities map[string][]string
 
 	// Branch name cache (keyed by job ID) - caches derived branches to avoid repeated git calls
 	branchNames map[int64]string
@@ -332,8 +333,9 @@ type model struct {
 	branchBackfillDone bool
 
 	// Repo root and branch detected from cwd at launch (for filter sort priority)
-	cwdRepoRoot string
-	cwdBranch   string
+	cwdRepoRoot     string
+	cwdRepoIdentity string
+	cwdBranch       string
 
 	// Pending closed state changes (prevents flash during refresh race)
 	// Each pending entry stores the requested state and a sequence number to
@@ -479,7 +481,7 @@ func newModel(ep daemon.DaemonEndpoint, opts ...option) model {
 	hiddenCols := parseHiddenColumns(nil)
 	colOrder := parseColumnOrder(nil)
 	taskColOrder := parseTaskColumnOrder(nil)
-	var cwdRepoRoot, cwdBranch string
+	var cwdRepoRoot, cwdRepoIdentity, cwdBranch string
 
 	if !opt.disableExternalIO {
 		// Read daemon version from runtime file
@@ -513,6 +515,7 @@ func newModel(ep daemon.DaemonEndpoint, opts ...option) model {
 		// Detect current repo/branch for filter sort priority
 		if repoRoot, err := git.GetMainRepoRoot("."); err == nil && repoRoot != "" {
 			cwdRepoRoot = repoRoot
+			cwdRepoIdentity = config.ResolveRepoIdentity(repoRoot, nil)
 			cwdBranch = git.GetCurrentBranch(".")
 		}
 	}
@@ -529,6 +532,7 @@ func newModel(ep daemon.DaemonEndpoint, opts ...option) model {
 	if opt.autoFilterRepo {
 		autoFilterRepo = true
 		cwdRepoRoot = opt.cwdRepoRoot
+		cwdRepoIdentity = opt.cwdRepoIdentity
 	}
 	if opt.autoFilterBranch {
 		autoFilterBranch = true
@@ -599,6 +603,7 @@ func newModel(ep daemon.DaemonEndpoint, opts ...option) model {
 		lockedRepoFilter:    lockedRepo,
 		lockedBranchFilter:  lockedBranch,
 		cwdRepoRoot:         cwdRepoRoot,
+		cwdRepoIdentity:     cwdRepoIdentity,
 		cwdBranch:           cwdBranch,
 		displayNames:        make(map[string]string),      // Cache display names to avoid disk reads on render
 		branchNames:         make(map[int64]string),       // Cache derived branch names to avoid git calls on render

--- a/cmd/roborev/tui/types.go
+++ b/cmd/roborev/tui/types.go
@@ -191,6 +191,7 @@ type updateCheckMsg struct {
 }
 type reposMsg struct {
 	repos          []repoFilterItem
+	identities     map[string][]string
 	branchFiltered bool // true if fetched with a branch constraint
 }
 
@@ -198,7 +199,8 @@ type reposMsg struct {
 // /api/repos, used by the control socket to resolve display names in
 // set-filter commands. Fetched once at init.
 type repoNamesMsg struct {
-	names map[string][]string // display name → root paths
+	names      map[string][]string // display name → root paths
+	identities map[string][]string // repo identity → root paths
 }
 type branchesMsg struct {
 	backfillCount int // Number of branches successfully backfilled to the database
@@ -323,6 +325,10 @@ func withAutoFilterRepo(repo string) option {
 	}
 }
 
+func withCwdRepoIdentity(identity string) option {
+	return func(o *options) { o.cwdRepoIdentity = identity }
+}
+
 // options holds optional overrides for the TUI model, set from CLI flags.
 type options struct {
 	repoFilter        string // --repo flag: lock filter to this repo path
@@ -332,6 +338,7 @@ type options struct {
 	autoFilterRepo    bool   // tests: simulate auto_filter_repo config
 	autoFilterBranch  bool   // tests: simulate auto_filter_branch config
 	cwdRepoRoot       string // tests: simulate detected repo root
+	cwdRepoIdentity   string // tests: simulate detected repo identity
 	cwdBranch         string // tests: simulate detected branch
 }
 

--- a/internal/daemon/server_repos_test.go
+++ b/internal/daemon/server_repos_test.go
@@ -92,6 +92,35 @@ func TestHandleListRepos(t *testing.T) {
 		}
 	})
 
+	t.Run("repos include identity", func(t *testing.T) {
+		repo, err := db.GetRepoByName("repo1")
+		require.NoError(t, err)
+		identity := "https://github.com/test/repo1.git"
+		require.NoError(t, db.SetRepoIdentity(repo.ID, identity))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/repos", nil)
+		w := httptest.NewRecorder()
+		server.httpServer.Handler.ServeHTTP(w, req)
+		testutil.AssertStatusCode(t, w, http.StatusOK)
+
+		var response struct {
+			Repos []struct {
+				Name     string `json:"name"`
+				Identity string `json:"identity"`
+			} `json:"repos"`
+		}
+		testutil.DecodeJSON(t, w, &response)
+
+		var found bool
+		for _, r := range response.Repos {
+			if r.Name == "repo1" {
+				found = true
+				assert.Equal(t, identity, r.Identity)
+			}
+		}
+		assert.True(t, found)
+	})
+
 	t.Run("wrong method fails", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/api/repos", nil)
 		w := httptest.NewRecorder()

--- a/internal/daemon/server_repos_test.go
+++ b/internal/daemon/server_repos_test.go
@@ -141,6 +141,14 @@ func TestHandleListReposWithBranchFilter(t *testing.T) {
 	// Create repos and jobs
 	seedRepoWithJobs(t, db, filepath.Join(tmpDir, "repo1"), 3, "repo1")
 	seedRepoWithJobs(t, db, filepath.Join(tmpDir, "repo2"), 2, "repo2")
+	repo1, err := db.GetRepoByName("repo1")
+	require.NoError(t, err)
+	repo2, err := db.GetRepoByName("repo2")
+	require.NoError(t, err)
+	repo1Identity := "https://github.com/test/repo1.git"
+	repo2Identity := "https://github.com/test/repo2.git"
+	require.NoError(t, db.SetRepoIdentity(repo1.ID, repo1Identity))
+	require.NoError(t, db.SetRepoIdentity(repo2.ID, repo2Identity))
 
 	// Set branches: repo1 jobs 1,2 = main, job 3 = feature; repo2 jobs 4,5 = main
 	setJobBranch(t, db, 1, "main")
@@ -150,8 +158,11 @@ func TestHandleListReposWithBranchFilter(t *testing.T) {
 	setJobBranch(t, db, 3, "feature")
 
 	type reposResponse struct {
-		Repos      []struct{ Name string } `json:"repos"`
-		TotalCount int                     `json:"total_count"`
+		Repos []struct {
+			Name     string `json:"name"`
+			Identity string `json:"identity"`
+		} `json:"repos"`
+		TotalCount int `json:"total_count"`
 	}
 
 	t.Run("filter by main branch", func(t *testing.T) {
@@ -172,6 +183,12 @@ func TestHandleListReposWithBranchFilter(t *testing.T) {
 				return false
 			}, "Expected total_count 4, got %d", response.TotalCount)
 		}
+		identities := map[string]string{}
+		for _, repo := range response.Repos {
+			identities[repo.Name] = repo.Identity
+		}
+		assert.Equal(t, repo1Identity, identities["repo1"])
+		assert.Equal(t, repo2Identity, identities["repo2"])
 	})
 
 	t.Run("filter by feature branch", func(t *testing.T) {
@@ -192,6 +209,8 @@ func TestHandleListReposWithBranchFilter(t *testing.T) {
 				return false
 			}, "Expected total_count 1, got %d", response.TotalCount)
 		}
+		require.Len(t, response.Repos, 1)
+		assert.Equal(t, repo1Identity, response.Repos[0].Identity)
 	})
 
 	t.Run("nonexistent branch returns empty", func(t *testing.T) {

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -1409,6 +1409,199 @@ func (db *DB) migrateSyncColumns() error {
 		}
 	}
 
+	if err := db.migrateRepoRootPathNormalization(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type repoRootPathMigrationRow struct {
+	id         int64
+	rootPath   string
+	normalized string
+}
+
+func (db *DB) migrateRepoRootPathNormalization() error {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin repo root_path normalization: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	rows, err := tx.Query(`SELECT id, root_path FROM repos ORDER BY id`)
+	if err != nil {
+		return fmt.Errorf("query repo root_paths: %w", err)
+	}
+	groups := map[string][]repoRootPathMigrationRow{}
+	for rows.Next() {
+		var r repoRootPathMigrationRow
+		if err := rows.Scan(&r.id, &r.rootPath); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan repo root_path: %w", err)
+		}
+		r.normalized = normalizeStoredRepoPath(r.rootPath)
+		groups[r.normalized] = append(groups[r.normalized], r)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return fmt.Errorf("iterate repo root_paths: %w", err)
+	}
+	rows.Close()
+
+	for normalized, group := range groups {
+		if len(group) == 1 {
+			if group[0].rootPath != normalized {
+				if _, err := tx.Exec(`UPDATE repos SET root_path = ? WHERE id = ?`, normalized, group[0].id); err != nil {
+					return fmt.Errorf("normalize repo root_path %q: %w", group[0].rootPath, err)
+				}
+			}
+			continue
+		}
+
+		target := chooseRepoRootPathMigrationTarget(normalized, group)
+		if target.rootPath != normalized {
+			if _, err := tx.Exec(`UPDATE repos SET root_path = ? WHERE id = ?`, normalized, target.id); err != nil {
+				return fmt.Errorf("normalize target repo root_path %q: %w", target.rootPath, err)
+			}
+		}
+		for _, source := range group {
+			if source.id == target.id {
+				continue
+			}
+			if err := mergeRepoRootPathConflict(tx, source.id, target.id); err != nil {
+				return fmt.Errorf("merge repo root_path conflict %d into %d: %w", source.id, target.id, err)
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit repo root_path normalization: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func chooseRepoRootPathMigrationTarget(
+	normalized string,
+	rows []repoRootPathMigrationRow,
+) repoRootPathMigrationRow {
+	target := rows[0]
+	for _, r := range rows {
+		if r.rootPath == normalized {
+			return r
+		}
+		if r.id < target.id {
+			target = r
+		}
+	}
+	return target
+}
+
+func mergeRepoRootPathConflict(tx *sql.Tx, sourceRepoID, targetRepoID int64) error {
+	if _, err := tx.Exec(`
+		UPDATE repos
+		SET identity = (SELECT identity FROM repos WHERE id = ?)
+		WHERE id = ?
+		  AND (identity IS NULL OR identity = '')
+		  AND COALESCE((SELECT identity FROM repos WHERE id = ?), '') != ''
+	`, sourceRepoID, targetRepoID, sourceRepoID); err != nil {
+		return fmt.Errorf("copy repo identity: %w", err)
+	}
+
+	rows, err := tx.Query(`
+		SELECT sc.id, tc.id
+		FROM commits sc
+		JOIN commits tc ON tc.repo_id = ? AND tc.sha = sc.sha
+		WHERE sc.repo_id = ?
+	`, targetRepoID, sourceRepoID)
+	if err != nil {
+		return fmt.Errorf("query duplicate commits: %w", err)
+	}
+	type commitPair struct {
+		sourceID int64
+		targetID int64
+	}
+	var duplicateCommits []commitPair
+	for rows.Next() {
+		var pair commitPair
+		if err := rows.Scan(&pair.sourceID, &pair.targetID); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan duplicate commit: %w", err)
+		}
+		duplicateCommits = append(duplicateCommits, pair)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return fmt.Errorf("iterate duplicate commits: %w", err)
+	}
+	rows.Close()
+
+	for _, pair := range duplicateCommits {
+		if _, err := tx.Exec(`UPDATE review_jobs SET commit_id = ? WHERE commit_id = ?`, pair.targetID, pair.sourceID); err != nil {
+			return fmt.Errorf("remap review job commit %d to %d: %w", pair.sourceID, pair.targetID, err)
+		}
+		if _, err := tx.Exec(`UPDATE responses SET commit_id = ? WHERE commit_id = ?`, pair.targetID, pair.sourceID); err != nil {
+			return fmt.Errorf("remap response commit %d to %d: %w", pair.sourceID, pair.targetID, err)
+		}
+		if _, err := tx.Exec(`DELETE FROM commits WHERE id = ?`, pair.sourceID); err != nil {
+			return fmt.Errorf("delete duplicate commit %d: %w", pair.sourceID, err)
+		}
+	}
+
+	if _, err := tx.Exec(`UPDATE commits SET repo_id = ? WHERE repo_id = ?`, targetRepoID, sourceRepoID); err != nil {
+		return fmt.Errorf("move commits: %w", err)
+	}
+	if err := demoteConflictingAutoDesignJobs(tx, sourceRepoID, targetRepoID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`UPDATE review_jobs SET repo_id = ? WHERE repo_id = ?`, targetRepoID, sourceRepoID); err != nil {
+		return fmt.Errorf("move review jobs: %w", err)
+	}
+	if _, err := tx.Exec(`DELETE FROM repos WHERE id = ?`, sourceRepoID); err != nil {
+		return fmt.Errorf("delete duplicate repo: %w", err)
+	}
+	return nil
+}
+
+func demoteConflictingAutoDesignJobs(tx *sql.Tx, sourceRepoID, targetRepoID int64) error {
+	var hasSource int
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('review_jobs') WHERE name = 'source'`).Scan(&hasSource); err != nil {
+		return fmt.Errorf("check review_jobs source column: %w", err)
+	}
+	if hasSource == 0 {
+		return nil
+	}
+
+	_, err := tx.Exec(`
+		UPDATE review_jobs AS sj
+		SET source = 'auto_design_duplicate'
+		WHERE sj.repo_id = ?
+		  AND sj.source = 'auto_design'
+		  AND EXISTS (
+			SELECT 1
+			FROM review_jobs AS tj
+			WHERE tj.repo_id = ?
+			  AND tj.source = 'auto_design'
+			  AND tj.review_type = sj.review_type
+			  AND (
+				tj.git_ref = sj.git_ref
+				OR (
+					tj.commit_id IS NOT NULL
+					AND sj.commit_id IS NOT NULL
+					AND tj.commit_id = sj.commit_id
+				)
+			  )
+		  )
+	`, sourceRepoID, targetRepoID)
+	if err != nil {
+		return fmt.Errorf("demote duplicate auto-design jobs: %w", err)
+	}
 	return nil
 }
 

--- a/internal/storage/db_filter_test.go
+++ b/internal/storage/db_filter_test.go
@@ -820,27 +820,33 @@ func TestPrefixFilterWithSpecialChars(t *testing.T) {
 		assert.Equal(t, 2, total)
 	})
 
-	t.Run("backslash in path does not cause SQL error", func(t *testing.T) {
+	t.Run("backslash prefix matches normalized Windows path", func(t *testing.T) {
 
 		createRepo(t, db, `C:\Users\dev\workspace\project-a`)
 		rA, _ := db.GetRepoByPath(`C:\Users\dev\workspace\project-a`)
 		cA := createCommit(t, db, rA.ID, "win-a")
 		enqueueJob(t, db, rA.ID, cA.ID, "win-a")
+		claimed := claimJob(t, db, "w2")
+		require.NoError(t, db.CompleteJob(claimed.ID, "codex", "p", "o"))
 
-		_, err := db.ListJobs(
+		jobs, err := db.ListJobs(
 			"", "", 50, 0, WithRepoPrefix(`C:\Users\dev\workspace`),
 		)
 		require.NoError(t, err, "ListJobs with backslash prefix should not error: %v")
+		assert.Len(t, jobs, 1)
 
-		_, err = db.CountJobStats(
+		stats, err := db.CountJobStats(
 			"", WithRepoPrefix(`C:\Users\dev\workspace`),
 		)
 		require.NoError(t, err, "CountJobStats with backslash prefix should not error: %v")
+		assert.Equal(t, 1, stats.Open)
 
-		_, _, err = db.ListReposWithReviewCounts(
+		repos, total, err := db.ListReposWithReviewCounts(
 			WithRepoPathPrefix(`C:\Users\dev\workspace`),
 		)
 		require.NoError(t, err, "ListReposWithReviewCounts with backslash prefix should not error: %v")
+		assert.Len(t, repos, 1)
+		assert.Equal(t, 1, total)
 
 	})
 }

--- a/internal/storage/db_filter_test.go
+++ b/internal/storage/db_filter_test.go
@@ -517,6 +517,10 @@ func TestListReposWithReviewCountsByBranch(t *testing.T) {
 
 	repo1 := createRepo(t, db, "/tmp/repo1")
 	repo2 := createRepo(t, db, "/tmp/repo2")
+	repo1Identity := "https://github.com/test/repo1.git"
+	repo2Identity := "https://github.com/test/repo2.git"
+	require.NoError(t, db.SetRepoIdentity(repo1.ID, repo1Identity))
+	require.NoError(t, db.SetRepoIdentity(repo2.ID, repo2Identity))
 
 	commit1 := createCommit(t, db, repo1.ID, "abc123")
 	commit2 := createCommit(t, db, repo1.ID, "def456")
@@ -536,6 +540,12 @@ func TestListReposWithReviewCountsByBranch(t *testing.T) {
 
 		assert.Len(t, repos, 2)
 		assert.Equal(t, 2, totalCount)
+		identities := map[string]string{}
+		for _, repo := range repos {
+			identities[repo.Name] = repo.Identity
+		}
+		assert.Equal(t, repo1Identity, identities["repo1"])
+		assert.Equal(t, repo2Identity, identities["repo2"])
 	})
 
 	t.Run("filter by feature branch", func(t *testing.T) {
@@ -544,6 +554,7 @@ func TestListReposWithReviewCountsByBranch(t *testing.T) {
 
 		assert.Len(t, repos, 1)
 		assert.Equal(t, 1, totalCount)
+		assert.Equal(t, repo1Identity, repos[0].Identity)
 	})
 
 	t.Run("filter by (none) branch", func(t *testing.T) {

--- a/internal/storage/db_migration_test.go
+++ b/internal/storage/db_migration_test.go
@@ -318,6 +318,86 @@ func TestMigrationFromOldSchema(t *testing.T) {
 	}
 }
 
+func TestMigrationNormalizesWindowsRepoRootPathConflicts(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "paths.db")
+	db, err := Open(dbPath)
+	require.NoError(t, err)
+
+	const (
+		sourceRepoID   = int64(1)
+		targetRepoID   = int64(2)
+		sourceCommitID = int64(10)
+		targetCommitID = int64(20)
+		sourceJobID    = int64(100)
+		targetJobID    = int64(200)
+	)
+	_, err = db.Exec(`
+		INSERT INTO repos (id, root_path, name, identity)
+		VALUES
+			(?, 'C:\Users\dev\workspace\repo', 'repo', 'https://github.com/test/repo.git'),
+			(?, 'C:/Users/dev/workspace/repo', 'repo', NULL)
+	`, sourceRepoID, targetRepoID)
+	require.NoError(t, err)
+	_, err = db.Exec(`
+		INSERT INTO commits (id, repo_id, sha, author, subject, timestamp)
+		VALUES
+			(?, ?, 'abc123', 'A', 'source commit', '2024-01-01T00:00:00Z'),
+			(?, ?, 'abc123', 'A', 'target commit', '2024-01-01T00:00:00Z')
+	`, sourceCommitID, sourceRepoID, targetCommitID, targetRepoID)
+	require.NoError(t, err)
+	_, err = db.Exec(`
+		INSERT INTO review_jobs (id, repo_id, commit_id, git_ref, agent, status, review_type, source)
+		VALUES
+			(?, ?, ?, 'abc123', 'codex', 'done', 'design', 'auto_design'),
+			(?, ?, ?, 'abc123', 'codex', 'done', 'design', 'auto_design')
+	`, sourceJobID, sourceRepoID, sourceCommitID, targetJobID, targetRepoID, targetCommitID)
+	require.NoError(t, err)
+	_, err = db.Exec(`
+		INSERT INTO responses (id, commit_id, job_id, responder, response)
+		VALUES (1, ?, ?, 'codex', 'source response')
+	`, sourceCommitID, sourceJobID)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	db, err = Open(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo, err := db.GetRepoByPath(`C:\Users\dev\workspace\repo`)
+	require.NoError(t, err)
+	assert.Equal(t, targetRepoID, repo.ID)
+	assert.Equal(t, "C:/Users/dev/workspace/repo", repo.RootPath)
+
+	var identity string
+	err = db.QueryRow(`SELECT COALESCE(identity, '') FROM repos WHERE id = ?`, targetRepoID).Scan(&identity)
+	require.NoError(t, err)
+	assert.Equal(t, "https://github.com/test/repo.git", identity)
+
+	var repoCount int
+	err = db.QueryRow(`SELECT COUNT(*) FROM repos WHERE root_path IN (?, ?)`,
+		`C:\Users\dev\workspace\repo`, `C:/Users/dev/workspace/repo`).Scan(&repoCount)
+	require.NoError(t, err)
+	assert.Equal(t, 1, repoCount)
+
+	var sourceJobRepoID, sourceJobCommitID int64
+	err = db.QueryRow(`SELECT repo_id, commit_id FROM review_jobs WHERE id = ?`, sourceJobID).
+		Scan(&sourceJobRepoID, &sourceJobCommitID)
+	require.NoError(t, err)
+	assert.Equal(t, targetRepoID, sourceJobRepoID)
+	assert.Equal(t, targetCommitID, sourceJobCommitID)
+
+	var sourceCommitCount int
+	err = db.QueryRow(`SELECT COUNT(*) FROM commits WHERE id = ?`, sourceCommitID).
+		Scan(&sourceCommitCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, sourceCommitCount)
+
+	var responseCommitID int64
+	err = db.QueryRow(`SELECT commit_id FROM responses WHERE id = 1`).Scan(&responseCommitID)
+	require.NoError(t, err)
+	assert.Equal(t, targetCommitID, responseCommitID)
+}
+
 func TestMigrationAddsVerdictBoolColumn(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -734,7 +734,7 @@ func WithRepoPrefix(prefix string) ListJobsOption {
 	return func(o *listJobsOptions) {
 		// Trim trailing slash so LIKE "prefix/%"  doesn't become "prefix//%".
 		// Root prefix "/" trims to "" which disables the filter (all repos match).
-		o.repoPrefix = escapeLike(strings.TrimRight(prefix, "/"))
+		o.repoPrefix = escapeLike(normalizeRepoPathPrefix(prefix))
 	}
 }
 

--- a/internal/storage/repos.go
+++ b/internal/storage/repos.go
@@ -315,6 +315,43 @@ func (db *DB) RenameRepo(identifier, newName string) (int64, error) {
 	return affected, nil
 }
 
+// ErrRepoPathConflict is returned when MoveRepo would create a duplicate root_path.
+var ErrRepoPathConflict = errors.New("a different repository already has the target path; use 'roborev repo merge' instead")
+
+// MoveRepo updates the root_path of an existing repo. The newPath is normalized
+// to an absolute path with forward slashes. Optionally updates the identity if
+// newIdentity is non-empty.
+//
+// Returns ErrRepoPathConflict if another repo (different ID) already has the
+// target path - users should `repo merge` in that case.
+func (db *DB) MoveRepo(repoID int64, newPath, newIdentity string) error {
+	absPath, err := filepath.Abs(newPath)
+	if err != nil {
+		return fmt.Errorf("resolve new path: %w", err)
+	}
+	absPath = filepath.ToSlash(absPath)
+
+	// Detect conflict: another repo already at this path
+	var existingID int64
+	err = db.QueryRow(`SELECT id FROM repos WHERE root_path = ?`, absPath).Scan(&existingID)
+	if err == nil && existingID != repoID {
+		return ErrRepoPathConflict
+	}
+	if err != nil && err != sql.ErrNoRows {
+		return fmt.Errorf("check path conflict: %w", err)
+	}
+
+	if newIdentity != "" {
+		_, err = db.Exec(`UPDATE repos SET root_path = ?, identity = ? WHERE id = ?`, absPath, newIdentity, repoID)
+	} else {
+		_, err = db.Exec(`UPDATE repos SET root_path = ? WHERE id = ?`, absPath, repoID)
+	}
+	if err != nil {
+		return fmt.Errorf("update repo path: %w", err)
+	}
+	return nil
+}
+
 // ListRepos returns all repos in the database
 func (db *DB) ListRepos() ([]Repo, error) {
 	rows, err := db.Query(`SELECT id, root_path, name, created_at FROM repos ORDER BY name`)

--- a/internal/storage/repos.go
+++ b/internal/storage/repos.go
@@ -12,7 +12,7 @@ import (
 
 func normalizeRepoPath(rootPath string) (string, error) {
 	if isWindowsAbsPath(rootPath) {
-		return strings.ReplaceAll(rootPath, `\`, "/"), nil
+		return normalizeStoredRepoPath(rootPath), nil
 	}
 
 	absPath, err := filepath.Abs(rootPath)
@@ -20,6 +20,13 @@ func normalizeRepoPath(rootPath string) (string, error) {
 		return "", err
 	}
 	return filepath.ToSlash(absPath), nil
+}
+
+func normalizeStoredRepoPath(rootPath string) string {
+	if isWindowsAbsPath(rootPath) {
+		return strings.ReplaceAll(rootPath, `\`, "/")
+	}
+	return rootPath
 }
 
 func normalizeRepoPathBestEffort(rootPath string) string {

--- a/internal/storage/repos.go
+++ b/internal/storage/repos.go
@@ -111,6 +111,7 @@ func (db *DB) GetRepoByPath(rootPath string) (*Repo, error) {
 type RepoWithCount struct {
 	Name     string `json:"name"`
 	RootPath string `json:"root_path"`
+	Identity string `json:"identity,omitempty"`
 	Count    int    `json:"count"`
 }
 
@@ -151,7 +152,7 @@ func (db *DB) ListReposWithReviewCounts(opts ...ListReposOption) ([]RepoWithCoun
 	}
 
 	query := fmt.Sprintf(`
-		SELECT r.name, r.root_path, COUNT(rj.id) as job_count
+		SELECT r.name, r.root_path, COALESCE(r.identity, ''), COUNT(rj.id) as job_count
 		FROM repos r
 		%s JOIN review_jobs rj ON rj.repo_id = r.id
 	`, joinType)
@@ -200,7 +201,7 @@ func (db *DB) ListReposWithReviewCounts(opts ...ListReposOption) ([]RepoWithCoun
 	totalCount := 0
 	for rows.Next() {
 		var rc RepoWithCount
-		if err := rows.Scan(&rc.Name, &rc.RootPath, &rc.Count); err != nil {
+		if err := rows.Scan(&rc.Name, &rc.RootPath, &rc.Identity, &rc.Count); err != nil {
 			return nil, 0, err
 		}
 		repos = append(repos, rc)

--- a/internal/storage/repos.go
+++ b/internal/storage/repos.go
@@ -10,16 +10,53 @@ import (
 	"strings"
 )
 
+func normalizeRepoPath(rootPath string) (string, error) {
+	if isWindowsAbsPath(rootPath) {
+		return strings.ReplaceAll(rootPath, `\`, "/"), nil
+	}
+
+	absPath, err := filepath.Abs(rootPath)
+	if err != nil {
+		return "", err
+	}
+	return filepath.ToSlash(absPath), nil
+}
+
+func normalizeRepoPathBestEffort(rootPath string) string {
+	normalized, err := normalizeRepoPath(rootPath)
+	if err == nil {
+		return normalized
+	}
+	if isWindowsAbsPath(rootPath) {
+		return strings.ReplaceAll(rootPath, `\`, "/")
+	}
+	return filepath.ToSlash(rootPath)
+}
+
+func normalizeRepoPathPrefix(prefix string) string {
+	if prefix == "" {
+		return ""
+	}
+	return strings.TrimRight(normalizeRepoPathBestEffort(prefix), "/")
+}
+
+func isWindowsAbsPath(p string) bool {
+	return len(p) >= 3 && isASCIIAlpha(p[0]) && p[1] == ':' && (p[2] == '\\' || p[2] == '/')
+}
+
+func isASCIIAlpha(b byte) bool {
+	return (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z')
+}
+
 // GetOrCreateRepo finds or creates a repo by its root path.
 // If identity is provided, it will be stored; otherwise the identity field remains NULL.
 func (db *DB) GetOrCreateRepo(rootPath string, identity ...string) (*Repo, error) {
 	// Normalize path to forward slashes for consistent storage
 	// across platforms (LIKE queries use '/' as separator).
-	absPath, err := filepath.Abs(rootPath)
+	absPath, err := normalizeRepoPath(rootPath)
 	if err != nil {
 		return nil, err
 	}
-	absPath = filepath.ToSlash(absPath)
 
 	// Extract optional identity
 	var repoIdentity string
@@ -90,11 +127,10 @@ func (db *DB) GetOrCreateRepo(rootPath string, identity ...string) (*Repo, error
 
 // GetRepoByPath returns a repo by its path
 func (db *DB) GetRepoByPath(rootPath string) (*Repo, error) {
-	absPath, err := filepath.Abs(rootPath)
+	absPath, err := normalizeRepoPath(rootPath)
 	if err != nil {
 		return nil, err
 	}
-	absPath = filepath.ToSlash(absPath)
 
 	var repo Repo
 	var createdAt string
@@ -126,7 +162,7 @@ type listReposOptions struct {
 // WithRepoPathPrefix filters repos whose root_path starts with the given prefix.
 func WithRepoPathPrefix(prefix string) ListReposOption {
 	return func(o *listReposOptions) {
-		o.prefix = strings.TrimRight(prefix, "/")
+		o.prefix = normalizeRepoPathPrefix(prefix)
 	}
 }
 
@@ -294,25 +330,26 @@ func (db *DB) ListBranchesWithCounts(repoPaths []string) (*BranchListResult, err
 // RenameRepo updates the display name of a repo identified by its path or current name
 func (db *DB) RenameRepo(identifier, newName string) (int64, error) {
 	// Try to match by root_path first (absolute or relative), then by name
-	absPath, _ := filepath.Abs(identifier)
-	absPath = filepath.ToSlash(absPath)
+	absPath, pathErr := normalizeRepoPath(identifier)
 
 	// Try path match first
-	result, err := db.Exec(`UPDATE repos SET name = ? WHERE root_path = ?`, newName, absPath)
+	if pathErr == nil {
+		result, err := db.Exec(`UPDATE repos SET name = ? WHERE root_path = ?`, newName, absPath)
+		if err != nil {
+			return 0, err
+		}
+		affected, _ := result.RowsAffected()
+		if affected > 0 {
+			return affected, nil
+		}
+	}
+
+	// Try name match
+	result, err := db.Exec(`UPDATE repos SET name = ? WHERE name = ?`, newName, identifier)
 	if err != nil {
 		return 0, err
 	}
 	affected, _ := result.RowsAffected()
-	if affected > 0 {
-		return affected, nil
-	}
-
-	// Try name match
-	result, err = db.Exec(`UPDATE repos SET name = ? WHERE name = ?`, newName, identifier)
-	if err != nil {
-		return 0, err
-	}
-	affected, _ = result.RowsAffected()
 	return affected, nil
 }
 
@@ -326,11 +363,10 @@ var ErrRepoPathConflict = errors.New("a different repository already has the tar
 // Returns ErrRepoPathConflict if another repo (different ID) already has the
 // target path - users should `repo merge` in that case.
 func (db *DB) MoveRepo(repoID int64, newPath, newIdentity string) error {
-	absPath, err := filepath.Abs(newPath)
+	absPath, err := normalizeRepoPath(newPath)
 	if err != nil {
 		return fmt.Errorf("resolve new path: %w", err)
 	}
-	absPath = filepath.ToSlash(absPath)
 
 	// Detect conflict: another repo already at this path
 	var existingID int64
@@ -403,8 +439,7 @@ func (db *DB) GetRepoByName(name string) (*Repo, error) {
 // FindRepo finds a repo by path or name (tries path first, then name)
 func (db *DB) FindRepo(identifier string) (*Repo, error) {
 	// Try by path first
-	absPath, _ := filepath.Abs(identifier)
-	repo, err := db.GetRepoByPath(absPath)
+	repo, err := db.GetRepoByPath(identifier)
 	if err == nil {
 		return repo, nil
 	}

--- a/internal/storage/repos_test.go
+++ b/internal/storage/repos_test.go
@@ -303,6 +303,88 @@ func TestRenameRepo(t *testing.T) {
 	})
 }
 
+func TestMoveRepo(t *testing.T) {
+	t.Run("updates root_path", func(t *testing.T) {
+		db, repo := setupDBAndRepo(t, "move-test")
+		newPath := filepath.Join(t.TempDir(), "new-location")
+
+		err := db.MoveRepo(repo.ID, newPath, "")
+		require.NoError(t, err)
+
+		updated, err := db.GetRepoByID(repo.ID)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.ToSlash(newPath), updated.RootPath)
+	})
+
+	t.Run("updates identity when provided", func(t *testing.T) {
+		db, repo := setupDBAndRepo(t, "move-identity-test")
+		newPath := filepath.Join(t.TempDir(), "new-location")
+		newIdentity := "local://" + filepath.ToSlash(newPath)
+
+		err := db.MoveRepo(repo.ID, newPath, newIdentity)
+		require.NoError(t, err)
+
+		updated, err := db.GetRepoByID(repo.ID)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.ToSlash(newPath), updated.RootPath)
+
+		// Verify identity was updated
+		fetched, err := db.GetRepoByIdentity(newIdentity)
+		require.NoError(t, err)
+		require.NotNil(t, fetched)
+		assert.Equal(t, repo.ID, fetched.ID)
+	})
+
+	t.Run("preserves jobs after move", func(t *testing.T) {
+		db, repo := setupDBAndRepo(t, "move-jobs-test")
+		commit := createCommit(t, db, repo.ID, "abc123")
+		_ = commit
+
+		// Verify a job exists for this repo
+		var beforeCount int
+		err := db.QueryRow(`SELECT COUNT(*) FROM commits WHERE repo_id = ?`, repo.ID).Scan(&beforeCount)
+		require.NoError(t, err)
+		assert.Equal(t, 1, beforeCount)
+
+		newPath := filepath.Join(t.TempDir(), "moved-repo")
+		err = db.MoveRepo(repo.ID, newPath, "")
+		require.NoError(t, err)
+
+		// Commits remain associated by repo_id
+		var afterCount int
+		err = db.QueryRow(`SELECT COUNT(*) FROM commits WHERE repo_id = ?`, repo.ID).Scan(&afterCount)
+		require.NoError(t, err)
+		assert.Equal(t, 1, afterCount)
+	})
+
+	t.Run("returns ErrRepoPathConflict when another repo has the target path", func(t *testing.T) {
+		db := openTestDB(t)
+		t.Cleanup(func() { db.Close() })
+
+		repoA := createRepo(t, db, filepath.Join(t.TempDir(), "repo-a"))
+		repoB := createRepo(t, db, filepath.Join(t.TempDir(), "repo-b"))
+
+		err := db.MoveRepo(repoA.ID, repoB.RootPath, "")
+		require.ErrorIs(t, err, ErrRepoPathConflict)
+
+		// Verify repo-a was not modified
+		unchanged, err := db.GetRepoByID(repoA.ID)
+		require.NoError(t, err)
+		assert.Equal(t, repoA.RootPath, unchanged.RootPath)
+	})
+
+	t.Run("moving to same path is a no-op", func(t *testing.T) {
+		db, repo := setupDBAndRepo(t, "move-same-path-test")
+
+		err := db.MoveRepo(repo.ID, repo.RootPath, "")
+		require.NoError(t, err)
+
+		updated, err := db.GetRepoByID(repo.ID)
+		require.NoError(t, err)
+		assert.Equal(t, repo.RootPath, updated.RootPath)
+	})
+}
+
 func TestListRepos(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()

--- a/internal/storage/repos_test.go
+++ b/internal/storage/repos_test.go
@@ -303,6 +303,25 @@ func TestRenameRepo(t *testing.T) {
 	})
 }
 
+func TestListReposWithReviewCountsIncludesIdentity(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	identity := "https://github.com/test/renamed-repo.git"
+	repo, err := db.GetOrCreateRepo(
+		filepath.Join(t.TempDir(), "renamed-repo"),
+		identity,
+	)
+	require.NoError(t, err)
+
+	repos, _, err := db.ListReposWithReviewCounts()
+	require.NoError(t, err)
+	require.Len(t, repos, 1)
+
+	assert.Equal(t, repo.RootPath, repos[0].RootPath)
+	assert.Equal(t, identity, repos[0].Identity)
+}
+
 func TestMoveRepo(t *testing.T) {
 	t.Run("updates root_path", func(t *testing.T) {
 		db, repo := setupDBAndRepo(t, "move-test")

--- a/internal/storage/repos_test.go
+++ b/internal/storage/repos_test.go
@@ -392,6 +392,26 @@ func TestMoveRepo(t *testing.T) {
 		assert.Equal(t, repoA.RootPath, unchanged.RootPath)
 	})
 
+	t.Run("returns ErrRepoPathConflict for normalized Windows target path", func(t *testing.T) {
+		db := openTestDB(t)
+		t.Cleanup(func() { db.Close() })
+
+		repoA := createRepo(t, db, filepath.Join(t.TempDir(), "repo-a"))
+		_, err := db.Exec(
+			`INSERT INTO repos (root_path, name) VALUES (?, ?)`,
+			`C:/Users/dev/workspace/repo-b`,
+			"repo-b",
+		)
+		require.NoError(t, err)
+
+		err = db.MoveRepo(repoA.ID, `C:\Users\dev\workspace\repo-b`, "")
+		require.ErrorIs(t, err, ErrRepoPathConflict)
+
+		unchanged, err := db.GetRepoByID(repoA.ID)
+		require.NoError(t, err)
+		assert.Equal(t, repoA.RootPath, unchanged.RootPath)
+	})
+
 	t.Run("moving to same path is a no-op", func(t *testing.T) {
 		db, repo := setupDBAndRepo(t, "move-same-path-test")
 


### PR DESCRIPTION
## Summary
- Add `repo move` so stored repo root paths can be updated after directory moves while preserving existing jobs/reviews.
- Reconcile TUI `auto_filter_repo` through repo display names and repo identities so renamed/moved repos keep showing existing reviews.
- Render repo filter labels from the stored display name and add regression coverage for renamed repos and identity fallback.

## Test Plan
- [x] `go test ./...`
- [x] pre-commit `golangci-lint` hook passed on commit
