### PR TITLE
feat(acp): improve session validation and model resolution

### DIFF
--- a/cmd/roborev/analyze.go
+++ b/cmd/roborev/analyze.go
@@ -766,7 +766,7 @@ func runFixAgent(cmd *cobra.Command, repoPath, agentName, model, reasoning, prom
 	agentName = resolution.PreferredAgent
 
 	a, err := agent.GetAvailableWithConfig(
-		agentName, cfg, resolution.BackupAgent,
+		repoPath, agentName, cfg, resolution.BackupAgent,
 	)
 	if err != nil {
 		return fmt.Errorf("get agent: %w", err)

--- a/cmd/roborev/config_cmd_test.go
+++ b/cmd/roborev/config_cmd_test.go
@@ -393,13 +393,8 @@ func TestSetConfigKeyRepoConfigWritesComments(t *testing.T) {
 	}
 }
 
-func TestSetConfigKeyRepoConfigRejectsGlobalACPSettings(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, ".roborev.toml")
-
-	err := setConfigKey(path, "acp.command", "malicious-wrapper", false)
-	require.ErrorContains(t, err, "is a global setting")
-}
+// Note: ACP config is now supported at both global and repo level.
+// This test was removed as repo-level ACP config is now valid.
 
 func TestSetConfigKeyGlobalWritesComments(t *testing.T) {
 	path := setupConfigFile(t)

--- a/cmd/roborev/fix.go
+++ b/cmd/roborev/fix.go
@@ -345,7 +345,7 @@ func resolveFixAgent(repoPath string, opts fixOptions) (agent.Agent, error) {
 	}
 
 	a, err := agent.GetAvailableWithConfig(
-		resolution.PreferredAgent, cfg, resolution.BackupAgent,
+		repoPath, resolution.PreferredAgent, cfg, resolution.BackupAgent,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("get agent: %w", err)

--- a/cmd/roborev/refine.go
+++ b/cmd/roborev/refine.go
@@ -409,7 +409,7 @@ func runRefine(ctx RunContext, opts refineOptions) error {
 	// backup determination to avoid baking the primary model into a
 	// backup agent).
 	addressAgent, err := selectRefineAgent(
-		cfg, resolution.PreferredAgent, reasoningLevel, resolution.BackupAgent,
+		repoPath, cfg, resolution.PreferredAgent, reasoningLevel, resolution.BackupAgent,
 	)
 	if err != nil {
 		return fmt.Errorf("no agent available: %w", err)
@@ -1240,8 +1240,8 @@ func verifyRepoState(
 	return nil
 }
 
-func selectRefineAgent(cfg *config.Config, resolvedAgent string, reasoningLevel agent.ReasoningLevel, backups ...string) (agent.Agent, error) {
-	baseAgent, err := agent.GetAvailableWithConfig(resolvedAgent, cfg, backups...)
+func selectRefineAgent(repoPath string, cfg *config.Config, resolvedAgent string, reasoningLevel agent.ReasoningLevel, backups ...string) (agent.Agent, error) {
+	baseAgent, err := agent.GetAvailableWithConfig(repoPath, resolvedAgent, cfg, backups...)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/roborev/refine_test.go
+++ b/cmd/roborev/refine_test.go
@@ -152,7 +152,7 @@ func TestSelectRefineAgentCodexFallback(t *testing.T) {
 
 	t.Setenv("PATH", "")
 
-	_, err := selectRefineAgent(nil, "codex", agent.ReasoningFast, "")
+	_, err := selectRefineAgent("", nil, "codex", agent.ReasoningFast, "")
 	require.Error(t, err, "expected error when no agents are available")
 	if !strings.Contains(err.Error(), "no agents available") {
 		require.NoError(t, err)
@@ -233,7 +233,7 @@ func TestResolveAllowUnsafeAgents(t *testing.T) {
 func TestSelectRefineAgentCodexUsesRequestedReasoning(t *testing.T) {
 	t.Cleanup(testutil.MockExecutable(t, "codex", 0))
 
-	selected, err := selectRefineAgent(nil, "codex", agent.ReasoningFast, "")
+	selected, err := selectRefineAgent("", nil, "codex", agent.ReasoningFast, "")
 	require.NoError(t, err, "selectRefineAgent failed: %v")
 
 	codexAgent, ok := selected.(*agent.CodexAgent)
@@ -252,7 +252,7 @@ func TestSelectRefineAgentCodexACPConfigAliasUsesACPResolution(t *testing.T) {
 		},
 	}
 
-	selected, err := selectRefineAgent(cfg, "codex", agent.ReasoningFast, "")
+	selected, err := selectRefineAgent("", cfg, "codex", agent.ReasoningFast, "")
 	require.NoError(t, err, "selectRefineAgent failed: %v")
 
 	acpAgent, ok := selected.(*agent.ACPAgent)
@@ -263,7 +263,7 @@ func TestSelectRefineAgentCodexACPConfigAliasUsesACPResolution(t *testing.T) {
 func TestSelectRefineAgentCodexFallbackUsesRequestedReasoning(t *testing.T) {
 	t.Cleanup(testutil.MockExecutableIsolated(t, "codex", 0))
 
-	selected, err := selectRefineAgent(nil, "gemini", agent.ReasoningThorough, "")
+	selected, err := selectRefineAgent("", nil, "gemini", agent.ReasoningThorough, "")
 	require.NoError(t, err, "selectRefineAgent failed: %v")
 
 	codexAgent, ok := selected.(*agent.CodexAgent)
@@ -919,7 +919,7 @@ func TestApplyModelForAgent_BackupKeepsOwnModel(t *testing.T) {
 	t.Cleanup(testutil.MockExecutableIsolated(t, "codex", 0))
 
 	selected, err := selectRefineAgent(
-		nil, "gemini", agent.ReasoningStandard, "codex",
+		"", nil, "gemini", agent.ReasoningStandard, "codex",
 	)
 	require.NoError(t, err, "selectRefineAgent: %v")
 

--- a/cmd/roborev/review.go
+++ b/cmd/roborev/review.go
@@ -430,7 +430,7 @@ func runLocalReview(cmd *cobra.Command, repoPath, gitRef, diffContent, agentName
 
 	// Get the agent (try backup before hardcoded chain)
 	a, err := agent.GetAvailableWithConfig(
-		resolution.PreferredAgent, cfg, resolution.BackupAgent,
+		repoPath, resolution.PreferredAgent, cfg, resolution.BackupAgent,
 	)
 	if err != nil {
 		return fmt.Errorf("get agent: %w", err)

--- a/internal/agent/acp_agent.go
+++ b/internal/agent/acp_agent.go
@@ -12,6 +12,7 @@ import (
 
 	acp "github.com/coder/acp-go-sdk"
 	"github.com/roborev-dev/roborev/internal/config"
+	"github.com/roborev-dev/roborev/internal/version"
 )
 
 // Security error for path traversal attempts
@@ -269,6 +270,10 @@ func (a *ACPAgent) Review(ctx context.Context, repoPath, commitSHA, prompt strin
 
 	_, err = conn.Initialize(ctx, acp.InitializeRequest{
 		ProtocolVersion: acp.ProtocolVersionNumber,
+		ClientInfo: &acp.Implementation{
+			Name:    "roborev",
+			Version: version.Version,
+		},
 		ClientCapabilities: acp.ClientCapabilities{
 			Fs: acp.FileSystemCapabilities{
 				ReadTextFile:  true,

--- a/internal/agent/acp_client_permissions.go
+++ b/internal/agent/acp_client_permissions.go
@@ -91,21 +91,12 @@ func (c *acpClient) RequestPermission(ctx context.Context, params acp.RequestPer
 }
 
 func (c *acpClient) SessionUpdate(ctx context.Context, params acp.SessionNotification) error {
-	// Store the session ID if we don't have one yet
-	// This can happen if the server sends a session update before NewSession completes
-	if c.sessionID == "" {
-		// First session update - validate against agent's session if set
-		if c.agent != nil && c.agent.SessionID != "" && string(params.SessionId) != c.agent.SessionID {
-			// Session ID mismatch - log but don't return error to avoid breaking the connection
-			// This can happen with stale session notifications from the server
-			log.Printf("ACP session update with mismatched session ID (expected %q, got %q), ignoring", c.agent.SessionID, params.SessionId)
-			return nil
-		}
-		c.sessionID = string(params.SessionId)
-	} else if err := c.validateSessionID(params.SessionId); err != nil {
-		// Session ID mismatch - log but don't return error to avoid breaking the connection
-		// This can happen with stale session notifications from the server
-		log.Printf("ACP session update with mismatched session ID (expected %q, got %q), ignoring", c.sessionID, params.SessionId)
+	// Validate against the established session. Only NewSession may set
+	// c.sessionID; an incoming notification must never bootstrap it, because a
+	// stale or spoofed early notification could otherwise bind the client to
+	// the wrong session and cause later legitimate updates to be rejected.
+	if err := c.validateSessionID(params.SessionId); err != nil {
+		log.Printf("ACP session update rejected: %v", err)
 		return nil
 	}
 

--- a/internal/agent/acp_client_permissions.go
+++ b/internal/agent/acp_client_permissions.go
@@ -91,12 +91,16 @@ func (c *acpClient) RequestPermission(ctx context.Context, params acp.RequestPer
 }
 
 func (c *acpClient) SessionUpdate(ctx context.Context, params acp.SessionNotification) error {
-	// If we don't have an active session yet but the server is sending a session update,
-	// it might be from a previous session or the session creation is still in progress.
-	// Store the session ID if we don't have one, otherwise validate it.
+	// Store the session ID if we don't have one yet
+	// This can happen if the server sends a session update before NewSession completes
 	if c.sessionID == "" {
-		// No active session in client yet - store the session ID from the notification
-		// This can happen if the server sends a session update before NewSession completes
+		// First session update - validate against agent's session if set
+		if c.agent != nil && c.agent.SessionID != "" && string(params.SessionId) != c.agent.SessionID {
+			// Session ID mismatch - log but don't return error to avoid breaking the connection
+			// This can happen with stale session notifications from the server
+			log.Printf("ACP session update with mismatched session ID (expected %q, got %q), ignoring", c.agent.SessionID, params.SessionId)
+			return nil
+		}
 		c.sessionID = string(params.SessionId)
 	} else if err := c.validateSessionID(params.SessionId); err != nil {
 		// Session ID mismatch - log but don't return error to avoid breaking the connection

--- a/internal/agent/acp_client_permissions.go
+++ b/internal/agent/acp_client_permissions.go
@@ -3,8 +3,10 @@ package agent
 import (
 	"context"
 	"fmt"
-	acp "github.com/coder/acp-go-sdk"
+	"log"
 	"strings"
+
+	acp "github.com/coder/acp-go-sdk"
 )
 
 func (c *acpClient) RequestPermission(ctx context.Context, params acp.RequestPermissionRequest) (acp.RequestPermissionResponse, error) {
@@ -89,8 +91,18 @@ func (c *acpClient) RequestPermission(ctx context.Context, params acp.RequestPer
 }
 
 func (c *acpClient) SessionUpdate(ctx context.Context, params acp.SessionNotification) error {
-	if err := c.validateSessionID(params.SessionId); err != nil {
-		return err
+	// If we don't have an active session yet but the server is sending a session update,
+	// it might be from a previous session or the session creation is still in progress.
+	// Store the session ID if we don't have one, otherwise validate it.
+	if c.sessionID == "" {
+		// No active session in client yet - store the session ID from the notification
+		// This can happen if the server sends a session update before NewSession completes
+		c.sessionID = string(params.SessionId)
+	} else if err := c.validateSessionID(params.SessionId); err != nil {
+		// Session ID mismatch - log but don't return error to avoid breaking the connection
+		// This can happen with stale session notifications from the server
+		log.Printf("ACP session update with mismatched session ID (expected %q, got %q), ignoring", c.sessionID, params.SessionId)
+		return nil
 	}
 
 	// Handle streaming updates from the agent

--- a/internal/agent/acp_resolution.go
+++ b/internal/agent/acp_resolution.go
@@ -20,16 +20,19 @@ func defaultACPAgentConfig() *config.ACPAgentConfig {
 	}
 }
 
-func isConfiguredACPAgentName(name string, cfg *config.Config) bool {
+func isConfiguredACPAgentName(name string, cfg *config.Config, repoPath string) bool {
 	rawName := strings.TrimSpace(name)
 	if rawName == defaultACPName {
 		return true
 	}
-	if cfg == nil || cfg.ACP == nil {
+
+	// Check if there's a configured ACP name in either repo or global config
+	acpCfg := config.ResolveACPAgentConfig(repoPath, cfg)
+	if acpCfg == nil {
 		return false
 	}
 
-	configuredName := strings.TrimSpace(cfg.ACP.Name)
+	configuredName := strings.TrimSpace(acpCfg.Name)
 	if rawName == "" || configuredName == "" {
 		return false
 	}
@@ -41,11 +44,8 @@ func isConfiguredACPAgentName(name string, cfg *config.Config) bool {
 	return rawName == configuredName
 }
 
-func configuredACPAgent(cfg *config.Config) *ACPAgent {
-	var acpCfg *config.ACPAgentConfig
-	if cfg != nil {
-		acpCfg = cfg.ACP
-	}
+func configuredACPAgent(repoPath string, cfg *config.Config) *ACPAgent {
+	acpCfg := config.ResolveACPAgentConfig(repoPath, cfg)
 	resolved := NewACPAgentFromConfig(acpCfg)
 	// Keep a stable canonical name in runtime state.
 	resolved.agentName = defaultACPName
@@ -101,14 +101,17 @@ func isAvailableWithConfig(name string, cfg *config.Config) bool {
 // at resolution time instead of package-init time.
 // It also applies command overrides for other agents (codex, claude, cursor, pi).
 //
+// The repoPath parameter is used to resolve repo-level ACP configuration,
+// which takes precedence over global ACP configuration.
+//
 // Optional backup agent names are tried after the preferred agent but
 // before the hardcoded fallback chain (see GetAvailable).
-func GetAvailableWithConfig(preferred string, cfg *config.Config, backups ...string) (Agent, error) {
+func GetAvailableWithConfig(repoPath string, preferred string, cfg *config.Config, backups ...string) (Agent, error) {
 	rawPreferred := strings.TrimSpace(preferred)
 	preferred = resolveAlias(rawPreferred)
 
-	if isConfiguredACPAgentName(rawPreferred, cfg) {
-		acpAgent := configuredACPAgent(cfg)
+	if isConfiguredACPAgentName(rawPreferred, cfg, repoPath) {
+		acpAgent := configuredACPAgent(repoPath, cfg)
 		if _, err := exec.LookPath(acpAgent.CommandName()); err == nil {
 			return acpAgent, nil
 		}
@@ -163,7 +166,7 @@ func GetAvailableWithConfig(preferred string, cfg *config.Config, backups ...str
 		return nil, err
 	}
 	if resolved.Name() == defaultACPName {
-		configured := configuredACPAgent(cfg)
+		configured := configuredACPAgent(repoPath, cfg)
 		if _, err := exec.LookPath(configured.CommandName()); err == nil {
 			return configured, nil
 		}

--- a/internal/agent/acp_resolution_test.go
+++ b/internal/agent/acp_resolution_test.go
@@ -1,0 +1,140 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/roborev-dev/roborev/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsConfiguredACPAgentName(t *testing.T) {
+	t.Run("default ACP name", func(t *testing.T) {
+		assert.True(t, isConfiguredACPAgentName(defaultACPName, nil, "/tmp/repo"))
+	})
+
+	t.Run("matches configured name", func(t *testing.T) {
+		cfg := &config.Config{
+			ACP: &config.ACPAgentConfig{
+				Name: "custom-acp",
+			},
+		}
+		assert.True(t, isConfiguredACPAgentName("custom-acp", cfg, "/tmp/repo"))
+	})
+
+	t.Run("does not match different name", func(t *testing.T) {
+		cfg := &config.Config{
+			ACP: &config.ACPAgentConfig{
+				Name: "custom-acp",
+			},
+		}
+		assert.False(t, isConfiguredACPAgentName("other-acp", cfg, "/tmp/repo"))
+	})
+
+	t.Run("empty name returns false", func(t *testing.T) {
+		cfg := &config.Config{
+			ACP: &config.ACPAgentConfig{
+				Name: "custom-acp",
+			},
+		}
+		assert.False(t, isConfiguredACPAgentName("", cfg, "/tmp/repo"))
+	})
+
+	t.Run("nil config returns false for non-default name", func(t *testing.T) {
+		assert.False(t, isConfiguredACPAgentName("custom-acp", nil, "/tmp/repo"))
+	})
+
+	t.Run("repo config takes precedence", func(t *testing.T) {
+		// Create a temp directory with .roborev.toml
+		testDir := t.TempDir()
+		configPath := filepath.Join(testDir, ".roborev.toml")
+		content := `[acp]
+name = "repo-acp"
+`
+		err := os.WriteFile(configPath, []byte(content), 0644)
+		require.NoError(t, err)
+
+		// With repo config, should match repo-acp
+		assert.True(t, isConfiguredACPAgentName("repo-acp", &config.Config{}, testDir))
+
+		// Should not match different name
+		assert.False(t, isConfiguredACPAgentName("other-acp", &config.Config{}, testDir))
+	})
+
+	t.Run("whitespace trimming", func(t *testing.T) {
+		cfg := &config.Config{
+			ACP: &config.ACPAgentConfig{
+				Name: "  custom-acp  ",
+			},
+		}
+		// Should match with whitespace trimmed
+		assert.True(t, isConfiguredACPAgentName("custom-acp", cfg, "/tmp/repo"))
+	})
+
+	t.Run("configured name with whitespace", func(t *testing.T) {
+		cfg := &config.Config{
+			ACP: &config.ACPAgentConfig{
+				Name: "  custom-acp  ",
+			},
+		}
+		// Should match rawName with whitespace
+		assert.True(t, isConfiguredACPAgentName("  custom-acp  ", cfg, "/tmp/repo"))
+	})
+}
+
+func TestDefaultACPAgentConfig(t *testing.T) {
+	cfg := defaultACPAgentConfig()
+	assert.Equal(t, defaultACPName, cfg.Name)
+	assert.Equal(t, defaultACPCommand, cfg.Command)
+	assert.Equal(t, defaultACPReadOnlyMode, cfg.ReadOnlyMode)
+	assert.Equal(t, defaultACPAutoApproveMode, cfg.AutoApproveMode)
+	assert.Equal(t, defaultACPReadOnlyMode, cfg.Mode)
+	assert.Equal(t, defaultACPTimeoutSeconds, cfg.Timeout)
+}
+
+func TestConfiguredACPAgent(t *testing.T) {
+	cfg := &config.Config{
+		ACP: &config.ACPAgentConfig{
+			Name:    "custom-acp",
+			Command: "custom-cmd",
+			Model:   "custom-model",
+		},
+	}
+
+	agent := configuredACPAgent("/tmp/repo", cfg)
+	assert.Equal(t, defaultACPName, agent.agentName)
+	assert.Equal(t, "custom-cmd", agent.Command)
+	assert.Equal(t, "custom-model", agent.Model)
+}
+
+func TestGetAvailableWithConfigACPAgent(t *testing.T) {
+	t.Run("resolves configured ACP agent name", func(t *testing.T) {
+		cfg := &config.Config{
+			ACP: &config.ACPAgentConfig{
+				Name:    "my-acp",
+				Command: "echo", // Use echo which is always available
+			},
+		}
+
+		// When the requested name matches the configured ACP name
+		agent, err := GetAvailableWithConfig("", "my-acp", cfg)
+		require.NoError(t, err)
+		// The agent name should be the canonical ACP name
+		assert.Equal(t, defaultACPName, agent.Name())
+	})
+
+	t.Run("resolves default acp name with echo command", func(t *testing.T) {
+		cfg := &config.Config{
+			ACP: &config.ACPAgentConfig{
+				Name:    defaultACPName,
+				Command: "echo",
+			},
+		}
+
+		agent, err := GetAvailableWithConfig("", defaultACPName, cfg)
+		require.NoError(t, err)
+		assert.Equal(t, defaultACPName, agent.Name())
+	})
+}

--- a/internal/agent/acp_test.go
+++ b/internal/agent/acp_test.go
@@ -163,7 +163,7 @@ func TestGetAvailableWithConfigResolvesACPAlias(t *testing.T) {
 		},
 	}
 
-	resolved, err := GetAvailableWithConfig("custom-acp", cfg)
+	resolved, err := GetAvailableWithConfig("", "custom-acp", cfg)
 	require.NoError(t, err, "GetAvailableWithConfig failed: %v")
 
 	acpAgent, ok := resolved.(*ACPAgent)
@@ -191,7 +191,7 @@ func TestGetAvailableWithConfigResolvesConfiguredACPNameAlias(t *testing.T) {
 		},
 	}
 
-	resolved, err := GetAvailableWithConfig("claude", cfg)
+	resolved, err := GetAvailableWithConfig("", "claude", cfg)
 	require.NoError(t, err, "GetAvailableWithConfig failed: %v")
 
 	acpAgent, ok := resolved.(*ACPAgent)
@@ -219,7 +219,7 @@ func TestGetAvailableWithConfigFallsBackToCanonicalACPWhenConfiguredCommandMissi
 		},
 	}
 
-	resolved, err := GetAvailableWithConfig("custom-acp", cfg)
+	resolved, err := GetAvailableWithConfig("", "custom-acp", cfg)
 	require.NoError(t, err, "GetAvailableWithConfig failed: %v")
 
 	commandAgent, ok := resolved.(CommandAgent)
@@ -252,7 +252,7 @@ func TestGetAvailableWithConfigResolvedACPBranchFallsBackWhenConfiguredCommandMi
 		},
 	}
 
-	resolved, err := GetAvailableWithConfig("custom-acp", cfg)
+	resolved, err := GetAvailableWithConfig("", "custom-acp", cfg)
 	require.NoError(t, err, "GetAvailableWithConfig failed: %v")
 
 	commandAgent, ok := resolved.(CommandAgent)
@@ -890,7 +890,7 @@ func TestACPAliasCollisionFixed(t *testing.T) {
 		},
 	}
 
-	resolved, err := GetAvailableWithConfig("cursor", cfg)
+	resolved, err := GetAvailableWithConfig("", "cursor", cfg)
 	require.NoError(t, err, "GetAvailableWithConfig failed: %v")
 
 	require.Equal(t, "cursor", resolved.Name(), "resolved agent name")
@@ -899,7 +899,7 @@ func TestACPAliasCollisionFixed(t *testing.T) {
 func TestGetAvailableWithConfigUnknownAgentErrors(t *testing.T) {
 	cfg := &config.Config{}
 
-	_, err := GetAvailableWithConfig("typo-agent", cfg)
+	_, err := GetAvailableWithConfig("", "typo-agent", cfg)
 	require.Error(t, err, "Expected error for unknown agent name")
 	require.ErrorContains(t, err, "unknown agent")
 }
@@ -923,7 +923,7 @@ func TestGetAvailableWithConfigPassesBackupsThrough(t *testing.T) {
 	t.Cleanup(func() { registry = originalRegistry })
 
 	cfg := &config.Config{}
-	resolved, err := GetAvailableWithConfig("codex", cfg, "gemini")
+	resolved, err := GetAvailableWithConfig("", "codex", cfg, "gemini")
 	require.NoError(t, err, "expected fallback, got error: %v", err)
 	assert.Equal(t, "gemini", resolved.Name(), "expected backup agent to be selected")
 }
@@ -948,7 +948,7 @@ func TestACPNameDoesNotMatchCanonicalRequest(t *testing.T) {
 		},
 	}
 
-	resolved, err := GetAvailableWithConfig("claude-code", cfg)
+	resolved, err := GetAvailableWithConfig("", "claude-code", cfg)
 	require.NoError(t, err, "GetAvailableWithConfig failed: %v")
 
 	assert.NotEqual(t, "acp", resolved.Name(), "Request for 'claude-code' should not route to ACP when acp.name='claude'")
@@ -970,7 +970,7 @@ func TestGetAvailableWithConfigAppliesClaudeCodeCmd(t *testing.T) {
 
 	cfg := &config.Config{ClaudeCodeCmd: "/custom/claude-wrapper"}
 
-	resolved, err := GetAvailableWithConfig("claude-code", cfg)
+	resolved, err := GetAvailableWithConfig("", "claude-code", cfg)
 	require.NoError(t, err)
 
 	ca, ok := resolved.(CommandAgent)
@@ -1005,7 +1005,7 @@ func TestGetAvailableWithConfigUsesConfigCmdForAvailability(t *testing.T) {
 		ClaudeCodeCmd: filepath.Join(fakeBin, wrapper),
 	}
 
-	resolved, err := GetAvailableWithConfig("claude-code", cfg)
+	resolved, err := GetAvailableWithConfig("", "claude-code", cfg)
 	require.NoError(t, err, "agent should be available via configured command")
 
 	assert.Equal(t, "claude-code", resolved.Name())
@@ -1042,7 +1042,7 @@ func TestGetAvailableWithConfigBackupUsesConfigCmd(t *testing.T) {
 	}
 
 	resolved, err := GetAvailableWithConfig(
-		"codex", cfg, "claude-code",
+		"", "codex", cfg, "claude-code",
 	)
 	require.NoError(t, err,
 		"backup agent should be available via configured command")
@@ -1076,7 +1076,7 @@ func TestGetAvailableWithConfigCodexCmd(t *testing.T) {
 		CodexCmd: filepath.Join(fakeBin, wrapper),
 	}
 
-	resolved, err := GetAvailableWithConfig("codex", cfg)
+	resolved, err := GetAvailableWithConfig("", "codex", cfg)
 	require.NoError(t, err)
 	assert.Equal(t, "codex", resolved.Name())
 
@@ -1108,7 +1108,7 @@ func TestGetAvailableWithConfigCursorCmd(t *testing.T) {
 		CursorCmd: filepath.Join(fakeBin, wrapper),
 	}
 
-	resolved, err := GetAvailableWithConfig("cursor", cfg)
+	resolved, err := GetAvailableWithConfig("", "cursor", cfg)
 	require.NoError(t, err)
 	assert.Equal(t, "cursor", resolved.Name())
 
@@ -1140,7 +1140,7 @@ func TestGetAvailableWithConfigPiCmd(t *testing.T) {
 		PiCmd: filepath.Join(fakeBin, wrapper),
 	}
 
-	resolved, err := GetAvailableWithConfig("pi", cfg)
+	resolved, err := GetAvailableWithConfig("", "pi", cfg)
 	require.NoError(t, err)
 	assert.Equal(t, "pi", resolved.Name())
 
@@ -1172,7 +1172,7 @@ func TestGetAvailableWithConfigOpenCodeCmd(t *testing.T) {
 		OpenCodeCmd: filepath.Join(fakeBin, wrapper),
 	}
 
-	resolved, err := GetAvailableWithConfig("opencode", cfg)
+	resolved, err := GetAvailableWithConfig("", "opencode", cfg)
 	require.NoError(t, err)
 	assert.Equal(t, "opencode", resolved.Name())
 
@@ -1213,7 +1213,7 @@ func TestGetAvailableWithConfigACPFallbackBackupUsesConfigCmd(t *testing.T) {
 	}
 
 	resolved, err := GetAvailableWithConfig(
-		"my-acp", cfg, "claude-code",
+		"", "my-acp", cfg, "claude-code",
 	)
 	require.NoError(t, err,
 		"backup should resolve via config cmd when ACP is unavailable")
@@ -1250,7 +1250,7 @@ func TestGetAvailableWithConfigEmptyPreferredBackupUsesConfigCmd(t *testing.T) {
 		ClaudeCodeCmd: filepath.Join(fakeBin, wrapper),
 	}
 
-	resolved, err := GetAvailableWithConfig("", cfg, "claude-code")
+	resolved, err := GetAvailableWithConfig("", "", cfg, "claude-code")
 	require.NoError(t, err,
 		"backup agent should be available via config cmd even with empty preferred")
 	assert.Equal(t, "claude-code", resolved.Name())

--- a/internal/agent/acp_validation_test.go
+++ b/internal/agent/acp_validation_test.go
@@ -211,11 +211,8 @@ func TestSessionUpdateValidatesSessionID(t *testing.T) {
 			AgentMessageChunk: messageChunk,
 		},
 	})
-	require.Error(t, err, "Expected session mismatch error for SessionUpdate")
+	require.NoError(t, err, "SessionUpdate should not return error for mismatched session ID")
 
-	if !strings.Contains(err.Error(), "session ID mismatch") {
-		require.Failf(t, "unexpected error", "Expected session mismatch error, got: %v", err)
-	}
 	if client.result.String() != "" {
 		assert.Empty(t, client.result.String(), "Expected no output to be appended on session mismatch, got: %q", client.result.String())
 	}

--- a/internal/agent/acp_validation_test.go
+++ b/internal/agent/acp_validation_test.go
@@ -228,3 +228,58 @@ func TestSessionUpdateValidatesSessionID(t *testing.T) {
 	assert.Equal(t, "hello", client.result.String(), "Expected session output to be appended, got: %q", client.result.String())
 
 }
+
+// TestSessionUpdateRejectsBeforeSessionEstablished verifies that an early
+// SessionUpdate notification cannot bind c.sessionID before NewSession has
+// completed. A spoofed or stale notification arriving before the session is
+// established must be rejected, not used to bootstrap the client's session ID.
+func TestSessionUpdateRejectsBeforeSessionEstablished(t *testing.T) {
+	t.Parallel()
+
+	client := &acpClient{
+		agent:  &ACPAgent{},
+		result: &bytes.Buffer{},
+	}
+
+	messageChunk := &acp.SessionUpdateAgentMessageChunk{
+		Content:       acp.TextBlock("attacker-content"),
+		SessionUpdate: "agent_message_chunk",
+	}
+
+	err := client.SessionUpdate(context.Background(), acp.SessionNotification{
+		SessionId: acp.SessionId("attacker-session"),
+		Update: acp.SessionUpdate{
+			AgentMessageChunk: messageChunk,
+		},
+	})
+	require.NoError(t, err, "SessionUpdate should not return an error when rejecting a notification")
+
+	assert.Empty(t, client.sessionID, "SessionUpdate must not bootstrap c.sessionID from an incoming notification")
+	assert.Empty(t, client.result.String(), "Rejected SessionUpdate must not append output")
+
+	// After NewSession would set the session ID, subsequent updates with the
+	// real session ID are accepted, while the earlier "attacker-session" ID
+	// remains rejected.
+	client.sessionID = "real-session"
+
+	err = client.SessionUpdate(context.Background(), acp.SessionNotification{
+		SessionId: acp.SessionId("attacker-session"),
+		Update: acp.SessionUpdate{
+			AgentMessageChunk: messageChunk,
+		},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, client.result.String(), "Stale notification for non-matching session must remain rejected")
+
+	err = client.SessionUpdate(context.Background(), acp.SessionNotification{
+		SessionId: acp.SessionId("real-session"),
+		Update: acp.SessionUpdate{
+			AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+				Content:       acp.TextBlock("real-content"),
+				SessionUpdate: "agent_message_chunk",
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "real-content", client.result.String(), "Valid SessionUpdate after NewSession must be accepted")
+}

--- a/internal/agent/model_resolution.go
+++ b/internal/agent/model_resolution.go
@@ -42,8 +42,8 @@ func ResolveWorkflowConfig(
 // AgentMatches reports whether two agent names refer to the same logical
 // agent after alias and ACP-name normalization.
 func (w WorkflowConfig) AgentMatches(left, right string) bool {
-	return workflowModelComparableAgentName(left, w.GlobalConfig) ==
-		workflowModelComparableAgentName(right, w.GlobalConfig)
+	return workflowModelComparableAgentName(left, w.RepoPath, w.GlobalConfig) ==
+		workflowModelComparableAgentName(right, w.RepoPath, w.GlobalConfig)
 }
 
 // UsesBackupAgent reports whether the selected agent is the configured
@@ -102,8 +102,8 @@ func ResolveWorkflowModelForAgent(
 	}
 
 	defaultAgent := config.ResolveAgent("", repoPath, globalCfg)
-	if workflowModelComparableAgentName(selectedAgent, globalCfg) !=
-		workflowModelComparableAgentName(defaultAgent, globalCfg) {
+	if workflowModelComparableAgentName(selectedAgent, repoPath, globalCfg) !=
+		workflowModelComparableAgentName(defaultAgent, repoPath, globalCfg) {
 		return config.ResolveWorkflowModel(
 			repoPath, globalCfg, workflow, level,
 		)
@@ -114,9 +114,9 @@ func ResolveWorkflowModelForAgent(
 	)
 }
 
-func workflowModelComparableAgentName(name string, cfg *config.Config) string {
+func workflowModelComparableAgentName(name string, repoPath string, cfg *config.Config) string {
 	name = strings.TrimSpace(name)
-	if isConfiguredACPAgentName(name, cfg) {
+	if isConfiguredACPAgentName(name, cfg, repoPath) {
 		return defaultACPName
 	}
 	return CanonicalName(name)

--- a/internal/agent/model_resolution.go
+++ b/internal/agent/model_resolution.go
@@ -72,10 +72,19 @@ func (w WorkflowConfig) ModelForSelectedAgent(
 		strings.TrimSpace(cliModel) == "" {
 		return w.BackupModel()
 	}
-	return ResolveWorkflowModelForAgent(
+	model := ResolveWorkflowModelForAgent(
 		selectedAgent, cliModel, w.RepoPath,
 		w.GlobalConfig, w.Workflow, w.Reasoning,
 	)
+	// For ACP agents with no CLI/workflow model, fall back to configured ACP model
+	if model == "" && strings.TrimSpace(cliModel) == "" &&
+		isConfiguredACPAgentName(selectedAgent, w.GlobalConfig, w.RepoPath) {
+		acpCfg := config.ResolveACPAgentConfig(w.RepoPath, w.GlobalConfig)
+		if acpCfg != nil && acpCfg.Model != "" {
+			return acpCfg.Model
+		}
+	}
+	return model
 }
 
 // ResolveWorkflowModelForAgent resolves a workflow model for the actual

--- a/internal/agent/model_resolution.go
+++ b/internal/agent/model_resolution.go
@@ -76,8 +76,8 @@ func (w WorkflowConfig) ModelForSelectedAgent(
 		selectedAgent, cliModel, w.RepoPath,
 		w.GlobalConfig, w.Workflow, w.Reasoning,
 	)
-	// For ACP agents with no CLI/workflow model, fall back to configured ACP model
-	if model == "" && strings.TrimSpace(cliModel) == "" &&
+	// For ACP agents with no workflow model, fall back to configured ACP model
+	if model == "" &&
 		isConfiguredACPAgentName(selectedAgent, w.GlobalConfig, w.RepoPath) {
 		acpCfg := config.ResolveACPAgentConfig(w.RepoPath, w.GlobalConfig)
 		if acpCfg != nil && acpCfg.Model != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1076,6 +1076,9 @@ type RepoConfig struct {
 
 	// Analysis settings
 	MaxPromptSize int `toml:"max_prompt_size" comment:"Maximum prompt size for this repo before falling back to file paths."` // Max prompt size in bytes before falling back to paths (overrides global default)
+
+	// ACP (Agent Client Protocol) configuration for this repo
+	ACP *ACPAgentConfig `toml:"acp"`
 }
 
 // DefaultConfig returns the default configuration
@@ -2209,6 +2212,32 @@ func ResolveBackupModelForWorkflow(repoPath string, globalCfg *Config, workflow 
 	}
 
 	return ""
+}
+
+// ResolveACPAgentConfig returns the effective ACP agent configuration for a repo.
+// Priority: repo [acp] config > global [acp] config > nil (no ACP config).
+// Repo-level ACP config completely overrides global ACP config (no merging of individual fields).
+func ResolveACPAgentConfig(repoPath string, globalCfg *Config) *ACPAgentConfig {
+	// Try repo config first
+	repoCfg, err := LoadRepoConfig(repoPath)
+	if err != nil {
+		// Malformed repo config - fall through to global
+		if IsConfigParseError(err) {
+			// Parse error - skip repo config
+		} else {
+			return nil
+		}
+	}
+	if repoCfg != nil && repoCfg.ACP != nil {
+		return repoCfg.ACP
+	}
+
+	// Fall back to global config
+	if globalCfg != nil && globalCfg.ACP != nil {
+		return globalCfg.ACP
+	}
+
+	return nil
 }
 
 // lookupFieldByTag finds a struct field by its TOML tag and returns its trimmed value.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2225,7 +2225,7 @@ func ResolveACPAgentConfig(repoPath string, globalCfg *Config) *ACPAgentConfig {
 		if IsConfigParseError(err) {
 			// Parse error - skip repo config
 		} else {
-			return nil
+			repoCfg = nil
 		}
 	}
 	if repoCfg != nil && repoCfg.ACP != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2218,18 +2218,20 @@ func ResolveBackupModelForWorkflow(repoPath string, globalCfg *Config, workflow 
 // Priority: repo [acp] config > global [acp] config > nil (no ACP config).
 // Repo-level ACP config completely overrides global ACP config (no merging of individual fields).
 func ResolveACPAgentConfig(repoPath string, globalCfg *Config) *ACPAgentConfig {
-	// Try repo config first
-	repoCfg, err := LoadRepoConfig(repoPath)
-	if err != nil {
-		// Malformed repo config - fall through to global
-		if IsConfigParseError(err) {
-			// Parse error - skip repo config
-		} else {
-			repoCfg = nil
+	// Only try repo config if repoPath is non-empty
+	if repoPath != "" {
+		repoCfg, err := LoadRepoConfig(repoPath)
+		if err != nil {
+			// Malformed repo config - fall through to global
+			if IsConfigParseError(err) {
+				// Parse error - skip repo config
+			} else {
+				repoCfg = nil
+			}
 		}
-	}
-	if repoCfg != nil && repoCfg.ACP != nil {
-		return repoCfg.ACP
+		if repoCfg != nil && repoCfg.ACP != nil {
+			return repoCfg.ACP
+		}
 	}
 
 	// Fall back to global config

--- a/internal/config/config_classify_test.go
+++ b/internal/config/config_classify_test.go
@@ -1,0 +1,158 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveClassifyModel(t *testing.T) {
+	t.Run("explicit CLI model takes precedence", func(t *testing.T) {
+		model := ResolveClassifyModel("claude-3-opus", "/tmp/repo", nil)
+		assert.Equal(t, "claude-3-opus", model)
+	})
+
+	t.Run("falls back to repo config", func(t *testing.T) {
+		testDir := t.TempDir()
+		writeRepoConfigStr(t, testDir, `classify_model = "claude-3-sonnet"`)
+
+		model := ResolveClassifyModel("", testDir, nil)
+		assert.Equal(t, "claude-3-sonnet", model)
+	})
+
+	t.Run("falls back to global config", func(t *testing.T) {
+		globalCfg := &Config{
+			ClassifyModel: "claude-3-haiku",
+		}
+
+		model := ResolveClassifyModel("", "/tmp/nonexistent", globalCfg)
+		assert.Equal(t, "claude-3-haiku", model)
+	})
+
+	t.Run("returns empty when no config", func(t *testing.T) {
+		model := ResolveClassifyModel("", "/tmp/nonexistent", nil)
+		assert.Equal(t, "", model)
+	})
+}
+
+func TestResolveBackupClassifyModel(t *testing.T) {
+	t.Run("repo config takes precedence", func(t *testing.T) {
+		testDir := t.TempDir()
+		writeRepoConfigStr(t, testDir, `classify_backup_model = "backup-sonnet"`)
+
+		globalCfg := &Config{
+			ClassifyBackupModel: "global-backup",
+		}
+
+		model := ResolveBackupClassifyModel(testDir, globalCfg)
+		assert.Equal(t, "backup-sonnet", model)
+	})
+
+	t.Run("falls back to global config", func(t *testing.T) {
+		globalCfg := &Config{
+			ClassifyBackupModel: "global-backup",
+		}
+
+		model := ResolveBackupClassifyModel("/tmp/nonexistent", globalCfg)
+		assert.Equal(t, "global-backup", model)
+	})
+
+	t.Run("returns empty when no config", func(t *testing.T) {
+		model := ResolveBackupClassifyModel("/tmp/nonexistent", nil)
+		assert.Equal(t, "", model)
+	})
+}
+
+func TestResolveClassifyAgent(t *testing.T) {
+	t.Run("explicit CLI agent takes precedence", func(t *testing.T) {
+		agent, err := ResolveClassifyAgent("claude-3-opus", "/tmp/repo", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "claude-3-opus", agent)
+	})
+
+	t.Run("falls back to repo config", func(t *testing.T) {
+		testDir := t.TempDir()
+		writeRepoConfigStr(t, testDir, `classify_agent = "repo-agent"`)
+
+		agent, err := ResolveClassifyAgent("", testDir, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "repo-agent", agent)
+	})
+
+	t.Run("falls back to global config", func(t *testing.T) {
+		globalCfg := &Config{
+			ClassifyAgent: "global-agent",
+		}
+
+		agent, err := ResolveClassifyAgent("", "/tmp/nonexistent", globalCfg)
+		require.NoError(t, err)
+		assert.Equal(t, "global-agent", agent)
+	})
+
+	t.Run("defaults to constant", func(t *testing.T) {
+		agent, err := ResolveClassifyAgent("", "/tmp/nonexistent", nil)
+		require.NoError(t, err)
+		assert.Equal(t, DefaultClassifyAgent, agent)
+	})
+}
+
+func TestResolveClassifyReasoning(t *testing.T) {
+	t.Run("explicit CLI reasoning takes precedence", func(t *testing.T) {
+		reasoning := ResolveClassifyReasoning("thorough", "/tmp/repo", nil)
+		assert.Equal(t, "thorough", reasoning)
+	})
+
+	t.Run("falls back to repo config", func(t *testing.T) {
+		testDir := t.TempDir()
+		writeRepoConfigStr(t, testDir, `classify_reasoning = "medium"`)
+
+		reasoning := ResolveClassifyReasoning("", testDir, nil)
+		assert.Equal(t, "medium", reasoning)
+	})
+
+	t.Run("falls back to global config", func(t *testing.T) {
+		globalCfg := &Config{
+			ClassifyReasoning: "fast",
+		}
+
+		reasoning := ResolveClassifyReasoning("", "/tmp/nonexistent", globalCfg)
+		assert.Equal(t, "fast", reasoning)
+	})
+
+	t.Run("defaults to fast", func(t *testing.T) {
+		reasoning := ResolveClassifyReasoning("", "/tmp/nonexistent", nil)
+		assert.Equal(t, DefaultClassifyReasoning, reasoning)
+	})
+}
+
+func TestResolveBackupClassifyAgent(t *testing.T) {
+	t.Run("repo config takes precedence", func(t *testing.T) {
+		testDir := t.TempDir()
+		writeRepoConfigStr(t, testDir, `classify_backup_agent = "repo-backup"`)
+
+		globalCfg := &Config{
+			ClassifyBackupAgent: "global-backup",
+		}
+
+		agent, err := ResolveBackupClassifyAgent(testDir, globalCfg)
+		require.NoError(t, err)
+		assert.Equal(t, "repo-backup", agent)
+	})
+
+	t.Run("falls back to global config", func(t *testing.T) {
+		globalCfg := &Config{
+			ClassifyBackupAgent: "global-backup",
+		}
+
+		agent, err := ResolveBackupClassifyAgent("/tmp/nonexistent", globalCfg)
+		require.NoError(t, err)
+		assert.Equal(t, "global-backup", agent)
+	})
+
+	t.Run("returns empty when no config", func(t *testing.T) {
+		agent, err := ResolveBackupClassifyAgent("/tmp/nonexistent", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "", agent)
+	})
+}

--- a/internal/config/config_classify_test.go
+++ b/internal/config/config_classify_test.go
@@ -32,7 +32,7 @@ func TestResolveClassifyModel(t *testing.T) {
 
 	t.Run("returns empty when no config", func(t *testing.T) {
 		model := ResolveClassifyModel("", "/tmp/nonexistent", nil)
-		assert.Equal(t, "", model)
+		assert.Empty(t, model)
 	})
 }
 
@@ -60,7 +60,7 @@ func TestResolveBackupClassifyModel(t *testing.T) {
 
 	t.Run("returns empty when no config", func(t *testing.T) {
 		model := ResolveBackupClassifyModel("/tmp/nonexistent", nil)
-		assert.Equal(t, "", model)
+		assert.Empty(t, model)
 	})
 }
 
@@ -153,6 +153,6 @@ func TestResolveBackupClassifyAgent(t *testing.T) {
 	t.Run("returns empty when no config", func(t *testing.T) {
 		agent, err := ResolveBackupClassifyAgent("/tmp/nonexistent", nil)
 		require.NoError(t, err)
-		assert.Equal(t, "", agent)
+		assert.Empty(t, agent)
 	})
 }

--- a/internal/config/config_error_test.go
+++ b/internal/config/config_error_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigParseError(t *testing.T) {
+	t.Run("Error method", func(t *testing.T) {
+		innerErr := errors.New("invalid toml")
+		err := &ConfigParseError{
+			Ref: "origin/main",
+			Err: innerErr,
+		}
+		assert.Equal(t, "parse .roborev.toml at origin/main: invalid toml", err.Error())
+	})
+
+	t.Run("Unwrap method", func(t *testing.T) {
+		innerErr := errors.New("invalid toml")
+		err := &ConfigParseError{
+			Ref: "origin/main",
+			Err: innerErr,
+		}
+		assert.Equal(t, innerErr, err.Unwrap())
+	})
+
+	t.Run("IsConfigParseError with ConfigParseError", func(t *testing.T) {
+		innerErr := errors.New("invalid toml")
+		err := &ConfigParseError{
+			Ref: "origin/main",
+			Err: innerErr,
+		}
+		assert.True(t, IsConfigParseError(err))
+	})
+
+	t.Run("IsConfigParseError with wrapped ConfigParseError", func(t *testing.T) {
+		innerErr := errors.New("invalid toml")
+		cfgErr := &ConfigParseError{
+			Ref: "origin/main",
+			Err: innerErr,
+		}
+		wrappedErr := fmt.Errorf("wrapped: %w", cfgErr)
+		assert.True(t, IsConfigParseError(wrappedErr))
+	})
+
+	t.Run("IsConfigParseError with toml.ParseError", func(t *testing.T) {
+		// Create a TOML parse error
+		_, err := toml.Decode("invalid", &Config{})
+		require.Error(t, err)
+		assert.True(t, IsConfigParseError(err))
+	})
+
+	t.Run("IsConfigParseError with other error", func(t *testing.T) {
+		otherErr := errors.New("some other error")
+		assert.False(t, IsConfigParseError(otherErr))
+	})
+}

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -624,7 +624,7 @@ func (p *CIPoller) processPR(ctx context.Context, ghRepo string, pr ghPR, cfg *c
 			}
 			resolvedAgent = name
 		} else if resolved, err := agent.GetAvailableWithConfig(
-			resolvedAgent, cfg, resolution.BackupAgent,
+			repo.RootPath, resolvedAgent, cfg, resolution.BackupAgent,
 		); err != nil {
 			rollback("No agent available — check agent config or quota")
 			return fmt.Errorf("no review agent available for type=%s: %w", rt, err)
@@ -1968,7 +1968,7 @@ func runSynthesisAgent(
 	agentName, model, repoPath, prompt string,
 	cfg *config.Config,
 ) (string, error) {
-	a, err := agent.GetAvailableWithConfig(agentName, cfg)
+	a, err := agent.GetAvailableWithConfig(repoPath, agentName, cfg)
 	if err != nil {
 		return "", fmt.Errorf("get agent %q: %w", agentName, err)
 	}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -534,7 +534,7 @@ func validatedWorktreePath(worktreePath, repoPath string) string {
 }
 
 func resolveRerunModelProvider(job *storage.ReviewJob, cfg *config.Config) (string, string, error) {
-	if err := validateRerunAgent(job.Agent, cfg); err != nil {
+	if err := validateRerunAgent(job.RepoPath, job.Agent, cfg); err != nil {
 		return "", "", err
 	}
 
@@ -567,8 +567,8 @@ func resolveRerunModelProvider(job *storage.ReviewJob, cfg *config.Config) (stri
 	return model, provider, nil
 }
 
-func validateRerunAgent(agentName string, cfg *config.Config) error {
-	_, err := agent.GetAvailableWithConfig(agentName, cfg)
+func validateRerunAgent(repoPath string, agentName string, cfg *config.Config) error {
+	_, err := agent.GetAvailableWithConfig(repoPath, agentName, cfg)
 	if err != nil {
 		var unknownErr *agent.UnknownAgentError
 		if errors.As(err, &unknownErr) {
@@ -1466,7 +1466,7 @@ func (s *Server) humaEnqueue(
 	}
 	agentName := resolution.PreferredAgent
 	if resolved, err := agent.GetAvailableWithConfig(
-		agentName, cfg, resolution.BackupAgent,
+		resolutionPath, agentName, cfg, resolution.BackupAgent,
 	); err != nil {
 		var unknownErr *agent.UnknownAgentError
 		if errors.As(err, &unknownErr) {
@@ -2103,7 +2103,7 @@ func (s *Server) humaFixJob(
 	}
 	agentName := resolution.PreferredAgent
 	if resolved, err := agent.GetAvailableWithConfig(
-		agentName, cfg, resolution.BackupAgent,
+		resolutionPath, agentName, cfg, resolution.BackupAgent,
 	); err != nil {
 		var unknownErr *agent.UnknownAgentError
 		if errors.As(err, &unknownErr) {

--- a/internal/daemon/server_auto_design.go
+++ b/internal/daemon/server_auto_design.go
@@ -237,7 +237,7 @@ func resolveDesignAgent(repoPath string, cfg *config.Config) (string, string) {
 		return config.ResolveAgent("", repoPath, cfg), ""
 	}
 	primary := resolution.PreferredAgent
-	chosen, err := agent.GetAvailableWithConfig(primary, cfg, resolution.BackupAgent)
+	chosen, err := agent.GetAvailableWithConfig(repoPath, primary, cfg, resolution.BackupAgent)
 	if err != nil {
 		// Nothing installed — fall back to the primary name anyway so
 		// the row has a readable agent value, even if the worker will

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -479,7 +479,7 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 	}
 
 	// Get the agent (falls back to available agent if preferred not installed)
-	baseAgent, err := agent.GetAvailableWithConfig(job.Agent, cfg)
+	baseAgent, err := agent.GetAvailableWithConfig(job.RepoPath, job.Agent, cfg)
 	if err != nil {
 		log.Printf("[%s] Error getting agent: %v", workerID, err)
 		wp.failOrRetryAgent(workerID, job, job.Agent, fmt.Sprintf("get agent: %v", err))

--- a/internal/daemon/worker_classify.go
+++ b/internal/daemon/worker_classify.go
@@ -207,7 +207,7 @@ func (wp *WorkerPool) resolveDesignFollowUp(repoPath string) (string, string) {
 		return config.ResolveAgent("", repoPath, cfg), ""
 	}
 	primary := resolution.PreferredAgent
-	chosen, err := agent.GetAvailableWithConfig(primary, cfg, resolution.BackupAgent)
+	chosen, err := agent.GetAvailableWithConfig(repoPath, primary, cfg, resolution.BackupAgent)
 	if err != nil {
 		return primary, resolution.ModelForSelectedAgent(primary, "")
 	}

--- a/internal/review/batch.go
+++ b/internal/review/batch.go
@@ -117,7 +117,7 @@ func runSingle(
 		}
 	} else {
 		resolvedAgent, err = agent.GetAvailableWithConfig(
-			resolvedName, cfg.GlobalConfig, backupAgent)
+			cfg.RepoPath, resolvedName, cfg.GlobalConfig, backupAgent)
 	}
 
 	if err == nil && cfg.GlobalConfig != nil {

--- a/internal/review/synthesize.go
+++ b/internal/review/synthesize.go
@@ -18,7 +18,11 @@ import (
 var ErrAllFailed = errors.New(
 	"all review jobs failed")
 
-var getAvailableWithConfig = agent.GetAvailableWithConfig
+// getAvailableWithConfig is a variable for dependency injection in tests.
+// It wraps agent.GetAvailableWithConfig with repoPath as the first parameter.
+var getAvailableWithConfig = func(repoPath string, preferred string, cfg *config.Config, backups ...string) (agent.Agent, error) {
+	return agent.GetAvailableWithConfig(repoPath, preferred, cfg, backups...)
+}
 
 // SynthesizeOpts controls synthesis behavior.
 type SynthesizeOpts struct {
@@ -123,7 +127,7 @@ func runSynthesis(
 	results []ReviewResult,
 	opts SynthesizeOpts,
 ) (string, error) {
-	synthAgent, err := getAvailableWithConfig(opts.Agent, opts.GlobalConfig)
+	synthAgent, err := getAvailableWithConfig(opts.RepoPath, opts.Agent, opts.GlobalConfig)
 	if err != nil {
 		return "", fmt.Errorf("get synthesis agent: %w", err)
 	}

--- a/internal/review/synthesize_test.go
+++ b/internal/review/synthesize_test.go
@@ -272,7 +272,7 @@ func TestSynthesize_PassesGlobalConfigToResolver(t *testing.T) {
 	var seenAgent string
 	var seenCfg *config.Config
 	cap := newCapturingAgent()
-	getAvailableWithConfig = func(agentName string, cfg *config.Config, backups ...string) (agent.Agent, error) {
+	getAvailableWithConfig = func(repoPath string, agentName string, cfg *config.Config, backups ...string) (agent.Agent, error) {
 		seenAgent = agentName
 		seenCfg = cfg
 		return cap, nil


### PR DESCRIPTION
- Fix session validation in `SessionUpdate` to validate first ACP session update against agent's configured session ID before storing
- Update test expectations to match new behavior where session mismatches log but don't return errors (avoiding connection breaks)
- Add fallback to ACP config model in `ModelForSelectedAgent` when no workflow model is configured
- Remove redundant `cliModel` empty check in fallback condition