### PR TITLE
Fix branch base auto-detection with URL upstreams

### DIFF
--- a/cmd/roborev/analyze.go
+++ b/cmd/roborev/analyze.go
@@ -969,6 +969,9 @@ func getBranchFiles(cmd *cobra.Command, repoRoot string, opts analyzeOptions) (m
 	// Determine base branch
 	base := opts.baseBranch
 	if base == "" {
+		base = git.GetBranchBase(repoRoot, targetRef)
+	}
+	if base == "" {
 		// Prefer the branch's upstream tracking ref only when it resolves to
 		// a trunk-named branch (e.g., local main tracking upstream/main in a
 		// fork). A branch tracking its own remote counterpart (feature

--- a/cmd/roborev/refine.go
+++ b/cmd/roborev/refine.go
@@ -278,26 +278,29 @@ func validateRefineContext(
 				)
 		}
 	} else {
-		// Prefer the current branch's upstream tracking ref only when it
-		// resolves to a trunk-named branch (e.g., local main tracking
-		// upstream/main in a fork). A branch tracking its own remote
-		// counterpart is not trunk — use GetDefaultBranch instead.
-		upstream, uerr := git.GetUpstream(repoPath, "HEAD")
-		var missing *git.UpstreamMissingError
-		if errors.As(uerr, &missing) {
-			return "", "", "", "",
-				fmt.Errorf(
-					"%w (run 'git fetch' or pass --since)", missing,
-				)
-		}
-		if uerr != nil {
-			return "", "", "", "",
-				fmt.Errorf(
-					"resolve upstream for HEAD: %w (pass --since to skip)", uerr,
-				)
-		}
-		if upstream != "" && git.UpstreamIsTrunk(repoPath, "HEAD") {
-			base = upstream
+		base = git.GetBranchBase(repoPath, "HEAD")
+		if base == "" {
+			// Prefer the current branch's upstream tracking ref only when it
+			// resolves to a trunk-named branch (e.g., local main tracking
+			// upstream/main in a fork). A branch tracking its own remote
+			// counterpart is not trunk — use GetDefaultBranch instead.
+			upstream, uerr := git.GetUpstream(repoPath, "HEAD")
+			var missing *git.UpstreamMissingError
+			if errors.As(uerr, &missing) {
+				return "", "", "", "",
+					fmt.Errorf(
+						"%w (run 'git fetch' or pass --since)", missing,
+					)
+			}
+			if uerr != nil {
+				return "", "", "", "",
+					fmt.Errorf(
+						"resolve upstream for HEAD: %w (pass --since to skip)", uerr,
+					)
+			}
+			if upstream != "" && git.UpstreamIsTrunk(repoPath, "HEAD") {
+				base = upstream
+			}
 		}
 		if base == "" {
 			base, err = git.GetDefaultBranch(repoPath)

--- a/cmd/roborev/review.go
+++ b/cmd/roborev/review.go
@@ -162,6 +162,9 @@ Examples:
 
 				base := baseBranch
 				if base == "" {
+					base = git.GetBranchBase(root, targetRef)
+				}
+				if base == "" {
 					// Prefer the branch's upstream tracking ref only when it resolves
 					// to a trunk-named branch (e.g., local main tracking upstream/main
 					// in a fork). A branch tracking its own remote counterpart
@@ -528,6 +531,9 @@ func tryBranchReview(root, baseBranchOverride string) (string, bool) {
 	}
 
 	base := baseBranchOverride
+	if base == "" {
+		base = git.GetBranchBase(root, "HEAD")
+	}
 	if base == "" {
 		// Prefer the branch's upstream tracking ref only when it resolves to
 		// trunk. Hooks must never block commits, but any GetUpstream failure

--- a/cmd/roborev/review_test.go
+++ b/cmd/roborev/review_test.go
@@ -454,6 +454,26 @@ func TestReviewBranchFlag(t *testing.T) {
 		assert.Contains(t, req.GitRef, mainSHA)
 		assert.True(t, strings.HasSuffix(req.GitRef, "..HEAD"))
 	})
+
+	t.Run("branch review uses branch base before url upstream", func(t *testing.T) {
+		repo, mux := setupTestEnvironment(t)
+		reqCh := mockEnqueue(t, mux)
+
+		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.CommitFile("file.txt", "content", "initial")
+		mainSHA := repo.Run("rev-parse", "HEAD")
+		repo.Run("checkout", "-b", "feature")
+		repo.Run("config", "branch.feature.remote", "https://example.com/fork.git")
+		repo.Run("config", "branch.feature.merge", "refs/heads/feature")
+		repo.Run("config", "branch.feature.base", "main")
+		repo.CommitFile("feature.txt", "feature", "feature commit")
+
+		_, _, err := executeReviewCmd("--repo", repo.Dir, "--branch")
+		require.NoError(t, err)
+
+		req := <-reqCh
+		assert.Equal(t, mainSHA+"..HEAD", req.GitRef)
+	})
 }
 
 func TestReviewFastFlag(t *testing.T) {
@@ -597,6 +617,23 @@ func TestTryBranchReview(t *testing.T) {
 
 		want := developSHA + "..HEAD"
 		assert.Equal(t, want, ref)
+	})
+
+	t.Run("uses branch base before url upstream", func(t *testing.T) {
+		repo := newTestGitRepo(t)
+		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.CommitFile("file.txt", "content", "initial")
+		mainSHA := repo.Run("rev-parse", "HEAD")
+		repo.Run("checkout", "-b", "feature")
+		repo.Run("config", "branch.feature.remote", "https://example.com/fork.git")
+		repo.Run("config", "branch.feature.merge", "refs/heads/feature")
+		repo.Run("config", "branch.feature.base", "main")
+		repo.CommitFile("feature.txt", "feature", "feature commit")
+		writeRoborevConfig(t, repo, `post_commit_review = "branch"`)
+
+		ref, ok := tryBranchReview(repo.Dir, "")
+		require.True(t, ok, "expected branch base config to enable branch review")
+		assert.Equal(t, mainSHA+"..HEAD", ref)
 	})
 
 	t.Run("returns false on detached HEAD", func(t *testing.T) {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1385,7 +1385,9 @@ func remoteValueIsURL(repoPath, remote string) bool {
 	}
 	return strings.Contains(remote, "://") ||
 		strings.Contains(remote, ":") ||
-		strings.Contains(remote, "/") ||
+		strings.HasPrefix(remote, "/") ||
+		strings.HasPrefix(remote, "./") ||
+		strings.HasPrefix(remote, "../") ||
 		strings.HasPrefix(remote, "~")
 }
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -1326,17 +1327,9 @@ type upstreamConfig struct {
 // indicating @{upstream} is configured even if rev-parse cannot resolve the
 // ref. Returns (zero, false) otherwise.
 func readUpstreamConfig(repoPath, ref string) (upstreamConfig, bool) {
-	branch := ref
-	if branch == "HEAD" || branch == "" {
-		branch = GetCurrentBranch(repoPath)
-		if branch == "" {
-			return upstreamConfig{}, false
-		}
-	} else {
-		// Accept fully-qualified local branch refs (e.g., "refs/heads/feature")
-		// so callers who pass a ResolveSHA-style ref still resolve to the
-		// correct branch.<name>.* config keys.
-		branch = strings.TrimPrefix(branch, "refs/heads/")
+	branch := branchNameForConfig(repoPath, ref)
+	if branch == "" {
+		return upstreamConfig{}, false
 	}
 	remote := readGitConfig(repoPath, "branch."+branch+".remote")
 	merge := readGitConfig(repoPath, "branch."+branch+".merge")
@@ -1351,10 +1344,57 @@ func readUpstreamConfig(repoPath, ref string) (upstreamConfig, bool) {
 			qualified: "refs/heads/" + mergeBranch,
 		}, true
 	}
+	if remoteValueIsURL(repoPath, remote) {
+		return upstreamConfig{}, false
+	}
 	return upstreamConfig{
 		short:     remote + "/" + mergeBranch,
 		qualified: "refs/remotes/" + remote + "/" + mergeBranch,
 	}, true
+}
+
+// GetBranchBase returns roborev's branch.<name>.base config value for ref.
+// Passing an empty ref is equivalent to HEAD.
+func GetBranchBase(repoPath, ref string) string {
+	branch := branchNameForConfig(repoPath, ref)
+	if branch == "" {
+		return ""
+	}
+	return readGitConfig(repoPath, "branch."+branch+".base")
+}
+
+func branchNameForConfig(repoPath, ref string) string {
+	branch := ref
+	if branch == "HEAD" || branch == "" {
+		branch = GetCurrentBranch(repoPath)
+		if branch == "" {
+			return ""
+		}
+	} else {
+		// Accept fully-qualified local branch refs (e.g., "refs/heads/feature")
+		// so callers who pass a ResolveSHA-style ref still resolve to the
+		// correct branch.<name>.* config keys.
+		branch = strings.TrimPrefix(branch, "refs/heads/")
+	}
+	return branch
+}
+
+func remoteValueIsURL(repoPath, remote string) bool {
+	if remoteNameExists(repoPath, remote) {
+		return false
+	}
+	return strings.Contains(remote, "://") ||
+		strings.Contains(remote, ":") ||
+		strings.Contains(remote, "/") ||
+		strings.HasPrefix(remote, "~")
+}
+
+func remoteNameExists(repoPath, remote string) bool {
+	remotes, err := listRemotes(repoPath)
+	if err != nil {
+		return false
+	}
+	return slices.Contains(remotes, remote)
 }
 
 // readGitConfig returns the value of a git config key, or "" if missing.

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -777,6 +777,20 @@ func TestGetUpstream(t *testing.T) {
 		assert.Equal(t, "upstream/main", missing.Upstream)
 	})
 
+	t.Run("errors for missing slash-named remote tracking config", func(t *testing.T) {
+		repo := NewTestRepo(t)
+		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.CommitFile("file.txt", "content", "initial")
+		repo.Run("config", "branch.main.remote", "company/fork")
+		repo.Run("config", "branch.main.merge", "refs/heads/main")
+
+		upstream, err := GetUpstream(repo.Dir, "HEAD")
+		assert.Empty(t, upstream)
+		var missing *UpstreamMissingError
+		require.ErrorAs(t, err, &missing, "expected UpstreamMissingError, got %T: %v", err, err)
+		assert.Equal(t, "company/fork/main", missing.Upstream)
+	})
+
 	t.Run("ignores url remote tracking config", func(t *testing.T) {
 		repo := NewTestRepo(t)
 		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -777,6 +777,19 @@ func TestGetUpstream(t *testing.T) {
 		assert.Equal(t, "upstream/main", missing.Upstream)
 	})
 
+	t.Run("ignores url remote tracking config", func(t *testing.T) {
+		repo := NewTestRepo(t)
+		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.CommitFile("file.txt", "content", "initial")
+		repo.Run("checkout", "-b", "feature")
+		repo.Run("config", "branch.feature.remote", "https://example.com/fork.git")
+		repo.Run("config", "branch.feature.merge", "refs/heads/feature")
+
+		upstream, err := GetUpstream(repo.Dir, "HEAD")
+		require.NoError(t, err)
+		assert.Empty(t, upstream)
+	})
+
 	t.Run("handles branch names containing dots", func(t *testing.T) {
 		// Regression: git parses section/subsection/key by splitting on the
 		// first and last dots, so "branch.release/1.2.3.remote" correctly


### PR DESCRIPTION
## Summary

Fixes branch-base auto-detection for the review, refine, and analyze branch flows in two scenarios where it previously failed.

### URL-shaped `branch.<name>.remote` values

Git lets `branch.<name>.remote` hold either a registered remote name (e.g. `origin`) or a raw URL (e.g. `https://example.com/fork.git`). When users push to a URL-shaped remote, `readUpstreamConfig` was concatenating the URL with the merge branch and producing invalid refs like `refs/remotes/https://example.com/fork.git/main`. That nonsense ref failed to resolve, which made branch base detection fail for the affected repos.

The fix detects URL-shaped remote values via `remoteValueIsURL` and returns "no upstream" in that case so callers fall through to the next detection step. The heuristic checks for `://`, `:` (scp-like), and `/`, `./`, `../`, `~` prefixes, but only after confirming the value is not a registered remote name — so legitimate slash-containing remote names like `company/fork` are still treated as remotes.

### `branch.<name>.base` was ignored

roborev already documented `branch.<name>.base` as a per-branch override for the base branch, but the review/refine/analyze flows skipped past it and went straight to upstream tracking detection. The fix adds `GetBranchBase()` and consults it before the upstream / default-branch fallback, so an explicit `branch.<name>.base` always wins.

### Refactor

Branch-name normalization (`HEAD`/empty → `GetCurrentBranch`, `refs/heads/x` → `x`) was duplicated between `readUpstreamConfig` and `GetBranchBase`. Extracted into shared `branchNameForConfig`.

### Tests

- `internal/git/git_test.go`: URL-shaped `branch.<name>.remote` is ignored without error; slash-named remote (e.g. `company/fork`) without a local tracking ref still surfaces `UpstreamMissingError` rather than being silently treated as a URL.
- `cmd/roborev/review_test.go`: `roborev review --branch` and `tryBranchReview` both prefer `branch.<name>.base` over a URL upstream.