### PR TITLE
fix: keep large diff prompts external

### DIFF
--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -529,13 +528,16 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 		log.Printf("[%s] Error saving command line: %v", workerID, err)
 	}
 
-	// Codex --sandbox read-only cannot read files inside .git/.
-	// When the prompt references a snapshot file (oversized diff),
-	// read the file and inline its content so Codex gets the full
-	// diff via stdin without needing filesystem access. The DB
-	// keeps the truncated prompt; only the agent prompt expands.
-	if agentName == "codex" && !agentic {
-		reviewPrompt = expandSnapshotInline(reviewPrompt)
+	// Enforce the final submission size after all prompt transformations.
+	// Oversized prompts are deterministic and should never be sent to any
+	// agent just to discover a context-window failure.
+	maxPromptSize := config.ResolveMaxPromptSize(effectiveRepoPath, cfg)
+	if maxPromptSize > 0 && len(reviewPrompt) > maxPromptSize {
+		wp.failoverOrFailNonRetryableAgent(
+			workerID, job, agentName,
+			fmt.Sprintf("prompt exceeds size limit before agent submission: prompt is %d bytes, limit is %d bytes; use a backup agent that can read snapshot diff files or review a smaller range", len(reviewPrompt), maxPromptSize),
+		)
+		return
 	}
 
 	// Use the effective worktree path for events (empty when worktree is gone or not a worktree job).
@@ -795,6 +797,10 @@ func (wp *WorkerPool) failOrRetryInner(workerID string, job *storage.ReviewJob, 
 		wp.failoverOrFail(workerID, job, agentName, errorMsg)
 		return
 	}
+	if agentError && isContextWindowError(errorMsg) {
+		wp.failoverOrFailNonRetryableAgent(workerID, job, agentName, errorMsg)
+		return
+	}
 
 	retried, err := wp.db.RetryJob(job.ID, workerID, maxRetries)
 	if err != nil {
@@ -847,6 +853,39 @@ func (wp *WorkerPool) failOrRetryInner(workerID string, job *storage.ReviewJob, 
 			}
 			wp.logJobFailed(job.ID, workerID, agentName, errorMsg)
 		}
+	}
+}
+
+func (wp *WorkerPool) failoverOrFailNonRetryableAgent(
+	workerID string, job *storage.ReviewJob,
+	agentName, errorMsg string,
+) {
+	backupAgent := wp.resolveBackupAgent(job)
+	if backupAgent != "" && !wp.isAgentCoolingDown(backupAgent) {
+		backupModel := wp.resolveBackupModel(job)
+		failedOver, err := wp.db.FailoverJob(job.ID, workerID, backupAgent, backupModel)
+		if err != nil {
+			log.Printf("[%s] Error attempting failover for job %d: %v",
+				workerID, job.ID, err)
+		}
+		if failedOver {
+			log.Printf("[%s] Job %d failing over from %s to %s (non-retryable): %s",
+				workerID, job.ID, agentName, backupAgent, errorMsg)
+			return
+		}
+	}
+
+	if updated, err := wp.db.FailJob(job.ID, workerID, errorMsg); err != nil {
+		log.Printf("[%s] Error failing job %d: %v", workerID, job.ID, err)
+	} else if updated {
+		log.Printf("[%s] Job %d %s %sreview/%s failed without retry: %s",
+			workerID, job.ID, job.RepoName,
+			reviewTypeTag(job.ReviewType), agentName, errorMsg)
+		wp.broadcastFailed(job, agentName, errorMsg)
+		if wp.errorLog != nil {
+			wp.errorLog.LogError("worker", fmt.Sprintf("job %d failed without retry: %s", job.ID, errorMsg), job.ID)
+		}
+		wp.logJobFailed(job.ID, workerID, agentName, errorMsg)
 	}
 }
 
@@ -944,6 +983,24 @@ func isQuotaError(errMsg string) bool {
 		"exhausted your capacity",
 		"capacity_exhausted",
 		"capacity exhausted",
+	}
+	for _, p := range patterns {
+		if strings.Contains(lower, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func isContextWindowError(errMsg string) bool {
+	lower := strings.ToLower(errMsg)
+	patterns := []string{
+		"context window",
+		"ran out of room",
+		"context_length_exceeded",
+		"maximum context length",
+		"input is too long",
+		"prompt is too long",
 	}
 	for _, p := range patterns {
 		if strings.Contains(lower, p) {
@@ -1082,63 +1139,6 @@ func preparePrebuiltPrompt(
 		prompt.DiffFilePathPlaceholder, diffFile,
 	)
 	return replacer.Replace(reviewPrompt), cleanup, nil
-}
-
-// snapshotFileRefRE matches the file-reference lines emitted by
-// diffFileFallbackVariants in the prompt builder when a diff is too
-// large to inline. Example:
-//
-//	Read the diff from: `/path/to/.git/roborev-snapshot-1234.diff`
-var snapshotFileRefRE = regexp.MustCompile(
-	"`([^`]+roborev-snapshot-[^`]+\\.diff)`",
-)
-
-// expandSnapshotInline reads snapshot files referenced in a prompt
-// and replaces the file-reference section with the actual diff
-// content. This allows sandboxed agents that cannot access .git/ to
-// receive the full diff via stdin.
-func expandSnapshotInline(reviewPrompt string) string {
-	m := snapshotFileRefRE.FindStringSubmatch(reviewPrompt)
-	if m == nil {
-		return reviewPrompt
-	}
-	snapshotPath := m[1]
-	data, err := os.ReadFile(snapshotPath)
-	if err != nil {
-		// File unreadable — return the prompt as-is; the agent
-		// will see the truncated reference (same as before).
-		log.Printf("expand snapshot inline: read %s: %v", snapshotPath, err)
-		return reviewPrompt
-	}
-
-	// Replace the entire "(Diff too large …) … Read the diff from …"
-	// block with an inline diff fence.
-	inline := "```diff\n" + string(data)
-	if len(data) > 0 && data[len(data)-1] != '\n' {
-		inline += "\n"
-	}
-	inline += "```\n"
-
-	// The fallback block always starts with "(Diff too large" and
-	// ends after the file-reference line. Replace that span.
-	start := strings.Index(reviewPrompt, "(Diff too large")
-	if start < 0 {
-		// Dirty-review fallback uses different wording.
-		start = strings.Index(reviewPrompt, "The full diff is also available at:")
-		if start < 0 {
-			return reviewPrompt
-		}
-	}
-	refEnd := strings.Index(reviewPrompt[start:], m[0])
-	if refEnd < 0 {
-		return reviewPrompt
-	}
-	// Include the trailing backtick and any newlines after it.
-	end := start + refEnd + len(m[0])
-	for end < len(reviewPrompt) && reviewPrompt[end] == '\n' {
-		end++
-	}
-	return reviewPrompt[:start] + inline + reviewPrompt[end:]
 }
 
 func shellQuoteForPrompt(s string) string {

--- a/internal/daemon/worker_snapshot_test.go
+++ b/internal/daemon/worker_snapshot_test.go
@@ -156,11 +156,12 @@ func TestSnapshotFlow_SnapshotFileContentMatchesDiff(t *testing.T) {
 
 	// The snapshot file should have existed during the review.
 	// After processJob returns, cleanup runs and deletes it.
-	// Verify the file was in the git dir.
+	// Verify the file was not hidden under .git, where sandboxed agents
+	// may be unable to read it.
 	gitDir, err := gitpkg.ResolveGitDir(tc.TmpDir)
 	require.NoError(t, err)
-	assert.True(t, strings.HasPrefix(snapshotPath, gitDir),
-		"snapshot should be in git dir: got %s, want prefix %s",
+	assert.False(t, strings.HasPrefix(snapshotPath, gitDir),
+		"snapshot should not be in git dir: got %s, git dir %s",
 		snapshotPath, gitDir)
 
 	// Verify it was cleaned up

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 
 	"github.com/roborev-dev/roborev/internal/agent"
@@ -515,7 +516,7 @@ func TestProcessJob_RebuildsAndPersistsFreshPromptForReviewRetry(t *testing.T) {
 	assert.Equal(t, capturedPrompt, updated.Prompt)
 }
 
-func TestPrepareDiffFileForCodex_WritesDiffInWorktreeGitDir(t *testing.T) {
+func TestWriteDiffSnapshot_WritesExternalReadableTempFile(t *testing.T) {
 	repo := testutil.NewTestRepoWithCommit(t)
 	worktreeDir := filepath.Join(t.TempDir(), "feature-worktree")
 
@@ -550,9 +551,9 @@ func TestPrepareDiffFileForCodex_WritesDiffInWorktreeGitDir(t *testing.T) {
 		gitDir = filepath.Join(worktreeDir, gitDir)
 	}
 
-	assert.True(t,
+	assert.False(t,
 		strings.HasPrefix(filepath.Clean(diffFile), filepath.Clean(gitDir)),
-		"snapshot should be in git dir: got %s, want prefix %s", diffFile, gitDir)
+		"snapshot should not live in git dir: got %s, git dir %s", diffFile, gitDir)
 	data, err := os.ReadFile(diffFile)
 	require.NoError(t, err)
 	assert.Contains(t, string(data), "diff --git")
@@ -564,7 +565,7 @@ func TestPrepareDiffFileForCodex_WritesDiffInWorktreeGitDir(t *testing.T) {
 	assert.True(t, os.IsNotExist(err), "expected cleanup to remove diff file, got %v", err)
 }
 
-func TestPreparePrebuiltCodexPrompt_ReplacesDiffFilePlaceholder(t *testing.T) {
+func TestPreparePrebuiltPrompt_ReplacesDiffFilePlaceholder(t *testing.T) {
 	tc := newWorkerTestContext(t, 1)
 	sha := testutil.GetHeadSHA(t, tc.TmpDir)
 	job := &storage.ReviewJob{ID: 73, Agent: "codex", GitRef: sha}
@@ -584,7 +585,7 @@ func TestPreparePrebuiltCodexPrompt_ReplacesDiffFilePlaceholder(t *testing.T) {
 	cleanup()
 }
 
-func TestPreparePrebuiltCodexPrompt_RequotesDiffPathWithSingleQuote(t *testing.T) {
+func TestPreparePrebuiltPrompt_RequotesDiffPathWithSingleQuote(t *testing.T) {
 	baseDir := t.TempDir()
 	repoPath := filepath.Join(baseDir, "repo's")
 	require.NoError(t, os.MkdirAll(repoPath, 0o755))
@@ -609,7 +610,7 @@ func TestPreparePrebuiltCodexPrompt_RequotesDiffPathWithSingleQuote(t *testing.T
 	cleanup()
 }
 
-func TestPreparePrebuiltCodexPrompt_AllowsUnsafeModeByStillWritingDiffFile(t *testing.T) {
+func TestPreparePrebuiltPrompt_AllowsUnsafeModeByStillWritingDiffFile(t *testing.T) {
 	prev := agent.AllowUnsafeAgents()
 	agent.SetAllowUnsafeAgents(true)
 	t.Cleanup(func() { agent.SetAllowUnsafeAgents(prev) })
@@ -632,7 +633,7 @@ func TestPreparePrebuiltCodexPrompt_AllowsUnsafeModeByStillWritingDiffFile(t *te
 	cleanup()
 }
 
-func TestProcessJob_SmallDiffSucceedsWhenSnapshotFails(t *testing.T) {
+func TestProcessJob_SmallDiffSucceedsWhenGitDirReadOnly(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("chmod does not restrict writes on Windows")
 	}
@@ -662,7 +663,7 @@ func TestProcessJob_SmallDiffSucceedsWhenSnapshotFails(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Make git dir read-only so diff file write fails
+	// Make git dir read-only. Small diffs should not need a snapshot.
 	gitDir, err := gitpkg.ResolveGitDir(tc.TmpDir)
 	require.NoError(t, err)
 	info, err := os.Stat(gitDir)
@@ -677,12 +678,12 @@ func TestProcessJob_SmallDiffSucceedsWhenSnapshotFails(t *testing.T) {
 
 	tc.Pool.processJob(testWorkerID, claimed)
 
-	// Small diff fits inline — snapshot failure doesn't matter
+	// Small diff fits inline.
 	tc.assertJobStatus(t, job.ID, storage.JobStatusDone)
-	assert.True(t, agentCalled, "agent should run for small diffs even when snapshot fails")
+	assert.True(t, agentCalled, "agent should run for small diffs even when .git is read-only")
 }
 
-func TestProcessJob_LargeDiffRetriesWhenSnapshotFails(t *testing.T) {
+func TestProcessJob_LargeDiffUsesExternalSnapshotWhenGitDirReadOnly(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("chmod does not restrict writes on Windows")
 	}
@@ -731,7 +732,8 @@ func TestProcessJob_LargeDiffRetriesWhenSnapshotFails(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Make git dir read-only so diff file write fails
+	// Make git dir read-only. Large-diff snapshots should still work
+	// because they are written outside .git.
 	gitDir, err := gitpkg.ResolveGitDir(tc.TmpDir)
 	require.NoError(t, err)
 	info, err := os.Stat(gitDir)
@@ -746,52 +748,130 @@ func TestProcessJob_LargeDiffRetriesWhenSnapshotFails(t *testing.T) {
 
 	tc.Pool.processJob(testWorkerID, claimed)
 
-	// Large diff can't inline and snapshot failed — must retry
-	tc.assertJobStatus(t, job.ID, storage.JobStatusQueued)
-	assert.False(t, agentCalled, "agent should not run when large diff has no snapshot")
+	tc.assertJobStatus(t, job.ID, storage.JobStatusDone)
+	assert.True(t, agentCalled, "agent should run because snapshots no longer require writing to .git")
 }
 
-func TestExpandSnapshotInline_ReplacesFileRef(t *testing.T) {
-	// Write a temp snapshot file
-	f, err := os.CreateTemp(t.TempDir(), "roborev-snapshot-*.diff")
+func TestProcessJob_LargeDiffUsesExternalSnapshotWithoutOversizedPrompt(t *testing.T) {
+	originalTest, err := agent.Get("test")
 	require.NoError(t, err)
-	_, err = f.WriteString("diff --git a/file.go b/file.go\n+added line\n")
+
+	agentCalled := false
+	var capturedPrompt string
+	snapshotRE := regexp.MustCompile("`([^`]+roborev-snapshot-[^`]+\\.diff)`")
+	agent.Register(&agent.FakeAgent{
+		NameStr: "test",
+		ReviewFn: func(ctx context.Context, repoPath, commitSHA, p string, output io.Writer) (string, error) {
+			agentCalled = true
+			capturedPrompt = p
+			require.LessOrEqual(t, len(p), 4096, "submitted prompt must stay within configured cap")
+			match := snapshotRE.FindStringSubmatch(p)
+			require.NotNil(t, match, "large diff prompt should reference a snapshot file")
+			snapshotPath := match[1]
+			assert.NotContains(t, snapshotPath, string(filepath.Separator)+".git"+string(filepath.Separator))
+			data, readErr := os.ReadFile(snapshotPath)
+			require.NoError(t, readErr)
+			assert.Contains(t, string(data), "large-agent.txt")
+			return "No issues found.", nil
+		},
+	})
+	t.Cleanup(func() { agent.Register(originalTest) })
+
+	tc := newWorkerTestContext(t, 1)
+	cfg := config.DefaultConfig()
+	cfg.DefaultMaxPromptSize = 4096
+	tc.reconfigurePool(cfg)
+
+	var content strings.Builder
+	for range 300 {
+		content.WriteString("+")
+		content.WriteString(strings.Repeat("large diff content ", 8))
+		content.WriteString("\n")
+	}
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tc.TmpDir, "large-agent.txt"),
+		[]byte(content.String()), 0o644,
+	))
+	cmd := exec.Command("git", "-C", tc.TmpDir, "add", "large-agent.txt")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git add failed: %s", out)
+	cmd = exec.Command("git", "-C", tc.TmpDir, "commit", "-m", "large agent diff")
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, "git commit failed: %s", out)
+
+	sha := testutil.GetHeadSHA(t, tc.TmpDir)
+	commit, err := tc.DB.GetOrCreateCommit(tc.Repo.ID, sha, "Author", "large", time.Now())
 	require.NoError(t, err)
-	require.NoError(t, f.Close())
+	job, err := tc.DB.EnqueueJob(storage.EnqueueOpts{
+		RepoID:   tc.Repo.ID,
+		CommitID: commit.ID,
+		GitRef:   sha,
+		Agent:    "test",
+	})
+	require.NoError(t, err)
 
-	prompt := fmt.Sprintf(
-		"### Diff\n\n"+
-			"(Diff too large to include inline)\n\n"+
-			"The full diff has been written to a file for review.\n"+
-			"Read the diff from: `%s`\n\n"+
-			"Review the actual diff before writing findings.\n"+
-			"\n## Summary\n",
-		f.Name(),
-	)
+	claimed, err := tc.DB.ClaimJob(testWorkerID)
+	require.NoError(t, err)
+	require.Equal(t, job.ID, claimed.ID)
 
-	result := expandSnapshotInline(prompt)
+	tc.Pool.processJob(testWorkerID, claimed)
 
-	assert := assert.New(t)
-	assert.NotContains(result, "Diff too large")
-	assert.NotContains(result, "roborev-snapshot-")
-	assert.Contains(result, "```diff")
-	assert.Contains(result, "+added line")
-	assert.Contains(result, "## Summary")
+	updated := tc.assertJobStatus(t, job.ID, storage.JobStatusDone)
+	assert.True(t, agentCalled, "agent should run with an external snapshot prompt")
+	assert.Equal(t, 0, updated.RetryCount)
+	assert.NotEmpty(t, capturedPrompt)
+	assert.NotContains(t, capturedPrompt, "```diff")
 }
 
-func TestExpandSnapshotInline_NoRef(t *testing.T) {
-	prompt := "### Diff\n\n```diff\n+inline diff\n```\n"
-	result := expandSnapshotInline(prompt)
-	assert.Equal(t, prompt, result)
+func TestProcessJob_OversizedFinalPromptFailsBeforeAnyAgent(t *testing.T) {
+	originalTest, err := agent.Get("test")
+	require.NoError(t, err)
+
+	agentCalled := false
+	agent.Register(&agent.FakeAgent{
+		NameStr: "test",
+		ReviewFn: func(ctx context.Context, repoPath, commitSHA, p string, output io.Writer) (string, error) {
+			agentCalled = true
+			return "No issues found.", nil
+		},
+	})
+	t.Cleanup(func() { agent.Register(originalTest) })
+
+	tc := newWorkerTestContext(t, 1)
+	cfg := config.DefaultConfig()
+	cfg.DefaultMaxPromptSize = 1024
+	tc.reconfigurePool(cfg)
+
+	job, err := tc.DB.EnqueueJob(storage.EnqueueOpts{
+		RepoID:  tc.Repo.ID,
+		GitRef:  "run:large-prompt",
+		Agent:   "test",
+		Prompt:  strings.Repeat("x", 2048),
+		JobType: storage.JobTypeTask,
+	})
+	require.NoError(t, err)
+
+	claimed, err := tc.DB.ClaimJob(testWorkerID)
+	require.NoError(t, err)
+	require.Equal(t, job.ID, claimed.ID)
+
+	tc.Pool.processJob(testWorkerID, claimed)
+
+	updated := tc.assertJobStatus(t, job.ID, storage.JobStatusFailed)
+	assert.False(t, agentCalled, "oversized final prompt must not be submitted")
+	assert.Equal(t, 0, updated.RetryCount)
+	assert.Contains(t, updated.Error, "prompt exceeds size limit before agent submission")
 }
 
-func TestExpandSnapshotInline_MissingFile(t *testing.T) {
-	prompt := "### Diff\n\n" +
-		"(Diff too large to include inline)\n\n" +
-		"Read the diff from: `/nonexistent/roborev-snapshot-123.diff`\n"
-	result := expandSnapshotInline(prompt)
-	// Should return unchanged when file doesn't exist
-	assert.Equal(t, prompt, result)
+func TestFailOrRetryAgent_ContextWindowErrorFailsWithoutRetry(t *testing.T) {
+	tc := newWorkerTestContext(t, 1)
+	job := tc.createAndClaimJobWithAgent(t, "context-limit-test", testWorkerID, "codex")
+
+	tc.Pool.failOrRetryAgent(testWorkerID, job, "codex", "agent: codex failed: Codex ran out of room in the model's context window")
+
+	updated := tc.assertJobStatus(t, job.ID, storage.JobStatusFailed)
+	assert.Equal(t, 0, updated.RetryCount)
+	assert.Contains(t, updated.Error, "context window")
 }
 
 func TestWorkerPoolCancelJobFinalCheckDeadlockSafe(t *testing.T) {

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -164,7 +164,9 @@ func (b *Builder) BuildWithSnapshot(repoPath, gitRef string, repoID int64, conte
 	return SnapshotResult{Prompt: p, Cleanup: cleanup}, nil
 }
 
-// WriteDiffSnapshot writes the full diff for a git ref to a file in the repo's git dir.
+// WriteDiffSnapshot writes the full diff for a git ref to an external temp
+// file. The file intentionally lives outside .git so sandboxed agents can read
+// it without inlining oversized diffs into the submitted prompt.
 func WriteDiffSnapshot(repoPath, gitRef string, excludes []string) (string, func(), error) {
 	var (
 		fullDiff string
@@ -181,16 +183,16 @@ func WriteDiffSnapshot(repoPath, gitRef string, excludes []string) (string, func
 	if fullDiff == "" {
 		return "", nil, fmt.Errorf("diff is empty")
 	}
-	gitDir, err := git.ResolveGitDir(repoPath)
-	if err != nil {
-		return "", nil, fmt.Errorf("resolve git dir: %w", err)
-	}
-	f, err := os.CreateTemp(gitDir, "roborev-snapshot-*.diff")
+	return writeExternalDiffSnapshot(fullDiff)
+}
+
+func writeExternalDiffSnapshot(diff string) (string, func(), error) {
+	f, err := os.CreateTemp("", "roborev-snapshot-*.diff")
 	if err != nil {
 		return "", nil, fmt.Errorf("create snapshot: %w", err)
 	}
 	diffFile := f.Name()
-	_, writeErr := f.WriteString(fullDiff)
+	_, writeErr := f.WriteString(diff)
 	closeErr := f.Close()
 	if writeErr != nil || closeErr != nil {
 		os.Remove(diffFile)
@@ -210,26 +212,12 @@ func (b *Builder) BuildDirtyWithSnapshot(repoPath, diff string, repoID int64, co
 		return SnapshotResult{}, err
 	}
 	if strings.Contains(p, "(Diff too large to include in full)") && len(diff) > 0 {
-		gitDir, dirErr := git.ResolveGitDir(repoPath)
-		if dirErr != nil {
-			return SnapshotResult{}, fmt.Errorf("dirty diff snapshot: %w", dirErr)
-		}
-		f, createErr := os.CreateTemp(gitDir, "roborev-snapshot-*.diff")
-		if createErr != nil {
-			return SnapshotResult{}, fmt.Errorf("dirty diff snapshot: %w", createErr)
-		}
-		diffFile := f.Name()
-		_, writeErr := f.WriteString(diff)
-		closeErr := f.Close()
-		if writeErr != nil || closeErr != nil {
-			os.Remove(diffFile)
-			if writeErr != nil {
-				return SnapshotResult{}, fmt.Errorf("dirty diff snapshot: %w", writeErr)
-			}
-			return SnapshotResult{}, fmt.Errorf("dirty diff snapshot: %w", closeErr)
+		diffFile, cleanup, snapErr := writeExternalDiffSnapshot(diff)
+		if snapErr != nil {
+			return SnapshotResult{}, fmt.Errorf("dirty diff snapshot: %w", snapErr)
 		}
 		p += fmt.Sprintf("\nThe full diff is also available at: `%s`\n", diffFile)
-		return SnapshotResult{Prompt: p, Cleanup: func() { os.Remove(diffFile) }}, nil
+		return SnapshotResult{Prompt: p, Cleanup: cleanup}, nil
 	}
 	return SnapshotResult{Prompt: p}, nil
 }

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -370,11 +370,14 @@ func dirtySnapshotReferenceVariants(diffFile string) []string {
 }
 
 func fitPrefixWithSuffixVariants(prefix string, limit int, variants ...string) string {
-	if limit <= 0 {
-		return ""
-	}
 	if len(variants) == 0 {
+		if limit <= 0 {
+			return prefix
+		}
 		return truncateUTF8(prefix, limit)
+	}
+	if limit <= 0 {
+		return prefix + variants[0]
 	}
 	for _, variant := range variants {
 		if len(prefix)+len(variant) <= limit {

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -218,7 +218,11 @@ func (b *Builder) BuildDirtyWithSnapshot(repoPath, diff string, repoID int64, co
 		if snapErr != nil {
 			return SnapshotResult{}, fmt.Errorf("dirty diff snapshot: %w", snapErr)
 		}
-		p = fitDirtySnapshotReference(p, diffFile, b.resolveMaxPromptSize(repoPath))
+		p, err = fitDirtySnapshotReference(p, diffFile, b.resolveMaxPromptSize(repoPath))
+		if err != nil {
+			cleanup()
+			return SnapshotResult{}, err
+		}
 		return SnapshotResult{Prompt: p, Cleanup: cleanup}, nil
 	}
 	return SnapshotResult{Prompt: p}, nil
@@ -352,7 +356,7 @@ func (b *Builder) BuildDirty(repoPath, diff string, repoID int64, contextCount i
 	return ctx.requiredPrefix + hardCapPrompt(body, bodyLimit), nil
 }
 
-func fitDirtySnapshotReference(prompt, diffFile string, limit int) string {
+func fitDirtySnapshotReference(prompt, diffFile string, limit int) (string, error) {
 	variants := dirtySnapshotReferenceVariants(diffFile)
 	prefix := prompt
 	if before, _, found := strings.Cut(prompt, dirtyTruncatedDiffMarker); found {
@@ -369,23 +373,23 @@ func dirtySnapshotReferenceVariants(diffFile string) []string {
 	}
 }
 
-func fitPrefixWithSuffixVariants(prefix string, limit int, variants ...string) string {
+func fitPrefixWithSuffixVariants(prefix string, limit int, variants ...string) (string, error) {
 	if limit <= 0 {
-		return ""
+		return "", fmt.Errorf("prompt limit must be positive, got %d", limit)
 	}
 	if len(variants) == 0 {
-		return truncateUTF8(prefix, limit)
+		return truncateUTF8(prefix, limit), nil
 	}
 	for _, variant := range variants {
 		if len(prefix)+len(variant) <= limit {
-			return prefix + variant
+			return prefix + variant, nil
 		}
 	}
 	shortest := variants[len(variants)-1]
-	if len(shortest) >= limit {
-		return truncateUTF8(shortest, limit)
+	if len(shortest) > limit {
+		return "", fmt.Errorf("required prompt suffix is %d bytes but prompt limit is %d bytes", len(shortest), limit)
 	}
-	return truncateUTF8(prefix, limit-len(shortest)) + shortest
+	return truncateUTF8(prefix, limit-len(shortest)) + shortest, nil
 }
 
 func isCodexReviewAgent(agentName string) bool {

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -67,6 +67,8 @@ type Builder struct {
 // reusable across retries.
 const DiffFilePathPlaceholder = "/tmp/roborev diff placeholder"
 
+const dirtyTruncatedDiffMarker = "(Diff too large to include in full)"
+
 // NewBuilder creates a new prompt builder
 func NewBuilder(db *storage.DB) *Builder {
 	return &Builder{db: db}
@@ -211,12 +213,12 @@ func (b *Builder) BuildDirtyWithSnapshot(repoPath, diff string, repoID int64, co
 	if err != nil {
 		return SnapshotResult{}, err
 	}
-	if strings.Contains(p, "(Diff too large to include in full)") && len(diff) > 0 {
+	if strings.Contains(p, dirtyTruncatedDiffMarker) && len(diff) > 0 {
 		diffFile, cleanup, snapErr := writeExternalDiffSnapshot(diff)
 		if snapErr != nil {
 			return SnapshotResult{}, fmt.Errorf("dirty diff snapshot: %w", snapErr)
 		}
-		p += fmt.Sprintf("\nThe full diff is also available at: `%s`\n", diffFile)
+		p = fitDirtySnapshotReference(p, diffFile, b.resolveMaxPromptSize(repoPath))
 		return SnapshotResult{Prompt: p, Cleanup: cleanup}, nil
 	}
 	return SnapshotResult{Prompt: p}, nil
@@ -348,6 +350,42 @@ func (b *Builder) BuildDirty(repoPath, diff string, repoID int64, contextCount i
 		return "", err
 	}
 	return ctx.requiredPrefix + hardCapPrompt(body, bodyLimit), nil
+}
+
+func fitDirtySnapshotReference(prompt, diffFile string, limit int) string {
+	variants := dirtySnapshotReferenceVariants(diffFile)
+	prefix := prompt
+	if before, _, found := strings.Cut(prompt, dirtyTruncatedDiffMarker); found {
+		prefix = before
+	}
+	return fitPrefixWithSuffixVariants(prefix, limit, variants...)
+}
+
+func dirtySnapshotReferenceVariants(diffFile string) []string {
+	return []string{
+		fmt.Sprintf("%s\nThe full diff has been written to a file for review.\nRead the diff from: `%s`\n\nReview the actual diff before writing findings.\n", dirtyTruncatedDiffMarker, diffFile),
+		fmt.Sprintf("%s\nRead the diff from: `%s`\n", dirtyTruncatedDiffMarker, diffFile),
+		fmt.Sprintf("(Diff too large; read `%s`.)\n", diffFile),
+	}
+}
+
+func fitPrefixWithSuffixVariants(prefix string, limit int, variants ...string) string {
+	if limit <= 0 {
+		return ""
+	}
+	if len(variants) == 0 {
+		return truncateUTF8(prefix, limit)
+	}
+	for _, variant := range variants {
+		if len(prefix)+len(variant) <= limit {
+			return prefix + variant
+		}
+	}
+	shortest := variants[len(variants)-1]
+	if len(shortest) >= limit {
+		return truncateUTF8(shortest, limit)
+	}
+	return truncateUTF8(prefix, limit-len(shortest)) + shortest
 }
 
 func isCodexReviewAgent(agentName string) bool {

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -370,14 +370,11 @@ func dirtySnapshotReferenceVariants(diffFile string) []string {
 }
 
 func fitPrefixWithSuffixVariants(prefix string, limit int, variants ...string) string {
-	if len(variants) == 0 {
-		if limit <= 0 {
-			return prefix
-		}
-		return truncateUTF8(prefix, limit)
-	}
 	if limit <= 0 {
-		return prefix + variants[0]
+		return ""
+	}
+	if len(variants) == 0 {
+		return truncateUTF8(prefix, limit)
 	}
 	for _, variant := range variants {
 		if len(prefix)+len(variant) <= limit {

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -1032,12 +1032,6 @@ func TestBuildDirtyWithSnapshotKeepsReferenceWithinCap(t *testing.T) {
 		"dirty snapshot prompt should include the generated snapshot path")
 }
 
-func TestFitPrefixWithSuffixVariantsTreatsNonPositiveLimitAsUnbounded(t *testing.T) {
-	prompt := fitPrefixWithSuffixVariants("prefix", 0, "long suffix", "short")
-
-	assert.Equal(t, "prefixlong suffix", prompt)
-}
-
 func TestResolveMaxPromptSizeWithoutConfigUsesConfigDefault(t *testing.T) {
 	b := NewBuilder(nil)
 	assert.Equal(t, config.DefaultMaxPromptSize, b.resolveMaxPromptSize(t.TempDir()))

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -1032,6 +1032,12 @@ func TestBuildDirtyWithSnapshotKeepsReferenceWithinCap(t *testing.T) {
 		"dirty snapshot prompt should include the generated snapshot path")
 }
 
+func TestFitPrefixWithSuffixVariantsTreatsNonPositiveLimitAsUnbounded(t *testing.T) {
+	prompt := fitPrefixWithSuffixVariants("prefix", 0, "long suffix", "short")
+
+	assert.Equal(t, "prefixlong suffix", prompt)
+}
+
 func TestResolveMaxPromptSizeWithoutConfigUsesConfigDefault(t *testing.T) {
 	b := NewBuilder(nil)
 	assert.Equal(t, config.DefaultMaxPromptSize, b.resolveMaxPromptSize(t.TempDir()))

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -1032,6 +1032,22 @@ func TestBuildDirtyWithSnapshotKeepsReferenceWithinCap(t *testing.T) {
 		"dirty snapshot prompt should include the generated snapshot path")
 }
 
+func TestFitPrefixWithSuffixVariantsRejectsNonPositiveLimit(t *testing.T) {
+	prompt, err := fitPrefixWithSuffixVariants("prefix", 0, "suffix")
+
+	require.Error(t, err)
+	assert.Empty(t, prompt)
+	assert.Contains(t, err.Error(), "prompt limit must be positive")
+}
+
+func TestFitPrefixWithSuffixVariantsRejectsUnfittableSuffix(t *testing.T) {
+	prompt, err := fitPrefixWithSuffixVariants("prefix", 4, "required suffix")
+
+	require.Error(t, err)
+	assert.Empty(t, prompt)
+	assert.Contains(t, err.Error(), "required prompt suffix")
+}
+
 func TestResolveMaxPromptSizeWithoutConfigUsesConfigDefault(t *testing.T) {
 	b := NewBuilder(nil)
 	assert.Equal(t, config.DefaultMaxPromptSize, b.resolveMaxPromptSize(t.TempDir()))

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -1012,6 +1012,26 @@ func TestBuildDirtySmallCapStaysWithinCap(t *testing.T) {
 		"expected oversized optional context to be trimmed")
 }
 
+func TestBuildDirtyWithSnapshotKeepsReferenceWithinCap(t *testing.T) {
+	repoPath, _ := setupLargeDiffRepoWithGuidelines(t, 5000)
+	diff := strings.Repeat("+ line\n", 50000)
+	cap := 10000
+	cfg := &config.Config{DefaultMaxPromptSize: cap}
+	b := NewBuilderWithConfig(nil, cfg)
+
+	result, err := b.BuildDirtyWithSnapshot(repoPath, diff, 0, 0, "claude-code", "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result.Cleanup)
+	defer result.Cleanup()
+
+	assert.LessOrEqual(t, len(result.Prompt), cap,
+		"dirty snapshot prompt should keep the file reference within the configured cap")
+	assert.Contains(t, result.Prompt, "Read the diff from:",
+		"dirty snapshot prompt should point reviewers at the external diff file")
+	assert.Contains(t, result.Prompt, "roborev-snapshot-",
+		"dirty snapshot prompt should include the generated snapshot path")
+}
+
 func TestResolveMaxPromptSizeWithoutConfigUsesConfigDefault(t *testing.T) {
 	b := NewBuilder(nil)
 	assert.Equal(t, config.DefaultMaxPromptSize, b.resolveMaxPromptSize(t.TempDir()))


### PR DESCRIPTION
## Summary
- stop expanding external diff snapshots back into Codex prompts
- add an agent-agnostic final prompt size gate before submission
- treat context-window failures as non-retryable/failover candidates instead of retrying the same oversized prompt
- write large diff snapshots to external temp files readable by all agents

## Validation
- go test ./internal/daemon -run 'TestWriteDiffSnapshot_WritesExternalReadableTempFile|TestPreparePrebuiltPrompt|TestProcessJob_SmallDiffSucceedsWhenGitDirReadOnly|TestProcessJob_LargeDiffUsesExternalSnapshotWhenGitDirReadOnly|TestProcessJob_LargeDiffUsesExternalSnapshotWithoutOversizedPrompt|TestProcessJob_OversizedFinalPromptFailsBeforeAnyAgent|TestFailOrRetryAgent_ContextWindowErrorFailsWithoutRetry'
- go test ./internal/prompt ./internal/daemon
- go test -tags=integration ./internal/daemon -run 'TestSnapshotFlow'
- go fmt ./...
- go vet ./...
- go test ./...
- retried the failed large Codex review locally; Codex read /var/folders/.../roborev-snapshot-*.diff directly and completed without the previous context-window failure
