### PR TITLE
feat(status): expose daemon endpoint in JSON output

### DIFF
--- a/cmd/roborev/status.go
+++ b/cmd/roborev/status.go
@@ -14,13 +14,31 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type statusJSONResult struct {
+	Running bool                  `json:"running"`
+	Daemon  *storage.DaemonStatus `json:"daemon,omitempty"`
+	Health  *storage.HealthStatus `json:"health,omitempty"`
+	Jobs    []storage.ReviewJob   `json:"jobs,omitempty"`
+}
+
 func statusCmd() *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Show daemon and queue status",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			writeJSONResult := func(result statusJSONResult) error {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(result)
+			}
+
 			// Ensure daemon is running (and restart if version mismatch)
 			if err := ensureDaemon(); err != nil {
+				if jsonOutput {
+					return writeJSONResult(statusJSONResult{Running: false})
+				}
 				fmt.Println("Daemon: not running")
 				fmt.Println()
 				fmt.Println("Start with: roborev daemon start")
@@ -32,6 +50,9 @@ func statusCmd() *cobra.Command {
 			client := ep.HTTPClient(2 * time.Second)
 			resp, err := client.Get(addr + "/api/status")
 			if err != nil {
+				if jsonOutput {
+					return writeJSONResult(statusJSONResult{Running: false})
+				}
 				fmt.Println("Daemon: not running")
 				fmt.Println()
 				fmt.Println("Start with: roborev daemon start")
@@ -46,17 +67,43 @@ func statusCmd() *cobra.Command {
 
 			// Get health status
 			healthResp, err := client.Get(addr + "/api/health")
-			var health storage.HealthStatus
+			var health *storage.HealthStatus
 			if err == nil {
 				defer healthResp.Body.Close()
-				if err := json.NewDecoder(healthResp.Body).Decode(&health); err != nil {
+				var decoded storage.HealthStatus
+				if err := json.NewDecoder(healthResp.Body).Decode(&decoded); err != nil {
 					log.Printf("failed to parse health response: %v", err)
+				} else {
+					health = &decoded
 				}
+			}
+
+			// Get recent jobs
+			var jobs []storage.ReviewJob
+			resp, err = client.Get(addr + "/api/jobs?limit=10")
+			if err == nil {
+				defer resp.Body.Close()
+
+				var jobsResp struct {
+					Jobs []storage.ReviewJob `json:"jobs"`
+				}
+				if err := json.NewDecoder(resp.Body).Decode(&jobsResp); err == nil {
+					jobs = jobsResp.Jobs
+				}
+			}
+
+			if jsonOutput {
+				return writeJSONResult(statusJSONResult{
+					Running: true,
+					Daemon:  &status,
+					Health:  health,
+					Jobs:    jobs,
+				})
 			}
 
 			// Display daemon info with uptime and version
 			daemonLine := "Daemon: running"
-			if health.Uptime != "" {
+			if health != nil && health.Uptime != "" {
 				daemonLine += fmt.Sprintf(" (uptime: %s)", health.Uptime)
 			}
 			if status.Version != "" {
@@ -69,7 +116,7 @@ func statusCmd() *cobra.Command {
 			fmt.Println()
 
 			// Display health status
-			if health.Version != "" {
+			if health != nil && health.Version != "" {
 				if health.Healthy {
 					fmt.Println("Health: OK")
 				} else {
@@ -103,25 +150,11 @@ func statusCmd() *cobra.Command {
 				}
 			}
 
-			// Get recent jobs
-			resp, err = client.Get(addr + "/api/jobs?limit=10")
-			if err != nil {
-				return nil
-			}
-			defer resp.Body.Close()
-
-			var jobsResp struct {
-				Jobs []storage.ReviewJob `json:"jobs"`
-			}
-			if err := json.NewDecoder(resp.Body).Decode(&jobsResp); err != nil {
-				return nil
-			}
-
-			if len(jobsResp.Jobs) > 0 {
+			if len(jobs) > 0 {
 				fmt.Println("Recent Jobs:")
 				w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 				fmt.Fprintf(w, "  ID\tSHA\tRepo\tAgent\tStatus\tTime\n")
-				for _, j := range jobsResp.Jobs {
+				for _, j := range jobs {
 					elapsed := ""
 					if j.StartedAt != nil {
 						if j.FinishedAt != nil {
@@ -157,4 +190,7 @@ func statusCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "structured output for scripting")
+	return cmd
 }

--- a/cmd/roborev/status_test.go
+++ b/cmd/roborev/status_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/roborev-dev/roborev/internal/storage"
+	"github.com/roborev-dev/roborev/internal/version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type statusJSONOutput struct {
+	Running bool                 `json:"running"`
+	Daemon  storage.DaemonStatus `json:"daemon"`
+	Jobs    []storage.ReviewJob  `json:"jobs,omitempty"`
+}
+
+func TestStatusCmdJSONIncludesDaemonEndpoint(t *testing.T) {
+	md := NewMockDaemon(t, MockRefineHooks{
+		OnStatus: func(w http.ResponseWriter, r *http.Request, _ *mockRefineState) bool {
+			_ = json.NewEncoder(w).Encode(storage.DaemonStatus{
+				Version: version.Version,
+				Network: "tcp",
+				Address: "127.0.0.1:7373",
+				Port:    7373,
+			})
+			return true
+		},
+		OnUnhandled: func(w http.ResponseWriter, r *http.Request, _ *mockRefineState) bool {
+			if r.URL.Path != "/api/health" {
+				return false
+			}
+			_ = json.NewEncoder(w).Encode(storage.HealthStatus{
+				Healthy: true,
+				Version: version.Version,
+			})
+			return true
+		},
+	})
+	defer md.Close()
+
+	output := captureStdout(t, func() {
+		cmd := statusCmd()
+		cmd.SetArgs([]string{"--json"})
+		err := cmd.Execute()
+		require.NoError(t, err)
+	})
+
+	var parsed statusJSONOutput
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed))
+	assert.True(t, parsed.Running)
+	assert.Equal(t, version.Version, parsed.Daemon.Version)
+	assert.Equal(t, "tcp", parsed.Daemon.Network)
+	assert.Equal(t, "127.0.0.1:7373", parsed.Daemon.Address)
+	assert.Equal(t, 7373, parsed.Daemon.Port)
+}

--- a/internal/daemon/routes_test.go
+++ b/internal/daemon/routes_test.go
@@ -125,6 +125,7 @@ func TestHumaGetStatus(t *testing.T) {
 	srv, db, _ := newTestServer(t)
 	repo := testutil.CreateTestRepo(t, db)
 	testutil.CreateTestJobs(t, db, repo, 2, "test-agent")
+	srv.endpoint = DaemonEndpoint{Network: "tcp", Address: "127.0.0.1:7373"}
 
 	rr := serveHuma(
 		t, srv, http.MethodGet, "/api/status", nil,
@@ -135,6 +136,9 @@ func TestHumaGetStatus(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &status))
 	assert.NotEmpty(t, status.Version)
 	assert.Equal(t, 2, status.QueuedJobs)
+	assert.Equal(t, "tcp", status.Network)
+	assert.Equal(t, "127.0.0.1:7373", status.Address)
+	assert.Equal(t, 7373, status.Port)
 }
 
 func TestHumaGetReview_NotFound(t *testing.T) {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -1089,6 +1089,10 @@ func (s *Server) humaGetStatus(
 	}
 	configReloadCounter := s.configWatcher.ReloadCounter()
 
+	s.endpointMu.Lock()
+	ep := s.endpoint
+	s.endpointMu.Unlock()
+
 	resp := &GetStatusOutput{}
 	resp.Body = storage.DaemonStatus{
 		Version:             version.Version,
@@ -1103,6 +1107,9 @@ func (s *Server) humaGetStatus(
 		AutoDesign:          s.autoDesignStatusForResponse(),
 		ActiveWorkers:       s.workerPool.ActiveWorkers(),
 		MaxWorkers:          s.workerPool.MaxWorkers(),
+		Network:             ep.Network,
+		Address:             ep.Address,
+		Port:                ep.Port(),
 		MachineID:           s.getMachineID(),
 		ConfigReloadedAt:    configReloadedAt,
 		ConfigReloadCounter: configReloadCounter,

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -253,6 +253,9 @@ type DaemonStatus struct {
 	SkippedJobs         int    `json:"skipped_jobs"`
 	ActiveWorkers       int    `json:"active_workers"`
 	MaxWorkers          int    `json:"max_workers"`
+	Network             string `json:"network,omitempty"`
+	Address             string `json:"address,omitempty"`
+	Port                int    `json:"port,omitempty"`
 	MachineID           string `json:"machine_id,omitempty"`            // Local machine ID for remote job detection
 	ConfigReloadedAt    string `json:"config_reloaded_at,omitempty"`    // Last config reload timestamp (RFC3339Nano)
 	ConfigReloadCounter uint64 `json:"config_reload_counter,omitempty"` // Monotonic reload counter (for sub-second detection)


### PR DESCRIPTION
## Summary
- add `roborev status --json` structured output for scripting
- include daemon `network`, `address`, and `port` in status JSON so clients do not need to read runtime files
- expose same endpoint fields from `/api/status` and cover behavior with CLI and daemon tests

Fixes #653

## Validation
- go test ./...
- go vet ./...