### PR TITLE
feat(analyze): add security mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ roborev tui           # View reviews in interactive UI
 - **Auto-Fix** - `roborev fix` feeds review findings to an agent that
   applies fixes and commits. `roborev refine` iterates until reviews pass.
 - **Code Analysis** - Built-in analysis types (duplication, complexity,
-  refactoring, test fixtures, dead code) that agents can fix automatically.
+  refactoring, test fixtures, dead code, security) that agents can fix
+  automatically.
 - **Multi-Agent** - Works with Codex, Claude Code, Gemini, Copilot,
   OpenCode, Cursor, Kiro, Kilo, Droid, and Pi.
 - **Runs Locally** - No hosted service or additional infrastructure.
@@ -83,10 +84,11 @@ roborev analyze duplication ./...           # Find duplication
 roborev analyze refactor --fix *.go         # Suggest and apply refactors
 roborev analyze complexity --wait main.go   # Analyze and show results
 roborev analyze test-fixtures *_test.go     # Find test helper opportunities
+roborev analyze security ./...              # Find security risks in existing code
 ```
 
 Available types: `test-fixtures`, `duplication`, `refactor`, `complexity`,
-`api-design`, `dead-code`, `architecture`.
+`api-design`, `dead-code`, `architecture`, `security`.
 
 Analysis jobs appear in the review queue. Use `roborev fix <id>` to
 apply findings later, or pass `--fix` to apply immediately.

--- a/cmd/roborev/analyze.go
+++ b/cmd/roborev/analyze.go
@@ -81,6 +81,7 @@ Available analysis types:
   api-design     Review API consistency and design patterns
   dead-code      Find unused exports and unreachable code
   architecture   Review architectural patterns and structure
+  security       Find concrete security risks in existing code
 
 Examples:
   roborev analyze test-fixtures internal/storage/*_test.go
@@ -88,6 +89,7 @@ Examples:
   roborev analyze refactor --wait main.go utils.go
   roborev analyze complexity --agent gemini ./...
   roborev analyze architecture internal/storage/    # analyze a directory
+  roborev analyze security ./...                    # security hardening pass
   roborev analyze --list
 
 Per-file mode (--per-file):
@@ -512,6 +514,7 @@ func enqueueAnalysisJob(ep daemon.DaemonEndpoint, repoRoot, prompt, outputPrefix
 		Agent:        opts.agentName,
 		Model:        opts.model,
 		Reasoning:    opts.reasoning,
+		ReviewType:   analysisReviewType(label),
 		CustomPrompt: prompt,
 		OutputPrefix: outputPrefix,
 		Agentic:      true, // Agentic mode needed for reading files when prompt exceeds size limit
@@ -538,6 +541,13 @@ func enqueueAnalysisJob(ep daemon.DaemonEndpoint, repoRoot, prompt, outputPrefix
 	}
 
 	return &job, nil
+}
+
+func analysisReviewType(label string) string {
+	if label == config.ReviewTypeSecurity {
+		return config.ReviewTypeSecurity
+	}
+	return ""
 }
 
 // runAnalyzeAndFix waits for analysis to complete, runs a fixer agent, then marks closed

--- a/cmd/roborev/analyze_test.go
+++ b/cmd/roborev/analyze_test.go
@@ -351,6 +351,7 @@ func TestListAnalysisTypes(t *testing.T) {
 		"api-design",
 		"dead-code",
 		"architecture",
+		"security",
 	}
 
 	for _, typ := range expectedTypes {
@@ -444,6 +445,32 @@ func TestEnqueueAnalysisJob(t *testing.T) {
 	require.NoError(t, err, "enqueueAnalysisJob")
 
 	assert.Equal(t, int64(42), job.ID, "job.ID")
+}
+
+func TestEnqueueSecurityAnalysisJobUsesSecurityReviewType(t *testing.T) {
+	repo := newTestGitRepo(t)
+	repo.CommitFile("main.go", "package main", "initial")
+
+	var gotReviewType string
+	ts, _ := newMockServer(t, MockServerOpts{
+		OnEnqueue: func(w http.ResponseWriter, r *http.Request) {
+			var req daemon.EnqueueRequest
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			gotReviewType = req.ReviewType
+
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(storage.ReviewJob{
+				ID:     42,
+				Agent:  "test",
+				Status: storage.JobStatusQueued,
+			})
+		},
+	})
+
+	_, err := enqueueAnalysisJob(mustParseEndpoint(t, ts.URL), repo.Dir, "test prompt", "", "security", analyzeOptions{agentName: "test"})
+	require.NoError(t, err, "enqueueAnalysisJob")
+
+	assert.Equal(t, "security", gotReviewType, "security analysis should resolve security workflow config")
 }
 
 func TestEnqueueAnalysisJobBranchName(t *testing.T) {

--- a/internal/prompt/analyze/analyze.go
+++ b/internal/prompt/analyze/analyze.go
@@ -55,6 +55,11 @@ var (
 		Description: "Review architectural patterns and structure",
 		promptFile:  "architecture.txt",
 	}
+	Security = AnalysisType{
+		Name:        "security",
+		Description: "Find concrete security risks in existing code",
+		promptFile:  "security.txt",
+	}
 )
 
 // AllTypes returns all available analysis types
@@ -66,6 +71,7 @@ var AllTypes = []AnalysisType{
 	APIDesign,
 	DeadCode,
 	Architecture,
+	Security,
 }
 
 // GetType returns an analysis type by name, or nil if not found

--- a/internal/prompt/analyze/analyze_test.go
+++ b/internal/prompt/analyze/analyze_test.go
@@ -22,6 +22,7 @@ func TestGetType(t *testing.T) {
 		{"api-design", "api-design", false},
 		{"dead-code", "dead-code", false},
 		{"architecture", "architecture", false},
+		{"security", "security", false},
 		{"invalid", "", true},
 		{"", "", true},
 	}
@@ -50,6 +51,20 @@ func TestAllTypesHavePrompts(t *testing.T) {
 				"GetPrompt() returned suspiciously short prompt: %q", prompt)
 		})
 	}
+}
+
+func TestSecurityPromptRequiresActionableFindings(t *testing.T) {
+	prompt, err := Security.GetPrompt()
+	require.NoError(t, err, "GetPrompt()")
+
+	assert.Contains(t, prompt, "file path", "prompt should require file paths")
+	assert.Contains(t, prompt, "evidence", "prompt should require evidence")
+	assert.Contains(t, prompt, "severity", "prompt should require severity")
+	assert.Contains(t, prompt, "confidence", "prompt should require confidence")
+	assert.Contains(t, prompt, "trust boundary", "prompt should require trust-boundary reasoning")
+	assert.Contains(t, prompt, "suggested fix", "prompt should require mitigations")
+	assert.Contains(t, prompt, "exploitable", "prompt should require exploitability assessment")
+	assert.Contains(t, prompt, "concrete", "prompt should discourage generic findings")
 }
 
 func TestBuildPrompt(t *testing.T) {

--- a/internal/prompt/analyze/security.txt
+++ b/internal/prompt/analyze/security.txt
@@ -1,0 +1,49 @@
+Analyze the provided files for concrete security vulnerabilities and risky security patterns in the current codebase.
+
+Focus on issues with specific evidence in the files being analyzed:
+1. Authentication and authorization mistakes:
+   - Missing permission checks
+   - Broken object ownership checks
+   - Insecure session or token handling
+   - Privilege escalation paths
+2. Trust-boundary failures:
+   - Missing validation or normalization of untrusted input
+   - Insecure direct object references
+   - Tenant isolation mistakes
+   - Unsafe data crossing API, filesystem, process, network, or database boundaries
+3. Injection and unsafe execution:
+   - SQL, command, template, LDAP, header, or path injection
+   - Unsafe subprocess usage
+   - SSRF or unvalidated outbound requests
+   - Unsafe deserialization
+4. File, secret, and data handling:
+   - Path traversal
+   - Insecure file upload/download handling
+   - Hardcoded secrets or unsafe secret logging
+   - Sensitive data in logs or error messages
+   - Insecure defaults for data storage or transport
+5. Cryptography and randomness:
+   - Weak algorithms
+   - Predictable random values for security decisions
+   - Incorrect key, nonce, or token generation
+6. Dependency and configuration risks:
+   - Dangerous dependency or plugin execution patterns
+   - CI/CD settings that expose secrets or run untrusted code
+   - Overly broad permissions or insecure default configuration
+
+Avoid noisy generic findings. Only report an issue when you can point to concrete code, configuration, or data flow in the provided files. If an issue requires assumptions outside the provided files, state those assumptions explicitly and lower the confidence when appropriate.
+
+Output format:
+- **SECURITY SUMMARY:** Brief risk overview and the most important trust boundaries reviewed
+- **FINDINGS:** For each finding include:
+  - file path and narrowest available location
+  - severity: critical, high, medium, or low
+  - Confidence: high, medium, or low
+  - Evidence: exact code path, configuration, or data flow that creates the risk
+  - trust boundary or threat model: who controls the input and what asset is at risk
+  - Exploitability: whether the issue is directly exploitable or requires specific assumptions
+  - suggested fix or mitigation
+- **NO FINDINGS:** If no concrete security issues are found, state "No security findings with concrete evidence."
+- **FOLLOW-UP CHECKS:** Optional manual checks that could not be confirmed from these files
+
+Do not include general code quality, refactoring, performance, or style findings unless they have direct security impact.


### PR DESCRIPTION
## Summary
- add `security` as a built-in `roborev analyze` mode for existing files/codebases
- add a security-focused analysis prompt requiring evidence, severity, confidence, trust-boundary reasoning, exploitability, and mitigations
- send security analysis jobs with `review_type=security` so `security_agent` and `security_model` config are respected
- update README/help text and regression tests

Fixes #718

## Validation
- go fmt ./...
- go test ./...
- go vet ./...