### PR TITLE
prompt: let review agents read repo files to verify diff claims

### DIFF
--- a/internal/prompt/templates/claude-code_review.md.gotmpl
+++ b/internal/prompt/templates/claude-code_review.md.gotmpl
@@ -2,7 +2,7 @@ You are a code reviewer. Review the code changes shown below.
 
 Return only the final review. Do NOT narrate your process, mention files you opened, or describe intermediate checks.
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
-Do NOT build the project, run the test suite, or execute the code while reviewing. Base your review on the diff and static analysis only.
+Do NOT build the project, run the test suite, or execute the code while reviewing. You may read other files in the repository to verify claims made by the diff. If the diff references a file, package, function, or symbol that is not present in the diff itself, check whether it exists in the repo before asserting it doesn't.
 
 ## Output Format
 

--- a/internal/prompt/templates/codex_review.md.gotmpl
+++ b/internal/prompt/templates/codex_review.md.gotmpl
@@ -2,7 +2,7 @@ You are a code reviewer. Review the code changes shown below.
 
 Return only the final review. Do NOT narrate your process, mention files you opened, or describe intermediate checks.
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
-Do NOT build the project, run the test suite, or execute the code while reviewing. Base your review on the diff and static analysis only.
+Do NOT build the project, run the test suite, or execute the code while reviewing. You may read other files in the repository to verify claims made by the diff. If the diff references a file, package, function, or symbol that is not present in the diff itself, check whether it exists in the repo before asserting it doesn't.
 Do NOT search or read files outside the repository checkout, except for an explicitly provided diff file path for this review. Do not use tools like rg, find, or cat on unrelated paths outside the repo.
 
 ## Output Format

--- a/internal/prompt/templates/gemini_review.md.gotmpl
+++ b/internal/prompt/templates/gemini_review.md.gotmpl
@@ -2,7 +2,7 @@ You are a code reviewer. Review the code changes shown below.
 
 Your goal is to be extremely concise and professional. Do NOT explain your process or list the steps you are taking. Just provide the final review results.
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
-Do NOT build the project, run the test suite, or execute the code while reviewing. Base your review on the diff and static analysis only.
+Do NOT build the project, run the test suite, or execute the code while reviewing. You may read other files in the repository to verify claims made by the diff. If the diff references a file, package, function, or symbol that is not present in the diff itself, check whether it exists in the repo before asserting it doesn't.
 
 ## Output Format
 

--- a/internal/prompt/testdata/golden/range_truncated_codex_in_range.golden
+++ b/internal/prompt/testdata/golden/range_truncated_codex_in_range.golden
@@ -2,7 +2,7 @@ You are a code reviewer. Review the code changes shown below.
 
 Return only the final review. Do NOT narrate your process, mention files you opened, or describe intermediate checks.
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
-Do NOT build the project, run the test suite, or execute the code while reviewing. Base your review on the diff and static analysis only.
+Do NOT build the project, run the test suite, or execute the code while reviewing. You may read other files in the repository to verify claims made by the diff. If the diff references a file, package, function, or symbol that is not present in the diff itself, check whether it exists in the repo before asserting it doesn't.
 Do NOT search or read files outside the repository checkout, except for an explicitly provided diff file path for this review. Do not use tools like rg, find, or cat on unrelated paths outside the repo.
 
 ## Output Format

--- a/internal/prompt/testdata/golden/single_review_claude_code.golden
+++ b/internal/prompt/testdata/golden/single_review_claude_code.golden
@@ -2,7 +2,7 @@ You are a code reviewer. Review the code changes shown below.
 
 Return only the final review. Do NOT narrate your process, mention files you opened, or describe intermediate checks.
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
-Do NOT build the project, run the test suite, or execute the code while reviewing. Base your review on the diff and static analysis only.
+Do NOT build the project, run the test suite, or execute the code while reviewing. You may read other files in the repository to verify claims made by the diff. If the diff references a file, package, function, or symbol that is not present in the diff itself, check whether it exists in the repo before asserting it doesn't.
 
 ## Output Format
 

--- a/internal/prompt/testdata/golden/single_review_codex.golden
+++ b/internal/prompt/testdata/golden/single_review_codex.golden
@@ -2,7 +2,7 @@ You are a code reviewer. Review the code changes shown below.
 
 Return only the final review. Do NOT narrate your process, mention files you opened, or describe intermediate checks.
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
-Do NOT build the project, run the test suite, or execute the code while reviewing. Base your review on the diff and static analysis only.
+Do NOT build the project, run the test suite, or execute the code while reviewing. You may read other files in the repository to verify claims made by the diff. If the diff references a file, package, function, or symbol that is not present in the diff itself, check whether it exists in the repo before asserting it doesn't.
 Do NOT search or read files outside the repository checkout, except for an explicitly provided diff file path for this review. Do not use tools like rg, find, or cat on unrelated paths outside the repo.
 
 ## Output Format

--- a/internal/prompt/testdata/golden/single_review_gemini.golden
+++ b/internal/prompt/testdata/golden/single_review_gemini.golden
@@ -2,7 +2,7 @@ You are a code reviewer. Review the code changes shown below.
 
 Your goal is to be extremely concise and professional. Do NOT explain your process or list the steps you are taking. Just provide the final review results.
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
-Do NOT build the project, run the test suite, or execute the code while reviewing. Base your review on the diff and static analysis only.
+Do NOT build the project, run the test suite, or execute the code while reviewing. You may read other files in the repository to verify claims made by the diff. If the diff references a file, package, function, or symbol that is not present in the diff itself, check whether it exists in the repo before asserting it doesn't.
 
 ## Output Format
 

--- a/internal/prompt/testdata/golden/single_truncated_diff_codex.golden
+++ b/internal/prompt/testdata/golden/single_truncated_diff_codex.golden
@@ -2,7 +2,7 @@ You are a code reviewer. Review the code changes shown below.
 
 Return only the final review. Do NOT narrate your process, mention files you opened, or describe intermediate checks.
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
-Do NOT build the project, run the test suite, or execute the code while reviewing. Base your review on the diff and static analysis only.
+Do NOT build the project, run the test suite, or execute the code while reviewing. You may read other files in the repository to verify claims made by the diff. If the diff references a file, package, function, or symbol that is not present in the diff itself, check whether it exists in the repo before asserting it doesn't.
 Do NOT search or read files outside the repository checkout, except for an explicitly provided diff file path for this review. Do not use tools like rg, find, or cat on unrelated paths outside the repo.
 
 ## Output Format


### PR DESCRIPTION
## Summary

- Review templates told agents to base findings on "the diff and static analysis only". Agents took that literally and treated anything not in the diff as absent from the repo, producing false-negative claims like "this package doesn't exist" on docs PRs that describe code living outside the diff.
- Drop the "diff only" framing in the codex, claude-code, and gemini review templates. Keep the prohibition on building, running tests, and executing code.
- Explicitly permit reading other repo files to verify claims, and instruct agents to check existence before asserting a referenced file, package, function, or symbol is absent.
- Non-templated agents (copilot, opencode, cursor, kiro, kilo, droid, pi) still hit the fallback constants in `prompt.go` and are unchanged; they aren't currently used for CI review.