### PR TITLE
fix(agent): adapt Codex resume args

### DIFF
--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -27,6 +28,8 @@ const codexDangerousFlag = "--dangerously-bypass-approvals-and-sandbox"
 const codexAutoApproveFlag = "--full-auto"
 const codexIgnoreUserConfigFlag = "--ignore-user-config"
 const codexDisableSkillsConfig = "skills.include_instructions=false"
+const codexReadOnlySandboxConfig = `sandbox_mode="read-only"`
+const codexReviewPermissionsProfile = "roborev_review"
 
 var codexDangerousSupport sync.Map
 var codexAutoApproveSupport sync.Map
@@ -171,8 +174,9 @@ type codexArgOptions struct {
 
 func (a *CodexAgent) commandArgs(opts codexArgOptions) []string {
 	sessionID := sanitizedResumeSessionID(a.SessionID)
-	args := []string{
-		"exec",
+	args := []string{"exec"}
+	if sessionID != "" {
+		args = append(args, "resume")
 	}
 	args = append(args, "--json")
 	if a.IgnoreUserConfig {
@@ -186,15 +190,19 @@ func (a *CodexAgent) commandArgs(opts codexArgOptions) []string {
 			// --full-auto still uses bwrap internally, so we
 			// need the full bypass flag on broken systems.
 			args = append(args, codexDangerousFlag)
+		} else if sessionID != "" {
+			args = append(args, codexReadOnlyResumeConfigArgs(opts.addDirs)...)
 		} else {
 			args = append(args, "--sandbox", "read-only")
 		}
 	}
-	if !opts.preview {
+	if sessionID == "" && !opts.preview {
 		args = append(args, "-C", opts.repoPath)
 	}
-	for _, dir := range opts.addDirs {
-		args = append(args, "--add-dir", dir)
+	if sessionID == "" {
+		for _, dir := range opts.addDirs {
+			args = append(args, "--add-dir", dir)
+		}
 	}
 	if a.Model != "" {
 		args = append(args, "-m", a.Model)
@@ -206,9 +214,6 @@ func (a *CodexAgent) commandArgs(opts codexArgOptions) []string {
 		args = append(args, "-c", fmt.Sprintf(`model_reasoning_effort="%s"`, effort))
 	}
 	if sessionID != "" {
-		args = append(args, "resume")
-	}
-	if sessionID != "" {
 		args = append(args, sessionID)
 	}
 	if !opts.preview {
@@ -217,6 +222,27 @@ func (a *CodexAgent) commandArgs(opts codexArgOptions) []string {
 		args = append(args, "-")
 	}
 	return args
+}
+
+func codexReadOnlyResumeConfigArgs(addDirs []string) []string {
+	args := []string{"-c", codexReadOnlySandboxConfig}
+	if len(addDirs) == 0 {
+		return args
+	}
+
+	args = append(args,
+		"-c", fmt.Sprintf(`default_permissions="%s"`, codexReviewPermissionsProfile),
+		"-c", fmt.Sprintf(`permissions.%s.filesystem=%s`, codexReviewPermissionsProfile, codexReadOnlyFilesystemConfig(addDirs)),
+	)
+	return args
+}
+
+func codexReadOnlyFilesystemConfig(addDirs []string) string {
+	entries := []string{strconv.Quote(":project_roots") + `={"."="read"}`}
+	for _, dir := range addDirs {
+		entries = append(entries, strconv.Quote(dir)+`="read"`)
+	}
+	return "{" + strings.Join(entries, ",") + "}"
 }
 
 func codexSupportsDangerousFlag(ctx context.Context, command string, ignoreUserConfig bool) (bool, error) {

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -86,15 +86,43 @@ func TestCodexBuildArgsWithSessionResume(t *testing.T) {
 
 	assert.Equal(t, []string{
 		"exec",
+		"resume",
 		"--json",
-		"--sandbox", "read-only",
-		"-C", "/repo",
+		"-c", codexReadOnlySandboxConfig,
 		"-m", "o4-mini",
 		"-c", `model_reasoning_effort="high"`,
-		"resume",
 		"session-123",
 		"-",
 	}, args)
+	assert.NotContains(t, args, "--sandbox")
+	assert.NotContains(t, args, "-C")
+	assert.NotContains(t, args, "--add-dir")
+	assert.Contains(t, args, codexReadOnlySandboxConfig)
+}
+
+func TestCodexBuildArgsWithSessionResumeAddsSnapshotDirectoriesViaConfig(t *testing.T) {
+	a := NewCodexAgent("codex").WithSessionID("session-123").(*CodexAgent)
+	snapshotDir, err := os.MkdirTemp("", "roborev-snapshot-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(snapshotDir) })
+	diffFile := snapshotDir + string(os.PathSeparator) + "roborev-snapshot-content.diff"
+	require.NoError(t, os.WriteFile(diffFile, []byte("diff --git a/x b/x\n"), 0o600))
+
+	args := a.buildArgs(
+		"/repo",
+		false,
+		true,
+		false,
+		"Read the diff from: `"+diffFile+"`",
+	)
+
+	assert.NotContains(t, args, "--add-dir")
+	assert.Contains(t, args, "-c")
+	assert.Contains(t, args, `default_permissions="roborev_review"`)
+	assert.Contains(t, args, fmt.Sprintf(
+		`permissions.roborev_review.filesystem={":project_roots"={"."="read"},%q="read"}`,
+		snapshotDir,
+	))
 }
 
 func TestCodexBuildArgsCanDisableSkills(t *testing.T) {
@@ -187,10 +215,10 @@ func TestCodexCommandLineOmitsRuntimeOnlyArgs(t *testing.T) {
 
 	cmdLine := a.CommandLine()
 
-	assert.Contains(t, cmdLine, "exec --json")
-	assert.Contains(t, cmdLine, "resume session-123")
+	assert.Contains(t, cmdLine, "exec resume --json")
 	assert.Contains(t, cmdLine, "session-123")
-	assert.Contains(t, cmdLine, "--sandbox read-only")
+	assert.NotContains(t, cmdLine, "--sandbox read-only")
+	assert.Contains(t, cmdLine, codexReadOnlySandboxConfig)
 	assert.NotContains(t, cmdLine, " -C ")
 	assert.False(t, strings.HasSuffix(cmdLine, " -"), "command line should omit stdin marker: %q", cmdLine)
 }
@@ -346,7 +374,10 @@ func TestCodexReviewWithSessionResumePassesResumeArgs(t *testing.T) {
 	args := readMockArgs(t, mock.ArgsFile)
 	require.GreaterOrEqual(t, len(args), 4)
 	assert.Equal(t, "exec", args[0])
-	assert.Equal(t, "resume", args[len(args)-3])
+	assert.Equal(t, "resume", args[1])
+	assertNotContainsArg(t, args, "--sandbox")
+	assertNotContainsArg(t, args, "-C")
+	assertContainsArg(t, args, codexReadOnlySandboxConfig)
 	assertContainsArg(t, args, "session-123")
 }
 


### PR DESCRIPTION
## Summary
- invoke Codex resumed sessions as `codex exec resume --json ...` without resume-unsupported runtime flags
- preserve read-only review behavior through config overrides for resumed runs
- expose diff snapshot directories to resumed Codex reviews through a temporary permissions profile

## Validation
- `go fmt ./...`
- `git diff --check`
- `go vet ./...`
- `go test ./internal/agent -count=1`
- `go test ./...`