### PR TITLE
fix(cli): show usage for invocation errors, plain Error for runtime failures

### DIFF
--- a/cmd/roborev/check_agents.go
+++ b/cmd/roborev/check_agents.go
@@ -110,7 +110,6 @@ Examples:
 		},
 	}
 
-	cmd.SilenceUsage = true
 	cmd.Flags().IntVar(&timeoutSecs, "timeout", 60, "timeout in seconds per agent")
 	cmd.Flags().StringVar(&agentFilter, "agent", "", "check only this agent")
 	cmd.Flags().BoolVar(&largePrompt, "large-prompt", false,

--- a/cmd/roborev/comment.go
+++ b/cmd/roborev/comment.go
@@ -49,7 +49,7 @@ Examples:
 				// --job flag: treat ref as job ID
 				id, err := strconv.ParseInt(ref, 10, 64)
 				if err != nil {
-					return fmt.Errorf("--job requires numeric job ID, got %q", ref)
+					return usageErr(cmd, fmt.Errorf("--job requires numeric job ID, got %q", ref))
 				}
 				jobID = id
 			} else {

--- a/cmd/roborev/compact.go
+++ b/cmd/roborev/compact.go
@@ -69,7 +69,7 @@ Examples:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Validate flags
 			if branch != "" && allBranches {
-				return fmt.Errorf("--branch and --all-branches are mutually exclusive")
+				return usageErr(cmd, fmt.Errorf("--branch and --all-branches are mutually exclusive"))
 			}
 
 			return runCompact(cmd, compactOptions{

--- a/cmd/roborev/daemon_client.go
+++ b/cmd/roborev/daemon_client.go
@@ -91,8 +91,11 @@ func waitForJob(cmd *cobra.Command, ep daemon.DaemonEndpoint, jobID int64, quiet
 	}
 }
 
-// showReview fetches and displays a review by job ID
+// showReview fetches and displays a review by job ID.
 // When quiet is true, suppresses output but still returns exit code based on verdict.
+// On a FAIL verdict returns a bare *exitError (no cmd mutation) so the function
+// is safe to call from concurrent goroutines; the top-level caller is responsible
+// for silencing cobra after all concurrent waits complete.
 func showReview(cmd *cobra.Command, ep daemon.DaemonEndpoint, jobID int64, quiet bool) error {
 	ctx := cmd.Context()
 	if ctx == nil {
@@ -116,7 +119,6 @@ func showReview(cmd *cobra.Command, ep daemon.DaemonEndpoint, jobID int64, quiet
 	// Return exit code based on verdict
 	verdict := storage.ParseVerdict(review.Output)
 	if verdict == "F" {
-		// Use a special error that cobra will treat as exit code 1
 		return &exitError{code: 1}
 	}
 

--- a/cmd/roborev/fix.go
+++ b/cmd/roborev/fix.go
@@ -95,22 +95,22 @@ Examples:
 			}
 
 			if allBranches && branch != "" {
-				return fmt.Errorf("--all-branches and --branch are mutually exclusive")
+				return usageErr(cmd, fmt.Errorf("--all-branches and --branch are mutually exclusive"))
 			}
 			if allBranches && len(args) > 0 {
-				return fmt.Errorf("--all-branches cannot be used with positional job IDs")
+				return usageErr(cmd, fmt.Errorf("--all-branches cannot be used with positional job IDs"))
 			}
 			if branch != "" && len(args) > 0 {
-				return fmt.Errorf("--branch cannot be used with positional job IDs")
+				return usageErr(cmd, fmt.Errorf("--branch cannot be used with positional job IDs"))
 			}
 			if newestFirst && len(args) > 0 {
-				return fmt.Errorf("--newest-first cannot be used with positional job IDs")
+				return usageErr(cmd, fmt.Errorf("--newest-first cannot be used with positional job IDs"))
 			}
 			if list && len(args) > 0 {
-				return fmt.Errorf("--list cannot be used with positional job IDs")
+				return usageErr(cmd, fmt.Errorf("--list cannot be used with positional job IDs"))
 			}
 			if list && batch {
-				return fmt.Errorf("--list and --batch are mutually exclusive")
+				return usageErr(cmd, fmt.Errorf("--list and --batch are mutually exclusive"))
 			}
 			if list && batchSize > 0 {
 				return fmt.Errorf("--list and --batch-size are mutually exclusive")
@@ -164,7 +164,7 @@ Examples:
 					jobIDs = append(jobIDs, id)
 				}
 				if len(jobIDs) > 0 && (branch != "" || allBranches || newestFirst) {
-					return fmt.Errorf("--branch, --all-branches, and --newest-first cannot be used with explicit job IDs")
+					return usageErr(cmd, fmt.Errorf("--branch, --all-branches, and --newest-first cannot be used with explicit job IDs"))
 				}
 				if len(jobIDs) == 0 {
 					effectiveBranch := resolveCurrentBranchFilter(

--- a/cmd/roborev/helpers.go
+++ b/cmd/roborev/helpers.go
@@ -9,15 +9,78 @@ import (
 	"github.com/roborev-dev/roborev/internal/git"
 	"github.com/roborev-dev/roborev/internal/githook"
 	"github.com/roborev-dev/roborev/internal/storage"
+	"github.com/spf13/cobra"
 )
 
-// exitError is an error that signals a specific exit code
+// exitError signals a specific exit code with no further error output.
+// Always construct via silentExit so cobra's "Error: ..." line is suppressed
+// for this command — the caller has already printed any user-facing message.
+// If cause is set, Error()/Unwrap() expose it so programmatic callers can
+// still inspect the underlying failure; cobra's printing is still silenced
+// via the SilenceErrors flag that silentExit sets.
 type exitError struct {
-	code int
+	code  int
+	cause error
 }
 
 func (e *exitError) Error() string {
+	if e.cause != nil {
+		return e.cause.Error()
+	}
 	return fmt.Sprintf("exit code %d", e.code)
+}
+
+func (e *exitError) Unwrap() error { return e.cause }
+
+// silentExit returns an exitError and silences cobra's error output for
+// the given command. Use when the caller has already printed any user-
+// facing message and just needs the process to exit with a specific code.
+// Must only be called from a single-threaded context (RunE, post-join code),
+// not from goroutines that share cmd.
+func silentExit(cmd *cobra.Command, code int) error {
+	cmd.SilenceErrors = true
+	return &exitError{code: code}
+}
+
+// silenceIfExit silences cobra's error output for cmd when err is an
+// *exitError, then returns err unchanged. Use at top-level RunE return
+// points whose error may have originated in concurrent code that could
+// not safely mutate cmd itself.
+func silenceIfExit(cmd *cobra.Command, err error) error {
+	if _, ok := err.(*exitError); ok {
+		cmd.SilenceErrors = true
+	}
+	return err
+}
+
+// usageErr re-enables the usage block for cmd and returns err. Use inside
+// RunE for validation that's semantically part of the invocation contract
+// (mutually exclusive flags, missing required values, bad enum values).
+// PersistentPreRunE on the root silences usage for runtime errors; this
+// flips it back for the specific case of "the user invoked me wrong."
+func usageErr(cmd *cobra.Command, err error) error {
+	cmd.SilenceUsage = false
+	return err
+}
+
+// quietExit prepares a --quiet command's error for return. It silences
+// the usage block (so an upstream usageErr doesn't print a help wall
+// in quiet mode) and wraps plain errors in *exitError{code: 1} so the
+// process exits non-zero, but it does NOT silence cobra's "Error: ..."
+// line — runtime failures (daemon down, bad git ref, polling errors)
+// should still tell the user what went wrong. Verdict-based exits use
+// the bare *exitError sentinel; their callers silence cobra separately
+// via silenceIfExit because that path has already shown the review
+// output (or chose not to in quiet mode).
+func quietExit(cmd *cobra.Command, err error) error {
+	if err == nil {
+		return nil
+	}
+	cmd.SilenceUsage = true
+	if _, ok := err.(*exitError); ok {
+		return err
+	}
+	return &exitError{code: 1, cause: err}
 }
 
 func shortRef(ref string) string {

--- a/cmd/roborev/insights.go
+++ b/cmd/roborev/insights.go
@@ -55,7 +55,6 @@ Examples:
   roborev insights --repo /path/to/repo     # Specific repo
   roborev insights --agent gemini --wait    # Use specific agent, wait for result
   roborev insights --json                   # Output job info as JSON`,
-		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runInsights(cmd, insightsOptions{
 				repoPath:   repoPath,

--- a/cmd/roborev/main.go
+++ b/cmd/roborev/main.go
@@ -17,7 +17,17 @@ func main() {
 		Short: "Automatic code review for git commits",
 		Long:  "roborev automatically reviews git commits using AI agents (Codex, Claude Code, Gemini, Copilot, OpenCode, Cursor, Kiro, Pi)",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return validateServerFlag()
+			// validateServerFlag is itself part of the invocation contract
+			// (an invalid --server value is a usage problem, not a runtime
+			// problem), so run it first while SilenceUsage is still false.
+			if err := validateServerFlag(); err != nil {
+				return err
+			}
+			// Past this point cobra has validated everything it can, so
+			// errors from RunE just get a plain "Error: ..." line without
+			// the usage wall.
+			cmd.SilenceUsage = true
+			return nil
 		},
 	}
 
@@ -62,10 +72,12 @@ func main() {
 	rootCmd.AddCommand(versionCmd())
 
 	if err := rootCmd.Execute(); err != nil {
-		// Check for exitError to exit with specific code without extra output
+		// exitError carries a specific exit code; the RunE that returned
+		// it has already silenced cobra's error printing via silentExit.
 		if exitErr, ok := err.(*exitError); ok {
 			os.Exit(exitErr.code)
 		}
+		// All other errors: cobra already printed them.
 		os.Exit(1)
 	}
 }

--- a/cmd/roborev/postcommit.go
+++ b/cmd/roborev/postcommit.go
@@ -33,9 +33,13 @@ func postCommitCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:           "post-commit",
-		Short:         "Hook entry point: enqueue a review after commit",
-		Args:          cobra.NoArgs,
+		Use:   "post-commit",
+		Short: "Hook entry point: enqueue a review after commit",
+		Args:  cobra.NoArgs,
+		// Hook entrypoint: any failure must be silent (logged to the
+		// hook log file, never printed to git's stderr). Set both
+		// silences explicitly so future changes that return non-nil
+		// from RunE don't leak Cobra-formatted output to git.
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/roborev/refine.go
+++ b/cmd/roborev/refine.go
@@ -50,9 +50,8 @@ func refineCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:          "refine",
-		Short:        "Iterative review-fix loop until all reviews pass",
-		SilenceUsage: true,
+		Use:   "refine",
+		Short: "Iterative review-fix loop until all reviews pass",
 		Long: `Automatically address failed code reviews in a loop.
 
 Refine finds failed reviews on the current branch, runs an agent to fix

--- a/cmd/roborev/review.go
+++ b/cmd/roborev/review.go
@@ -65,11 +65,11 @@ Examples:
   roborev review --type security   # Security-focused review of HEAD
   roborev review --branch --type security  # Security review of branch
 `,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			// In quiet mode, suppress cobra's error output (hook uses &, so exit code doesn't matter)
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			// In quiet mode, any error becomes a silent non-zero exit
+			// (hook backgrounds the call, so output would be noise).
 			if quiet {
-				cmd.SilenceErrors = true
-				cmd.SilenceUsage = true
+				defer func() { err = quietExit(cmd, err) }()
 			}
 
 			// --fast is shorthand for --reasoning fast (explicit --reasoning takes precedence)
@@ -110,24 +110,24 @@ Examples:
 
 			// Validate mutually exclusive options
 			if branch != "" && dirty {
-				return fmt.Errorf("cannot use --branch with --dirty")
+				return usageErr(cmd, fmt.Errorf("cannot use --branch with --dirty"))
 			}
 			if branch != "" && since != "" {
-				return fmt.Errorf("cannot use --branch with --since")
+				return usageErr(cmd, fmt.Errorf("cannot use --branch with --since"))
 			}
 			if since != "" && dirty {
-				return fmt.Errorf("cannot use --since with --dirty")
+				return usageErr(cmd, fmt.Errorf("cannot use --since with --dirty"))
 			}
 			if branch != "" && len(args) > 0 {
-				return fmt.Errorf("cannot specify commits with --branch (to review a specific branch, use --branch=<name>)")
+				return usageErr(cmd, fmt.Errorf("cannot specify commits with --branch (to review a specific branch, use --branch=<name>)"))
 			}
 			if since != "" && len(args) > 0 {
-				return fmt.Errorf("cannot specify commits with --since")
+				return usageErr(cmd, fmt.Errorf("cannot specify commits with --since"))
 			}
 
 			// Validate --type flag
 			if reviewType != "" && reviewType != "security" && reviewType != "design" {
-				return fmt.Errorf("invalid --type %q (valid: security, design)", reviewType)
+				return usageErr(cmd, fmt.Errorf("invalid --type %q (valid: security, design)", reviewType))
 			}
 
 			// Auto-install/upgrade hooks when running from CLI
@@ -354,16 +354,12 @@ Examples:
 				}
 			}
 
-			// If --wait, poll until job completes and show result
+			// If --wait, poll until job completes and show result.
+			// Verdict-fail comes back as a bare *exitError; silence cobra
+			// here so the user doesn't see "Error: exit code 1" after the
+			// review output is already on screen.
 			if wait {
-				err := waitForJob(cmd, ep, job.ID, quiet)
-				// Only silence Cobra's error output for exitError (verdict-based exit codes)
-				// Keep error output for actual failures (network errors, job not found, etc.)
-				if _, isExitErr := err.(*exitError); isExitErr {
-					cmd.SilenceErrors = true
-					cmd.SilenceUsage = true
-				}
-				return err
+				return silenceIfExit(cmd, waitForJob(cmd, ep, job.ID, quiet))
 			}
 
 			return nil
@@ -376,7 +372,7 @@ Examples:
 	cmd.Flags().StringVar(&model, "model", "", "model for agent (format varies: opencode uses provider/model, others use model name)")
 	cmd.Flags().StringVar(&reasoning, "reasoning", "", "reasoning level: fast, standard, medium, thorough (default), or maximum")
 	cmd.Flags().BoolVar(&fast, "fast", false, "shorthand for --reasoning fast")
-	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "suppress output (for use in hooks)")
+	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "suppress informational output and the usage block; runtime errors are still printed")
 	cmd.Flags().BoolVar(&dirty, "dirty", false, "review uncommitted changes instead of a commit")
 	cmd.Flags().BoolVar(&wait, "wait", false, "wait for review to complete and show result")
 	cmd.Flags().StringVar(&branch, "branch", "", "review all changes since branch diverged from base (optionally specify branch name)")

--- a/cmd/roborev/review_test.go
+++ b/cmd/roborev/review_test.go
@@ -28,6 +28,9 @@ func executeReviewCmd(
 	var stdout, stderr bytes.Buffer
 
 	cmd := reviewCmd()
+	// Mirror main.go: the production root sets SilenceUsage in
+	// PersistentPreRunE, which a standalone reviewCmd() bypasses.
+	cmd.SilenceUsage = true
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
 	cmd.SetArgs(args)

--- a/cmd/roborev/show.go
+++ b/cmd/roborev/show.go
@@ -53,7 +53,7 @@ Examples:
 
 			if len(args) == 0 {
 				if forceJobID {
-					return fmt.Errorf("--job requires a job ID argument")
+					return usageErr(cmd, fmt.Errorf("--job requires a job ID argument"))
 				}
 				// Default to HEAD
 				sha := "HEAD"

--- a/cmd/roborev/wait.go
+++ b/cmd/roborev/wait.go
@@ -45,19 +45,19 @@ Examples:
   roborev wait --job 10 20 30    # Wait for multiple job IDs
   roborev wait --sha HEAD~1      # Wait for job matching HEAD~1`,
 		Args: cobra.ArbitraryArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			// In quiet mode, suppress cobra's error output
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			// In quiet mode (post-commit hook), collapse any error into a
+			// silent non-zero exit so the hook doesn't write to stderr.
 			if quiet {
-				cmd.SilenceErrors = true
-				cmd.SilenceUsage = true
+				defer func() { err = quietExit(cmd, err) }()
 			}
 
 			// Validate flag/arg combinations
 			if len(args) > 0 && shaFlag != "" {
-				return fmt.Errorf("cannot use both a positional argument and --sha")
+				return usageErr(cmd, fmt.Errorf("cannot use both a positional argument and --sha"))
 			}
 			if forceJobID && len(args) == 0 {
-				return fmt.Errorf("--job requires a job ID argument")
+				return usageErr(cmd, fmt.Errorf("--job requires a job ID argument"))
 			}
 
 			// Multiple args: wait for all concurrently
@@ -131,38 +131,33 @@ Examples:
 					if !quiet {
 						cmd.Printf("No job found for %s\n", ref)
 					}
-					cmd.SilenceErrors = true
-					cmd.SilenceUsage = true
-					return &exitError{code: 1}
+					return silentExit(cmd, 1)
 				}
 				jobID = job.ID
 			}
 
 			ep := getDaemonEndpoint()
-			err := waitForJob(cmd, ep, jobID, quiet)
-			if err != nil {
+			waitErr := waitForJob(cmd, ep, jobID, quiet)
+			if waitErr != nil {
 				// Map ErrJobNotFound to exit 1 with a user-facing message
 				// (waitForJob returns a plain error to stay compatible with reviewCmd)
-				if errors.Is(err, ErrJobNotFound) {
+				if errors.Is(waitErr, ErrJobNotFound) {
 					if !quiet {
 						cmd.Printf("No job found for job %d\n", jobID)
 					}
-					cmd.SilenceErrors = true
-					cmd.SilenceUsage = true
-					return &exitError{code: 1}
-				}
-				if _, isExitErr := err.(*exitError); isExitErr {
-					cmd.SilenceErrors = true
-					cmd.SilenceUsage = true
+					return silentExit(cmd, 1)
 				}
 			}
-			return err
+			// Verdict-fail comes back as a bare *exitError from showReview;
+			// silence cobra's printing here (showReview can't, since it may
+			// be called from waitMultiple goroutines that share cmd).
+			return silenceIfExit(cmd, waitErr)
 		},
 	}
 
 	cmd.Flags().StringVar(&shaFlag, "sha", "", "git ref to find the most recent job for")
 	cmd.Flags().BoolVar(&forceJobID, "job", false, "force arguments to be treated as job IDs")
-	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "suppress output (for use in hooks)")
+	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "suppress informational output and the usage block; runtime errors are still printed")
 
 	return cmd
 }
@@ -239,9 +234,7 @@ func waitMultiple(
 			if !quiet {
 				cmd.Printf("No job found for %s\n", r.ref)
 			}
-			cmd.SilenceErrors = true
-			cmd.SilenceUsage = true
-			return &exitError{code: 1}
+			return silentExit(cmd, 1)
 		}
 		jobIDs = append(jobIDs, job.ID)
 	}
@@ -287,9 +280,23 @@ func waitMultiple(
 	}
 
 	if hasErr {
-		cmd.SilenceErrors = true
-		cmd.SilenceUsage = true
-		return &exitError{code: 1}
+		// In quiet mode the per-job loop above printed nothing, so a
+		// silent exit would leave the caller with no clue what failed.
+		// Surface the first runtime error (plain error, not *exitError)
+		// so the quiet defer's quietExit can wrap it and cobra can show
+		// the cause. If every error is an *exitError (verdict-fail or
+		// job-not-found), nothing more useful can be said.
+		if quiet {
+			for _, r := range results {
+				if r.err == nil {
+					continue
+				}
+				if _, ok := r.err.(*exitError); !ok {
+					return r.err
+				}
+			}
+		}
+		return silentExit(cmd, 1)
 	}
 
 	return nil

--- a/cmd/roborev/wait_test.go
+++ b/cmd/roborev/wait_test.go
@@ -84,11 +84,14 @@ func newWaitEnv(t *testing.T, handler http.Handler) *waitEnv {
 }
 
 // runWait executes the wait command with the given args and returns
-// captured stdout and the error.
+// captured stdout and the error. It mirrors main.go's setup by silencing
+// the usage block for runtime errors (the production root sets this in
+// PersistentPreRunE, which a freshly-constructed waitCmd() bypasses).
 func runWait(t *testing.T, args ...string) (stdout string, err error) {
 	t.Helper()
 	var out bytes.Buffer
 	cmd := waitCmd()
+	cmd.SilenceUsage = true
 	cmd.SetOut(&out)
 	cmd.SetErr(&bytes.Buffer{})
 	cmd.SetArgs(args)
@@ -494,13 +497,13 @@ func newMultiJobMockHandler(jobs map[int64]mockJobResult) http.HandlerFunc {
 	return mux.ServeHTTP
 }
 
-func TestWaitReviewFetchErrorIsPlainError(t *testing.T) {
+func TestWaitReviewFetchErrorExposesCauseInQuietMode(t *testing.T) {
 	setupFastPolling(t)
 
-	// Job completes but /api/review returns 404. This should surface as a
-	// plain error (from showReview), not an *exitError. Both map to exit 1
-	// in practice, but the distinction matters for error reporting: plain
-	// errors print Cobra's "Error:" prefix while exitError silences it.
+	// Job completes but /api/review returns 404. In --quiet mode the
+	// command exits with code 1, the usage block is suppressed, and
+	// cobra prints the underlying cause via err.Error() so the user
+	// (or the hook log) can still see what failed.
 	mock := mockConfig{
 		Jobs: []storage.ReviewJob{{ID: 1, Agent: "test", Status: "done"}},
 		// Review is nil, so 404
@@ -508,10 +511,8 @@ func TestWaitReviewFetchErrorIsPlainError(t *testing.T) {
 	newWaitEnv(t, newWaitMockHandler(mock))
 
 	_, err := runWait(t, "--sha", "HEAD", "--quiet")
-	require.Error(t, err)
-	// Should be a plain error, not an *exitError
-	_, ok := err.(*exitError)
-	assert.False(t, ok, "review fetch failure should be a plain error, not exitError")
+	requireExitCode(t, err, 1)
+	assert.Contains(t, err.Error(), "review", "underlying cause should remain accessible")
 }
 
 func TestWaitLookupNon200Response(t *testing.T) {


### PR DESCRIPTION
## Summary

Cobra's default behavior dumps the full usage block on every `RunE` error, which buries actual error messages under a wall of help text. The codebase had been working around this by scattering `cmd.SilenceUsage = true` assignments inside individual `RunE` handlers — a whack-a-mole pattern that drifted out of sync over time. This PR centralizes the policy and distinguishes three failure categories:

| Failure | Output |
|---|---|
| Invocation error (unknown flag, bad arg, unknown subcommand, mutex flags, bad enum, missing value, invalid `--server`) | `Error: ...` + usage block |
| Runtime error (daemon down, bad git ref, network failure, polling error) | `Error: ...` only |
| Caller-controlled exit (review verdict-fail, multi-job wait fail) | silent, exit with the right code |

## How it works

- **Root `PersistentPreRunE`** sets `cmd.SilenceUsage = true` **after** `validateServerFlag`. Cobra's invocation validation (flag parsing, arg validation, subcommand match, `--server`) all run while `SilenceUsage` is still false, so usage prints. Anything reached via `RunE` runs with usage silenced.
- **`usageErr(cmd, err)`** re-enables `SilenceUsage` for the specific case of `RunE`-internal flag validation (mutex flags, bad enums, missing required values). Applied across `review`/`wait`/`fix`/`compact`/`comment`/`show`.
- **`silentExit(cmd, code)`** returns an `*exitError` and sets `SilenceErrors` on `cmd`. Used for caller-controlled silent exits in single-threaded contexts.
- **`silenceIfExit(cmd, err)`** does the same conditionally; used at top-level `RunE` returns to silence cobra when the error came from concurrent code that couldn't safely mutate `cmd` itself. `showReview` is called from `waitMultiple` goroutines, so it now returns a bare `*exitError` with no `cmd` mutation; the serial `RunE`/post-join code silences after the fact. Verified clean under `go test -race`.
- **`quietExit(cmd, err)`** is the `--quiet` defer wrapper: silences the usage wall (so an upstream `usageErr` doesn't leave a help block in quiet mode) and wraps plain errors in `exitError{code:1, cause: err}`. It does **not** silence cobra's `Error: ...` line — runtime failures in quiet mode still tell the user what broke, matching CLI convention (`--quiet` < `--silent`). The `exitError` type carries an optional `cause` so the underlying message is preserved through `Error()`/`Unwrap()` for both display and programmatic inspection.
- **post-commit** hook entrypoint sets `SilenceErrors`/`SilenceUsage` on its own struct. It's a git-hook contract — failures go to the hook log file, never to git's stderr.

## Resulting behavior

| Invocation | Output |
|---|---|
| `roborev wait --bogus` | `Error: unknown flag: --bogus` + usage |
| `roborev review --branch --dirty` | `Error: cannot use --branch with --dirty` + usage |
| `roborev review --type=bogus` | `Error: invalid --type "bogus" (valid: security, design)` + usage |
| `roborev foobar` | `Error: unknown command "foobar" for "roborev"` + `Run 'roborev --help' for usage.` |
| `roborev --server=://garbage wait` | `Error: invalid --server address ...` + usage |
| `roborev wait --sha=does-not-exist` | `Error: invalid git ref: does-not-exist` (no usage) |
| `roborev wait --quiet --sha=does-not-exist` | `Error: invalid git ref: does-not-exist` (no usage) |
| `roborev wait --quiet --job` | `Error: --job requires a job ID argument` (no usage) |
| `roborev review --wait` (verdict FAIL) | already-printed review output, exit 1, no `Error:` line |
| `roborev review --wait --quiet` (verdict FAIL) | silent, exit 1 |

## Tests

- The `wait` / `review` test helpers now mirror production by setting `SilenceUsage` on the freshly-constructed subcommand (the root's `PersistentPreRunE` doesn't run for direct-`Execute` tests).
- `TestWaitReviewFetchErrorExposesCauseInQuietMode` replaces `TestWaitReviewFetchErrorIsPlainError`, whose assertion predated this work and contradicted both the current `--quiet` contract and the visible-runtime-errors invariant.
- `TestWaitForJobUnknownStatus` passes now that `exitError` preserves the underlying cause; it was failing at HEAD before this work.