### PR TITLE
fix(cli): silence Cobra usage on review failure

### DIFF
--- a/cmd/roborev/daemon_client.go
+++ b/cmd/roborev/daemon_client.go
@@ -21,6 +21,10 @@ import (
 // waitForJob polls until a job completes and displays the review
 // Uses the provided serverAddr to ensure we poll the same daemon that received the job.
 func waitForJob(cmd *cobra.Command, ep daemon.DaemonEndpoint, jobID int64, quiet bool) error {
+	// Errors from here on are runtime failures (job failure, network blip,
+	// canceled), never argument-parsing errors — suppress the --help dump
+	// Cobra would otherwise tack onto the error.
+	cmd.SilenceUsage = true
 	ctx := cmd.Context()
 	if ctx == nil {
 		ctx = context.Background()
@@ -28,7 +32,7 @@ func waitForJob(cmd *cobra.Command, ep daemon.DaemonEndpoint, jobID int64, quiet
 	api := newDaemonReviewAPI(ep.BaseURL(), ep.HTTPClient(5*time.Second))
 
 	if !quiet {
-		cmd.Printf("Waiting for review to complete...")
+		fmt.Fprint(cmd.OutOrStdout(), "Waiting for review to complete...")
 	}
 
 	// Poll with exponential backoff
@@ -46,20 +50,20 @@ func waitForJob(cmd *cobra.Command, ep daemon.DaemonEndpoint, jobID int64, quiet
 		switch job.Status {
 		case storage.JobStatusDone:
 			if !quiet {
-				cmd.Printf(" done!\n\n")
+				fmt.Fprint(cmd.OutOrStdout(), " done!\n\n")
 			}
 			// Fetch and display the review
 			return showReview(cmd, ep, jobID, quiet)
 
 		case storage.JobStatusFailed:
 			if !quiet {
-				cmd.Printf(" failed!\n")
+				fmt.Fprint(cmd.OutOrStdout(), " failed!\n")
 			}
 			return fmt.Errorf("review failed: %s", job.Error)
 
 		case storage.JobStatusCanceled:
 			if !quiet {
-				cmd.Printf(" canceled!\n")
+				fmt.Fprint(cmd.OutOrStdout(), " canceled!\n")
 			}
 			return fmt.Errorf("review was canceled")
 
@@ -81,7 +85,7 @@ func waitForJob(cmd *cobra.Command, ep daemon.DaemonEndpoint, jobID int64, quiet
 				return fmt.Errorf("received unknown status %q %d times, giving up (daemon may be newer than CLI)", job.Status, unknownStatusCount)
 			}
 			if !quiet {
-				cmd.Printf("\n(unknown status %q, continuing to poll...)", job.Status)
+				fmt.Fprintf(cmd.OutOrStdout(), "\n(unknown status %q, continuing to poll...)", job.Status)
 			}
 			time.Sleep(pollInterval)
 			if pollInterval < maxInterval {
@@ -108,9 +112,9 @@ func showReview(cmd *cobra.Command, ep daemon.DaemonEndpoint, jobID int64, quiet
 	}
 
 	if !quiet {
-		cmd.Printf("Review (by %s)\n", review.Agent)
-		cmd.Println(strings.Repeat("-", 60))
-		cmd.Println(review.Output)
+		fmt.Fprintf(cmd.OutOrStdout(), "Review (by %s)\n", review.Agent)
+		fmt.Fprintln(cmd.OutOrStdout(), strings.Repeat("-", 60))
+		fmt.Fprintln(cmd.OutOrStdout(), review.Output)
 	}
 
 	// Return exit code based on verdict

--- a/cmd/roborev/wait_test.go
+++ b/cmd/roborev/wait_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/roborev-dev/roborev/internal/storage"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -155,6 +156,39 @@ func TestWaitArgValidationWithoutDaemon(t *testing.T) {
 
 	_, err = runWait(t, "--sha", "not-a-valid-ref")
 	assertErrorContains(t, err, "invalid git ref")
+}
+
+// TestWaitForJob_SilencesUsageOnFailure verifies that waitForJob marks the
+// command to suppress Cobra's usage dump for runtime failures (failed job,
+// canceled job, network errors). Without this, every legitimate agent failure
+// is followed by the full --help blob.
+func TestWaitForJob_SilencesUsageOnFailure(t *testing.T) {
+	setupFastPolling(t)
+
+	cases := []struct {
+		name   string
+		status storage.JobStatus
+		errMsg string
+		want   string
+	}{
+		{"failed", storage.JobStatusFailed, "agent crashed", "review failed"},
+		{"canceled", storage.JobStatusCanceled, "", "canceled"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			newWaitEnv(t, newWaitMockHandler(mockConfig{
+				Jobs: []storage.ReviewJob{{ID: 1, Agent: "test", Status: tc.status, Error: tc.errMsg}},
+			}))
+
+			cmd := &cobra.Command{}
+			err := waitForJob(cmd, getDaemonEndpoint(), 1, true)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+			assert.True(t, cmd.SilenceUsage,
+				"SilenceUsage should be set so Cobra does not dump --help after a runtime failure")
+		})
+	}
 }
 
 func TestWait_Scenarios(t *testing.T) {


### PR DESCRIPTION
## Summary

- `waitForJob` now sets `cmd.SilenceUsage = true` at entry so review failures, cancellations, and network errors no longer dump the full `--help` text after the error message — these are runtime failures, never argument-parsing errors.
- In-flight progress messages (`Waiting for review to complete...`, ` done!`, ` failed!`, ` canceled!`) route through `cmd.OutOrStdout()` instead of `cmd.Printf()`, which writes to stderr in Cobra.