### PR TITLE
fix(daemon): defer retried jobs via retry_not_before column

### DIFF
--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -55,6 +55,14 @@ type WorkerPool struct {
 	// Output capture for tail command
 	outputBuffers *OutputBuffer
 
+	// retryBackoff is the delay applied to requeued jobs before they
+	// become claimable again. Stored on the job (via retry_not_before)
+	// so any worker — not just the one that failed — honors it. Prevents
+	// rapid concurrent agent startups racing on shared state (notably
+	// opencode's sqlite WAL, where PRAGMA wal_checkpoint(PASSIVE) fails
+	// when a prior crashed instance left the WAL mid-write).
+	retryBackoff time.Duration
+
 	// Test hooks for deterministic synchronization (nil in production)
 	testHookAfterSecondCheck    func() // Called after second runningJobs check, before second DB lookup
 	testHookCooldownLockUpgrade func() // Called between RUnlock and Lock in isAgentCoolingDown
@@ -76,6 +84,7 @@ func NewWorkerPool(db *storage.DB, cfgGetter ConfigGetter, numWorkers int, broad
 		agentCooldowns: make(map[string]time.Time),
 		outputBuffers:  NewOutputBuffer(512*1024, 4*1024*1024), // 512KB/job, 4MB total
 		classify:       agent.ClassifyLimit,
+		retryBackoff:   2 * time.Second,
 	}
 }
 
@@ -851,7 +860,7 @@ func (wp *WorkerPool) failOrRetryInner(workerID string, job *storage.ReviewJob, 
 		return
 	}
 
-	retried, err := wp.db.RetryJob(job.ID, workerID, maxRetries)
+	retried, err := wp.db.RetryJob(job.ID, workerID, maxRetries, wp.retryBackoff)
 	if err != nil {
 		log.Printf("[%s] Error retrying job: %v", workerID, err)
 		if updated, fErr := wp.db.FailJob(job.ID, workerID, errorMsg); fErr != nil {

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"fmt"
 	"log"
 	"os"
@@ -60,6 +61,7 @@ func newWorkerTestContext(t *testing.T, workers int) *workerTestContext {
 
 	b := NewBroadcaster()
 	pool := NewWorkerPool(db, NewStaticConfig(cfg), cfg.MaxWorkers, b, nil, nil)
+	pool.retryBackoff = 0 // keep retry-driven tests fast
 
 	return &workerTestContext{
 		DB:          db,
@@ -162,6 +164,7 @@ func (c *workerTestContext) startPool() {
 // and 1 worker, preserving the existing DB and broadcaster.
 func (c *workerTestContext) reconfigurePool(cfg *config.Config) {
 	c.Pool = NewWorkerPool(c.DB, NewStaticConfig(cfg), 1, c.Broadcaster, nil, nil)
+	c.Pool.retryBackoff = 0
 }
 
 func TestWorkerPoolConcurrency(t *testing.T) {
@@ -1303,6 +1306,46 @@ func TestFailOrRetryInner_UnmatchedAgentErrorLogsWarn(t *testing.T) {
 	assert.Contains(logged, "unclassified agent error", "expected WARN line for unmatched error")
 	assert.Contains(logged, "from test:", "log line should include agent name as 'from <agent>:'")
 	assert.Contains(logged, "some brand new error wording", "log line should include error preview")
+}
+
+func TestFailOrRetryInner_SetsRetryNotBefore(t *testing.T) {
+	tc := newWorkerTestContext(t, 1)
+	sha := testutil.GetHeadSHA(t, tc.TmpDir)
+	job := tc.createAndClaimJob(t, sha, testWorkerID)
+
+	// A long backoff makes the test robust to setup overhead. We don't
+	// wait for it to elapse — we just verify the column is populated and
+	// is in the future.
+	tc.Pool.retryBackoff = time.Hour
+
+	tc.Pool.failOrRetryInner(testWorkerID, job, "gemini", "connection reset", true)
+	tc.assertJobStatus(t, job.ID, storage.JobStatusQueued)
+
+	var stored sql.NullString
+	require.NoError(t, tc.DB.QueryRow(`SELECT retry_not_before FROM review_jobs WHERE id = ?`, job.ID).Scan(&stored))
+	require.True(t, stored.Valid, "retry_not_before should be set with non-zero retryBackoff")
+
+	parsed, err := time.Parse(time.RFC3339Nano, stored.String)
+	require.NoError(t, err, "retry_not_before should be RFC3339Nano-formatted")
+	assert.True(t, parsed.After(time.Now()),
+		"retry_not_before should be in the future, got %s", stored.String)
+}
+
+func TestClaimJob_HonorsRetryNotBeforeAcrossWorkers(t *testing.T) {
+	// A different worker than the one that failed must also be blocked
+	// by retry_not_before — that's the whole point of moving the gate
+	// from a per-worker sleep to a job column.
+	tc := newWorkerTestContext(t, 1)
+	sha := testutil.GetHeadSHA(t, tc.TmpDir)
+	job := tc.createAndClaimJob(t, sha, "worker-A")
+
+	tc.Pool.retryBackoff = time.Hour
+	tc.Pool.failOrRetryInner("worker-A", job, "gemini", "connection reset", true)
+	tc.assertJobStatus(t, job.ID, storage.JobStatusQueued)
+
+	claimed, err := tc.DB.ClaimJob("worker-B")
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "a second worker must also honor retry_not_before")
 }
 
 func TestFailoverOrFail_FailsOverToBackup(t *testing.T) {

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -1326,7 +1326,7 @@ func TestFailOrRetryInner_SetsRetryNotBefore(t *testing.T) {
 	require.True(t, stored.Valid, "retry_not_before should be set with non-zero retryBackoff")
 
 	parsed, err := time.Parse(time.RFC3339Nano, stored.String)
-	require.NoError(t, err, "retry_not_before should be RFC3339Nano-formatted")
+	require.NoError(t, err, "retry_not_before should parse as RFC3339-with-nanos")
 	assert.True(t, parsed.After(time.Now()),
 		"retry_not_before should be in the future, got %s", stored.String)
 }

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -808,6 +808,21 @@ func (db *DB) migrate() error {
 		}
 	}
 
+	// Migration: add retry_not_before column to review_jobs if missing.
+	// ClaimJob skips jobs whose retry_not_before is in the future so the
+	// retry backoff is enforced at the queue level, regardless of which
+	// worker happened to fail the prior attempt.
+	err = db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('review_jobs') WHERE name = 'retry_not_before'`).Scan(&count)
+	if err != nil {
+		return fmt.Errorf("check retry_not_before column: %w", err)
+	}
+	if count == 0 {
+		_, err = db.Exec(`ALTER TABLE review_jobs ADD COLUMN retry_not_before TIMESTAMP`)
+		if err != nil {
+			return fmt.Errorf("add retry_not_before column: %w", err)
+		}
+	}
+
 	// Run sync-related migrations
 	if err := db.migrateSyncColumns(); err != nil {
 		return err

--- a/internal/storage/db_job_test.go
+++ b/internal/storage/db_job_test.go
@@ -439,7 +439,7 @@ func TestRetryJobBackoffDefersClaim(t *testing.T) {
 	// Once the gate is in the past, the same job is claimable. Set the
 	// column directly instead of sleeping a real backoff — we're testing
 	// the predicate, not the clock.
-	past := time.Now().Add(-time.Minute).Format(time.RFC3339Nano)
+	past := time.Now().Add(-time.Minute).Format(retryNotBeforeLayout)
 	_, err = db.Exec(`UPDATE review_jobs SET retry_not_before = ? WHERE id = ?`, past, job.ID)
 	require.NoError(t, err)
 

--- a/internal/storage/db_job_test.go
+++ b/internal/storage/db_job_test.go
@@ -439,7 +439,7 @@ func TestRetryJobBackoffDefersClaim(t *testing.T) {
 	// Once the gate is in the past, the same job is claimable. Set the
 	// column directly instead of sleeping a real backoff — we're testing
 	// the predicate, not the clock.
-	past := time.Now().Add(-time.Minute).Format(retryNotBeforeLayout)
+	past := retryNotBeforeAt(time.Now().Add(-time.Minute))
 	_, err = db.Exec(`UPDATE review_jobs SET retry_not_before = ? WHERE id = ?`, past, job.ID)
 	require.NoError(t, err)
 

--- a/internal/storage/db_job_test.go
+++ b/internal/storage/db_job_test.go
@@ -108,7 +108,7 @@ func TestRetryJobOwnerScoped(t *testing.T) {
 	claimJob(t, env.db, "worker-1")
 
 	// Wrong worker should not be able to retry the job
-	retried, err := env.db.RetryJob(env.job.ID, "worker-2", 3)
+	retried, err := env.db.RetryJob(env.job.ID, "worker-2", 3, 0)
 	require.NoError(t, err, "RetryJob with wrong worker failed")
 
 	assert.False(t, retried)
@@ -120,7 +120,7 @@ func TestRetryJobOwnerScoped(t *testing.T) {
 	assert.Equal(t, JobStatusRunning, j.Status)
 
 	// Correct worker should succeed
-	retried, err = env.db.RetryJob(env.job.ID, "worker-1", 3)
+	retried, err = env.db.RetryJob(env.job.ID, "worker-1", 3, 0)
 	require.NoError(t, err, "RetryJob with correct worker failed")
 
 	assert.True(t, retried)
@@ -344,7 +344,7 @@ func TestRetryJob(t *testing.T) {
 	claimJob(t, db, "worker-1")
 
 	// Retry should succeed (retry_count: 0 -> 1)
-	retried, err := db.RetryJob(job.ID, "", 3)
+	retried, err := db.RetryJob(job.ID, "", 3, 0)
 	require.NoError(t, err, "RetryJob failed: %v")
 
 	assert.True(t, retried)
@@ -357,16 +357,16 @@ func TestRetryJob(t *testing.T) {
 
 	// Claim again and retry twice more (retry_count: 1->2, 2->3)
 	_, _ = db.ClaimJob("worker-1")
-	db.RetryJob(job.ID, "", 3) // retry_count becomes 2
+	db.RetryJob(job.ID, "", 3, 0) // retry_count becomes 2
 	_, _ = db.ClaimJob("worker-1")
-	db.RetryJob(job.ID, "", 3) // retry_count becomes 3
+	db.RetryJob(job.ID, "", 3, 0) // retry_count becomes 3
 
 	count, _ = db.GetJobRetryCount(job.ID)
 	assert.Equal(t, 3, count)
 
 	// Claim again - next retry should fail (at max)
 	_, _ = db.ClaimJob("worker-1")
-	retried, err = db.RetryJob(job.ID, "", 3)
+	retried, err = db.RetryJob(job.ID, "", 3, 0)
 	require.NoError(t, err, "RetryJob at max failed: %v")
 
 	assert.False(t, retried)
@@ -383,7 +383,7 @@ func TestRetryJobOnlyWorksForRunning(t *testing.T) {
 	_, _, job := createJobChain(t, db, "/tmp/test-repo", "retry-status")
 
 	// Try to retry a queued job (should fail - not running)
-	retried, err := db.RetryJob(job.ID, "", 3)
+	retried, err := db.RetryJob(job.ID, "", 3, 0)
 	require.NoError(t, err, "RetryJob on queued job failed: %v")
 
 	assert.False(t, retried)
@@ -392,7 +392,7 @@ func TestRetryJobOnlyWorksForRunning(t *testing.T) {
 	_, _ = db.ClaimJob("worker-1")
 	db.CompleteJob(job.ID, "codex", "p", "o")
 
-	retried, err = db.RetryJob(job.ID, "", 3)
+	retried, err = db.RetryJob(job.ID, "", 3, 0)
 	require.NoError(t, err, "RetryJob on done job failed: %v")
 
 	assert.False(t, retried)
@@ -407,8 +407,8 @@ func TestRetryJobAtomic(t *testing.T) {
 
 	// Simulate two concurrent retries - only first should succeed
 	// (In practice this tests the atomic update)
-	retried1, _ := db.RetryJob(job.ID, "", 3)
-	retried2, _ := db.RetryJob(job.ID, "", 3) // Job is now queued, not running
+	retried1, _ := db.RetryJob(job.ID, "", 3, 0)
+	retried2, _ := db.RetryJob(job.ID, "", 3, 0) // Job is now queued, not running
 
 	assert.True(t, retried1)
 	assert.False(t, retried2, "Second retry should fail (job is no longer running)")
@@ -416,6 +416,58 @@ func TestRetryJobAtomic(t *testing.T) {
 	// Verify retry_count is 1, not 2
 	count, _ := db.GetJobRetryCount(job.ID)
 	assert.Equal(t, 1, count)
+}
+
+func TestRetryJobBackoffDefersClaim(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	_, _, job := createJobChain(t, db, "/tmp/test-repo", "retry-backoff")
+	claimJob(t, db, "worker-1")
+
+	// Long backoff so the test isn't racing the wall clock — we only
+	// check that ClaimJob refuses to return jobs whose retry_not_before
+	// hasn't elapsed.
+	retried, err := db.RetryJob(job.ID, "worker-1", 3, time.Hour)
+	require.NoError(t, err)
+	require.True(t, retried)
+
+	skipped, err := db.ClaimJob("worker-2")
+	require.NoError(t, err)
+	assert.Nil(t, skipped, "ClaimJob must not return jobs still in their retry backoff window")
+
+	// Once the gate is in the past, the same job is claimable. Set the
+	// column directly instead of sleeping a real backoff — we're testing
+	// the predicate, not the clock.
+	past := time.Now().Add(-time.Minute).Format(time.RFC3339Nano)
+	_, err = db.Exec(`UPDATE review_jobs SET retry_not_before = ? WHERE id = ?`, past, job.ID)
+	require.NoError(t, err)
+
+	claimed, err := db.ClaimJob("worker-2")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, job.ID, claimed.ID)
+}
+
+func TestRetryJobZeroBackoffLeavesNotBeforeNull(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	_, _, job := createJobChain(t, db, "/tmp/test-repo", "retry-no-backoff")
+	claimJob(t, db, "worker-1")
+
+	retried, err := db.RetryJob(job.ID, "worker-1", 3, 0)
+	require.NoError(t, err)
+	require.True(t, retried)
+
+	var stored sql.NullString
+	require.NoError(t, db.QueryRow(`SELECT retry_not_before FROM review_jobs WHERE id = ?`, job.ID).Scan(&stored))
+	assert.False(t, stored.Valid, "zero backoff should leave retry_not_before NULL")
+
+	claimed, err := db.ClaimJob("worker-2")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, job.ID, claimed.ID)
 }
 
 func TestFailoverJob(t *testing.T) {
@@ -451,6 +503,32 @@ func TestFailoverJob(t *testing.T) {
 		assert.Equal(t, JobStatusQueued, updated.Status)
 		count, _ := db.GetJobRetryCount(job.ID)
 		assert.Equal(t, 0, count)
+	})
+
+	t.Run("clears retry_not_before on failover", func(t *testing.T) {
+		// Switching agents resets the retry path, so any prior backoff
+		// gate left by RetryJob should be cleared. Otherwise the new
+		// agent can't even be claimed until the old gate expires.
+		db := openTestDB(t)
+		defer db.Close()
+
+		_, _, job := createJobChain(t, db, "/tmp/failover-backoff", "fo-backoff")
+		claimJob(t, db, "worker-1")
+
+		// Stamp a far-future retry_not_before to simulate a job that
+		// hit its retry backoff right before failover took over.
+		future := time.Now().Add(30 * time.Second).Format(time.RFC3339)
+		_, err := db.Exec(`UPDATE review_jobs SET retry_not_before = ? WHERE id = ?`, future, job.ID)
+		require.NoError(t, err)
+
+		ok, err := db.FailoverJob(job.ID, "worker-1", "backup", "")
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		claimed, err := db.ClaimJob("worker-2")
+		require.NoError(t, err)
+		require.NotNil(t, claimed, "failover should clear retry_not_before so the new agent is claimable")
+		assert.Equal(t, "backup", claimed.Agent)
 	})
 
 	t.Run("clears model on failover", func(t *testing.T) {

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -11,12 +11,21 @@ import (
 )
 
 // retryNotBeforeLayout is a fixed-width timestamp layout used for the
-// retry_not_before column. Go's time.RFC3339Nano strips trailing zeros
-// from the fractional seconds (".5" instead of ".500000000"), which
-// breaks lexicographic comparison in SQL — e.g. "...:00.6-04:00" sorts
-// less than "...:00.55-04:00" because '-' < '5'. By padding to a fixed
-// 9-digit fraction, string comparison matches chronological order.
+// retry_not_before column. Two reasons it differs from RFC3339Nano:
+//   - The 9-digit padded fractional seconds avoid the RFC3339Nano quirk
+//     of stripping trailing zeros (".5" vs ".500000000"), which would
+//     break lexicographic SQL comparison around fractional widths.
+//   - Callers must format in UTC (see retryNotBeforeAt). Mixing local
+//     offsets would break comparison during DST fall-back, where the
+//     same local clock time repeats with different UTC offsets.
 const retryNotBeforeLayout = "2006-01-02T15:04:05.000000000Z07:00"
+
+// retryNotBeforeAt returns t formatted for the retry_not_before column.
+// Always normalizes to UTC so DST fall-back can't produce two ordered-
+// differently-but-equal local strings.
+func retryNotBeforeAt(t time.Time) string {
+	return t.UTC().Format(retryNotBeforeLayout)
+}
 
 // parseSQLiteTime parses a time string from SQLite which may be in different formats.
 // Handles RFC3339 (what we write), SQLite datetime('now') format, and timezone variants.
@@ -197,10 +206,10 @@ func (db *DB) EnqueueJob(opts EnqueueOpts) (*ReviewJob, error) {
 func (db *DB) ClaimJob(workerID string) (*ReviewJob, error) {
 	now := time.Now()
 	nowStr := now.Format(time.RFC3339)
-	// retry_not_before uses a fixed-width sub-second layout so the
-	// lexicographic SQL comparison agrees with chronological order.
-	// See retryNotBeforeLayout for why RFC3339Nano is unsafe here.
-	nowNano := now.Format(retryNotBeforeLayout)
+	// retry_not_before is stored UTC + fixed-width nano (see
+	// retryNotBeforeLayout) so the SQL comparison stays monotonic with
+	// time. Format the comparison value the same way.
+	nowNano := retryNotBeforeAt(now)
 
 	// Atomically claim a job by updating it in a single statement
 	// This prevents race conditions where two workers select the same job
@@ -631,10 +640,7 @@ func (db *DB) ReenqueueJob(jobID int64, opts ReenqueueOpts) error {
 func (db *DB) RetryJob(jobID int64, workerID string, maxRetries int, retryBackoff time.Duration) (bool, error) {
 	var notBefore any
 	if retryBackoff > 0 {
-		// Fixed-width layout (not RFC3339Nano) so the SQL string
-		// comparison in ClaimJob agrees with chronological order
-		// for sub-second backoffs.
-		notBefore = time.Now().Add(retryBackoff).Format(retryNotBeforeLayout)
+		notBefore = retryNotBeforeAt(time.Now().Add(retryBackoff))
 	}
 
 	var result sql.Result

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -182,10 +182,17 @@ func (db *DB) EnqueueJob(opts EnqueueOpts) (*ReviewJob, error) {
 	return job, nil
 }
 
-// ClaimJob atomically claims the next queued job for a worker
+// ClaimJob atomically claims the next queued job for a worker.
+// Jobs whose retry_not_before is in the future are skipped so the retry
+// backoff applies regardless of which worker happened to fail the prior
+// attempt.
 func (db *DB) ClaimJob(workerID string) (*ReviewJob, error) {
 	now := time.Now()
 	nowStr := now.Format(time.RFC3339)
+	// retry_not_before is stored with sub-second precision (see RetryJob),
+	// so compare it against a nano-precision string to avoid sub-second
+	// backoffs collapsing into "equal" after second-precision truncation.
+	nowNano := now.Format(time.RFC3339Nano)
 
 	// Atomically claim a job by updating it in a single statement
 	// This prevents race conditions where two workers select the same job
@@ -195,10 +202,11 @@ func (db *DB) ClaimJob(workerID string) (*ReviewJob, error) {
 		WHERE id = (
 			SELECT id FROM review_jobs
 			WHERE status = 'queued'
+			  AND (retry_not_before IS NULL OR retry_not_before <= ?)
 			ORDER BY enqueued_at, id
 			LIMIT 1
 		)
-	`, workerID, nowStr, nowStr)
+	`, workerID, nowStr, nowStr, nowNano)
 	if err != nil {
 		return nil, err
 	}
@@ -608,21 +616,32 @@ func (db *DB) ReenqueueJob(jobID int64, opts ReenqueueOpts) error {
 // When workerID is non-empty the update is scoped to the owning worker,
 // preventing a stale/zombie worker from requeuing a reclaimed job.
 // Pass empty workerID to skip the ownership check (for admin/test callers).
-func (db *DB) RetryJob(jobID int64, workerID string, maxRetries int) (bool, error) {
+//
+// retryBackoff, when > 0, defers the requeued job from being claimed until
+// now + retryBackoff. This avoids rapid concurrent agent startups racing on
+// shared agent state (notably opencode's sqlite WAL).
+func (db *DB) RetryJob(jobID int64, workerID string, maxRetries int, retryBackoff time.Duration) (bool, error) {
+	var notBefore any
+	if retryBackoff > 0 {
+		// RFC3339Nano so sub-second backoffs (used in tests and for
+		// tight retry windows) aren't truncated to whole seconds.
+		notBefore = time.Now().Add(retryBackoff).Format(time.RFC3339Nano)
+	}
+
 	var result sql.Result
 	var err error
 	if workerID != "" {
 		result, err = db.Exec(`
 			UPDATE review_jobs
-			SET status = 'queued', worker_id = NULL, started_at = NULL, finished_at = NULL, error = NULL, retry_count = retry_count + 1, session_id = NULL
+			SET status = 'queued', worker_id = NULL, started_at = NULL, finished_at = NULL, error = NULL, retry_count = retry_count + 1, session_id = NULL, retry_not_before = ?
 			WHERE id = ? AND retry_count < ? AND status = 'running' AND worker_id = ?
-		`, jobID, maxRetries, workerID)
+		`, notBefore, jobID, maxRetries, workerID)
 	} else {
 		result, err = db.Exec(`
 			UPDATE review_jobs
-			SET status = 'queued', worker_id = NULL, started_at = NULL, finished_at = NULL, error = NULL, retry_count = retry_count + 1, session_id = NULL
+			SET status = 'queued', worker_id = NULL, started_at = NULL, finished_at = NULL, error = NULL, retry_count = retry_count + 1, session_id = NULL, retry_not_before = ?
 			WHERE id = ? AND retry_count < ? AND status = 'running'
-		`, jobID, maxRetries)
+		`, notBefore, jobID, maxRetries)
 	}
 	if err != nil {
 		return false, err
@@ -656,7 +675,8 @@ func (db *DB) FailoverJob(jobID int64, workerID, backupAgent, backupModel string
 		    started_at = NULL,
 		    finished_at = NULL,
 		    error = NULL,
-		    session_id = NULL
+		    session_id = NULL,
+		    retry_not_before = NULL
 		WHERE id = ?
 		  AND status = 'running'
 		  AND worker_id = ?

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -10,6 +10,14 @@ import (
 	"unicode"
 )
 
+// retryNotBeforeLayout is a fixed-width timestamp layout used for the
+// retry_not_before column. Go's time.RFC3339Nano strips trailing zeros
+// from the fractional seconds (".5" instead of ".500000000"), which
+// breaks lexicographic comparison in SQL — e.g. "...:00.6-04:00" sorts
+// less than "...:00.55-04:00" because '-' < '5'. By padding to a fixed
+// 9-digit fraction, string comparison matches chronological order.
+const retryNotBeforeLayout = "2006-01-02T15:04:05.000000000Z07:00"
+
 // parseSQLiteTime parses a time string from SQLite which may be in different formats.
 // Handles RFC3339 (what we write), SQLite datetime('now') format, and timezone variants.
 // Returns zero time for empty strings. Logs a warning for non-empty unrecognized formats
@@ -189,10 +197,10 @@ func (db *DB) EnqueueJob(opts EnqueueOpts) (*ReviewJob, error) {
 func (db *DB) ClaimJob(workerID string) (*ReviewJob, error) {
 	now := time.Now()
 	nowStr := now.Format(time.RFC3339)
-	// retry_not_before is stored with sub-second precision (see RetryJob),
-	// so compare it against a nano-precision string to avoid sub-second
-	// backoffs collapsing into "equal" after second-precision truncation.
-	nowNano := now.Format(time.RFC3339Nano)
+	// retry_not_before uses a fixed-width sub-second layout so the
+	// lexicographic SQL comparison agrees with chronological order.
+	// See retryNotBeforeLayout for why RFC3339Nano is unsafe here.
+	nowNano := now.Format(retryNotBeforeLayout)
 
 	// Atomically claim a job by updating it in a single statement
 	// This prevents race conditions where two workers select the same job
@@ -623,9 +631,10 @@ func (db *DB) ReenqueueJob(jobID int64, opts ReenqueueOpts) error {
 func (db *DB) RetryJob(jobID int64, workerID string, maxRetries int, retryBackoff time.Duration) (bool, error) {
 	var notBefore any
 	if retryBackoff > 0 {
-		// RFC3339Nano so sub-second backoffs (used in tests and for
-		// tight retry windows) aren't truncated to whole seconds.
-		notBefore = time.Now().Add(retryBackoff).Format(time.RFC3339Nano)
+		// Fixed-width layout (not RFC3339Nano) so the SQL string
+		// comparison in ClaimJob agrees with chronological order
+		// for sub-second backoffs.
+		notBefore = time.Now().Add(retryBackoff).Format(retryNotBeforeLayout)
 	}
 
 	var result sql.Result

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -15,12 +15,12 @@ import (
 )
 
 // PostgreSQL schema version - increment when schema changes
-const pgSchemaVersion = 12
+const pgSchemaVersion = 13
 
 // pgSchemaName is the PostgreSQL schema used to isolate roborev tables
 const pgSchemaName = "roborev"
 
-//go:embed schemas/postgres_v12.sql
+//go:embed schemas/postgres_v13.sql
 var pgSchemaSQL string
 
 // pgSchemaStatements returns the individual DDL statements for schema creation.
@@ -335,6 +335,11 @@ func (p *PgPool) EnsureSchema(ctx context.Context) error {
 				ON review_jobs(repo_id, git_ref, review_type)
 				WHERE source = 'auto_design' AND commit_id IS NULL`); err != nil {
 				return fmt.Errorf("v12 migration (add dedup ref index): %w", err)
+			}
+		}
+		if currentVersion < 13 {
+			if _, err = p.pool.Exec(ctx, `ALTER TABLE review_jobs ADD COLUMN IF NOT EXISTS retry_not_before TIMESTAMP WITH TIME ZONE`); err != nil {
+				return fmt.Errorf("v13 migration (add retry_not_before): %w", err)
 			}
 		}
 		// Update version

--- a/internal/storage/repos_test.go
+++ b/internal/storage/repos_test.go
@@ -1046,7 +1046,7 @@ func TestRetriedReviewJobNotRoutedAsPromptJob(t *testing.T) {
 				}
 			}
 
-			retried, err := db.RetryJob(claimed.ID, "", 3)
+			retried, err := db.RetryJob(claimed.ID, "", 3, 0)
 			require.NoError(t, err, "RetryJob failed: %v")
 
 			assert.True(t, retried)

--- a/internal/storage/schemas/postgres_v13.sql
+++ b/internal/storage/schemas/postgres_v13.sql
@@ -1,0 +1,115 @@
+-- PostgreSQL schema version 13
+-- Adds retry_not_before to review_jobs so ClaimJob can defer requeued
+-- jobs by their backoff window, replacing the per-worker sleep that
+-- couldn't enforce spacing across a multi-worker pool.
+-- Note: Version is managed by EnsureSchema(), not this file.
+
+CREATE SCHEMA IF NOT EXISTS roborev;
+
+CREATE TABLE IF NOT EXISTS roborev.schema_version (
+  version INTEGER PRIMARY KEY,
+  applied_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.machines (
+  id SERIAL PRIMARY KEY,
+  machine_id UUID UNIQUE NOT NULL,
+  name TEXT,
+  last_seen_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.repos (
+  id SERIAL PRIMARY KEY,
+  identity TEXT UNIQUE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.commits (
+  id SERIAL PRIMARY KEY,
+  repo_id INTEGER REFERENCES roborev.repos(id),
+  sha TEXT NOT NULL,
+  author TEXT NOT NULL,
+  subject TEXT NOT NULL,
+  timestamp TIMESTAMP WITH TIME ZONE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  UNIQUE(repo_id, sha)
+);
+
+CREATE TABLE IF NOT EXISTS roborev.review_jobs (
+  id SERIAL PRIMARY KEY,
+  uuid UUID UNIQUE NOT NULL,
+  repo_id INTEGER NOT NULL REFERENCES roborev.repos(id),
+  commit_id INTEGER REFERENCES roborev.commits(id),
+  git_ref TEXT NOT NULL,
+  branch TEXT,
+  session_id TEXT,
+  agent TEXT NOT NULL,
+  model TEXT,
+  provider TEXT,
+  requested_model TEXT,
+  requested_provider TEXT,
+  reasoning TEXT,
+  job_type TEXT NOT NULL DEFAULT 'review',
+  review_type TEXT NOT NULL DEFAULT '',
+  patch_id TEXT,
+  status TEXT NOT NULL CHECK(status IN ('queued', 'running', 'done', 'failed', 'canceled', 'applied', 'rebased', 'skipped')),
+  agentic BOOLEAN DEFAULT FALSE,
+  enqueued_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  started_at TIMESTAMP WITH TIME ZONE,
+  finished_at TIMESTAMP WITH TIME ZONE,
+  retry_not_before TIMESTAMP WITH TIME ZONE,
+  prompt TEXT,
+  diff_content TEXT,
+  error TEXT,
+  token_usage TEXT,
+  worktree_path TEXT,
+  min_severity TEXT NOT NULL DEFAULT '',
+  skip_reason TEXT,
+  source TEXT,
+  source_machine_id UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.reviews (
+  id SERIAL PRIMARY KEY,
+  uuid UUID UNIQUE NOT NULL,
+  job_uuid UUID NOT NULL REFERENCES roborev.review_jobs(uuid),
+  agent TEXT NOT NULL,
+  prompt TEXT NOT NULL,
+  output TEXT NOT NULL,
+  closed BOOLEAN NOT NULL DEFAULT FALSE,
+  updated_by_machine_id UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.responses (
+  id SERIAL PRIMARY KEY,
+  uuid UUID UNIQUE NOT NULL,
+  job_uuid UUID NOT NULL REFERENCES roborev.review_jobs(uuid),
+  responder TEXT NOT NULL,
+  response TEXT NOT NULL,
+  source_machine_id UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_review_jobs_source ON roborev.review_jobs(source_machine_id);
+CREATE INDEX IF NOT EXISTS idx_review_jobs_updated ON roborev.review_jobs(updated_at);
+-- Note: idx_review_jobs_branch, idx_review_jobs_job_type, and
+-- idx_review_jobs_patch_id are created by migration code, not here
+-- (to support upgrades from older versions where those columns
+-- don't exist yet).
+CREATE INDEX IF NOT EXISTS idx_reviews_job_uuid ON roborev.reviews(job_uuid);
+CREATE INDEX IF NOT EXISTS idx_reviews_updated ON roborev.reviews(updated_at);
+CREATE INDEX IF NOT EXISTS idx_responses_job_uuid ON roborev.responses(job_uuid);
+CREATE INDEX IF NOT EXISTS idx_responses_id ON roborev.responses(id);
+-- Partial unique indexes for auto-design dedup are created by EnsureSchema
+-- (fresh-init block + v12 migration step) — placing them here would break
+-- v1→v12 migrations where the source column doesn't yet exist when this
+-- schema is replayed.
+
+CREATE TABLE IF NOT EXISTS roborev.sync_metadata (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);


### PR DESCRIPTION
## Summary

- New nullable `retry_not_before` column on `review_jobs` (SQLite migration + postgres v13). Moves the retry-backoff gate from a per-worker `time.Sleep` onto the job itself, so any worker in the pool honors it — not just the worker that happened to fail.
- `RetryJob` now takes a `retryBackoff time.Duration` and stamps `now + retryBackoff` in RFC3339Nano (so sub-second windows aren't truncated to whole seconds). `ClaimJob` filters with `retry_not_before IS NULL OR retry_not_before <= ?`. `FailoverJob` clears the column so a fresh agent isn't held by the prior gate.
- `WorkerPool.retryBackoff` defaults to 2s; tests override to 0. The previous in-worker sleep is removed.
- Motivation: opencode's startup `PRAGMA wal_checkpoint(PASSIVE)` fails when a prior crashed instance left the WAL mid-write. With rapid no-spacing retries, multiple opencode processes raced on the shared DB and every retry inherited the broken state. The DB-level gate gives the prior process time to fully exit before the next claim.
- Tests: `TestRetryJobBackoffDefersClaim`, `TestRetryJobZeroBackoffLeavesNotBeforeNull`, `TestFailoverJob/clears_retry_not_before_on_failover` (storage); `TestFailOrRetryInner_SetsRetryNotBefore`, `TestClaimJob_HonorsRetryNotBeforeAcrossWorkers` (daemon). The cross-worker test is the load-bearing one: worker-A requeues, worker-B can't claim until the gate elapses.