### PR TITLE
Prefer Antigravity CLI for Gemini agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ REPORT.md
 .dolt/
 *.db
 .codex
+.antigravitycli/

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ See [configuration guide](https://roborev.io/configuration/) for all options.
 |-------|---------|
 | Codex | `npm install -g @openai/codex` |
 | Claude Code | `npm install -g @anthropic-ai/claude-code` |
-| Gemini | `npm install -g @google/gemini-cli` |
+| Gemini | `curl -fsSL https://antigravity.google/cli/install.sh \| bash` (preferred Antigravity CLI) or `npm install -g @google/gemini-cli` |
 | Copilot | `npm install -g @github/copilot` |
 | OpenCode | `go install github.com/opencode-ai/opencode@latest` |
 | Cursor | [cursor.com](https://www.cursor.com/) |

--- a/internal/agent/acp_resolution.go
+++ b/internal/agent/acp_resolution.go
@@ -63,7 +63,7 @@ func resolveAvailableBackupWithConfig(preferred string, backups []string, cfg *c
 		registryMu.RUnlock()
 		if inReg && isAvailableWithConfig(backup, cfg) {
 			agent, _ := Get(backup)
-			return applyCommandOverrides(agent, cfg), true
+			return applyAvailableCommand(agent, cfg), true
 		}
 	}
 	return nil, false
@@ -92,8 +92,7 @@ func isAvailableWithConfig(name string, cfg *config.Config) bool {
 		}
 	}
 	// Fall back to the default (hardcoded) command.
-	_, err := exec.LookPath(ca.CommandName())
-	return err == nil
+	return firstAvailableCommand(ca) != ""
 }
 
 // GetAvailableWithConfig resolves an available agent while honoring runtime ACP config.
@@ -149,7 +148,7 @@ func GetAvailableWithConfig(repoPath string, preferred string, cfg *config.Confi
 		}
 		if isAvailableWithConfig(preferred, cfg) {
 			a, _ := Get(preferred)
-			return applyCommandOverrides(a, cfg), nil
+			return applyAvailableCommand(a, cfg), nil
 		}
 	}
 
@@ -174,6 +173,16 @@ func GetAvailableWithConfig(repoPath string, preferred string, cfg *config.Confi
 	}
 
 	return applyCommandOverrides(resolved, cfg), nil
+}
+
+func applyAvailableCommand(a Agent, cfg *config.Config) Agent {
+	if a == nil {
+		return nil
+	}
+	if commandOverrideForAgent(a.Name(), cfg) != "" {
+		return applyCommandOverrides(a, cfg)
+	}
+	return applyResolvedCommand(a)
 }
 
 func applyACPAgentConfigOverride(cfg *config.ACPAgentConfig, override *config.ACPAgentConfig) {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -87,6 +87,13 @@ type CommandAgent interface {
 	CommandName() string
 }
 
+// CommandCandidatesAgent is implemented by command agents that can run
+// through more than one compatible executable, ordered by preference.
+type CommandCandidatesAgent interface {
+	CommandAgent
+	CommandNames() []string
+}
+
 // SessionAgent is implemented by agents that can resume an existing session.
 type SessionAgent interface {
 	WithSessionID(sessionID string) Agent
@@ -198,8 +205,7 @@ func IsAvailable(name string) bool {
 
 	// Check if agent implements CommandAgent interface
 	if ca, ok := a.(CommandAgent); ok {
-		_, err := exec.LookPath(ca.CommandName())
-		return err == nil
+		return firstAvailableCommand(ca) != ""
 	}
 
 	// Non-command agents (like test) are always available
@@ -235,7 +241,8 @@ func GetAvailable(preferred string, backups ...string) (Agent, error) {
 
 	// Try preferred agent first
 	if preferred != "" && IsAvailable(preferred) {
-		return Get(preferred)
+		a, _ := Get(preferred)
+		return applyResolvedCommand(a), nil
 	}
 
 	// Try backup agents before the hardcoded fallback chain.
@@ -248,13 +255,15 @@ func GetAvailable(preferred string, backups ...string) (Agent, error) {
 		_, ok := registry[b]
 		registryMu.RUnlock()
 		if ok && IsAvailable(b) {
-			return Get(b)
+			a, _ := Get(b)
+			return applyResolvedCommand(a), nil
 		}
 	}
 
 	for _, name := range fallbackAgentOrder {
 		if name != preferred && IsAvailable(name) {
-			return Get(name)
+			a, _ := Get(name)
+			return applyResolvedCommand(a), nil
 		}
 	}
 
@@ -272,7 +281,47 @@ func GetAvailable(preferred string, backups ...string) (Agent, error) {
 		return nil, fmt.Errorf("no agents available (install one of: %s)\nYou may need to run 'roborev daemon restart' from a shell that has access to your agents", strings.Join(installHintAgentNames(), ", "))
 	}
 
-	return Get(available[0])
+	a, _ := Get(available[0])
+	return applyResolvedCommand(a), nil
+}
+
+func firstAvailableCommand(a CommandAgent) string {
+	if candidates, ok := a.(CommandCandidatesAgent); ok {
+		for _, command := range candidates.CommandNames() {
+			if command == "" {
+				continue
+			}
+			if _, err := exec.LookPath(command); err == nil {
+				return command
+			}
+		}
+		return ""
+	}
+
+	command := a.CommandName()
+	if command == "" {
+		return ""
+	}
+	if _, err := exec.LookPath(command); err == nil {
+		return command
+	}
+	return ""
+}
+
+func applyResolvedCommand(a Agent) Agent {
+	ca, ok := a.(CommandAgent)
+	if !ok {
+		return a
+	}
+	command := firstAvailableCommand(ca)
+	if command == "" || command == ca.CommandName() {
+		return a
+	}
+	spec, ok := agentSpecsByName[resolveAlias(a.Name())]
+	if !ok || spec.CloneWithCommand == nil {
+		return a
+	}
+	return spec.CloneWithCommand(a, command)
 }
 
 // syncWriter wraps an io.Writer with mutex protection for concurrent writes.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -550,6 +550,85 @@ func TestGetAvailableTriesBackupBeforeChain(t *testing.T) {
 	assert.Equal(t, "claude-code", resolved.Name())
 }
 
+func TestGetAvailablePrefersAntigravityForGemini(t *testing.T) {
+	fakeBin := t.TempDir()
+	for _, bin := range []string{"agy", "gemini"} {
+		name := bin
+		if runtime.GOOS == "windows" {
+			name += ".exe"
+		}
+		p := filepath.Join(fakeBin, name)
+		require.NoError(t, os.WriteFile(p, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	}
+	t.Setenv("PATH", fakeBin)
+
+	originalRegistry := registry
+	registry = map[string]Agent{
+		"gemini": NewGeminiAgent(""),
+	}
+	t.Cleanup(func() { registry = originalRegistry })
+
+	resolved, err := GetAvailable("gemini")
+	require.NoError(t, err)
+	require.IsType(t, &GeminiAgent{}, resolved)
+	gemini := resolved.(*GeminiAgent)
+	assert.Equal(t, "gemini", gemini.Name())
+	assert.Equal(t, "agy", gemini.CommandName())
+	assert.True(t, gemini.CommandAuto)
+}
+
+func TestGeminiWithModelUsesLegacyCommandWhenAutoSelectedAntigravity(t *testing.T) {
+	fakeBin := t.TempDir()
+	for _, bin := range []string{"agy", "gemini"} {
+		name := bin
+		if runtime.GOOS == "windows" {
+			name += ".exe"
+		}
+		p := filepath.Join(fakeBin, name)
+		require.NoError(t, os.WriteFile(p, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	}
+	t.Setenv("PATH", fakeBin)
+
+	originalRegistry := registry
+	registry = map[string]Agent{
+		"gemini": NewGeminiAgent(""),
+	}
+	t.Cleanup(func() { registry = originalRegistry })
+
+	resolved, err := GetAvailable("gemini")
+	require.NoError(t, err)
+
+	withModel := resolved.WithModel("gemini-1.5-pro")
+	require.IsType(t, &GeminiAgent{}, withModel)
+	gemini := withModel.(*GeminiAgent)
+	assert.Equal(t, "gemini", gemini.CommandName())
+	assert.True(t, gemini.ModelExplicit)
+	assert.False(t, gemini.CommandAuto)
+}
+
+func TestGetAvailableFallsBackToGeminiWhenAntigravityMissing(t *testing.T) {
+	fakeBin := t.TempDir()
+	name := "gemini"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	p := filepath.Join(fakeBin, name)
+	require.NoError(t, os.WriteFile(p, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("PATH", fakeBin)
+
+	originalRegistry := registry
+	registry = map[string]Agent{
+		"gemini": NewGeminiAgent(""),
+	}
+	t.Cleanup(func() { registry = originalRegistry })
+
+	resolved, err := GetAvailable("gemini")
+	require.NoError(t, err)
+	require.IsType(t, &GeminiAgent{}, resolved)
+	gemini := resolved.(*GeminiAgent)
+	assert.Equal(t, "gemini", gemini.CommandName())
+}
+
 func TestGetAvailableBackupSkipsDuplicateAndEmpty(t *testing.T) {
 	// Backup that matches preferred or is empty should be skipped.
 	fakeBin := t.TempDir()

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os/exec"
+	"path"
 	"strings"
 )
 
@@ -31,10 +33,12 @@ const defaultGeminiModel = "gemini-3.1-pro-preview"
 
 // GeminiAgent runs code reviews using the Gemini CLI
 type GeminiAgent struct {
-	Command   string         // The gemini command to run (default: "gemini")
-	Model     string         // Model to use (e.g., "gemini-3.1-pro-preview")
-	Reasoning ReasoningLevel // Reasoning level (for future support)
-	Agentic   bool           // Whether agentic mode is enabled (allow file edits)
+	Command       string         // The gemini-compatible command to run (default: "gemini"; "agy" is preferred at resolution time)
+	Model         string         // Model to use (e.g., "gemini-3.1-pro-preview")
+	ModelExplicit bool           // Whether Model came from WithModel/config rather than the built-in default
+	CommandAuto   bool           // Whether Command was selected from compatible command candidates
+	Reasoning     ReasoningLevel // Reasoning level (for future support)
+	Agentic       bool           // Whether agentic mode is enabled (allow file edits)
 }
 
 // NewGeminiAgent creates a new Gemini agent
@@ -55,10 +59,12 @@ func (a *GeminiAgent) clone(opts ...agentCloneOption) *GeminiAgent {
 		opts...,
 	)
 	return &GeminiAgent{
-		Command:   cfg.Command,
-		Model:     cfg.Model,
-		Reasoning: cfg.Reasoning,
-		Agentic:   cfg.Agentic,
+		Command:       cfg.Command,
+		Model:         cfg.Model,
+		ModelExplicit: a.ModelExplicit,
+		CommandAuto:   a.CommandAuto,
+		Reasoning:     cfg.Reasoning,
+		Agentic:       cfg.Agentic,
 	}
 }
 
@@ -77,7 +83,15 @@ func (a *GeminiAgent) WithModel(model string) Agent {
 	if model == "" {
 		return a
 	}
-	return a.clone(withClonedModel(model))
+	clone := a.clone(withClonedModel(model))
+	clone.ModelExplicit = true
+	if clone.usesAntigravity() && clone.CommandAuto {
+		if _, err := exec.LookPath("gemini"); err == nil {
+			clone.Command = "gemini"
+			clone.CommandAuto = false
+		}
+	}
+	return clone
 }
 
 func (a *GeminiAgent) Name() string {
@@ -86,6 +100,13 @@ func (a *GeminiAgent) Name() string {
 
 func (a *GeminiAgent) CommandName() string {
 	return a.Command
+}
+
+func (a *GeminiAgent) CommandNames() []string {
+	if a.Command == "gemini" {
+		return []string{"agy", "gemini"}
+	}
+	return []string{a.Command}
 }
 
 func (a *GeminiAgent) CommandLine() string {
@@ -99,6 +120,10 @@ func (a *GeminiAgent) buildArgs(agenticMode bool) []string {
 }
 
 func (a *GeminiAgent) Review(ctx context.Context, repoPath, commitSHA, prompt string, output io.Writer) (string, error) {
+	if a.usesAntigravity() && a.ModelExplicit {
+		return "", fmt.Errorf("antigravity CLI does not support explicit Gemini model selection; remove the model override or configure gemini_cmd to the legacy gemini CLI")
+	}
+
 	agenticMode := a.Agentic || AllowUnsafeAgents()
 	args := a.buildArgs(agenticMode)
 
@@ -118,6 +143,10 @@ func (a *GeminiAgent) Review(ctx context.Context, repoPath, commitSHA, prompt st
 // buildArgsWithModel builds CLI args with an explicit model override
 // (empty string omits the -m flag entirely).
 func (a *GeminiAgent) buildArgsWithModel(model string, agenticMode bool) []string {
+	if a.usesAntigravity() {
+		return a.buildAntigravityArgs(agenticMode)
+	}
+
 	args := []string{"--output-format", "stream-json"}
 
 	if model != "" {
@@ -133,9 +162,35 @@ func (a *GeminiAgent) buildArgsWithModel(model string, agenticMode bool) []strin
 	return args
 }
 
+func (a *GeminiAgent) usesAntigravity() bool {
+	return commandBaseName(a.Command) == "agy"
+}
+
+func commandBaseName(command string) string {
+	base := strings.ToLower(path.Base(strings.ReplaceAll(command, "\\", "/")))
+	base = strings.TrimSuffix(base, ".exe")
+	return base
+}
+
+func (a *GeminiAgent) buildAntigravityArgs(agenticMode bool) []string {
+	args := []string{"--print", "--print-timeout", "30m"}
+
+	if agenticMode {
+		args = append(args, "--dangerously-skip-permissions")
+	} else {
+		args = append(args, "--sandbox")
+	}
+
+	return args
+}
+
 // runGemini executes the Gemini CLI with the given args and returns
 // the review result, captured stderr, and any error.
 func (a *GeminiAgent) runGemini(ctx context.Context, repoPath, prompt string, args []string, output io.Writer) (string, string, error) {
+	if a.usesAntigravity() {
+		return a.runAntigravity(ctx, repoPath, prompt, args, output)
+	}
+
 	runResult, runErr := runStreamingCLI(ctx, streamingCLISpec{
 		Name:         "gemini",
 		Command:      a.Command,
@@ -169,6 +224,48 @@ func (a *GeminiAgent) runGemini(ctx context.Context, repoPath, prompt string, ar
 	}
 
 	return "No review output generated", runResult.Stderr, nil
+}
+
+func (a *GeminiAgent) runAntigravity(ctx context.Context, repoPath, prompt string, args []string, output io.Writer) (string, string, error) {
+	runResult, runErr := runStreamingCLI(ctx, streamingCLISpec{
+		Name:         "antigravity",
+		Command:      a.Command,
+		Args:         args,
+		Dir:          repoPath,
+		Stdin:        strings.NewReader(strings.TrimRight(prompt, "\n") + "\n"),
+		Output:       output,
+		StreamStderr: true,
+		Parse: func(r io.Reader, sw *syncWriter) (string, error) {
+			return parseAntigravityOutput(r, sw)
+		},
+	})
+	if runErr != nil {
+		return "", "", runErr
+	}
+
+	if runResult.WaitErr != nil {
+		return "", runResult.Stderr, formatStreamingCLIWaitError("antigravity", runResult, truncateStderr(runResult.Stderr))
+	}
+
+	if runResult.ParseErr != nil {
+		return "", runResult.Stderr, runResult.ParseErr
+	}
+
+	if runResult.Result != "" {
+		return runResult.Result, runResult.Stderr, nil
+	}
+
+	return "No review output generated", runResult.Stderr, nil
+}
+
+func parseAntigravityOutput(r io.Reader, sw *syncWriter) (string, error) {
+	var buf strings.Builder
+	if sw == nil {
+		_, err := io.Copy(&buf, r)
+		return strings.TrimSpace(buf.String()), err
+	}
+	_, err := io.Copy(io.MultiWriter(&buf, sw), r)
+	return strings.TrimSpace(buf.String()), err
 }
 
 // isModelNotFoundError returns true if stderr indicates the requested

--- a/internal/agent/gemini_test.go
+++ b/internal/agent/gemini_test.go
@@ -89,6 +89,68 @@ func TestGeminiBuildArgs(t *testing.T) {
 	}
 }
 
+func TestGeminiAntigravityBuildArgs(t *testing.T) {
+	tests := []struct {
+		name         string
+		agentic      bool
+		wantFlag     string
+		unwantedArgs []string
+	}{
+		{
+			name:     "ReviewMode",
+			agentic:  false,
+			wantFlag: "--sandbox",
+			unwantedArgs: []string{
+				"--output-format",
+				"--approval-mode",
+				"-m",
+				"--dangerously-skip-permissions",
+			},
+		},
+		{
+			name:     "AgenticMode",
+			agentic:  true,
+			wantFlag: "--dangerously-skip-permissions",
+			unwantedArgs: []string{
+				"--output-format",
+				"--approval-mode",
+				"-m",
+				"--sandbox",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a := NewGeminiAgent("agy").WithModel("gemini-1.5-pro").(*GeminiAgent)
+			args := a.buildArgs(tc.agentic)
+
+			assert.Contains(t, args, "--print")
+			assertFlagValue(t, args, "--print-timeout", "30m")
+			assert.Contains(t, args, tc.wantFlag)
+			for _, unwanted := range tc.unwantedArgs {
+				assert.NotContains(t, args, unwanted)
+			}
+		})
+	}
+}
+
+func TestGeminiDetectsAntigravityCommandNames(t *testing.T) {
+	tests := []string{
+		"agy",
+		"agy.exe",
+		"/usr/local/bin/agy",
+		`C:\Users\marius\AppData\Local\bin\agy.exe`,
+	}
+
+	for _, command := range tests {
+		t.Run(command, func(t *testing.T) {
+			a := NewGeminiAgent(command)
+			assert.True(t, a.usesAntigravity())
+		})
+	}
+}
+
 func assertFlagValue(t *testing.T, args []string, flag, expectedVal string) {
 	t.Helper()
 	assert := assert.New(t)
@@ -237,6 +299,41 @@ No issues found in the code.
 			}
 		})
 	}
+}
+
+func TestGeminiAntigravityReviewPlainText(t *testing.T) {
+	skipIfWindows(t)
+
+	scriptPath := writeTempCommand(t, `#!/bin/sh
+cat > "$STDIN_FILE"
+echo "Plain text review output"
+echo "No issues found."
+`)
+
+	stdinFile := filepath.Join(t.TempDir(), "stdin")
+	t.Setenv("STDIN_FILE", stdinFile)
+	a := NewGeminiAgent(scriptPath)
+	a.Command = filepath.Join(filepath.Dir(scriptPath), "agy")
+	require.NoError(t, os.Rename(scriptPath, a.Command))
+
+	var output bytes.Buffer
+	res, err := a.Review(context.Background(), t.TempDir(), "sha", "prompt", &output)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Plain text review output\nNo issues found.", res)
+	assert.Contains(t, output.String(), "Plain text review output")
+	stdinBytes, readErr := os.ReadFile(stdinFile)
+	require.NoError(t, readErr)
+	assert.Equal(t, "prompt\n", string(stdinBytes))
+}
+
+func TestGeminiAntigravityExplicitModelFailsClearly(t *testing.T) {
+	a := NewGeminiAgent("agy").WithModel("gemini-1.5-pro")
+
+	_, err := a.Review(context.Background(), t.TempDir(), "sha", "prompt", nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support explicit Gemini model selection")
 }
 
 func TestGemini_Review_Integration(t *testing.T) {

--- a/internal/agent/spec.go
+++ b/internal/agent/spec.go
@@ -57,6 +57,16 @@ var allAgentSpecs = []agentSpec{
 		Name:           "gemini",
 		DefaultCommand: "gemini",
 		FallbackRank:   3,
+		CloneWithCommand: func(a Agent, command string) Agent {
+			agent, ok := a.(*GeminiAgent)
+			if !ok {
+				return a
+			}
+			clone := *agent
+			clone.Command = command
+			clone.CommandAuto = true
+			return &clone
+		},
 	},
 	{
 		Name:           "copilot",


### PR DESCRIPTION
Due to google deprecating the gemini cli we need this one.  The antigravity CLI lacks a LOT of the functionality that we currently rely on (like --model) so we are forced to make some compromises :(

## Summary
- prefer the Antigravity `agy` CLI for the existing Gemini agent while falling back to legacy `gemini`
- invoke Antigravity in print mode, pipe prompts over stdin, and map review/agentic permissions to `--sandbox` and `--dangerously-skip-permissions`
- keep legacy Gemini stream-json handling and document the preferred Antigravity install path

## Validation
- `printf 'Return exactly: ok\\n' | agy --print --print-timeout 30s --sandbox`\n- `go test ./internal/agent`\n- `go vet ./...`\n- `go test ./...`