### PR TITLE
chore(lint): enable errorlint and fix violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ linters:
   default: none
   enable:
     - errcheck
+    - errorlint
     - govet
     - ineffassign
     - modernize

--- a/cmd/roborev/daemon_cmd.go
+++ b/cmd/roborev/daemon_cmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -38,7 +39,7 @@ func daemonCmd() *cobra.Command {
 		Use:   "stop",
 		Short: "Stop the daemon",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := stopDaemon(); err == ErrDaemonNotRunning {
+			if err := stopDaemon(); errors.Is(err, ErrDaemonNotRunning) {
 				fmt.Println("Daemon was not running")
 				return nil
 			} else if err != nil {
@@ -54,7 +55,7 @@ func daemonCmd() *cobra.Command {
 		Short: "Restart the daemon",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			wasRunning := true
-			if err := stopDaemon(); err == ErrDaemonNotRunning {
+			if err := stopDaemon(); errors.Is(err, ErrDaemonNotRunning) {
 				wasRunning = false
 			} else if err != nil {
 				return err

--- a/cmd/roborev/fix_test.go
+++ b/cmd/roborev/fix_test.go
@@ -579,12 +579,12 @@ func TestFixSingleJobRecoversPostFixDaemonCalls(t *testing.T) {
 			cmd := exec.Command("git", "add", "fix.txt")
 			cmd.Dir = repoPath
 			if out, err := cmd.CombinedOutput(); err != nil {
-				return "", fmt.Errorf("git add: %v (%s)", err, out)
+				return "", fmt.Errorf("git add: %w (%s)", err, out)
 			}
 			cmd = exec.Command("git", "commit", "-m", "fix: apply retry test")
 			cmd.Dir = repoPath
 			if out, err := cmd.CombinedOutput(); err != nil {
-				return "", fmt.Errorf("git commit: %v (%s)", err, out)
+				return "", fmt.Errorf("git commit: %w (%s)", err, out)
 			}
 			return "applied fix", nil
 		},

--- a/cmd/roborev/helpers.go
+++ b/cmd/roborev/helpers.go
@@ -47,7 +47,8 @@ func silentExit(cmd *cobra.Command, code int) error {
 // points whose error may have originated in concurrent code that could
 // not safely mutate cmd itself.
 func silenceIfExit(cmd *cobra.Command, err error) error {
-	if _, ok := err.(*exitError); ok {
+	var exitErr *exitError
+	if errors.As(err, &exitErr) {
 		cmd.SilenceErrors = true
 	}
 	return err
@@ -77,7 +78,8 @@ func quietExit(cmd *cobra.Command, err error) error {
 		return nil
 	}
 	cmd.SilenceUsage = true
-	if _, ok := err.(*exitError); ok {
+	var exitErr *exitError
+	if errors.As(err, &exitErr) {
 		return err
 	}
 	return &exitError{code: 1, cause: err}

--- a/cmd/roborev/main.go
+++ b/cmd/roborev/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -74,7 +75,8 @@ func main() {
 	if err := rootCmd.Execute(); err != nil {
 		// exitError carries a specific exit code; the RunE that returned
 		// it has already silenced cobra's error printing via silentExit.
-		if exitErr, ok := err.(*exitError); ok {
+		var exitErr *exitError
+		if errors.As(err, &exitErr) {
 			os.Exit(exitErr.code)
 		}
 		// All other errors: cobra already printed them.

--- a/cmd/roborev/review_test.go
+++ b/cmd/roborev/review_test.go
@@ -255,8 +255,8 @@ func TestWaitQuietVerdictExitCode(t *testing.T) {
 		stdout, stderr, err := executeReviewCmd("--repo", repo.Dir, "--wait", "--quiet")
 
 		require.Error(t, err, "expected review command to fail in this case")
-		exitErr, ok := err.(*exitError)
-		require.True(t, ok, "expected exitError, got: %T %v", err)
+		var exitErr *exitError
+		require.ErrorAs(t, err, &exitErr)
 		require.Equal(t, 1, exitErr.code, "expected exit code 1")
 		assert.Empty(t, stdout)
 		assert.Empty(t, stderr)

--- a/cmd/roborev/update.go
+++ b/cmd/roborev/update.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -223,7 +224,7 @@ func restartDaemonAfterUpdate(binDir string, noRestart bool) {
 	}
 
 	stopErr := stopDaemonForUpdate()
-	stopFailed := stopErr != nil && stopErr != ErrDaemonNotRunning
+	stopFailed := stopErr != nil && !errors.Is(stopErr, ErrDaemonNotRunning)
 	if stopFailed {
 		fmt.Printf("warning: failed to stop daemon: %v\n", stopErr)
 	}

--- a/cmd/roborev/wait.go
+++ b/cmd/roborev/wait.go
@@ -291,7 +291,8 @@ func waitMultiple(
 				if r.err == nil {
 					continue
 				}
-				if _, ok := r.err.(*exitError); !ok {
+				var exitErr *exitError
+				if !errors.As(r.err, &exitErr) {
 					return r.err
 				}
 			}

--- a/cmd/roborev/wait_test.go
+++ b/cmd/roborev/wait_test.go
@@ -61,8 +61,8 @@ func newWaitMockHandler(cfg mockConfig) http.HandlerFunc {
 func requireExitCode(t *testing.T, err error, code int) {
 	t.Helper()
 	require.Error(t, err)
-	exitErr, ok := err.(*exitError)
-	assert.True(t, ok)
+	var exitErr *exitError
+	require.ErrorAs(t, err, &exitErr)
 	assert.Equal(t, exitErr.code, code)
 }
 

--- a/internal/agent/acp_client_files.go
+++ b/internal/agent/acp_client_files.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	acp "github.com/coder/acp-go-sdk"
 	"io"
@@ -68,7 +69,7 @@ func readTextFileWindow(path string, startLine int, limit *int, maxBytes int) (s
 
 	for {
 		chunk, readErr := reader.ReadSlice('\n')
-		if readErr == bufio.ErrBufferFull {
+		if errors.Is(readErr, bufio.ErrBufferFull) {
 			if currentLine >= startLine && (limit == nil || selectedLines < *limit) {
 				if err := appendLineChunk(chunk); err != nil {
 					return "", err
@@ -320,7 +321,7 @@ func (c *acpClient) validateAndResolvePath(requestedPath string, forWrite bool) 
 		parentDir := filepath.Dir(absPath)
 		resolvedParent, err := filepath.EvalSymlinks(parentDir)
 		if err != nil {
-			return "", fmt.Errorf("%w: failed to resolve parent directory symlinks for path %s: %v", ErrPathTraversal, requestedPath, err)
+			return "", fmt.Errorf("%w: failed to resolve parent directory symlinks for path %s: %w", ErrPathTraversal, requestedPath, err)
 		}
 
 		// Check if parent directory is within repository root
@@ -354,7 +355,7 @@ func (c *acpClient) validateAndResolvePath(requestedPath string, forWrite bool) 
 		if info.Mode()&os.ModeSymlink != 0 {
 			resolvedTarget, err := filepath.EvalSymlinks(validatedPath)
 			if err != nil {
-				return "", fmt.Errorf("%w: failed to resolve write target symlink for path %s: %v", ErrPathTraversal, requestedPath, err)
+				return "", fmt.Errorf("%w: failed to resolve write target symlink for path %s: %w", ErrPathTraversal, requestedPath, err)
 			}
 			resolvedTarget = filepath.Clean(resolvedTarget)
 			if !pathWithinRoot(resolvedTarget, resolvedRepoRoot) {
@@ -371,7 +372,7 @@ func (c *acpClient) validateAndResolvePath(requestedPath string, forWrite bool) 
 	if err != nil {
 		// If we can't resolve symlinks (e.g., broken symlink or permission issue),
 		// we treat this as an invalid path for security
-		return "", fmt.Errorf("%w: failed to resolve symlinks for path %s: %v", ErrPathTraversal, requestedPath, err)
+		return "", fmt.Errorf("%w: failed to resolve symlinks for path %s: %w", ErrPathTraversal, requestedPath, err)
 	}
 
 	// Check if the resolved path is within the repository root

--- a/internal/agent/cli_wait_error.go
+++ b/internal/agent/cli_wait_error.go
@@ -15,7 +15,7 @@ type detailedCLIWaitErrorOptions struct {
 
 func formatStreamingCLIWaitError(agentName string, runResult streamingCLIResult, stderr string) error {
 	if runResult.ParseErr != nil {
-		return fmt.Errorf("%s failed: %w (parse error: %v)\nstderr: %s", agentName, runResult.WaitErr, runResult.ParseErr, stderr)
+		return fmt.Errorf("%s failed: %w (parse error: %w)\nstderr: %s", agentName, runResult.WaitErr, runResult.ParseErr, stderr)
 	}
 	return fmt.Errorf("%s failed: %w\nstderr: %s", agentName, runResult.WaitErr, stderr)
 }

--- a/internal/config/config_test_helpers_test.go
+++ b/internal/config/config_test_helpers_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -54,7 +55,8 @@ func execGit(t *testing.T, dir string, args ...string) string {
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
 			require.NoError(t, err, "git %v failed\nstderr: %s", args, exitError.Stderr)
 		}
 		require.NoError(t, err, "git %v failed", args)

--- a/internal/config/keyval.go
+++ b/internal/config/keyval.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -377,8 +378,8 @@ func (e unknownConfigKeyError) Error() string {
 }
 
 func isUnknownConfigKeyError(err error) bool {
-	_, ok := err.(unknownConfigKeyError)
-	return ok
+	var u unknownConfigKeyError
+	return errors.As(err, &u)
 }
 
 // nestedStructValue resolves a field value to an underlying struct value.

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -1273,7 +1273,7 @@ func ghClone(
 		cmd.Env = env
 	}
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git clone: %s: %s", err, string(out))
+		return fmt.Errorf("git clone: %w: %s", err, string(out))
 	}
 	return nil
 }
@@ -1480,7 +1480,7 @@ func gitFetchCtx(ctx context.Context, repoPath string, env []string) error {
 		cmd.Env = env
 	}
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("%s: %s", err, string(out))
+		return fmt.Errorf("%w: %s", err, string(out))
 	}
 	return nil
 }
@@ -1494,7 +1494,7 @@ func gitFetchPRHead(ctx context.Context, repoPath string, prNumber int, env []st
 		cmd.Env = env
 	}
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("%s: %s", err, string(out))
+		return fmt.Errorf("%w: %s", err, string(out))
 	}
 	return nil
 }

--- a/internal/daemon/hooks_test.go
+++ b/internal/daemon/hooks_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/roborev-dev/roborev/internal/config"
@@ -770,7 +771,7 @@ func TestRedactURLError(t *testing.T) {
 	}
 
 	got := redactURLError(urlErr)
-	if got != inner {
+	if !errors.Is(got, inner) {
 		require.Condition(t, func() bool {
 			return false
 		}, "expected inner error, got %v", got)
@@ -782,7 +783,7 @@ func TestRedactURLError(t *testing.T) {
 	}
 
 	plain := fmt.Errorf("some other error")
-	if redactURLError(plain) != plain {
+	if !errors.Is(redactURLError(plain), plain) {
 		require.Condition(t, func() bool {
 			return false
 		}, "non-url.Error should be returned as-is")

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -286,7 +286,7 @@ func (s *Server) Start(ctx context.Context) error {
 		}
 	}
 
-	if err := <-serveErrCh; err != http.ErrServerClosed {
+	if err := <-serveErrCh; err != nil && !errors.Is(err, http.ErrServerClosed) {
 		s.configWatcher.Stop()
 		s.workerPool.Stop()
 		return err
@@ -304,7 +304,7 @@ func waitForServerReady(ctx context.Context, ep DaemonEndpoint, timeout time.Dur
 		}
 		select {
 		case err := <-serveErrCh:
-			if err == http.ErrServerClosed && ctx.Err() != nil {
+			if errors.Is(err, http.ErrServerClosed) && ctx.Err() != nil {
 				return false, true, nil
 			}
 			if err == nil {
@@ -326,7 +326,7 @@ func waitForServerReady(ctx context.Context, ep DaemonEndpoint, timeout time.Dur
 	}
 	select {
 	case err := <-serveErrCh:
-		if err == http.ErrServerClosed && ctx.Err() != nil {
+		if errors.Is(err, http.ErrServerClosed) && ctx.Err() != nil {
 			return false, true, nil
 		}
 		if err == nil {
@@ -346,7 +346,7 @@ func awaitServeExitOnUnreadyStartup(serveExited bool, serveErrCh <-chan error) e
 		return nil
 	}
 
-	if err := <-serveErrCh; err != http.ErrServerClosed {
+	if err := <-serveErrCh; err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return err
 	}
 	return nil

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1290,7 +1290,8 @@ func GetUpstream(repoPath, ref string) (string, error) {
 		// Exit code 128 covers both "no upstream configured" and "upstream
 		// configured but ref not resolvable" (git varies between versions).
 		// Distinguish by re-reading branch.<name>.remote/merge.
-		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 128 {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 128 {
 			if cfg, ok := readUpstreamConfig(repoPath, ref); ok {
 				return "", &UpstreamMissingError{Ref: ref, Upstream: cfg.short}
 			}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -3,6 +3,7 @@ package git
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -320,7 +321,8 @@ func IsAncestor(repoPath, ancestor, descendant string) (bool, error) {
 		return true, nil
 	}
 	// Exit code 1 means "not ancestor", which is not an error
-	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
 		return false, nil
 	}
 	// Any other error (exit code 128, etc.) is a real git error

--- a/internal/storage/ci.go
+++ b/internal/storage/ci.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 )
@@ -484,7 +485,7 @@ func (db *DB) CancelSupersededBatches(githubRepo string, prNumber int, newHeadSH
 		}
 		for _, jid := range jobIDs {
 			if err := db.CancelJob(jid); err != nil {
-				if err == sql.ErrNoRows {
+				if errors.Is(err, sql.ErrNoRows) {
 					continue // already terminal
 				}
 				return canceledIDs, fmt.Errorf("cancel job %d: %w", jid, err)
@@ -633,7 +634,7 @@ func (db *DB) CancelClosedPRBatches(
 		}
 		for _, jid := range jobIDs {
 			if err := db.CancelJob(jid); err != nil {
-				if err == sql.ErrNoRows {
+				if errors.Is(err, sql.ErrNoRows) {
 					continue
 				}
 				return canceledIDs, fmt.Errorf(

--- a/internal/storage/commits.go
+++ b/internal/storage/commits.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"database/sql"
+	"errors"
 	"time"
 )
 
@@ -13,7 +14,7 @@ func (db *DB) GetOrCreateCommit(repoID int64, sha, author, subject string, times
 	if err == nil {
 		return commit, nil
 	}
-	if err != sql.ErrNoRows {
+	if !errors.Is(err, sql.ErrNoRows) {
 		return nil, err
 	}
 

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -1673,7 +1673,7 @@ func (db *DB) migrateReviewJobsConstraintsForAutoDesign() error {
 		return err
 	}
 	defer func() {
-		if rbErr := tx.Rollback(); rbErr != nil && rbErr != sql.ErrTxDone {
+		if rbErr := tx.Rollback(); rbErr != nil && !errors.Is(rbErr, sql.ErrTxDone) {
 			return
 		}
 	}()

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -330,7 +331,7 @@ func (db *DB) migrate() error {
 			return fmt.Errorf("begin migration transaction: %w", err)
 		}
 		defer func() {
-			if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+			if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
 				return
 			}
 		}()
@@ -503,7 +504,7 @@ func (db *DB) migrate() error {
 	// Check if commit_id is NOT NULL by examining the schema
 	var responsesSql string
 	err = db.QueryRow(`SELECT sql FROM sqlite_master WHERE type='table' AND name='responses'`).Scan(&responsesSql)
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("check responses schema: %w", err)
 	}
 	// Only migrate if commit_id is NOT NULL (old schema)
@@ -526,7 +527,7 @@ func (db *DB) migrate() error {
 			return fmt.Errorf("begin responses migration transaction: %w", err)
 		}
 		defer func() {
-			if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+			if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
 				return
 			}
 		}()
@@ -996,7 +997,7 @@ func (db *DB) migrateJobStatusConstraint() error {
 		return err
 	}
 	defer func() {
-		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
 			return
 		}
 	}()
@@ -1281,7 +1282,7 @@ func (db *DB) migrateSyncColumns() error {
 	// Migration: If an old UNIQUE index exists, drop it first
 	var indexSQL sql.NullString
 	err = db.QueryRow(`SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_repos_identity'`).Scan(&indexSQL)
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("check existing idx_repos_identity: %w", err)
 	}
 	if indexSQL.Valid && strings.Contains(strings.ToUpper(indexSQL.String), "UNIQUE") {
@@ -1337,7 +1338,7 @@ func (db *DB) migrateSyncColumns() error {
 			return fmt.Errorf("begin commits migration transaction: %w", err)
 		}
 		defer func() {
-			if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+			if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
 				return
 			}
 		}()

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -324,7 +325,7 @@ func (db *DB) CompleteFixJob(jobID int64, agent, prompt, output, patch string) e
 	// Fetch output_prefix from job (if any)
 	var outputPrefix sql.NullString
 	err = conn.QueryRowContext(ctx, `SELECT output_prefix FROM review_jobs WHERE id = ?`, jobID).Scan(&outputPrefix)
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return err
 	}
 
@@ -399,7 +400,7 @@ func (db *DB) CompleteJob(jobID int64, agent, prompt, output string) error {
 	// Fetch output_prefix from job (if any)
 	var outputPrefix sql.NullString
 	err = conn.QueryRowContext(ctx, `SELECT output_prefix FROM review_jobs WHERE id = ?`, jobID).Scan(&outputPrefix)
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return err
 	}
 
@@ -1061,7 +1062,7 @@ func (db *DB) RemapJob(
 		`SELECT id FROM commits WHERE repo_id = ? AND sha = ?`,
 		repoID, newSHA,
 	).Scan(&commitID)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		result, insertErr := tx.Exec(`
 			INSERT INTO commits (repo_id, sha, author, subject, timestamp)
 			VALUES (?, ?, ?, ?, ?)

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -619,7 +619,7 @@ func (p *PgPool) Tx(ctx context.Context, fn func(tx pgx.Tx) error) error {
 		return fmt.Errorf("begin transaction: %w", err)
 	}
 	defer func() {
-		if err := tx.Rollback(ctx); err != nil && err != pgx.ErrTxClosed {
+		if err := tx.Rollback(ctx); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
 			return
 		}
 	}()

--- a/internal/storage/repos.go
+++ b/internal/storage/repos.go
@@ -91,7 +91,7 @@ func (db *DB) GetOrCreateRepo(rootPath string, identity ...string) (*Repo, error
 		}
 		return &repo, nil
 	}
-	if err != sql.ErrNoRows {
+	if !errors.Is(err, sql.ErrNoRows) {
 		return nil, err
 	}
 
@@ -450,7 +450,7 @@ func (db *DB) FindRepo(identifier string) (*Repo, error) {
 	if err == nil {
 		return repo, nil
 	}
-	if err != sql.ErrNoRows {
+	if !errors.Is(err, sql.ErrNoRows) {
 		return nil, err
 	}
 

--- a/internal/storage/repos.go
+++ b/internal/storage/repos.go
@@ -381,7 +381,7 @@ func (db *DB) MoveRepo(repoID int64, newPath, newIdentity string) error {
 	if err == nil && existingID != repoID {
 		return ErrRepoPathConflict
 	}
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("check path conflict: %w", err)
 	}
 

--- a/internal/storage/reviews.go
+++ b/internal/storage/reviews.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -420,7 +421,7 @@ func (db *DB) AddCommentToJob(jobID int64, responder, response string) (*Respons
 	var exists int
 	err := db.QueryRow(`SELECT 1 FROM review_jobs WHERE id = ?`, jobID).Scan(&exists)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, sql.ErrNoRows // Job not found
 		}
 		return nil, err

--- a/internal/storage/sync.go
+++ b/internal/storage/sync.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -655,7 +656,7 @@ func (db *DB) UpsertPulledReview(r PulledReview) error {
 	// First, find the job_id by uuid
 	var jobID int64
 	err := db.QueryRow(`SELECT id FROM review_jobs WHERE uuid = ?`, r.JobUUID).Scan(&jobID)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		// Job doesn't exist locally - skip this review (orphaned)
 		return nil
 	}
@@ -684,7 +685,7 @@ func (db *DB) UpsertPulledResponse(r PulledResponse) error {
 	// First, find the job_id by uuid
 	var jobID int64
 	err := db.QueryRow(`SELECT id FROM review_jobs WHERE uuid = ?`, r.JobUUID).Scan(&jobID)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		// Job doesn't exist locally - skip this response (orphaned)
 		return nil
 	}
@@ -767,7 +768,7 @@ func (db *DB) GetOrCreateRepoByIdentity(identity string) (int64, error) {
 	if err == nil {
 		return placeholderID, nil
 	}
-	if err != sql.ErrNoRows {
+	if !errors.Is(err, sql.ErrNoRows) {
 		return 0, fmt.Errorf("find placeholder repo: %w", err)
 	}
 
@@ -828,7 +829,7 @@ func (db *DB) GetOrCreateCommitByRepoAndSHA(repoID int64, sha, author, subject s
 	if err == nil {
 		return id, nil
 	}
-	if err != sql.ErrNoRows {
+	if !errors.Is(err, sql.ErrNoRows) {
 		return 0, fmt.Errorf("find commit: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- Enable `errorlint` in `.golangci.yml`
- Replace `err == X` / `err != X` comparisons with `errors.Is` across storage, daemon, agent, and cmd packages
- Replace `err.(*T)` type assertions with `errors.As`
- Switch `fmt.Errorf` formatters from `%v`/`%s` for wrapped errors to `%w` (Go 1.25 supports multiple `%w`)