### PR TITLE
Fix CI batch stale repost race

### DIFF
--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -1841,6 +1841,9 @@ func (p *CIPoller) postBatchResults(batch *storage.CIPRBatch) {
 		if isPermanentGitHubAccessError(err) {
 			log.Printf("CI poller: abandoning batch %d for inaccessible GitHub repo/PR %s#%d",
 				batch.ID, batch.GithubRepo, batch.PRNumber)
+			if statusErr := p.callSetCommitStatus(batch.GithubRepo, batch.HeadSHA, "error", "Review failed to post"); statusErr != nil {
+				log.Printf("CI poller: failed to set error status for inaccessible %s@%s: %v", batch.GithubRepo, batch.HeadSHA, statusErr)
+			}
 			if finalizeErr := p.db.FinalizeBatch(batch.ID); finalizeErr != nil {
 				log.Printf("CI poller: error finalizing inaccessible batch %d: %v", batch.ID, finalizeErr)
 			}

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -18,6 +19,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	googlegithub "github.com/google/go-github/v84/github"
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 	gitpkg "go.kenn.io/roborev/internal/git"
@@ -50,6 +52,7 @@ type ghPR struct {
 const (
 	prDiscussionMaxComments = 40
 	prDiscussionBodyLimit   = 600
+	staleBatchClaimAge      = 5 * time.Minute
 )
 
 // CIPoller polls GitHub for open PRs and enqueues security reviews.
@@ -1743,11 +1746,17 @@ func (p *CIPoller) reconcileStaleBatches() {
 
 		if updated.CompletedJobs+updated.FailedJobs >= updated.TotalJobs {
 			if updated.Synthesized {
-				// Stale claim: daemon crashed mid-post. Unclaim so
-				// postBatchResults can re-claim via CAS.
+				// Stale claim: daemon crashed mid-post. Unclaim only
+				// if the claim is still stale; another path may have
+				// finalized it after GetStaleBatches selected it.
 				log.Printf("CI poller: unclaiming stale batch %d (claimed_at expired)", updated.ID)
-				if err := p.db.UnclaimBatch(updated.ID); err != nil {
+				unclaimed, err := p.db.UnclaimStaleBatchClaim(updated.ID, staleBatchClaimAge)
+				if err != nil {
 					log.Printf("CI poller: error unclaiming batch %d: %v", batch.ID, err)
+					continue
+				}
+				if !unclaimed {
+					log.Printf("CI poller: stale batch %d was already finalized or reclaimed, skipping post", updated.ID)
 					continue
 				}
 			}
@@ -1829,6 +1838,14 @@ func (p *CIPoller) postBatchResults(batch *storage.CIPRBatch) {
 	if err := p.callPostPRComment(batch.GithubRepo, batch.PRNumber, comment); err != nil {
 		log.Printf("CI poller: error posting batch comment for %s#%d: %v",
 			batch.GithubRepo, batch.PRNumber, err)
+		if isPermanentGitHubAccessError(err) {
+			log.Printf("CI poller: abandoning batch %d for inaccessible GitHub repo/PR %s#%d",
+				batch.ID, batch.GithubRepo, batch.PRNumber)
+			if finalizeErr := p.db.FinalizeBatch(batch.ID); finalizeErr != nil {
+				log.Printf("CI poller: error finalizing inaccessible batch %d: %v", batch.ID, finalizeErr)
+			}
+			return
+		}
 		if err := p.callSetCommitStatus(batch.GithubRepo, batch.HeadSHA, "error", "Review failed to post"); err != nil {
 			log.Printf("CI poller: failed to set error status for %s@%s: %v", batch.GithubRepo, batch.HeadSHA, err)
 		}
@@ -1882,6 +1899,22 @@ func (p *CIPoller) postBatchResults(batch *storage.CIPRBatch) {
 
 	log.Printf("CI poller: posted batch comment on %s#%d (batch %d, %d reviews)",
 		batch.GithubRepo, batch.PRNumber, batch.ID, len(reviews))
+}
+
+func isPermanentGitHubAccessError(err error) bool {
+	var githubErr *googlegithub.ErrorResponse
+	if !errors.As(err, &githubErr) || githubErr.Response == nil {
+		return false
+	}
+	switch githubErr.Response.StatusCode {
+	case http.StatusNotFound, http.StatusGone:
+		return true
+	case http.StatusForbidden:
+		msg := strings.ToLower(githubErr.Message)
+		return strings.Contains(msg, "resource not accessible")
+	default:
+		return false
+	}
 }
 
 // unclaimBatch resets the synthesized flag so the batch can be retried.

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -898,12 +898,16 @@ func TestCIPollerPostBatchResults_PermanentGitHubAccessErrorFinalizesBatch(t *te
 			Message:  "Resource not accessible by integration",
 		})
 	}
-	h.Poller.setCommitStatusFn = func(string, string, string, string) error {
-		return nil
-	}
+	statuses := h.CaptureCommitStatuses()
 
 	h.Poller.postBatchResults(batch)
 	h.AssertBatchState(t, batch.ID, 1, false)
+	require.NotEmpty(t, *statuses)
+	last := (*statuses)[len(*statuses)-1]
+	assert.Equal(t, "acme/api", last.Repo)
+	assert.Equal(t, "head-sha", last.SHA)
+	assert.Equal(t, "error", last.State)
+	assert.Equal(t, "Review failed to post", last.Desc)
 
 	h.Poller.postBatchResults(batch)
 	assert.Equal(t, 1, postAttempts, "finalized inaccessible batch should not be retried")

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -882,6 +882,33 @@ func TestCIPollerPostBatchResults_PostFailureUnclaimsBatch(t *testing.T) {
 	h.AssertBatchUnclaimed(t, batch.ID)
 }
 
+func TestCIPollerPostBatchResults_PermanentGitHubAccessErrorFinalizesBatch(t *testing.T) {
+	h := newCIPollerHarness(t, "https://github.com/acme/api.git")
+	batch, _ := h.seedBatchWithJobs(t, 16, "head-sha", jobSpec{
+		Agent: "codex", ReviewType: "security", Status: "done", Output: "ok",
+	})
+	_, err := h.DB.IncrementBatchCompleted(batch.ID)
+	require.NoError(t, err)
+
+	postAttempts := 0
+	h.Poller.postPRCommentFn = func(string, int, string) error {
+		postAttempts++
+		return fmt.Errorf("create PR comment: %w", &googlegithub.ErrorResponse{
+			Response: &http.Response{StatusCode: http.StatusForbidden},
+			Message:  "Resource not accessible by integration",
+		})
+	}
+	h.Poller.setCommitStatusFn = func(string, string, string, string) error {
+		return nil
+	}
+
+	h.Poller.postBatchResults(batch)
+	h.AssertBatchState(t, batch.ID, 1, false)
+
+	h.Poller.postBatchResults(batch)
+	assert.Equal(t, 1, postAttempts, "finalized inaccessible batch should not be retried")
+}
+
 func TestCIPollerFindLocalRepo_PartialIdentityFallback(t *testing.T) {
 	h := newCIPollerHarness(t, "ssh://git@github.com/acme/api.git")
 

--- a/internal/storage/ci.go
+++ b/internal/storage/ci.go
@@ -430,6 +430,31 @@ func (db *DB) UnclaimBatch(batchID int64) error {
 	return err
 }
 
+// UnclaimStaleBatchClaim resets a synthesis claim only if it is still stale.
+// This lets the reconciler recover daemon-crash claims without reopening a
+// batch that another path finalized after GetStaleBatches selected it.
+func (db *DB) UnclaimStaleBatchClaim(batchID int64, maxAge time.Duration) (bool, error) {
+	if maxAge < 0 {
+		maxAge = 0
+	}
+	modifier := fmt.Sprintf("-%d seconds", int(maxAge.Seconds()))
+	result, err := db.Exec(`
+		UPDATE ci_pr_batches
+		SET synthesized = 0, claimed_at = NULL
+		WHERE id = ?
+		  AND synthesized = 1
+		  AND claimed_at IS NOT NULL
+		  AND claimed_at < datetime('now', ?)`, batchID, modifier)
+	if err != nil {
+		return false, err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows > 0, nil
+}
+
 // FinalizeBatch clears claimed_at after a successful post. The batch stays
 // synthesized=1 but with claimed_at=NULL, so GetStaleBatches won't re-pick it.
 func (db *DB) FinalizeBatch(batchID int64) error {

--- a/internal/storage/ci_test.go
+++ b/internal/storage/ci_test.go
@@ -627,6 +627,39 @@ func TestGetStaleBatches_StaleClaim(t *testing.T) {
 
 }
 
+func TestUnclaimStaleBatchClaim_OnlyUnclaimsStillStaleClaims(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo, err := db.GetOrCreateRepo("/tmp/test")
+	require.NoError(t, err, "GetOrCreateRepo: %v")
+
+	batch, _ := mustCreateLinkedTerminalJob(t, db, repo.ID, testRepo, 1, testSHA, testSHA, testAgent, testReview, "done")
+
+	claimed, err := db.ClaimBatchForSynthesis(batch.ID)
+	require.NoError(t, err)
+	require.True(t, claimed, "expected claim to succeed")
+
+	setBatchClaimedAt(t, db, batch.ID, -10*time.Minute)
+	unclaimed, err := db.UnclaimStaleBatchClaim(batch.ID, 5*time.Minute)
+	require.NoError(t, err)
+	assert.True(t, unclaimed, "stale claim should be unclaimed")
+
+	claimed, err = db.ClaimBatchForSynthesis(batch.ID)
+	require.NoError(t, err)
+	require.True(t, claimed, "expected claim after stale unclaim to succeed")
+
+	require.NoError(t, db.FinalizeBatch(batch.ID))
+
+	unclaimed, err = db.UnclaimStaleBatchClaim(batch.ID, 5*time.Minute)
+	require.NoError(t, err)
+	assert.False(t, unclaimed, "finalized batch must not be unclaimed")
+
+	claimed, err = db.ClaimBatchForSynthesis(batch.ID)
+	require.NoError(t, err)
+	assert.False(t, claimed, "finalized batch must not be claimable")
+}
+
 func TestDeleteEmptyBatches(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()


### PR DESCRIPTION
## Summary
- Prevent stale CI batch reconciliation from unclaiming batches that were finalized by a racing event path.
- Finalize inaccessible moved-repo batches on permanent GitHub access errors instead of retrying indefinitely.
- Add regression coverage for stale-claim recovery and moved-repo access failures.

## Test Plan
- [x] go test ./internal/storage
- [x] go test ./internal/daemon
- [x] go test ./...
- [x] go vet ./...
