### PR TITLE
feat: show agentsview cost estimate in the queue view

### DIFF
--- a/cmd/roborev/backfill_tokens.go
+++ b/cmd/roborev/backfill_tokens.go
@@ -17,7 +17,7 @@ func backfillTokensCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "backfill-tokens",
 		Short: "Backfill token usage for completed jobs via agentsview",
-		Long: `Scan completed jobs that have a session ID but no token usage data,
+		Long: `Scan completed jobs that have a session ID but missing token cost data,
 and attempt to fetch token consumption from agentsview.
 
 This is best-effort: jobs whose session files have been deleted
@@ -106,8 +106,8 @@ will be skipped.`,
 }
 
 // backfillCandidates filters jobs to those eligible for token
-// backfill: completed, has a session ID, no existing token data,
-// and the session was not reused by another started job.
+// backfill: completed, has a session ID, missing cost data, and the
+// session was not reused by another started job.
 func backfillCandidates(
 	jobs []storage.ReviewJob,
 ) []storage.ReviewJob {
@@ -127,7 +127,7 @@ func backfillCandidates(
 		if !job.HasViewableOutput() {
 			continue
 		}
-		if job.TokenUsage != "" {
+		if !needsTokenCostBackfill(job.TokenUsage) {
 			continue
 		}
 		if job.SessionID == "" {
@@ -139,4 +139,9 @@ func backfillCandidates(
 		out = append(out, job)
 	}
 	return out
+}
+
+func needsTokenCostBackfill(tokenUsage string) bool {
+	usage := tokens.ParseJSON(tokenUsage)
+	return usage == nil || !usage.HasCost
 }

--- a/cmd/roborev/backfill_tokens_test.go
+++ b/cmd/roborev/backfill_tokens_test.go
@@ -34,12 +34,34 @@ func TestBackfillCandidates(t *testing.T) {
 			wantIDs: []int64{1},
 		},
 		{
-			name: "skip job that already has token data",
+			name: "skip job that already has token data and cost",
+			jobs: []storage.ReviewJob{
+				{
+					ID: 1, Status: storage.JobStatusDone,
+					SessionID: "s1", StartedAt: timePtr(now),
+					TokenUsage: `{"peak_context_tokens":100,"cost_usd":0.12,"has_cost":true}`,
+				},
+			},
+			wantIDs: nil,
+		},
+		{
+			name: "include job with token data but no cost",
 			jobs: []storage.ReviewJob{
 				{
 					ID: 1, Status: storage.JobStatusDone,
 					SessionID: "s1", StartedAt: timePtr(now),
 					TokenUsage: `{"peak_context_tokens":100}`,
+				},
+			},
+			wantIDs: []int64{1},
+		},
+		{
+			name: "skip job that already has cost",
+			jobs: []storage.ReviewJob{
+				{
+					ID: 1, Status: storage.JobStatusDone,
+					SessionID: "s1", StartedAt: timePtr(now),
+					TokenUsage: `{"peak_context_tokens":100,"cost_usd":0,"has_cost":true}`,
 				},
 			},
 			wantIDs: nil,

--- a/cmd/roborev/tui/queue_test.go
+++ b/cmd/roborev/tui/queue_test.go
@@ -631,6 +631,53 @@ func TestTUIJobCellsReviewTypeTag(t *testing.T) {
 	}
 }
 
+func TestTUIJobCellsCost(t *testing.T) {
+	m := model{width: 200}
+	// cells[k] maps to logical column colRef+k (see jobCells copy),
+	// so the cost cell is at colCost-colRef.
+	costIdx := colCost - colRef
+
+	t.Run("priced cost renders", func(t *testing.T) {
+		job := makeJob(1)
+		job.TokenUsage = `{"total_output_tokens":28800,` +
+			`"peak_context_tokens":118000,"cost_usd":0.42,"has_cost":true}`
+		cells := m.jobCells(job)
+		assert.Equal(t, "~$0.42", cells[costIdx])
+	})
+
+	t.Run("no usage blank", func(t *testing.T) {
+		cells := m.jobCells(makeJob(1))
+		assert.Empty(t, cells[costIdx])
+	})
+
+	t.Run("unpriced tokens blank", func(t *testing.T) {
+		job := makeJob(1)
+		job.TokenUsage = `{"total_output_tokens":28800,` +
+			`"peak_context_tokens":118000,"has_cost":false}`
+		cells := m.jobCells(job)
+		assert.Empty(t, cells[costIdx])
+	})
+}
+
+func TestTUIQueueShowsCostColumnByDefault(t *testing.T) {
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.width = 200
+	m.height = 30
+	job := makeJob(1, withRef("abc1234"),
+		withRepoName("repo"), withAgent("test"))
+	job.TokenUsage = `{"total_output_tokens":28800,` +
+		`"peak_context_tokens":118000,"cost_usd":0.42,"has_cost":true}`
+	m.jobs = []storage.ReviewJob{job}
+	m.selectedIdx = 0
+	m.selectedJobID = 1
+
+	out := stripTestANSI(m.renderQueueView())
+	assert.Contains(t, out, "Cost",
+		"Cost header should be visible by default")
+	assert.Contains(t, out, "~$0.42",
+		"cost value should render in the row")
+}
+
 func TestTUIQueueTableRendersWithinWidth(t *testing.T) {
 
 	widths := []int{80, 100, 120, 200}

--- a/cmd/roborev/tui/render_queue.go
+++ b/cmd/roborev/tui/render_queue.go
@@ -13,6 +13,7 @@ import (
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/tokens"
 	"go.kenn.io/roborev/internal/version"
 )
 
@@ -119,6 +120,7 @@ const (
 	colSessionID                // Session ID
 	colRequestedModel           // Explicitly requested model
 	colRequestedProvider        // Explicitly requested provider
+	colCost                     // Cost estimate (USD)
 	colCount                    // total number of columns
 )
 
@@ -268,7 +270,7 @@ func (m model) renderQueueView() string {
 		visCols := m.visibleColumns()
 
 		// Compute per-column max content widths, using cache when data hasn't changed.
-		allHeaders := [colCount]string{"", "JobID", "Ref", "Branch", "Repo", "Agent", "Queued", "Elapsed", "Status", "P/F", "Closed", "Session", "Req Model", "Req Provider"}
+		allHeaders := [colCount]string{"", "JobID", "Ref", "Branch", "Repo", "Agent", "Queued", "Elapsed", "Status", "P/F", "Closed", "Session", "Req Model", "Req Provider", "Cost"}
 		allFullRows := make([][]string, len(visibleJobList))
 		for i, job := range visibleJobList {
 			cells := m.jobCells(job)
@@ -327,6 +329,7 @@ func (m model) renderQueueView() string {
 			colSessionID:         min(max(contentWidth[colSessionID], 7), 12),          // "Session" header = 7, cap at 12
 			colRequestedModel:    min(max(contentWidth[colRequestedModel], 9), 24),     // "Req Model" header = 9
 			colRequestedProvider: min(max(contentWidth[colRequestedProvider], 12), 24), // "Req Provider" header = 12
+			colCost:              max(contentWidth[colCost], 4),                        // "Cost" header = 4
 		}
 
 		// Flexible columns absorb excess space
@@ -613,7 +616,7 @@ func (m model) renderQueueView() string {
 
 // jobCells returns plain text cell values for a job row.
 // Order: ref, branch, repo, agent, queued, elapsed, status, pf, handled,
-// session, requested model, requested provider.
+// session, requested model, requested provider, cost.
 func (m model) jobCells(job storage.ReviewJob) []string {
 	ref := shortJobRef(job)
 	if !config.IsDefaultReviewType(job.ReviewType) {
@@ -667,7 +670,15 @@ func (m model) jobCells(job storage.ReviewJob) []string {
 	requestedModel := stripControlChars(job.RequestedModel)
 	requestedProvider := stripControlChars(job.RequestedProvider)
 
-	return []string{ref, branch, repo, agentName, enqueued, elapsed, status, verdict, handled, sessionID, requestedModel, requestedProvider}
+	// Cost estimate from the stored agentsview usage blob; blank when
+	// no priced estimate is available (old agentsview, unpriced model,
+	// or usage not yet fetched for a running/queued job).
+	cost := ""
+	if tu := tokens.ParseJSON(job.TokenUsage); tu != nil {
+		cost = tu.FormatCost()
+	}
+
+	return []string{ref, branch, repo, agentName, enqueued, elapsed, status, verdict, handled, sessionID, requestedModel, requestedProvider, cost}
 }
 
 // statusLabel returns a capitalized display label for the job status.
@@ -840,7 +851,7 @@ func migrateColumnConfig(cfg *config.Config) bool {
 
 // toggleableColumns is the ordered list of columns the user can show/hide.
 // colSel and colJobID are always visible and not included here.
-var toggleableColumns = []int{colRef, colBranch, colRepo, colAgent, colQueued, colElapsed, colStatus, colPF, colHandled, colSessionID, colRequestedModel, colRequestedProvider}
+var toggleableColumns = []int{colRef, colBranch, colRepo, colAgent, colQueued, colElapsed, colStatus, colPF, colHandled, colCost, colSessionID, colRequestedModel, colRequestedProvider}
 
 // columnNames maps column constants to display names.
 var columnNames = map[int]string{
@@ -856,6 +867,7 @@ var columnNames = map[int]string{
 	colSessionID:         "Session",
 	colRequestedModel:    "Req Model",
 	colRequestedProvider: "Req Provider",
+	colCost:              "Cost",
 }
 
 // columnConfigNames maps column constants to config file names (lowercase).
@@ -872,6 +884,7 @@ var columnConfigNames = map[int]string{
 	colSessionID:         "session_id",
 	colRequestedModel:    "requested_model",
 	colRequestedProvider: "requested_provider",
+	colCost:              "cost",
 }
 
 // drainFlexOverflow reduces flex column widths to absorb overflow,

--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -14,33 +14,57 @@ import (
 
 // Usage holds token consumption data for a single review job.
 // Stored as JSON in the review_jobs.token_usage column.
-// Fields align with agentsview's token-use output.
+// Fields align with agentsview's session-usage output.
 type Usage struct {
-	OutputTokens      int64 `json:"total_output_tokens,omitempty"`
-	PeakContextTokens int64 `json:"peak_context_tokens,omitempty"`
+	OutputTokens      int64   `json:"total_output_tokens,omitempty"`
+	PeakContextTokens int64   `json:"peak_context_tokens,omitempty"`
+	CostUSD           float64 `json:"cost_usd,omitempty"`
+	HasCost           bool    `json:"has_cost,omitempty"`
 }
 
-// agentsviewResponse is the JSON shape returned by
-// `agentsview token-use <session-id>`.
+// agentsviewResponse is the JSON shape returned by both
+// `agentsview session usage <id> --format json` and the deprecated
+// `agentsview token-use <id>`. The session-usage shape is a strict
+// superset of token-use, adding the cost fields.
 type agentsviewResponse struct {
-	SessionID         string `json:"session_id"`
-	Agent             string `json:"agent"`
-	Project           string `json:"project"`
-	OutputTokens      int64  `json:"total_output_tokens"`
-	PeakContextTokens int64  `json:"peak_context_tokens"`
+	SessionID         string  `json:"session_id"`
+	Agent             string  `json:"agent"`
+	Project           string  `json:"project"`
+	OutputTokens      int64   `json:"total_output_tokens"`
+	PeakContextTokens int64   `json:"peak_context_tokens"`
+	CostUSD           float64 `json:"cost_usd"`
+	HasCost           bool    `json:"has_cost"`
 }
 
 // FormatSummary returns a compact human-readable summary like
-// "118.0k ctx · 28.8k out". Returns empty string if no data.
+// "118.0k ctx · 28.8k out · ~$0.42". The cost segment is appended only
+// when a cost estimate is available. Returns empty string when there
+// is neither token nor cost data.
 func (u Usage) FormatSummary() string {
-	if u.PeakContextTokens == 0 && u.OutputTokens == 0 {
-		return ""
+	hasTokens := u.PeakContextTokens != 0 || u.OutputTokens != 0
+	if !hasTokens {
+		// No token counts: show the cost alone when present.
+		return u.FormatCost()
 	}
-	return fmt.Sprintf(
+	s := fmt.Sprintf(
 		"%s ctx · %s out",
 		formatCount(u.PeakContextTokens),
 		formatCount(u.OutputTokens),
 	)
+	if cost := u.FormatCost(); cost != "" {
+		s += " · " + cost
+	}
+	return s
+}
+
+// FormatCost returns the cost estimate like "~$0.42", or "" when no
+// estimate is available. The tilde marks it as a model-pricing
+// estimate, matching agentsview's own rendering.
+func (u Usage) FormatCost() string {
+	if !u.HasCost {
+		return ""
+	}
+	return fmt.Sprintf("~$%.2f", u.CostUSD)
 }
 
 func formatCount(n int64) string {
@@ -54,53 +78,75 @@ func formatCount(n int64) string {
 	}
 }
 
-// minVersion is the minimum agentsview version that supports
-// the token-use subcommand (0.15.0).
+// capability describes which agentsview usage command the installed
+// binary supports.
+type capability int
+
+const (
+	// capNone means agentsview is missing or too old to query.
+	capNone capability = iota
+	// capTokenUse means only the deprecated `token-use` command is
+	// available (agentsview >= 0.15.0, < 0.30.0).
+	capTokenUse
+	// capSessionUsage means `session usage` is available (agentsview
+	// >= 0.30.0). It returns a cost estimate and supersedes token-use.
+	capSessionUsage
+)
+
+// minVersion is the minimum agentsview version that supports the
+// (deprecated) token-use subcommand (0.15.0).
 var minVersion = [3]int{0, 15, 0}
+
+// sessionUsageMinVersion is the minimum agentsview version that
+// supports `session usage` (0.30.0), which returns a cost estimate and
+// replaces token-use.
+var sessionUsageMinVersion = [3]int{0, 30, 0}
 
 // versionRe extracts major.minor.patch from "agentsview vX.Y.Z...".
 var versionRe = regexp.MustCompile(
 	`agentsview v(\d+)\.(\d+)\.(\d+)`,
 )
 
-// parseVersion checks whether the output of `agentsview version`
-// contains a semver >= minVersion. Returns (supported, parsed):
-// supported is true when the version meets the minimum; parsed is
-// true when a version string was found at all (regardless of
-// whether it is new enough).
-func parseVersion(out []byte) (supported, parsed bool) {
+// geVersion reports whether version a is >= version b, comparing
+// major, then minor, then patch.
+func geVersion(a, b [3]int) bool {
+	for i := range 3 {
+		if a[i] != b[i] {
+			return a[i] > b[i]
+		}
+	}
+	return true
+}
+
+// parseVersion inspects the output of `agentsview version` and reports
+// the capability level it supports plus whether a version string was
+// found at all. parsed is false only when no version could be matched,
+// so callers can distinguish "too old" from "unparseable" and retry
+// the latter.
+func parseVersion(out []byte) (level capability, parsed bool) {
 	m := versionRe.FindSubmatch(out)
 	if m == nil {
-		return false, false
+		return capNone, false
 	}
 	var ver [3]int
 	for i := range 3 {
 		ver[i], _ = strconv.Atoi(string(m[i+1]))
 	}
-	for i := range 3 {
-		if ver[i] > minVersion[i] {
-			return true, true
-		}
-		if ver[i] < minVersion[i] {
-			return false, true
-		}
+	switch {
+	case geVersion(ver, sessionUsageMinVersion):
+		return capSessionUsage, true
+	case geVersion(ver, minVersion):
+		return capTokenUse, true
+	default:
+		return capNone, true
 	}
-	return true, true // equal
 }
 
-// versionState tracks the cached probe result.
-type versionState int
-
-const (
-	versionUnchecked versionState = iota
-	versionOK
-	versionTooOld
-)
-
 var (
-	versionMu    sync.Mutex
-	versionProbe versionState
-	cachedBin    string
+	versionMu     sync.Mutex
+	cachedChecked bool
+	cachedCap     capability
+	cachedBin     string
 )
 
 // ResetVersionCache clears the cached version check result.
@@ -108,79 +154,77 @@ var (
 func ResetVersionCache() {
 	versionMu.Lock()
 	defer versionMu.Unlock()
-	versionProbe = versionUnchecked
+	cachedChecked = false
+	cachedCap = capNone
 	cachedBin = ""
 }
 
-// resolveAgentsview checks whether agentsview is installed and new
-// enough. The result is cached keyed to the resolved binary path,
-// so an upgrade, downgrade, or PATH change triggers a fresh probe.
+// resolveAgentsview checks whether agentsview is installed and which
+// usage capability it supports. The result is cached keyed to the
+// resolved binary path, so a PATH change triggers a fresh probe.
 // Transient failures (binary not found, timeout, exec error,
 // unparseable output) leave the cache unchecked so the next call
-// retries.
-func resolveAgentsview(ctx context.Context) (string, bool) {
+// retries. Returns ("", capNone) when agentsview cannot be used.
+func resolveAgentsview(ctx context.Context) (string, capability) {
 	// LookPath is cheap (PATH scan, no exec) — always run it so we
-	// detect installs, upgrades, and PATH changes.
+	// detect installs and PATH changes.
 	bin, err := exec.LookPath("agentsview")
 	if err != nil {
-		return "", false
+		return "", capNone
 	}
 
 	versionMu.Lock()
-	if cachedBin == bin {
-		switch versionProbe {
-		case versionOK:
-			versionMu.Unlock()
-			return bin, true
-		case versionTooOld:
-			versionMu.Unlock()
-			return "", false
+	if cachedChecked && cachedBin == bin {
+		level := cachedCap
+		versionMu.Unlock()
+		if level == capNone {
+			return "", capNone
 		}
+		return bin, level
 	}
 	versionMu.Unlock()
 
-	// Exec runs without holding the lock so concurrent callers are
-	// not blocked by the 5 s command timeout.
+	// Exec runs without holding the lock so concurrent callers are not
+	// blocked by the 5 s command timeout.
 	cmdCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	out, err := exec.CommandContext(
-		cmdCtx, bin, "version",
-	).Output()
+	out, err := exec.CommandContext(cmdCtx, bin, "version").Output()
 	if err != nil {
-		return "", false
+		return "", capNone
 	}
 
-	supported, parsed := parseVersion(out)
+	level, parsed := parseVersion(out)
 
 	versionMu.Lock()
 	defer versionMu.Unlock()
 
 	// Re-check: another goroutine may have updated the cache.
-	if cachedBin == bin {
-		switch versionProbe {
-		case versionOK:
-			return bin, true
-		case versionTooOld:
-			return "", false
+	if cachedChecked && cachedBin == bin {
+		if cachedCap == capNone {
+			return "", capNone
 		}
+		return bin, cachedCap
 	}
 
-	if supported {
-		versionProbe = versionOK
-		cachedBin = bin
-		return bin, true
-	}
+	// Only cache a parsed result. Unparseable output (parsed=false) is
+	// treated as transient and left unchecked so the next call retries.
 	if parsed {
-		versionProbe = versionTooOld
+		cachedChecked = true
+		cachedCap = level
 		cachedBin = bin
 	}
-	return "", false
+	if level == capNone {
+		return "", capNone
+	}
+	return bin, level
 }
 
-// FetchForSession calls `agentsview token-use <sessionID>` to get
-// token usage. Returns nil (no error) if agentsview is not installed,
-// is too old (< 0.15.0), or the session data is unavailable.
+// FetchForSession queries agentsview for a session's token usage and
+// cost estimate. It calls `session usage` on agentsview >= 0.30.0 and
+// falls back to the deprecated `token-use` on older versions. Returns
+// nil (no error) when agentsview is not installed, is too old, or the
+// session has no usage data.
 func FetchForSession(
 	ctx context.Context, sessionID string,
 ) (*Usage, error) {
@@ -188,33 +232,47 @@ func FetchForSession(
 		return nil, nil
 	}
 
-	binPath, ok := resolveAgentsview(ctx)
-	if !ok {
+	binPath, level := resolveAgentsview(ctx)
+	if level == capNone {
 		return nil, nil
 	}
 
 	cmdCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(
-		cmdCtx, binPath, "token-use", sessionID,
-	)
+	var cmd *exec.Cmd
+	if level == capSessionUsage {
+		cmd = exec.CommandContext(
+			cmdCtx, binPath, "session", "usage", sessionID,
+			"--format", "json",
+		)
+	} else {
+		cmd = exec.CommandContext(
+			cmdCtx, binPath, "token-use", sessionID,
+		)
+	}
+
 	out, err := cmd.Output()
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			stderr := string(exitErr.Stderr)
-			// Session not found: exit 1, no stdout, no stderr
-			if exitErr.ExitCode() == 1 &&
-				len(out) == 0 && len(stderr) == 0 {
+			// agentsview usage exit codes: 2 = session not found,
+			// 3 = found but no token/cost data. Both mean "no usage",
+			// not an error. Legacy token-use (< 0.30.0) signalled
+			// not-found with exit 1 and empty stdout+stderr.
+			switch code := exitErr.ExitCode(); {
+			case code == 2 || code == 3:
 				return nil, nil
+			case code == 1 && len(out) == 0 && len(exitErr.Stderr) == 0:
+				return nil, nil
+			default:
+				return nil, fmt.Errorf(
+					"agentsview usage: exit %d: %s",
+					code, exitErr.Stderr,
+				)
 			}
-			return nil, fmt.Errorf(
-				"agentsview token-use: exit %d: %s",
-				exitErr.ExitCode(), stderr,
-			)
 		}
-		return nil, fmt.Errorf("agentsview token-use: %w", err)
+		return nil, fmt.Errorf("agentsview usage: %w", err)
 	}
 
 	var resp agentsviewResponse
@@ -222,17 +280,20 @@ func FetchForSession(
 		return nil, fmt.Errorf("parse agentsview output: %w", err)
 	}
 
-	if resp.OutputTokens == 0 && resp.PeakContextTokens == 0 {
+	if resp.OutputTokens == 0 && resp.PeakContextTokens == 0 &&
+		!resp.HasCost {
 		return nil, nil
 	}
 	return &Usage{
 		OutputTokens:      resp.OutputTokens,
 		PeakContextTokens: resp.PeakContextTokens,
+		CostUSD:           resp.CostUSD,
+		HasCost:           resp.HasCost,
 	}, nil
 }
 
 // ParseJSON deserializes a token_usage JSON blob from the database.
-// Returns nil for empty/null values.
+// Returns nil for empty/null values or a blob carrying no usage data.
 func ParseJSON(data string) *Usage {
 	if data == "" {
 		return nil
@@ -241,7 +302,7 @@ func ParseJSON(data string) *Usage {
 	if err := json.Unmarshal([]byte(data), &u); err != nil {
 		return nil
 	}
-	if u.OutputTokens == 0 && u.PeakContextTokens == 0 {
+	if u.OutputTokens == 0 && u.PeakContextTokens == 0 && !u.HasCost {
 		return nil
 	}
 	return &u

--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -86,10 +86,10 @@ const (
 	// capNone means agentsview is missing or too old to query.
 	capNone capability = iota
 	// capTokenUse means only the deprecated `token-use` command is
-	// available (agentsview >= 0.15.0, < 0.30.0).
+	// available.
 	capTokenUse
-	// capSessionUsage means `session usage` is available (agentsview
-	// >= 0.30.0). It returns a cost estimate and supersedes token-use.
+	// capSessionUsage means `session usage` is available. It returns a
+	// cost estimate and supersedes token-use.
 	capSessionUsage
 )
 
@@ -97,9 +97,10 @@ const (
 // (deprecated) token-use subcommand (0.15.0).
 var minVersion = [3]int{0, 15, 0}
 
-// sessionUsageMinVersion is the minimum agentsview version that
-// supports `session usage` (0.30.0), which returns a cost estimate and
-// replaces token-use.
+// sessionUsageMinVersion is the tagged agentsview version that
+// supports `session usage`, which returns a cost estimate and replaces
+// token-use. Some prerelease builds below this tag also support the
+// command, so resolveAgentsview probes for it before falling back.
 var sessionUsageMinVersion = [3]int{0, 30, 0}
 
 // versionRe extracts major.minor.patch from "agentsview vX.Y.Z...".
@@ -195,6 +196,9 @@ func resolveAgentsview(ctx context.Context) (string, capability) {
 	}
 
 	level, parsed := parseVersion(out)
+	if level == capTokenUse && hasSessionUsageCommand(ctx, bin) {
+		level = capSessionUsage
+	}
 
 	versionMu.Lock()
 	defer versionMu.Unlock()
@@ -220,11 +224,21 @@ func resolveAgentsview(ctx context.Context) (string, capability) {
 	return bin, level
 }
 
+func hasSessionUsageCommand(ctx context.Context, binPath string) bool {
+	cmdCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(
+		cmdCtx, binPath, "session", "usage", "--help",
+	)
+	return cmd.Run() == nil
+}
+
 // FetchForSession queries agentsview for a session's token usage and
-// cost estimate. It calls `session usage` on agentsview >= 0.30.0 and
-// falls back to the deprecated `token-use` on older versions. Returns
-// nil (no error) when agentsview is not installed, is too old, or the
-// session has no usage data.
+// cost estimate. It calls `session usage` when supported and falls back
+// to the deprecated `token-use` on older versions. Returns nil (no
+// error) when agentsview is not installed, is too old, or the session
+// has no usage data.
 func FetchForSession(
 	ctx context.Context, sessionID string,
 ) (*Usage, error) {

--- a/internal/tokens/tokens_test.go
+++ b/internal/tokens/tokens_test.go
@@ -2,6 +2,7 @@ package tokens
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -39,12 +40,61 @@ func TestFormatSummary(t *testing.T) {
 			Usage{OutputTokens: 800},
 			"0 ctx · 800 out",
 		},
+		{
+			"tokens and cost",
+			Usage{
+				PeakContextTokens: 118000, OutputTokens: 28800,
+				CostUSD: 0.42, HasCost: true,
+			},
+			"118.0k ctx · 28.8k out · ~$0.42",
+		},
+		{
+			"tokens unpriced",
+			Usage{PeakContextTokens: 1000, OutputTokens: 200},
+			"1.0k ctx · 200 out",
+		},
+		{
+			"cost only",
+			Usage{CostUSD: 0.05, HasCost: true},
+			"~$0.05",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.usage.FormatSummary()
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFormatCost(t *testing.T) {
+	assert.Equal(t, "~$0.42",
+		Usage{CostUSD: 0.42, HasCost: true}.FormatCost())
+	assert.Empty(t, Usage{}.FormatCost())
+	assert.Empty(t, Usage{CostUSD: 0.42, HasCost: false}.FormatCost(),
+		"cost suppressed when has_cost is false")
+	assert.Equal(t, "~$0.00",
+		Usage{CostUSD: 0, HasCost: true}.FormatCost(),
+		"a genuine zero cost still renders")
+}
+
+func TestGeVersion(t *testing.T) {
+	tests := []struct {
+		a, b [3]int
+		want bool
+	}{
+		{[3]int{0, 30, 0}, [3]int{0, 30, 0}, true},
+		{[3]int{0, 30, 1}, [3]int{0, 30, 0}, true},
+		{[3]int{0, 29, 9}, [3]int{0, 30, 0}, false},
+		{[3]int{1, 0, 0}, [3]int{0, 30, 0}, true},
+		{[3]int{0, 15, 0}, [3]int{0, 15, 0}, true},
+		{[3]int{0, 14, 9}, [3]int{0, 15, 0}, false},
+		{[3]int{2, 0, 0}, [3]int{1, 99, 99}, true},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%v_ge_%v", tt.a, tt.b), func(t *testing.T) {
+			assert.Equal(t, tt.want, geVersion(tt.a, tt.b))
 		})
 	}
 }
@@ -63,6 +113,23 @@ func TestParseJSON(t *testing.T) {
 		assert.Equal(t, int64(200), u.OutputTokens)
 	})
 
+	t.Run("with cost", func(t *testing.T) {
+		u := ParseJSON(
+			`{"peak_context_tokens":1000,"total_output_tokens":200,` +
+				`"cost_usd":0.42,"has_cost":true}`,
+		)
+		require.NotNil(t, u)
+		assert.True(t, u.HasCost)
+		assert.InDelta(t, 0.42, u.CostUSD, 1e-9)
+	})
+
+	t.Run("cost only no tokens", func(t *testing.T) {
+		u := ParseJSON(`{"cost_usd":0.05,"has_cost":true}`)
+		require.NotNil(t, u)
+		assert.True(t, u.HasCost)
+		assert.InDelta(t, 0.05, u.CostUSD, 1e-9)
+	})
+
 	t.Run("all zeros", func(t *testing.T) {
 		assert.Nil(t, ParseJSON(
 			`{"peak_context_tokens":0,"total_output_tokens":0}`,
@@ -76,100 +143,171 @@ func TestParseJSON(t *testing.T) {
 
 func TestParseVersion(t *testing.T) {
 	tests := []struct {
-		name      string
-		output    string
-		supported bool
-		parsed    bool
+		name       string
+		output     string
+		wantLevel  capability
+		wantParsed bool
 	}{
 		{
-			"exact minimum",
-			"agentsview v0.15.0 (commit abc, built 2026-01-01)",
-			true, true,
-		},
-		{
-			"newer patch",
-			"agentsview v0.15.1 (commit abc, built 2026-01-01)",
-			true, true,
-		},
-		{
-			"newer minor",
-			"agentsview v0.16.0 (commit abc, built 2026-01-01)",
-			true, true,
-		},
-		{
-			"newer major",
-			"agentsview v1.0.0 (commit abc, built 2026-01-01)",
-			true, true,
-		},
-		{
-			"dev suffix",
-			"agentsview v0.15.0-1-g891cb62 (commit 891cb62, built 2026-03-18)",
-			true, true,
-		},
-		{
-			"too old",
+			"below token-use min",
 			"agentsview v0.14.9 (commit abc, built 2026-01-01)",
-			false, true,
+			capNone, true,
+		},
+		{
+			"token-use min",
+			"agentsview v0.15.0 (commit abc, built 2026-01-01)",
+			capTokenUse, true,
+		},
+		{
+			"token-use range",
+			"agentsview v0.29.0 (commit abc, built 2026-05-10)",
+			capTokenUse, true,
+		},
+		{
+			"session usage min",
+			"agentsview v0.30.0 (commit abc, built 2026-05-23)",
+			capSessionUsage, true,
+		},
+		{
+			"session usage newer patch",
+			"agentsview v0.31.2 (commit abc, built 2026-06-01)",
+			capSessionUsage, true,
+		},
+		{
+			"major bump",
+			"agentsview v1.0.0 (commit abc, built 2026-01-01)",
+			capSessionUsage, true,
+		},
+		{
+			"dev suffix at session min",
+			"agentsview v0.30.0-1-g891cb62 (commit 891cb62, built 2026-05-23)",
+			capSessionUsage, true,
 		},
 		{
 			"very old",
 			"agentsview v0.10.0 (commit abc, built 2026-01-01)",
-			false, true,
+			capNone, true,
 		},
-		{
-			"unparseable",
-			"something unexpected",
-			false, false,
-		},
-		{
-			"empty",
-			"",
-			false, false,
-		},
+		{"unparseable", "something unexpected", capNone, false},
+		{"empty", "", capNone, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			supported, parsed := parseVersion([]byte(tt.output))
-			assert.Equal(t, tt.supported, supported, "supported")
-			assert.Equal(t, tt.parsed, parsed, "parsed")
+			level, parsed := parseVersion([]byte(tt.output))
+			assert.Equal(t, tt.wantLevel, level, "level")
+			assert.Equal(t, tt.wantParsed, parsed, "parsed")
 		})
 	}
 }
 
-func TestFetchForSessionSkipsOldVersion(t *testing.T) {
+// installFakeAgentsview writes an executable "agentsview" shell script
+// into a fresh temp dir, prepends it to PATH, and resets the version
+// cache. Lets FetchForSession/resolveAgentsview run without a real
+// agentsview install. Skips on Windows (scripts are POSIX shell).
+func installFakeAgentsview(t *testing.T, script string) {
+	t.Helper()
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses shell scripts")
 	}
-
-	// Verify FetchForSession returns nil when agentsview is too old,
-	// rather than invoking token-use (which could spawn a server).
 	ResetVersionCache()
 	t.Cleanup(ResetVersionCache)
 
 	dir := t.TempDir()
 	bin := filepath.Join(dir, "agentsview")
-	script := `#!/bin/sh
+	require.NoError(t, os.WriteFile(bin, []byte(script), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, err := exec.LookPath("agentsview")
+	require.NoError(t, err)
+}
+
+func TestFetchForSessionSkipsOldVersion(t *testing.T) {
+	// agentsview too old (< 0.15.0): FetchForSession returns nil
+	// without invoking any usage command (which could spawn a server).
+	installFakeAgentsview(t, `#!/bin/sh
 if [ "$1" = "version" ]; then
   echo "agentsview v0.14.0 (commit abc, built 2026-01-01)"
   exit 0
 fi
 echo "ERROR: should not be called" >&2
 exit 99
-`
-	require.NoError(t, os.WriteFile(bin, []byte(script), 0o755))
+`)
 
-	origPath := os.Getenv("PATH")
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+origPath)
-
-	_, err := exec.LookPath("agentsview")
-	require.NoError(t, err)
-
-	usage, err := FetchForSession(
-		context.Background(), "test-session-id",
-	)
+	usage, err := FetchForSession(context.Background(), "test-session-id")
 	require.NoError(t, err)
 	assert.Nil(t, usage)
+}
+
+func TestFetchForSessionUsesSessionUsageOnNewVersion(t *testing.T) {
+	// agentsview >= 0.30.0: FetchForSession calls `session usage` and
+	// captures the cost estimate. The script errors on any other
+	// subcommand, so reaching the JSON proves command selection.
+	installFakeAgentsview(t, `#!/bin/sh
+if [ "$1" = "version" ]; then
+  echo "agentsview v0.30.0 (commit abc, built 2026-05-23)"
+  exit 0
+fi
+if [ "$1" = "session" ] && [ "$2" = "usage" ]; then
+  echo '{"session_id":"s","agent":"codex","total_output_tokens":28800,"peak_context_tokens":118000,"cost_usd":0.42,"has_cost":true}'
+  exit 0
+fi
+echo "unexpected args: $@" >&2
+exit 99
+`)
+
+	usage, err := FetchForSession(context.Background(), "s")
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	assert.Equal(t, int64(28800), usage.OutputTokens)
+	assert.Equal(t, int64(118000), usage.PeakContextTokens)
+	assert.True(t, usage.HasCost)
+	assert.InDelta(t, 0.42, usage.CostUSD, 1e-9)
+}
+
+func TestFetchForSessionFallsBackToTokenUse(t *testing.T) {
+	// agentsview in [0.15.0, 0.30.0): FetchForSession falls back to
+	// the deprecated token-use command, which emits no cost. The
+	// script errors on `session usage`, so success proves the fallback.
+	installFakeAgentsview(t, `#!/bin/sh
+if [ "$1" = "version" ]; then
+  echo "agentsview v0.15.0 (commit abc, built 2026-01-01)"
+  exit 0
+fi
+if [ "$1" = "token-use" ]; then
+  echo '{"session_id":"s","agent":"codex","total_output_tokens":1000,"peak_context_tokens":2000}'
+  exit 0
+fi
+echo "unexpected args: $@" >&2
+exit 99
+`)
+
+	usage, err := FetchForSession(context.Background(), "s")
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	assert.Equal(t, int64(1000), usage.OutputTokens)
+	assert.Equal(t, int64(2000), usage.PeakContextTokens)
+	assert.False(t, usage.HasCost, "token-use output carries no cost")
+}
+
+func TestFetchForSessionExitCodesMeanNoUsage(t *testing.T) {
+	// Exit 2 (not found) and 3 (no token/cost data) are not errors:
+	// FetchForSession returns (nil, nil) for both.
+	for _, code := range []int{2, 3} {
+		t.Run(fmt.Sprintf("exit%d", code), func(t *testing.T) {
+			installFakeAgentsview(t, fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "version" ]; then
+  echo "agentsview v0.30.0 (commit abc, built 2026-05-23)"
+  exit 0
+fi
+exit %d
+`, code))
+
+			usage, err := FetchForSession(context.Background(), "missing")
+			require.NoError(t, err)
+			assert.Nil(t, usage)
+		})
+	}
 }
 
 func TestResolveAgentsviewRetriesAfterTransientFailure(t *testing.T) {
@@ -182,8 +320,8 @@ func TestResolveAgentsviewRetriesAfterTransientFailure(t *testing.T) {
 
 	// First call: agentsview not on PATH → transient failure.
 	t.Setenv("PATH", t.TempDir())
-	_, ok := resolveAgentsview(context.Background())
-	assert.False(t, ok, "should fail when binary is absent")
+	_, level := resolveAgentsview(context.Background())
+	assert.Equal(t, capNone, level, "should fail when binary is absent")
 
 	// Install a valid agentsview and retry — should succeed.
 	dir := t.TempDir()
@@ -193,18 +331,14 @@ if [ "$1" = "version" ]; then
   echo "agentsview v0.15.0 (commit abc, built 2026-01-01)"
   exit 0
 fi
-if [ "$1" = "token-use" ]; then
-  echo '{"session_id":"s","agent":"a","project":"p","total_output_tokens":100,"peak_context_tokens":200}'
-  exit 0
-fi
 `
 	require.NoError(t, os.WriteFile(bin, []byte(script), 0o755))
 
 	origPath := os.Getenv("PATH")
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+origPath)
 
-	path, ok := resolveAgentsview(context.Background())
-	assert.True(t, ok, "should succeed after binary appears")
+	path, level := resolveAgentsview(context.Background())
+	assert.Equal(t, capTokenUse, level, "should succeed after binary appears")
 	assert.Equal(t, bin, path)
 }
 
@@ -226,17 +360,17 @@ echo "agentsview v0.14.0 (commit abc, built 2026-01-01)"
 	origPath := os.Getenv("PATH")
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+origPath)
 
-	_, ok := resolveAgentsview(context.Background())
-	assert.False(t, ok)
+	_, level := resolveAgentsview(context.Background())
+	assert.Equal(t, capNone, level)
 
 	// Even if we "upgrade" the script, the too-old result is cached.
 	script2 := `#!/bin/sh
-echo "agentsview v0.15.0 (commit abc, built 2026-01-01)"
+echo "agentsview v0.30.0 (commit abc, built 2026-05-23)"
 `
 	require.NoError(t, os.WriteFile(bin, []byte(script2), 0o755))
 
-	_, ok = resolveAgentsview(context.Background())
-	assert.False(t, ok, "too-old should be cached permanently")
+	_, level = resolveAgentsview(context.Background())
+	assert.Equal(t, capNone, level, "too-old should be cached permanently")
 }
 
 func TestResolveAgentsviewInvalidatesCacheOnPathChange(t *testing.T) {
@@ -256,19 +390,19 @@ func TestResolveAgentsviewInvalidatesCacheOnPathChange(t *testing.T) {
 	origPath := os.Getenv("PATH")
 	t.Setenv("PATH", dir1+string(os.PathListSeparator)+origPath)
 
-	_, ok := resolveAgentsview(context.Background())
-	assert.False(t, ok)
+	_, level := resolveAgentsview(context.Background())
+	assert.Equal(t, capNone, level)
 
 	// "Upgrade" by placing a new binary earlier in PATH.
 	dir2 := t.TempDir()
 	bin2 := filepath.Join(dir2, "agentsview")
-	script2 := "#!/bin/sh\necho 'agentsview v0.15.0 (commit def)'\n"
+	script2 := "#!/bin/sh\necho 'agentsview v0.30.0 (commit def)'\n"
 	require.NoError(t, os.WriteFile(bin2, []byte(script2), 0o755))
 
 	t.Setenv("PATH", dir2+string(os.PathListSeparator)+origPath)
 
-	path, ok := resolveAgentsview(context.Background())
-	assert.True(t, ok, "new path should trigger re-probe")
+	path, level := resolveAgentsview(context.Background())
+	assert.Equal(t, capSessionUsage, level, "new path should trigger re-probe")
 	assert.Equal(t, bin2, path)
 }
 
@@ -289,11 +423,11 @@ func TestResolveAgentsviewRetriesAfterUnparseableOutput(t *testing.T) {
 	origPath := os.Getenv("PATH")
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+origPath)
 
-	_, ok := resolveAgentsview(context.Background())
-	assert.False(t, ok, "unparseable should fail")
+	_, level := resolveAgentsview(context.Background())
+	assert.Equal(t, capNone, level, "unparseable should fail")
 
-	// Replace with valid version — should succeed because
-	// unparseable output was NOT cached as too-old.
+	// Replace with valid version — should succeed because unparseable
+	// output was NOT cached as too-old.
 	dir2 := t.TempDir()
 	bin2 := filepath.Join(dir2, "agentsview")
 	script2 := "#!/bin/sh\necho 'agentsview v0.15.0 (commit abc)'\n"
@@ -301,8 +435,8 @@ func TestResolveAgentsviewRetriesAfterUnparseableOutput(t *testing.T) {
 
 	t.Setenv("PATH", dir2+string(os.PathListSeparator)+origPath)
 
-	path, ok := resolveAgentsview(context.Background())
-	assert.True(t, ok, "should succeed after valid version appears")
+	path, level := resolveAgentsview(context.Background())
+	assert.NotEqual(t, capNone, level, "should succeed after valid version appears")
 	assert.NotEmpty(t, path)
 }
 
@@ -321,5 +455,18 @@ func TestToJSON(t *testing.T) {
 		require.NotNil(t, got)
 		assert.Equal(t, orig.PeakContextTokens, got.PeakContextTokens)
 		assert.Equal(t, orig.OutputTokens, got.OutputTokens)
+	})
+
+	t.Run("round trip with cost", func(t *testing.T) {
+		orig := &Usage{
+			PeakContextTokens: 5000,
+			OutputTokens:      300,
+			CostUSD:           1.23,
+			HasCost:           true,
+		}
+		got := ParseJSON(ToJSON(orig))
+		require.NotNil(t, got)
+		assert.True(t, got.HasCost)
+		assert.InDelta(t, 1.23, got.CostUSD, 1e-9)
 	})
 }

--- a/internal/tokens/tokens_test.go
+++ b/internal/tokens/tokens_test.go
@@ -265,9 +265,33 @@ exit 99
 	assert.InDelta(t, 0.42, usage.CostUSD, 1e-9)
 }
 
+func TestFetchForSessionUsesSessionUsageWhenPrereleaseSupportsIt(t *testing.T) {
+	installFakeAgentsview(t, `#!/bin/sh
+if [ "$1" = "version" ]; then
+  echo "agentsview v0.29.0-22-ga31468b4 (commit a31468b4, built 2026-05-23)"
+  exit 0
+fi
+if [ "$1" = "session" ] && [ "$2" = "usage" ]; then
+  echo '{"session_id":"s","agent":"codex","total_output_tokens":28800,"peak_context_tokens":118000,"cost_usd":0.42,"has_cost":true}'
+  exit 0
+fi
+echo "unexpected args: $@" >&2
+exit 99
+`)
+
+	usage, err := FetchForSession(context.Background(), "s")
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	assert.Equal(t, int64(28800), usage.OutputTokens)
+	assert.Equal(t, int64(118000), usage.PeakContextTokens)
+	assert.True(t, usage.HasCost)
+	assert.InDelta(t, 0.42, usage.CostUSD, 1e-9)
+}
+
 func TestFetchForSessionFallsBackToTokenUse(t *testing.T) {
-	// agentsview in [0.15.0, 0.30.0): FetchForSession falls back to
-	// the deprecated token-use command, which emits no cost. The
+	// agentsview in [0.15.0, before session usage support):
+	// FetchForSession falls back to the deprecated token-use command.
+	// The legacy output here has no cost, matching older builds. The
 	// script errors on `session usage`, so success proves the fallback.
 	installFakeAgentsview(t, `#!/bin/sh
 if [ "$1" = "version" ]; then
@@ -331,6 +355,10 @@ if [ "$1" = "version" ]; then
   echo "agentsview v0.15.0 (commit abc, built 2026-01-01)"
   exit 0
 fi
+if [ "$1" = "token-use" ]; then
+  exit 0
+fi
+exit 99
 `
 	require.NoError(t, os.WriteFile(bin, []byte(script), 0o755))
 


### PR DESCRIPTION
## Summary

- `internal/tokens` selects the agentsview usage command via a capability probe: `agentsview session usage <id> --format json` on agentsview >= 0.30.0, falling back to the deprecated `token-use` on 0.15.0-0.29.x. The new `cost_usd`/`has_cost` fields are parsed into `Usage`.
- Usage exit codes 2 (session not found) and 3 (found, no token/cost data) are treated as "no usage" rather than errors. The legacy `token-use` exit-1 empty-output case is still handled, so older agentsview keeps working.
- `FormatSummary` appends `· ~$0.42` when a cost estimate is present (the review detail view renders this automatically); `FormatCost` returns the cost alone.
- The TUI queue gains a default-visible "Cost" column showing the per-job estimate, blank when the model is unpriced or usage has not been fetched yet.
- Cost populates once agentsview 0.30.0 (kenn-io/agentsview#536) is installed; on older versions the column stays blank and token counts are unaffected. A `backfill-tokens` run refreshes existing jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)