### PR TITLE
fix(git): support git clone --bare-backed worktrees

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -609,6 +609,16 @@ func GetMainRepoRoot(path string) (string, error) {
 		// This is a worktree. For regular worktrees, commonDir ends with ".git"
 		// and the main repo is its parent. For submodule worktrees, commonDir
 		// is inside .git/modules/ and we need to read the core.worktree config.
+		//
+		// Some workspace managers create linked worktrees from a bare common
+		// repository (for example, commonDir=/path/to/repo.git). In that layout
+		// there is no main working tree, so the current checkout root is the
+		// stable repo-local path to register and use for config resolution.
+		bareCmd := exec.Command("git", "config", "--file", filepath.Join(commonDir, "config"), "--bool", "core.bare")
+		if out, err := bareCmd.Output(); err == nil && strings.TrimSpace(string(out)) == "true" {
+			return GetRepoRoot(path)
+		}
+
 		if filepath.Base(commonDir) == ".git" {
 			// Regular worktree - parent of .git is the repo root
 			return filepath.Dir(commonDir), nil

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -461,6 +461,27 @@ func TestIsRebaseInProgress(t *testing.T) {
 	})
 }
 
+func TestGetMainRepoRootForBareBackedWorktree(t *testing.T) {
+	bareRepo := NewBareTestRepo(t)
+	seedRepo := NewTestRepoWithCommit(t)
+	seedRepo.Run("remote", "add", "origin", bareRepo.Dir)
+	seedRepo.Run("push", "origin", "HEAD:main")
+
+	worktreeDir := t.TempDir()
+	bareRepo.Run("worktree", "add", worktreeDir, "main")
+	t.Cleanup(func() {
+		cmd := exec.Command("git", "-C", bareRepo.Dir, "worktree", "remove", worktreeDir)
+		_ = cmd.Run()
+	})
+
+	got, err := GetMainRepoRoot(worktreeDir)
+	require.NoError(t, err)
+
+	want, err := GetRepoRoot(worktreeDir)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
 func TestGetCommitInfo(t *testing.T) {
 	t.Run("commit with subject only", func(t *testing.T) {
 		repo := NewTestRepoWithAuthor(t, "Test Author")


### PR DESCRIPTION
## Summary
- Detect linked worktrees whose common git directory is a bare repository.
- Resolve those workspaces to the current checkout root so `roborev init` can register Middleman-style worktrees.
- Keep existing behavior for normal linked worktrees and submodule worktrees.

## Validation
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `go test ./internal/git -run 'TestGetMainRepoRootForBareBackedWorktree|TestGetMainRepoRoot' -count=1`\n- Verified `roborev init --no-daemon` from `/Users/mariusvniekerk/.config/middleman/worktrees/github.com/kenn-io/middleman/pr-365` against an isolated patched daemon successfully registers the repo.