### PR TITLE
Add internal-contradictions check as #1 in design review prompt

### DIFF
--- a/internal/prompt/templates/default_design_review.md.gotmpl
+++ b/internal/prompt/templates/default_design_review.md.gotmpl
@@ -1,6 +1,6 @@
 You are a design reviewer. The changes shown below are expected to contain design artifacts — PRDs, task lists, architectural proposals, or similar planning documents. Review them for:
 
-1. **Internal contradictions**: Flag places where two parts of the spec, PRD, or task list conflict — even if each is individually clear. Top priority, because downstream agents (codex, claude, etc.) may resolve them differently, producing inconsistent implementations.
+1. **Internal contradictions**: Flag places where parts of the spec, PRD, or task list conflict — even if each is individually clear. Top priority, because implementers could resolve these differently, resulting in inconsistencies.
 2. **Completeness**: Are goals, non-goals, success criteria, and edge cases defined?
 3. **Feasibility**: Are technical decisions grounded in the actual codebase?
 4. **Task scoping**: Are implementation stages small enough to review incrementally? Are dependencies ordered correctly?

--- a/internal/prompt/templates/default_design_review.md.gotmpl
+++ b/internal/prompt/templates/default_design_review.md.gotmpl
@@ -1,10 +1,11 @@
 You are a design reviewer. The changes shown below are expected to contain design artifacts — PRDs, task lists, architectural proposals, or similar planning documents. Review them for:
 
-1. **Completeness**: Are goals, non-goals, success criteria, and edge cases defined?
-2. **Feasibility**: Are technical decisions grounded in the actual codebase?
-3. **Task scoping**: Are implementation stages small enough to review incrementally? Are dependencies ordered correctly?
-4. **Missing considerations**: Security, performance, backwards compatibility, error handling
-5. **Clarity**: Are decisions justified and understandable?
+1. **Internal contradictions**: Flag places where two parts of the spec, PRD, or task list conflict — even if each is individually clear. Top priority, because downstream agents (codex, claude, etc.) may resolve them differently, producing inconsistent implementations.
+2. **Completeness**: Are goals, non-goals, success criteria, and edge cases defined?
+3. **Feasibility**: Are technical decisions grounded in the actual codebase?
+4. **Task scoping**: Are implementation stages small enough to review incrementally? Are dependencies ordered correctly?
+5. **Missing considerations**: Security, performance, backwards compatibility, error handling
+6. **Clarity**: Are decisions justified and understandable?
 
 If the changes do not appear to contain design documents, note this and review whatever design intent is evident from the code changes.
 

--- a/internal/prompt/testdata/golden/design_review.golden
+++ b/internal/prompt/testdata/golden/design_review.golden
@@ -1,6 +1,6 @@
 You are a design reviewer. The changes shown below are expected to contain design artifacts — PRDs, task lists, architectural proposals, or similar planning documents. Review them for:
 
-1. **Internal contradictions**: Flag places where two parts of the spec, PRD, or task list conflict — even if each is individually clear. Top priority, because downstream agents (codex, claude, etc.) may resolve them differently, producing inconsistent implementations.
+1. **Internal contradictions**: Flag places where parts of the spec, PRD, or task list conflict — even if each is individually clear. Top priority, because implementers could resolve these differently, resulting in inconsistencies.
 2. **Completeness**: Are goals, non-goals, success criteria, and edge cases defined?
 3. **Feasibility**: Are technical decisions grounded in the actual codebase?
 4. **Task scoping**: Are implementation stages small enough to review incrementally? Are dependencies ordered correctly?

--- a/internal/prompt/testdata/golden/design_review.golden
+++ b/internal/prompt/testdata/golden/design_review.golden
@@ -1,10 +1,11 @@
 You are a design reviewer. The changes shown below are expected to contain design artifacts — PRDs, task lists, architectural proposals, or similar planning documents. Review them for:
 
-1. **Completeness**: Are goals, non-goals, success criteria, and edge cases defined?
-2. **Feasibility**: Are technical decisions grounded in the actual codebase?
-3. **Task scoping**: Are implementation stages small enough to review incrementally? Are dependencies ordered correctly?
-4. **Missing considerations**: Security, performance, backwards compatibility, error handling
-5. **Clarity**: Are decisions justified and understandable?
+1. **Internal contradictions**: Flag places where two parts of the spec, PRD, or task list conflict — even if each is individually clear. Top priority, because downstream agents (codex, claude, etc.) may resolve them differently, producing inconsistent implementations.
+2. **Completeness**: Are goals, non-goals, success criteria, and edge cases defined?
+3. **Feasibility**: Are technical decisions grounded in the actual codebase?
+4. **Task scoping**: Are implementation stages small enough to review incrementally? Are dependencies ordered correctly?
+5. **Missing considerations**: Security, performance, backwards compatibility, error handling
+6. **Clarity**: Are decisions justified and understandable?
 
 If the changes do not appear to contain design documents, note this and review whatever design intent is evident from the code changes.
 


### PR DESCRIPTION
## What

Add a new top-priority bullet to the design review prompt that asks the reviewer to flag **internal contradictions** between two parts of a spec, PRD, or task list.

```diff
 You are a design reviewer. ...

-1. **Completeness**: ...
-2. **Feasibility**: ...
-3. **Task scoping**: ...
-4. **Missing considerations**: ...
-5. **Clarity**: ...
+1. **Internal contradictions**: Flag places where two parts of the spec, PRD, or task list conflict — even if each is individually clear. Top priority, because downstream agents (codex, claude, etc.) may resolve them differently, producing inconsistent implementations.
+2. **Completeness**: ...
+3. **Feasibility**: ...
+4. **Task scoping**: ...
+5. **Missing considerations**: ...
+6. **Clarity**: ...
```

## Why

I hit a case where roborev and codex effectively played tug-of-war over a contradiction between two parts of the spec — each side resolved the conflict differently, and neither flagged the underlying contradiction as the issue. The existing prompt covers **Completeness** ("are things defined?") and **Clarity** ("are decisions justified?"), but doesn't explicitly cover the case where two parts are each individually clear and complete, yet contradict each other.

Putting it at position #1 reflects the priority: when a spec contradicts itself, no implementation can satisfy all of it, and downstream agents will diverge in how they resolve the conflict — which compounds across commits.

## Changes

- `internal/prompt/templates/default_design_review.md.gotmpl`: new bullet inserted as #1, existing bullets renumbered 2–6.
- `internal/prompt/testdata/golden/design_review.golden`: golden updated to match.

## Verification

```
$ go test ./internal/prompt/...
ok  	go.kenn.io/roborev/internal/prompt	46.329s
ok  	go.kenn.io/roborev/internal/prompt/analyze	0.413s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)