### PR TITLE
Fix OpenCode install source

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ See [configuration guide](https://roborev.io/configuration/) for all options.
 | Claude Code | `npm install -g @anthropic-ai/claude-code` |
 | Gemini | `curl -fsSL https://antigravity.google/cli/install.sh \| bash` (preferred Antigravity CLI) or `npm install -g @google/gemini-cli` |
 | Copilot | `npm install -g @github/copilot` |
-| OpenCode | `go install github.com/opencode-ai/opencode@latest` |
+| OpenCode | `npm install -g opencode-ai@latest` ([anomalyco/opencode](https://github.com/anomalyco/opencode)) |
 | Cursor | [cursor.com](https://www.cursor.com/) |
 | Kiro | [kiro.dev](https://kiro.dev/) |
 | Kilo | `npm install -g @kilocode/cli` |

--- a/internal/ghaction/ghaction.go
+++ b/internal/ghaction/ghaction.go
@@ -116,7 +116,7 @@ func AgentInstallCmd(agentName string) string {
 	case "codex":
 		return "npm install -g @openai/codex@latest"
 	case "opencode":
-		return "go install github.com/opencode-ai/opencode@latest"
+		return "npm install -g opencode-ai@latest"
 	case "cursor":
 		return "echo 'Cursor agent is not available in CI" +
 			" environments; choose a different agent'"

--- a/internal/ghaction/ghaction_test.go
+++ b/internal/ghaction/ghaction_test.go
@@ -202,7 +202,7 @@ func TestGenerate(t *testing.T) {
 				Agents: []string{"opencode"},
 			},
 			wantStrs: []string{
-				"opencode-ai/opencode@latest",
+				"opencode-ai@latest",
 				"ANTHROPIC_API_KEY",
 				"different model provider",
 			},
@@ -246,7 +246,7 @@ func TestGenerate(t *testing.T) {
 			},
 			wantStrs: []string{
 				"@anthropic-ai/claude-code@latest",
-				"opencode-ai/opencode@latest",
+				"opencode-ai@latest",
 			},
 			envChecks: func(t *testing.T, env map[string]string) {
 				assert.Contains(t, env, "ANTHROPIC_API_KEY", "expected ANTHROPIC_API_KEY in env")


### PR DESCRIPTION
## Summary
- point README OpenCode setup at the supported anomalyco/opencode distribution
- update generated GitHub Action setup to install `opencode-ai@latest`
- adjust ghaction tests for the new install command

## Validation
- go fmt ./...
- go vet ./...
- go test ./internal/ghaction
- go test ./... (fails in unrelated internal/git TestGetMainRepoRootForBareBackedWorktree: git config core.worktree exit status 128)