### PR TITLE
fix(agent): disable Copilot streaming when supported

### DIFF
--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -12,6 +12,7 @@ import (
 )
 
 var copilotAllowAllToolsSupport sync.Map
+var copilotStreamOffSupport sync.Map
 
 // copilotSupportsAllowAllTools checks whether the copilot binary supports
 // the --allow-all-tools flag needed for non-interactive tool approval.
@@ -27,6 +28,23 @@ func copilotSupportsAllowAllTools(ctx context.Context, command string) (bool, er
 		return false, fmt.Errorf("check %s --help: %w: %s", command, err, output)
 	}
 	copilotAllowAllToolsSupport.Store(command, supported)
+	return supported, nil
+}
+
+// copilotSupportsStreamOff checks whether the copilot binary supports
+// disabling streaming output so stdout remains pipe-capturable.
+// Results are cached per command path.
+func copilotSupportsStreamOff(ctx context.Context, command string) (bool, error) {
+	if cached, ok := copilotStreamOffSupport.Load(command); ok {
+		return cached.(bool), nil
+	}
+	cmd := exec.CommandContext(ctx, command, "--help")
+	output, err := cmd.CombinedOutput()
+	supported := strings.Contains(string(output), "--stream")
+	if err != nil && !supported {
+		return false, fmt.Errorf("check %s --help: %w: %s", command, err, output)
+	}
+	copilotStreamOffSupport.Store(command, supported)
 	return supported, nil
 }
 
@@ -50,7 +68,7 @@ var copilotReviewDenyTools = []string{
 // In review mode, destructive tools are denied. In agentic mode, all tools
 // are allowed without restriction.
 func (a *CopilotAgent) buildArgs(agenticMode bool) []string {
-	return a.commandArgs(agenticMode, true)
+	return a.commandArgs(agenticMode, true, true)
 }
 
 // CopilotAgent runs code reviews using the GitHub Copilot CLI
@@ -116,24 +134,24 @@ func (a *CopilotAgent) CommandName() string {
 
 func (a *CopilotAgent) CommandLine() string {
 	agenticMode := a.Agentic || AllowUnsafeAgents()
-	args := a.commandArgs(agenticMode, false)
+	args := a.commandArgs(agenticMode, false, false)
 	return a.Command + " " + strings.Join(args, " ")
 }
 
 func (a *CopilotAgent) Review(ctx context.Context, repoPath, commitSHA, prompt string, output io.Writer) (string, error) {
 	agenticMode := a.Agentic || AllowUnsafeAgents()
 
-	supported, err := copilotSupportsAllowAllTools(ctx, a.Command)
+	supportsAllowAllTools, err := copilotSupportsAllowAllTools(ctx, a.Command)
 	if err != nil {
 		log.Printf("copilot: cannot detect --allow-all-tools support: %v", err)
 	}
 
-	var args []string
-	if supported {
-		args = a.commandArgs(agenticMode, true)
-	} else {
-		args = a.commandArgs(agenticMode, false)
+	supportsStreamOff, err := copilotSupportsStreamOff(ctx, a.Command)
+	if err != nil {
+		log.Printf("copilot: cannot detect --stream support: %v", err)
 	}
+
+	args := a.commandArgs(agenticMode, supportsAllowAllTools, supportsStreamOff)
 
 	cmd := exec.CommandContext(ctx, a.Command, args...)
 	cmd.Stdin = strings.NewReader(prompt)
@@ -164,10 +182,13 @@ func (a *CopilotAgent) Review(ctx context.Context, repoPath, commitSHA, prompt s
 	return result, nil
 }
 
-func (a *CopilotAgent) commandArgs(agenticMode, includePermissions bool) []string {
+func (a *CopilotAgent) commandArgs(agenticMode, includePermissions, includeStreamOff bool) []string {
 	args := []string{}
 	if includePermissions {
 		args = append(args, "-s", "--allow-all-tools")
+	}
+	if includeStreamOff {
+		args = append(args, "--stream", "off")
 	}
 	if a.Model != "" {
 		args = append(args, "--model", a.Model)

--- a/internal/agent/copilot_test.go
+++ b/internal/agent/copilot_test.go
@@ -32,6 +32,28 @@ func TestCopilotSupportsAllowAllTools(t *testing.T) {
 	})
 }
 
+func TestCopilotSupportsStreamOff(t *testing.T) {
+	skipIfWindows(t)
+
+	t.Run("supported", func(t *testing.T) {
+		mock := mockAgentCLI(t, MockCLIOpts{
+			HelpOutput: "Usage: copilot [flags]\n\n  --stream string  Control streaming output",
+		})
+		supported, err := copilotSupportsStreamOff(context.Background(), mock.CmdPath)
+		require.NoError(t, err)
+		assert.True(t, supported)
+	})
+
+	t.Run("not supported", func(t *testing.T) {
+		mock := mockAgentCLI(t, MockCLIOpts{
+			HelpOutput: "Usage: copilot [flags]\n\n  --model  Model to use",
+		})
+		supported, err := copilotSupportsStreamOff(context.Background(), mock.CmdPath)
+		require.NoError(t, err)
+		assert.False(t, supported)
+	})
+}
+
 func TestCopilotBuildArgs(t *testing.T) {
 	a := NewCopilotAgent("copilot")
 
@@ -40,6 +62,7 @@ func TestCopilotBuildArgs(t *testing.T) {
 		args := a.buildArgs(false)
 		assert.Contains(args, "-s")
 		assert.Contains(args, "--allow-all-tools")
+		assertArgPair(t, args, "--stream", "off")
 		// Verify deny-tool pairs exist for each denied tool
 		for _, tool := range copilotReviewDenyTools {
 			found := false
@@ -58,6 +81,7 @@ func TestCopilotBuildArgs(t *testing.T) {
 		args := a.buildArgs(true)
 		assert.Contains(args, "-s")
 		assert.Contains(args, "--allow-all-tools")
+		assertArgPair(t, args, "--stream", "off")
 		assert.NotContains(args, "--deny-tool")
 	})
 
@@ -159,10 +183,10 @@ func TestCopilotReview(t *testing.T) {
 func TestCopilotReviewPermissionFlags(t *testing.T) {
 	skipIfWindows(t)
 
-	t.Run("review mode passes permission flags", func(t *testing.T) {
+	t.Run("review mode passes permission and stream flags", func(t *testing.T) {
 		assert := assert.New(t)
 		mock := mockAgentCLI(t, MockCLIOpts{
-			HelpOutput:   "--allow-all-tools",
+			HelpOutput:   "--allow-all-tools\n--stream",
 			CaptureArgs:  true,
 			CaptureStdin: true,
 			StdoutLines:  []string{"review output"},
@@ -174,6 +198,7 @@ func TestCopilotReviewPermissionFlags(t *testing.T) {
 
 		args := readFileContent(t, mock.ArgsFile)
 		assert.Contains(args, "--allow-all-tools")
+		assert.Contains(args, "--stream off")
 		assert.Contains(args, "-s")
 		assert.Contains(args, "--deny-tool")
 		assertFileContent(t, mock.StdinFile, "prompt")
@@ -227,9 +252,22 @@ func TestCopilotReviewPermissionFlags(t *testing.T) {
 
 		args := readFileContent(t, mock.ArgsFile)
 		assert.NotContains(t, args, "--allow-all-tools")
+		assert.NotContains(t, args, "--stream")
 		assert.NotContains(t, args, "--deny-tool")
 		assert.NotContains(t, args, "-s")
 	})
+}
+
+func assertArgPair(t *testing.T, args []string, flag, value string) {
+	t.Helper()
+
+	pairs := make([]string, 0)
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag {
+			pairs = append(pairs, args[i]+" "+args[i+1])
+		}
+	}
+	assert.Contains(t, pairs, flag+" "+value)
 }
 
 // readFileContent reads a file and returns its trimmed content.


### PR DESCRIPTION
## Summary
- Probe Copilot CLI help output for `--stream` support.
- Pass `--stream off` when supported so review output is captured through stdout instead of being lost to streaming mode.
- Preserve compatibility with older Copilot CLIs by omitting the stream flag when unsupported.
- Add regression coverage for detection, argument construction, and fallback behavior.

Closes roborev#2vp5.
References original GitHub issue: https://github.com/kenn-io/roborev/issues/700

## Validation
- `go vet ./...`
- `go test ./...`