### PR TITLE
Raise default CI batch timeout from 3m to 15m

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -727,7 +727,7 @@ type CIConfig struct {
 
 	// BatchTimeout is how long to wait for all batch jobs to complete before
 	// posting results with available reviews. Jobs still running after this
-	// timeout are canceled. Default: "3m". Set to "0" to disable.
+	// timeout are canceled. Default: "15m". Set to "0" to disable.
 	BatchTimeout string `toml:"batch_timeout"`
 
 	// GitHub App authentication (optional — comments appear as bot instead of personal account)
@@ -834,18 +834,19 @@ func (c *CIConfig) ResolvedThrottleInterval() time.Duration {
 }
 
 // ResolvedBatchTimeout returns how long to wait for all batch jobs
-// before posting early with available results. Default: 3 minutes.
+// before posting early with available results. Default: 15 minutes.
 // Returns 0 (disabled) if explicitly set to "0".
 func (c *CIConfig) ResolvedBatchTimeout() time.Duration {
+	const defaultTimeout = 15 * time.Minute
 	if c.BatchTimeout == "" {
-		return 3 * time.Minute
+		return defaultTimeout
 	}
 	if c.BatchTimeout == "0" {
 		return 0
 	}
 	d, err := time.ParseDuration(c.BatchTimeout)
 	if err != nil || d < 0 {
-		return 3 * time.Minute
+		return defaultTimeout
 	}
 	return d
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3537,7 +3537,7 @@ func TestIsMarkerOnlyOutput(t *testing.T) {
 func TestCIConfig_ResolvedBatchTimeout(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		c := CIConfig{}
-		assert.Equal(t, 3*time.Minute, c.ResolvedBatchTimeout())
+		assert.Equal(t, 15*time.Minute, c.ResolvedBatchTimeout())
 	})
 	t.Run("custom", func(t *testing.T) {
 		c := CIConfig{BatchTimeout: "5m"}
@@ -3549,11 +3549,11 @@ func TestCIConfig_ResolvedBatchTimeout(t *testing.T) {
 	})
 	t.Run("invalid_falls_back", func(t *testing.T) {
 		c := CIConfig{BatchTimeout: "garbage"}
-		assert.Equal(t, 3*time.Minute, c.ResolvedBatchTimeout())
+		assert.Equal(t, 15*time.Minute, c.ResolvedBatchTimeout())
 	})
 	t.Run("negative_falls_back", func(t *testing.T) {
 		c := CIConfig{BatchTimeout: "-5m"}
-		assert.Equal(t, 3*time.Minute, c.ResolvedBatchTimeout())
+		assert.Equal(t, 15*time.Minute, c.ResolvedBatchTimeout())
 	})
 }
 


### PR DESCRIPTION
## Summary
- Bumps the default `[ci].batch_timeout` from 3 minutes to 15 minutes in `CIConfig.ResolvedBatchTimeout`.
- The 3m default expired before slower agents (codex, gemini) could finish, causing PR comments with partial counters (e.g. `1+0/3`) and discarded output from still-running child processes.
- Updates the doc comment on the `BatchTimeout` field and the unit tests that assert the default.