### PR TITLE
update: use HTML redirect endpoint to avoid GitHub API rate limit

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -22,9 +22,13 @@ import (
 )
 
 const (
-	githubAPIURL  = "https://api.github.com/repos/roborev-dev/roborev/releases/latest"
-	cacheFileName = "update_check.json"
-	cacheDuration = 1 * time.Hour
+	// githubLatestReleaseURL is the HTML endpoint that 302-redirects to
+	// /releases/tag/<tag>. Unlike api.github.com it is not rate-limited
+	// at 60 req/hr per IP for unauthenticated callers.
+	githubLatestReleaseURL    = "https://github.com/roborev-dev/roborev/releases/latest"
+	githubReleaseDownloadBase = "https://github.com/roborev-dev/roborev/releases/download"
+	cacheFileName             = "update_check.json"
+	cacheDuration             = 1 * time.Hour
 )
 
 var (
@@ -32,20 +36,6 @@ var (
 	checksumPattern    = regexp.MustCompile(`(?i)[a-f0-9]{64}`)
 	semverBasePattern  = regexp.MustCompile(`^\d+(?:\.\d+)+`)
 )
-
-// Release represents a GitHub release
-type Release struct {
-	TagName string  `json:"tag_name"`
-	Body    string  `json:"body"`
-	Assets  []Asset `json:"assets"`
-}
-
-// Asset represents a release asset
-type Asset struct {
-	Name               string `json:"name"`
-	Size               int64  `json:"size"`
-	BrowserDownloadURL string `json:"browser_download_url"`
-}
 
 // UpdateInfo contains information about an available update
 type UpdateInfo struct {
@@ -84,11 +74,6 @@ type Updater struct {
 type cachedCheck struct {
 	CheckedAt time.Time `json:"checked_at"`
 	Version   string    `json:"version"`
-}
-
-type platformInfo struct {
-	goos   string
-	goarch string
 }
 
 type buildInfo struct {
@@ -251,36 +236,40 @@ func (u *Updater) cachedUpdate(build buildInfo, forceCheck bool) (*UpdateInfo, b
 }
 
 func (u *Updater) fetchReleaseInfo(build buildInfo) (*UpdateInfo, error) {
-	release, err := u.fetchLatestRelease()
+	tag, err := u.resolveLatestTag(githubLatestReleaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("check for updates: %w", err)
 	}
 
 	// Cache failures should not block update checks.
-	_ = u.saveCache(release.TagName)
+	_ = u.saveCache(tag)
 
-	latest := parseVersion(release.TagName)
+	latest := parseVersion(tag)
 	if !build.version.dev && !latest.newerThan(build.version) {
 		return nil, nil
 	}
 
-	assetVersion := strings.TrimPrefix(release.TagName, "v")
-	asset, checksumsAsset, err := resolveAsset(release.Assets, platformInfo{
-		goos:   u.deps.GOOS,
-		goarch: u.deps.GOARCH,
-	}, assetVersion)
+	assetVersion := strings.TrimPrefix(tag, "v")
+	assetName := fmt.Sprintf("roborev_%s_%s_%s.tar.gz", assetVersion, u.deps.GOOS, u.deps.GOARCH)
+	downloadURL := fmt.Sprintf("%s/%s/%s", githubReleaseDownloadBase, tag, assetName)
+	checksumsURL := fmt.Sprintf("%s/%s/SHA256SUMS", githubReleaseDownloadBase, tag)
+
+	// HEAD the asset to confirm it exists for this platform. The previous
+	// API-based code returned "no release asset" up front; now that we
+	// construct the URL ourselves, we have to verify it resolves.
+	size, err := u.fetchContentLength(downloadURL)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("no release asset for %s/%s: %w", u.deps.GOOS, u.deps.GOARCH, err)
 	}
 
-	checksum, _ := u.resolveChecksum(release, asset.Name, checksumsAsset)
+	checksum, _ := u.fetchChecksumFromFile(checksumsURL, assetName)
 
 	return &UpdateInfo{
 		CurrentVersion: build.raw,
-		LatestVersion:  release.TagName,
-		DownloadURL:    asset.BrowserDownloadURL,
-		AssetName:      asset.Name,
-		Size:           asset.Size,
+		LatestVersion:  tag,
+		DownloadURL:    downloadURL,
+		AssetName:      assetName,
+		Size:           size,
 		Checksum:       checksum,
 		IsDevBuild:     build.version.dev,
 	}, nil
@@ -392,52 +381,6 @@ func (u *Updater) binaryNames() []string {
 	return []string{"roborev"}
 }
 
-func resolveAsset(assets []Asset, platform platformInfo, version string) (*Asset, *Asset, error) {
-	assetName := fmt.Sprintf("roborev_%s_%s_%s.tar.gz", version, platform.goos, platform.goarch)
-	asset, checksumsAsset := findAssets(assets, assetName)
-	if asset == nil {
-		return nil, nil, fmt.Errorf("no release asset found for %s/%s", platform.goos, platform.goarch)
-	}
-	return asset, checksumsAsset, nil
-}
-
-func (u *Updater) resolveChecksum(release *Release, assetName string, checksumsAsset *Asset) (string, error) {
-	if checksumsAsset != nil {
-		checksum, err := u.fetchChecksumFromFile(checksumsAsset.BrowserDownloadURL, assetName)
-		if checksum != "" {
-			return checksum, nil
-		}
-		if checksum = extractChecksum(release.Body, assetName); checksum != "" {
-			return checksum, nil
-		}
-		return "", err
-	}
-
-	return extractChecksum(release.Body, assetName), nil
-}
-
-// findAssets locates the platform-specific binary and checksums file from release assets.
-func findAssets(assets []Asset, assetName string) (asset *Asset, checksumsAsset *Asset) {
-	for i := range assets {
-		a := &assets[i]
-		if a.Name == assetName {
-			asset = a
-		}
-		if a.Name == "SHA256SUMS" || a.Name == "checksums.txt" {
-			checksumsAsset = a
-		}
-	}
-	return asset, checksumsAsset
-}
-
-func (u *Updater) fetchLatestRelease() (*Release, error) {
-	var release Release
-	if err := u.fetchJSON(githubAPIURL, &release); err != nil {
-		return nil, err
-	}
-	return &release, nil
-}
-
 func (u *Updater) newRequest(method, url string, body io.Reader) (*http.Request, error) {
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
@@ -455,24 +398,74 @@ func (u *Updater) get(url string) (*http.Response, error) {
 	return u.deps.Client.Do(req)
 }
 
-func (u *Updater) fetchJSON(url string, dst any) error {
+// resolveLatestTag follows the /releases/latest 302 redirect to
+// /releases/tag/<tag> and returns the tag. Using the HTML endpoint
+// avoids api.github.com's 60-req/hr unauthenticated rate limit.
+func (u *Updater) resolveLatestTag(url string) (string, error) {
 	req, err := u.newRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return err
+		return "", err
 	}
-	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	// Wrap the injected client so we don't follow the redirect; we just want
+	// to read the Location header off the 302. Sharing Transport/Timeout
+	// keeps test transports and configured timeouts in effect.
+	client := &http.Client{
+		Transport: u.deps.Client.Transport,
+		Timeout:   u.deps.Client.Timeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 300 || resp.StatusCode >= 400 {
+		return "", fmt.Errorf("expected redirect from %s, got %s", url, resp.Status)
+	}
+
+	loc, err := resp.Location()
+	if err != nil {
+		return "", fmt.Errorf("read Location header: %w", err)
+	}
+
+	const marker = "/releases/tag/"
+	idx := strings.Index(loc.Path, marker)
+	if idx < 0 {
+		return "", fmt.Errorf("unexpected redirect target %q", loc.String())
+	}
+	tag := loc.Path[idx+len(marker):]
+	if tag == "" {
+		return "", fmt.Errorf("empty tag in redirect target %q", loc.String())
+	}
+	return tag, nil
+}
+
+// fetchContentLength does a HEAD request and returns the Content-Length
+// of the eventual asset (following redirects to the S3 backend).
+// Returns 0 if the size can't be determined; callers degrade gracefully.
+func (u *Updater) fetchContentLength(url string) (int64, error) {
+	req, err := u.newRequest(http.MethodHead, url, nil)
+	if err != nil {
+		return 0, err
+	}
 
 	resp, err := u.deps.Client.Do(req)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("GitHub API returned %s", resp.Status)
+		return 0, fmt.Errorf("HEAD %s returned %s", url, resp.Status)
 	}
-
-	return json.NewDecoder(resp.Body).Decode(dst)
+	if resp.ContentLength < 0 {
+		return 0, nil
+	}
+	return resp.ContentLength, nil
 }
 
 func (u *Updater) downloadFile(url, dest string, totalSize int64, progressFn func(downloaded, total int64)) (string, error) {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -349,29 +349,32 @@ func TestUpdaterCheckForUpdateSkipsNetworkWithFreshCache(t *testing.T) {
 	assert.Equal(t, 0, requests)
 }
 
-func TestUpdaterCheckForUpdateFallsBackToReleaseBodyChecksum(t *testing.T) {
-	const releaseVersion = "v1.3.0"
+func TestUpdaterCheckForUpdateUsesHTMLRedirect(t *testing.T) {
+	const releaseTag = "v1.3.0"
 	const assetName = "roborev_1.3.0_darwin_arm64.tar.gz"
 	const checksum = "abc123def456789012345678901234567890123456789012345678901234abcd"
 
-	releaseBody, err := json.Marshal(Release{
-		TagName: releaseVersion,
-		Body:    fmt.Sprintf("%s  %s", checksum, assetName),
-		Assets: []Asset{
-			{Name: assetName, Size: 42, BrowserDownloadURL: "https://downloads.example/" + assetName},
-			{Name: "SHA256SUMS", Size: 12, BrowserDownloadURL: "https://downloads.example/SHA256SUMS"},
-		},
-	})
-	require.NoError(t, err)
+	downloadURL := fmt.Sprintf("%s/%s/%s", githubReleaseDownloadBase, releaseTag, assetName)
+	checksumsURL := fmt.Sprintf("%s/%s/SHA256SUMS", githubReleaseDownloadBase, releaseTag)
 
 	updater := NewUpdater(Deps{
 		Client: &http.Client{
 			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 				switch req.URL.String() {
-				case githubAPIURL:
-					return newHTTPResponse(http.StatusOK, string(releaseBody)), nil
-				case "https://downloads.example/SHA256SUMS":
-					return newHTTPResponse(http.StatusInternalServerError, "boom"), nil
+				case githubLatestReleaseURL:
+					resp := newHTTPResponse(http.StatusFound, "")
+					resp.Header.Set("Location", "https://github.com/roborev-dev/roborev/releases/tag/"+releaseTag)
+					resp.Request = req
+					return resp, nil
+				case downloadURL:
+					if req.Method != http.MethodHead {
+						return nil, fmt.Errorf("expected HEAD for %s, got %s", req.URL, req.Method)
+					}
+					resp := newHTTPResponse(http.StatusOK, "")
+					resp.ContentLength = 42
+					return resp, nil
+				case checksumsURL:
+					return newHTTPResponse(http.StatusOK, fmt.Sprintf("%s  %s\n", checksum, assetName)), nil
 				default:
 					return nil, fmt.Errorf("unexpected request to %s", req.URL.String())
 				}
@@ -388,10 +391,124 @@ func TestUpdaterCheckForUpdateFallsBackToReleaseBodyChecksum(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, info)
 	assert.Equal(t, "v1.2.0", info.CurrentVersion)
-	assert.Equal(t, releaseVersion, info.LatestVersion)
+	assert.Equal(t, releaseTag, info.LatestVersion)
 	assert.Equal(t, assetName, info.AssetName)
+	assert.Equal(t, downloadURL, info.DownloadURL)
+	assert.Equal(t, int64(42), info.Size)
 	assert.Equal(t, checksum, info.Checksum)
 	assert.False(t, info.IsDevBuild)
+}
+
+func TestResolveLatestTag(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		location   string
+		wantTag    string
+		wantErrSub string
+	}{
+		{
+			name:     "valid 302 redirect",
+			status:   http.StatusFound,
+			location: "https://github.com/roborev-dev/roborev/releases/tag/v0.55.0",
+			wantTag:  "v0.55.0",
+		},
+		{
+			name:     "pre-release tag",
+			status:   http.StatusFound,
+			location: "https://github.com/roborev-dev/roborev/releases/tag/v0.9.0-rc1",
+			wantTag:  "v0.9.0-rc1",
+		},
+		{
+			name:       "200 OK is not a redirect",
+			status:     http.StatusOK,
+			wantErrSub: "expected redirect",
+		},
+		{
+			name:       "redirect target without /tag/",
+			status:     http.StatusFound,
+			location:   "https://github.com/roborev-dev/roborev/releases",
+			wantErrSub: "unexpected redirect target",
+		},
+		{
+			name:       "empty tag after /tag/",
+			status:     http.StatusFound,
+			location:   "https://github.com/roborev-dev/roborev/releases/tag/",
+			wantErrSub: "empty tag",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updater := NewUpdater(Deps{
+				Client: &http.Client{
+					Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+						resp := newHTTPResponse(tt.status, "")
+						resp.Request = req
+						if tt.location != "" {
+							resp.Header.Set("Location", tt.location)
+						}
+						return resp, nil
+					}),
+				},
+			})
+
+			tag, err := updater.resolveLatestTag("https://example.invalid/releases/latest")
+			if tt.wantErrSub != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrSub)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantTag, tag)
+		})
+	}
+}
+
+func TestFetchContentLength(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		size       int64
+		wantSize   int64
+		wantErrSub string
+	}{
+		{
+			name:     "200 with Content-Length",
+			status:   http.StatusOK,
+			size:     1234,
+			wantSize: 1234,
+		},
+		{
+			name:       "404",
+			status:     http.StatusNotFound,
+			wantErrSub: "404",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updater := NewUpdater(Deps{
+				Client: &http.Client{
+					Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+						if req.Method != http.MethodHead {
+							return nil, fmt.Errorf("expected HEAD, got %s", req.Method)
+						}
+						resp := newHTTPResponse(tt.status, "")
+						resp.ContentLength = tt.size
+						return resp, nil
+					}),
+				},
+			})
+
+			size, err := updater.fetchContentLength("https://example.invalid/asset")
+			if tt.wantErrSub != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrSub)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantSize, size)
+		})
+	}
 }
 
 func TestUpdaterPerformUpdateInstallsBinary(t *testing.T) {
@@ -444,73 +561,6 @@ func TestUpdaterPerformUpdateInstallsBinary(t *testing.T) {
 	assert.NotEmpty(t, reporter.progress)
 }
 
-func TestFindAssets(t *testing.T) {
-	standardAssets := []Asset{
-		{Name: "roborev_linux_amd64.tar.gz", Size: 1000, BrowserDownloadURL: "https://example.com/linux_amd64"},
-		{Name: "roborev_darwin_arm64.tar.gz", Size: 2000, BrowserDownloadURL: "https://example.com/darwin_arm64"},
-		{Name: "SHA256SUMS", Size: 500, BrowserDownloadURL: "https://example.com/checksums"},
-		{Name: "roborev_darwin_amd64.tar.gz", Size: 3000, BrowserDownloadURL: "https://example.com/darwin_amd64"},
-		{Name: "roborev_windows_amd64.zip", Size: 4000, BrowserDownloadURL: "https://example.com/windows"},
-	}
-
-	noChecksumsAssets := []Asset{
-		{Name: "roborev_linux_amd64.tar.gz", Size: 1000, BrowserDownloadURL: "https://example.com/linux"},
-		{Name: "roborev_darwin_arm64.tar.gz", Size: 2000, BrowserDownloadURL: "https://example.com/darwin"},
-	}
-
-	tests := []struct {
-		name          string
-		assets        []Asset
-		assetName     string
-		wantAsset     *Asset
-		wantChecksums *Asset
-	}{
-		{
-			name:          "find darwin_arm64 (second in list)",
-			assets:        standardAssets,
-			assetName:     "roborev_darwin_arm64.tar.gz",
-			wantAsset:     &Asset{BrowserDownloadURL: "https://example.com/darwin_arm64", Size: 2000},
-			wantChecksums: &Asset{BrowserDownloadURL: "https://example.com/checksums", Size: 500},
-		},
-		{
-			name:          "find linux_amd64 (first in list)",
-			assets:        standardAssets,
-			assetName:     "roborev_linux_amd64.tar.gz",
-			wantAsset:     &Asset{BrowserDownloadURL: "https://example.com/linux_amd64", Size: 1000},
-			wantChecksums: &Asset{BrowserDownloadURL: "https://example.com/checksums", Size: 500},
-		},
-		{
-			name:          "find darwin_amd64 (after checksums)",
-			assets:        standardAssets,
-			assetName:     "roborev_darwin_amd64.tar.gz",
-			wantAsset:     &Asset{BrowserDownloadURL: "https://example.com/darwin_amd64", Size: 3000},
-			wantChecksums: &Asset{BrowserDownloadURL: "https://example.com/checksums", Size: 500},
-		},
-		{
-			name:          "asset not found",
-			assets:        standardAssets,
-			assetName:     "roborev_freebsd_amd64.tar.gz",
-			wantAsset:     nil,
-			wantChecksums: &Asset{BrowserDownloadURL: "https://example.com/checksums", Size: 500},
-		},
-		{
-			name:          "no checksums file",
-			assets:        noChecksumsAssets,
-			assetName:     "roborev_darwin_arm64.tar.gz",
-			wantAsset:     &Asset{BrowserDownloadURL: "https://example.com/darwin", Size: 2000},
-			wantChecksums: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			asset, checksums := findAssets(tt.assets, tt.assetName)
-			checkAsset(t, asset, tt.wantAsset)
-			checkAsset(t, checksums, tt.wantChecksums)
-		})
-	}
-}
-
 func createTestArchive(t *testing.T, path string, entries []archiveEntry) {
 	t.Helper()
 	require.NoError(t, os.WriteFile(path, createTestArchiveBytes(t, entries), 0644))
@@ -549,18 +599,6 @@ func createTestArchiveBytes(t *testing.T, entries []archiveEntry) []byte {
 	require.NoError(t, tw.Close())
 	require.NoError(t, gzw.Close())
 	return buf.Bytes()
-}
-
-func checkAsset(t *testing.T, got *Asset, want *Asset) {
-	t.Helper()
-	if want == nil {
-		require.Nil(t, got)
-		return
-	}
-
-	require.NotNil(t, got)
-	assert.Equal(t, want.BrowserDownloadURL, got.BrowserDownloadURL)
-	assert.Equal(t, want.Size, got.Size)
 }
 
 func skipUnlessTargetOS(t *testing.T, target string) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -55,13 +55,47 @@ function Invoke-WebRequestCompat {
 }
 
 function Get-LatestVersion {
-    $url = "https://api.github.com/repos/$repo/releases/latest"
-    try {
-        $response = Invoke-WebRequestCompat -Uri $url
-        return $response.tag_name
-    } catch {
-        throw "Failed to fetch latest version: $_"
+    # Use the HTML /releases/latest endpoint, which 302-redirects to
+    # /releases/tag/<version>. Unlike api.github.com it is not rate-limited
+    # at 60 req/hr per IP, so users behind shared NAT / VPN don't get 403.
+    $url = "https://github.com/$repo/releases/latest"
+
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     }
+
+    $params = @{
+        Uri = $url
+        MaximumRedirection = 0
+        ErrorAction = 'Stop'
+    }
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        $params.UseBasicParsing = $true
+    }
+
+    $location = $null
+    try {
+        # PowerShell 7+ returns the 302 as a normal response.
+        $response = Invoke-WebRequest @params
+        $location = $response.Headers.Location
+    } catch {
+        # PowerShell 5.x throws System.Net.WebException for 3xx when
+        # MaximumRedirection=0. The Location header lives on the response.
+        if ($_.Exception.Response) {
+            $location = $_.Exception.Response.Headers['Location']
+        } else {
+            throw "Failed to fetch latest version: $_"
+        }
+    }
+
+    if ($location -is [array]) { $location = $location[0] }
+    if (-not $location) {
+        throw "Failed to fetch latest version: no Location header from $url"
+    }
+    if ($location -notmatch '/releases/tag/([^/]+)/?$') {
+        throw "Failed to fetch latest version: unexpected redirect target $location"
+    }
+    return $Matches[1]
 }
 
 function Get-InstallDir {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -65,12 +65,25 @@ download() {
 
 # Get latest release version
 get_latest_version() {
-    local url="https://api.github.com/repos/${REPO}/releases/latest"
+    # Use the HTML /releases/latest endpoint, which 302-redirects to
+    # /releases/tag/<version>. Unlike api.github.com it is not rate-limited
+    # at 60 req/hr per IP, so users behind shared NAT / VPN don't get 403.
+    local url="https://github.com/${REPO}/releases/latest"
+    local final_url=""
     if command -v curl &>/dev/null; then
-        curl -fsSL "$url" | grep '"tag_name"' | head -1 | cut -d'"' -f4
+        final_url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "$url") || return 1
     elif command -v wget &>/dev/null; then
-        wget -qO- "$url" | grep '"tag_name"' | head -1 | cut -d'"' -f4
+        final_url=$(wget --spider -S "$url" 2>&1 \
+            | awk 'tolower($1)=="location:" {print $2}' \
+            | tail -1 \
+            | tr -d '\r\n') || return 1
+    else
+        return 1
     fi
+    case "$final_url" in
+        */releases/tag/*) echo "${final_url##*/releases/tag/}" ;;
+        *) return 1 ;;
+    esac
 }
 
 # Install from GitHub releases


### PR DESCRIPTION
## Summary

- `scripts/install.sh` and the in-binary `roborev update` previously called `api.github.com/repos/.../releases/latest`, which is rate-limited to 60 req/hr per IP for unauthenticated callers. Users behind shared NAT, VPN, or CGNAT hit 403s.
- Both paths now use the HTML `https://github.com/roborev-dev/roborev/releases/latest` endpoint, which 302-redirects to `/releases/tag/<tag>` and isn't subject to the same rate limit.
- `scripts/install.sh` reads the redirect target via `curl -fsSLI -w '%{url_effective}'` (or `wget --server-response`).
- `scripts/install.ps1` uses `Invoke-WebRequest -MaximumRedirection 0` and parses the Location header, with separate handling for the PowerShell 5.x `WebException` path.
- `internal/update/update.go` gains `resolveLatestTag` (follows the redirect with `CheckRedirect: ErrUseLastResponse`) and `fetchContentLength` (HEAD request for asset size). Download and `SHA256SUMS` URLs are constructed from the tag.
- Drops the now-unused `Release`/`Asset` structs, `findAssets`, `resolveAsset`, `resolveChecksum`, `fetchLatestRelease`, `fetchJSON`, and the release-body checksum fallback; every release publishes `SHA256SUMS` as an asset.
- Ports msgvault [052f42ff](https://github.com/wesm/msgvault/commit/052f42ff196260815eb73bd38a4e64668726111b).