### PR TITLE
Fix classifier availability and add Pi schema support

### DIFF
--- a/internal/agent/acp_resolution.go
+++ b/internal/agent/acp_resolution.go
@@ -172,17 +172,20 @@ func GetAvailableWithConfig(repoPath string, preferred string, cfg *config.Confi
 		return resolved, nil
 	}
 
-	return applyCommandOverrides(resolved, cfg), nil
+	return applyAgentConfigOverrides(applyCommandOverrides(resolved, cfg), cfg), nil
 }
 
 func applyAvailableCommand(a Agent, cfg *config.Config) Agent {
 	if a == nil {
 		return nil
 	}
+	var resolved Agent
 	if commandOverrideForAgent(a.Name(), cfg) != "" {
-		return applyCommandOverrides(a, cfg)
+		resolved = applyCommandOverrides(a, cfg)
+	} else {
+		resolved = applyResolvedCommand(a)
 	}
-	return applyResolvedCommand(a)
+	return applyAgentConfigOverrides(resolved, cfg)
 }
 
 func applyACPAgentConfigOverride(cfg *config.ACPAgentConfig, override *config.ACPAgentConfig) {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/testenv"
 )
 
@@ -411,6 +412,7 @@ func TestSessionAgentsPreserveStateAcrossCloneMethods(t *testing.T) {
 				assert.Equal(t, "claude-sonnet-4", pi.Model)
 				assert.Equal(t, ReasoningThorough, pi.Reasoning)
 				assert.True(t, pi.Agentic)
+				assert.Equal(t, config.DefaultPiJSONSchemaExtension, pi.JSONSchemaExtension)
 			},
 		},
 	}

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -124,6 +124,95 @@ func (a *PiAgent) thinkingLevel() string {
 	}
 }
 
+const piJSONSchemaExtension = "npm:@nqbao/pi-json-schema"
+
+func (a *PiAgent) classifyArgs(promptPath, outputPath string, schema json.RawMessage) []string {
+	args := []string{
+		"--no-session",
+		"--no-extensions",
+		"--no-builtin-tools",
+		"--no-skills",
+		"--no-prompt-templates",
+		"--no-themes",
+		"--no-context-files",
+		"--extension", piJSONSchemaExtension,
+		"--json-schema", string(schema),
+		"--json-output", outputPath,
+		"--json-fallback", "none",
+		"-p",
+	}
+	if a.Provider != "" {
+		args = append(args, "--provider", a.Provider)
+	}
+	if a.Model != "" {
+		args = append(args, "--model", a.Model)
+	}
+	if level := a.thinkingLevel(); level != "" {
+		args = append(args, "--thinking", level)
+	}
+	return append(args,
+		"@"+promptPath,
+		"Classify according to the attached instructions and write the result with the structured JSON output tool.",
+	)
+}
+
+// ClassifyWithSchema runs a single constrained Pi invocation and returns the
+// JSON document written by the pi-json-schema extension. The invocation disables
+// builtin tools, extension discovery, skills, prompt templates, themes, context
+// file discovery, and session persistence; only the explicit schema-output
+// extension is loaded.
+func (a *PiAgent) ClassifyWithSchema(
+	ctx context.Context,
+	repoPath, gitRef, prompt string,
+	schema json.RawMessage,
+	out io.Writer,
+) (json.RawMessage, error) {
+	tmpDir, err := os.MkdirTemp("", "roborev-pi-classify-*")
+	if err != nil {
+		return nil, fmt.Errorf("create temp classify dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	promptPath := filepath.Join(tmpDir, "prompt.md")
+	if err := os.WriteFile(promptPath, []byte(prompt), 0o600); err != nil {
+		return nil, fmt.Errorf("write classify prompt: %w", err)
+	}
+	outputPath := filepath.Join(tmpDir, "result.json")
+
+	args := a.classifyArgs(promptPath, outputPath, schema)
+	cmd := exec.CommandContext(ctx, a.Command, args...)
+	cmd.Dir = repoPath
+	tracker := configureSubprocess(cmd)
+
+	var stdoutBuf bytes.Buffer
+	var stderrBuf bytes.Buffer
+	if out != nil {
+		sw := newSyncWriter(out)
+		cmd.Stdout = io.MultiWriter(&stdoutBuf, sw)
+		cmd.Stderr = io.MultiWriter(&stderrBuf, sw)
+	} else {
+		cmd.Stdout = &stdoutBuf
+		cmd.Stderr = &stderrBuf
+	}
+
+	if err := cmd.Run(); err != nil {
+		if ctxErr := contextProcessError(ctx, tracker, err, nil); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, fmt.Errorf("pi classifier failed: %w\nstderr: %s", err, strings.TrimSpace(stderrBuf.String()))
+	}
+
+	result, err := os.ReadFile(outputPath)
+	if err != nil {
+		return nil, fmt.Errorf("read pi classifier output: %w", err)
+	}
+	result = bytes.TrimSpace(result)
+	if !json.Valid(result) {
+		return nil, fmt.Errorf("pi classifier output is not valid JSON: %q", string(result))
+	}
+	return json.RawMessage(result), nil
+}
+
 func (a *PiAgent) Review(
 	ctx context.Context,
 	repoPath, commitSHA, prompt string,
@@ -277,3 +366,5 @@ func parsePiJSON(r io.Reader) (string, error) {
 func init() {
 	Register(NewPiAgent(""))
 }
+
+var _ SchemaAgent = (*PiAgent)(nil)

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -11,16 +11,19 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"go.kenn.io/roborev/internal/config"
 )
 
 // PiAgent runs code reviews using the pi CLI
 type PiAgent struct {
-	Command   string         // The pi command to run (default: "pi")
-	Model     string         // Model to use (provider/model format or just model)
-	Provider  string         // Explicit provider (optional)
-	Reasoning ReasoningLevel // Reasoning level
-	Agentic   bool           // Agentic mode
-	SessionID string         // Existing session ID to resume
+	Command             string         // The pi command to run (default: "pi")
+	Model               string         // Model to use (provider/model format or just model)
+	Provider            string         // Explicit provider (optional)
+	Reasoning           ReasoningLevel // Reasoning level
+	Agentic             bool           // Agentic mode
+	SessionID           string         // Existing session ID to resume
+	JSONSchemaExtension string         // Pi extension source for classifier schema output
 }
 
 // NewPiAgent creates a new pi agent
@@ -28,7 +31,11 @@ func NewPiAgent(command string) *PiAgent {
 	if command == "" {
 		command = "pi"
 	}
-	return &PiAgent{Command: command, Reasoning: ReasoningStandard}
+	return &PiAgent{
+		Command:             command,
+		Reasoning:           ReasoningStandard,
+		JSONSchemaExtension: config.DefaultPiJSONSchemaExtension,
+	}
 }
 
 func (a *PiAgent) clone(opts ...agentCloneOption) *PiAgent {
@@ -41,12 +48,13 @@ func (a *PiAgent) clone(opts ...agentCloneOption) *PiAgent {
 		opts...,
 	)
 	return &PiAgent{
-		Command:   cfg.Command,
-		Model:     cfg.Model,
-		Provider:  a.Provider,
-		Reasoning: cfg.Reasoning,
-		Agentic:   cfg.Agentic,
-		SessionID: cfg.SessionID,
+		Command:             cfg.Command,
+		Model:               cfg.Model,
+		Provider:            a.Provider,
+		Reasoning:           cfg.Reasoning,
+		Agentic:             cfg.Agentic,
+		SessionID:           cfg.SessionID,
+		JSONSchemaExtension: a.JSONSchemaExtension,
 	}
 }
 
@@ -124,8 +132,6 @@ func (a *PiAgent) thinkingLevel() string {
 	}
 }
 
-const piJSONSchemaExtension = "npm:@nqbao/pi-json-schema@0.1.1"
-
 func (a *PiAgent) classifyArgs(promptPath, outputPath string, schema json.RawMessage) []string {
 	args := []string{
 		"--no-session",
@@ -135,7 +141,7 @@ func (a *PiAgent) classifyArgs(promptPath, outputPath string, schema json.RawMes
 		"--no-prompt-templates",
 		"--no-themes",
 		"--no-context-files",
-		"--extension", piJSONSchemaExtension,
+		"--extension", a.jsonSchemaExtension(),
 		"--json-schema", string(schema),
 		"--json-output", outputPath,
 		"--json-fallback", "none",
@@ -154,6 +160,13 @@ func (a *PiAgent) classifyArgs(promptPath, outputPath string, schema json.RawMes
 		"@"+promptPath,
 		"Classify according to the attached instructions and write the result with the structured JSON output tool.",
 	)
+}
+
+func (a *PiAgent) jsonSchemaExtension() string {
+	if ext := strings.TrimSpace(a.JSONSchemaExtension); ext != "" {
+		return ext
+	}
+	return config.DefaultPiJSONSchemaExtension
 }
 
 // ClassifyWithSchema runs a single constrained Pi invocation and returns the

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -124,7 +124,7 @@ func (a *PiAgent) thinkingLevel() string {
 	}
 }
 
-const piJSONSchemaExtension = "npm:@nqbao/pi-json-schema"
+const piJSONSchemaExtension = "npm:@nqbao/pi-json-schema@0.1.1"
 
 func (a *PiAgent) classifyArgs(promptPath, outputPath string, schema json.RawMessage) []string {
 	args := []string{

--- a/internal/agent/pi_test.go
+++ b/internal/agent/pi_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -89,4 +90,156 @@ func TestPiCommandLineOmitsResolvedSessionPath(t *testing.T) {
 	assert.NotContains(t, cmdLine, "--session")
 	assert.NotContains(t, cmdLine, sessionPath)
 	assert.Contains(t, cmdLine, "-p --mode json")
+}
+
+func TestPiClassifyWithSchemaUsesLockedDownSchemaOutput(t *testing.T) {
+	skipIfWindows(t)
+
+	tmpDir := t.TempDir()
+	argsFile := filepath.Join(tmpDir, "args.txt")
+	promptFile := filepath.Join(tmpDir, "prompt.txt")
+	script := fmt.Sprintf(`#!/bin/sh
+case "$1" in *etxtbsy*) exit 0;; esac
+args_file=%q
+prompt_file=%q
+: > "$args_file"
+json_output=""
+prev=""
+for arg in "$@"; do
+  printf '%%s\n' "$arg" >> "$args_file"
+  case "$arg" in
+    @*) cat "${arg#@}" > "$prompt_file" ;;
+  esac
+  if [ "$prev" = "--json-output" ]; then
+    json_output="$arg"
+  fi
+  prev="$arg"
+done
+if [ -z "$json_output" ]; then
+  echo "missing --json-output" >&2
+  exit 2
+fi
+echo "pi progress"
+printf '%%s\n' '{"design_review":false,"reason":"pi schema"}' > "$json_output"
+`, argsFile, promptFile)
+
+	cli := writeTempCommand(t, script)
+	agent := NewPiAgent(cli)
+	agent.Provider = "anthropic"
+	agent.Model = "sonnet"
+	agent.Reasoning = ReasoningFast
+
+	schema := jsonRaw(`{"type":"object","additionalProperties":false,"required":["design_review","reason"],"properties":{"design_review":{"type":"boolean"},"reason":{"type":"string"}}}`)
+	var output bytes.Buffer
+	result, err := agent.ClassifyWithSchema(context.Background(), t.TempDir(), "HEAD", "classify me", schema, &output)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"design_review":false,"reason":"pi schema"}`, string(result))
+	assert.Contains(t, output.String(), "pi progress")
+
+	args := readLineFile(t, argsFile)
+	for _, want := range []string{
+		"--no-session",
+		"--no-extensions",
+		"--no-builtin-tools",
+		"--no-skills",
+		"--no-prompt-templates",
+		"--no-themes",
+		"--no-context-files",
+		"--extension",
+		piJSONSchemaExtension,
+		"--json-fallback",
+		"none",
+		"-p",
+		"--provider",
+		"anthropic",
+		"--model",
+		"sonnet",
+		"--thinking",
+		"low",
+	} {
+		assert.Contains(t, args, want)
+	}
+	assert.Equal(t, string(schema), argAfter(args, "--json-schema"))
+	assert.Contains(t, argAfter(args, "--json-output"), "result.json")
+	assert.Equal(t, "classify me", strings.TrimSpace(readTextFile(t, promptFile)))
+}
+
+func TestPiClassifyWithSchemaRejectsInvalidJSONOutput(t *testing.T) {
+	skipIfWindows(t)
+
+	script := `#!/bin/sh
+case "$1" in *etxtbsy*) exit 0;; esac
+json_output=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--json-output" ]; then
+    json_output="$arg"
+  fi
+  prev="$arg"
+done
+printf '%s\n' 'not json' > "$json_output"
+`
+
+	_, err := NewPiAgent(writeTempCommand(t, script)).ClassifyWithSchema(
+		context.Background(),
+		t.TempDir(),
+		"HEAD",
+		"classify me",
+		jsonRaw(`{"type":"object"}`),
+		nil,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not valid JSON")
+}
+
+func TestPiClassifyWithSchemaReportsCommandFailure(t *testing.T) {
+	skipIfWindows(t)
+
+	script := `#!/bin/sh
+case "$1" in *etxtbsy*) exit 0;; esac
+echo "boom" >&2
+exit 12
+`
+
+	_, err := NewPiAgent(writeTempCommand(t, script)).ClassifyWithSchema(
+		context.Background(),
+		t.TempDir(),
+		"HEAD",
+		"classify me",
+		jsonRaw(`{"type":"object"}`),
+		nil,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pi classifier failed")
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func jsonRaw(s string) []byte {
+	return []byte(s)
+}
+
+func readLineFile(t *testing.T, path string) []string {
+	t.Helper()
+	content := readTextFile(t, path)
+	trimmed := strings.TrimRight(content, "\n")
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "\n")
+}
+
+func readTextFile(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(content)
+}
+
+func argAfter(args []string, flag string) string {
+	for i, arg := range args {
+		if arg == flag && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
 }

--- a/internal/agent/pi_test.go
+++ b/internal/agent/pi_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/roborev/internal/config"
 )
 
 func TestParsePiJSON(t *testing.T) {
@@ -146,7 +147,7 @@ printf '%%s\n' '{"design_review":false,"reason":"pi schema"}' > "$json_output"
 		"--no-themes",
 		"--no-context-files",
 		"--extension",
-		piJSONSchemaExtension,
+		config.DefaultPiJSONSchemaExtension,
 		"--json-fallback",
 		"none",
 		"-p",

--- a/internal/agent/schema_agent.go
+++ b/internal/agent/schema_agent.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
 	"go.kenn.io/roborev/internal/config"
 )
@@ -30,6 +31,84 @@ type SchemaAgent interface {
 func IsSchemaAgent(a Agent) bool {
 	_, ok := a.(SchemaAgent)
 	return ok
+}
+
+// GetAvailableSchemaExactWithConfig resolves exactly the requested
+// schema-capable agent and checks availability using the same config-aware
+// command override rules as normal review execution.
+func GetAvailableSchemaExactWithConfig(name string, cfg *config.Config) (SchemaAgent, error) {
+	canonical := resolveAlias(name)
+	registryMu.RLock()
+	a, ok := registry[canonical]
+	registryMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("classifier %q not registered", name)
+	}
+	if !IsSchemaAgent(a) {
+		return nil, fmt.Errorf("classify_agent %q is not a SchemaAgent", name)
+	}
+	if !isAvailableWithConfig(canonical, cfg) {
+		return nil, fmt.Errorf("classifier %q not installed (CLI not on PATH)", name)
+	}
+	resolved := applyAvailableCommand(a, cfg)
+	sa, ok := resolved.(SchemaAgent)
+	if !ok {
+		return nil, fmt.Errorf("classify_agent %q lost SchemaAgent capability after command resolution", name)
+	}
+	return sa, nil
+}
+
+// GetAvailableSchemaWithConfig resolves an installed schema-capable agent,
+// trying the preferred agent first, then configured backups, then roborev's
+// normal fallback order. Non-schema agents are skipped during fallback.
+func GetAvailableSchemaWithConfig(preferred string, cfg *config.Config, backups ...string) (SchemaAgent, error) {
+	preferred = resolveAlias(preferred)
+	if preferred != "" {
+		if sa, err := GetAvailableSchemaExactWithConfig(preferred, cfg); err == nil {
+			return sa, nil
+		}
+	}
+
+	for _, backup := range backups {
+		backup = resolveAlias(backup)
+		if backup == "" || backup == preferred {
+			continue
+		}
+		if sa, err := GetAvailableSchemaExactWithConfig(backup, cfg); err == nil {
+			return sa, nil
+		}
+	}
+
+	for _, name := range fallbackAgentOrder {
+		if name == preferred {
+			continue
+		}
+		if sa, err := GetAvailableSchemaExactWithConfig(name, cfg); err == nil {
+			return sa, nil
+		}
+	}
+
+	names := availableSchemaAgentNames()
+	if len(names) == 0 {
+		names = []string{"claude-code"}
+	}
+	return nil, fmt.Errorf(
+		"no schema-capable classifier agents available (install one of: %s)",
+		strings.Join(names, ", "),
+	)
+}
+
+func availableSchemaAgentNames() []string {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	names := make([]string, 0, len(registry))
+	for _, name := range fallbackAgentOrder {
+		a, ok := registry[name]
+		if ok && IsSchemaAgent(a) {
+			names = append(names, name)
+		}
+	}
+	return names
 }
 
 // ValidateClassifyAgent errors when the named agent isn't registered or isn't

--- a/internal/agent/schema_agent_test.go
+++ b/internal/agent/schema_agent_test.go
@@ -118,6 +118,36 @@ func TestGetAvailableSchemaExactWithConfigUsesCommandOverride(t *testing.T) {
 	assert.Equal(t, wrapper, resolved.(*ClaudeAgent).CommandName())
 }
 
+func TestGetAvailableSchemaExactWithConfigAppliesPiJSONSchemaExtension(t *testing.T) {
+	fakeBin := t.TempDir()
+	wrapper := filepath.Join(fakeBin, "pi-wrapper")
+	if runtime.GOOS == "windows" {
+		wrapper += ".exe"
+	}
+	require.NoError(t, os.WriteFile(wrapper, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("PATH", t.TempDir())
+
+	originalRegistry := registry
+	registry = map[string]Agent{
+		"pi": NewPiAgent(""),
+	}
+	t.Cleanup(func() { registry = originalRegistry })
+
+	resolved, err := GetAvailableSchemaExactWithConfig("pi", &config.Config{
+		PiCmd: wrapper,
+		Agent: config.AgentConfig{
+			Pi: config.PiConfig{
+				JSONSchemaExtension: "/opt/roborev/pi-json-schema/index.ts",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.IsType(t, &PiAgent{}, resolved)
+	pi := resolved.(*PiAgent)
+	assert.Equal(t, wrapper, pi.CommandName())
+	assert.Equal(t, "/opt/roborev/pi-json-schema/index.ts", pi.JSONSchemaExtension)
+}
+
 func TestGetAvailableSchemaWithConfigFallsBackToAvailableSchemaAgent(t *testing.T) {
 	fakeBin := t.TempDir()
 	codexBin := filepath.Join(fakeBin, "codex")

--- a/internal/agent/schema_agent_test.go
+++ b/internal/agent/schema_agent_test.go
@@ -91,6 +91,10 @@ func TestValidateClassifyAgent_CodexRejected(t *testing.T) {
 	assert.Contains(t, strings.ToLower(err.Error()), "structured output")
 }
 
+func TestValidateClassifyAgent_PiAccepted(t *testing.T) {
+	require.NoError(t, ValidateClassifyAgent("pi"))
+}
+
 func TestGetAvailableSchemaExactWithConfigUsesCommandOverride(t *testing.T) {
 	fakeBin := t.TempDir()
 	wrapper := filepath.Join(fakeBin, "claude-wrapper")

--- a/internal/agent/schema_agent_test.go
+++ b/internal/agent/schema_agent_test.go
@@ -4,17 +4,46 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/roborev/internal/config"
 )
 
 type fakeSchemaAgent struct {
 	*TestAgent
-	result json.RawMessage
-	err    error
+	name    string
+	command string
+	result  json.RawMessage
+	err     error
+}
+
+func (f *fakeSchemaAgent) Name() string {
+	if f.name != "" {
+		return f.name
+	}
+	return f.TestAgent.Name()
+}
+
+func (f *fakeSchemaAgent) CommandName() string {
+	return f.command
+}
+
+func (f *fakeSchemaAgent) WithReasoning(level ReasoningLevel) Agent {
+	return f
+}
+
+func (f *fakeSchemaAgent) WithAgentic(agentic bool) Agent {
+	return f
+}
+
+func (f *fakeSchemaAgent) WithModel(model string) Agent {
+	return f
 }
 
 func (f *fakeSchemaAgent) ClassifyWithSchema(
@@ -60,4 +89,52 @@ func TestValidateClassifyAgent_CodexRejected(t *testing.T) {
 	err := ValidateClassifyAgent("codex")
 	require.Error(t, err)
 	assert.Contains(t, strings.ToLower(err.Error()), "structured output")
+}
+
+func TestGetAvailableSchemaExactWithConfigUsesCommandOverride(t *testing.T) {
+	fakeBin := t.TempDir()
+	wrapper := filepath.Join(fakeBin, "claude-wrapper")
+	if runtime.GOOS == "windows" {
+		wrapper += ".exe"
+	}
+	require.NoError(t, os.WriteFile(wrapper, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("PATH", t.TempDir())
+
+	originalRegistry := registry
+	registry = map[string]Agent{
+		"claude-code": NewClaudeAgent(""),
+	}
+	t.Cleanup(func() { registry = originalRegistry })
+
+	resolved, err := GetAvailableSchemaExactWithConfig("claude", &config.Config{
+		ClaudeCodeCmd: wrapper,
+	})
+	require.NoError(t, err)
+	require.IsType(t, &ClaudeAgent{}, resolved)
+	assert.Equal(t, wrapper, resolved.(*ClaudeAgent).CommandName())
+}
+
+func TestGetAvailableSchemaWithConfigFallsBackToAvailableSchemaAgent(t *testing.T) {
+	fakeBin := t.TempDir()
+	codexBin := filepath.Join(fakeBin, "codex")
+	if runtime.GOOS == "windows" {
+		codexBin += ".exe"
+	}
+	require.NoError(t, os.WriteFile(codexBin, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("PATH", fakeBin)
+
+	originalRegistry := registry
+	registry = map[string]Agent{
+		"claude-code": NewClaudeAgent("definitely-not-on-path"),
+		"codex": &fakeSchemaAgent{
+			TestAgent: NewTestAgent(),
+			name:      "codex",
+			command:   "codex",
+		},
+	}
+	t.Cleanup(func() { registry = originalRegistry })
+
+	resolved, err := GetAvailableSchemaWithConfig("claude-code", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "codex", resolved.Name())
 }

--- a/internal/agent/spec.go
+++ b/internal/agent/spec.go
@@ -230,6 +230,22 @@ func applyCommandOverrides(a Agent, cfg *config.Config) Agent {
 	return spec.CloneWithCommand(a, override)
 }
 
+func applyAgentConfigOverrides(a Agent, cfg *config.Config) Agent {
+	if cfg == nil || a == nil {
+		return a
+	}
+	if pi, ok := a.(*PiAgent); ok {
+		ext := strings.TrimSpace(cfg.Agent.Pi.JSONSchemaExtension)
+		if ext == "" || ext == pi.JSONSchemaExtension {
+			return a
+		}
+		clone := *pi
+		clone.JSONSchemaExtension = ext
+		return &clone
+	}
+	return a
+}
+
 func installHintAgentNames() []string {
 	return slices.Clone(fallbackAgentOrder)
 }

--- a/internal/agent/spec_test.go
+++ b/internal/agent/spec_test.go
@@ -76,3 +76,21 @@ func TestAgentSpecsCommandOverrides(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyAgentConfigOverridesPiJSONSchemaExtension(t *testing.T) {
+	t.Parallel()
+
+	agent := NewPiAgent("pi")
+	overridden := applyAgentConfigOverrides(agent, &config.Config{
+		Agent: config.AgentConfig{
+			Pi: config.PiConfig{
+				JSONSchemaExtension: "/opt/roborev/pi-json-schema/index.ts",
+			},
+		},
+	})
+
+	pi, ok := overridden.(*PiAgent)
+	require.True(t, ok)
+	assert.Equal(t, "/opt/roborev/pi-json-schema/index.ts", pi.JSONSchemaExtension)
+	assert.Equal(t, config.DefaultPiJSONSchemaExtension, agent.JSONSchemaExtension)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,8 +59,13 @@ type CodexConfig struct {
 	IgnoreReviewUserConfig bool `toml:"ignore_review_user_config" comment:"Pass --ignore-user-config to Codex for review jobs."`
 }
 
+type PiConfig struct {
+	JSONSchemaExtension string `toml:"jsonschemaextension" comment:"Pi extension source for classifier JSON schema output."`
+}
+
 type AgentConfig struct {
 	Codex CodexConfig `toml:"codex"`
+	Pi    PiConfig    `toml:"pi"`
 }
 
 // Config holds the daemon configuration
@@ -1097,6 +1102,8 @@ type RepoConfig struct {
 	ACP *ACPAgentConfig `toml:"acp"`
 }
 
+const DefaultPiJSONSchemaExtension = "npm:@nqbao/pi-json-schema@0.1.1"
+
 // DefaultConfig returns the default configuration
 func DefaultConfig() *Config {
 	cfg := &Config{
@@ -1115,6 +1122,9 @@ func DefaultConfig() *Config {
 			Codex: CodexConfig{
 				DisableReviewSkills:    true,
 				IgnoreReviewUserConfig: true,
+			},
+			Pi: PiConfig{
+				JSONSchemaExtension: DefaultPiJSONSchemaExtension,
 			},
 		},
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -35,6 +35,7 @@ func TestDefaultConfig(t *testing.T) {
 	}, "Expected MouseEnabled to default to true")
 	assert.True(t, cfg.Agent.Codex.DisableReviewSkills, "expected Codex review skills to be disabled by default")
 	assert.True(t, cfg.Agent.Codex.IgnoreReviewUserConfig, "expected Codex review user config to be ignored by default")
+	assert.Equal(t, "npm:@nqbao/pi-json-schema@0.1.1", cfg.Agent.Pi.JSONSchemaExtension)
 
 }
 
@@ -132,6 +133,20 @@ func TestSaveAndLoadGlobal(t *testing.T) {
 		return loaded.MaxWorkers == 8
 	}, "Expected MaxWorkers 8, got %d", loaded.MaxWorkers)
 
+}
+
+func TestLoadGlobalPiJSONSchemaExtension(t *testing.T) {
+	testenv.SetDataDir(t)
+
+	path := filepath.Join(DataDir(), "config.toml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(`[agent.pi]
+jsonschemaextension = "/opt/roborev/pi-json-schema/index.ts"
+`), 0o600))
+
+	cfg, err := LoadGlobalFrom(path)
+	require.NoError(t, err)
+	assert.Equal(t, "/opt/roborev/pi-json-schema/index.ts", cfg.Agent.Pi.JSONSchemaExtension)
 }
 
 func TestSaveAndLoadGlobalAutoFilterBranch(t *testing.T) {

--- a/internal/daemon/worker_classify.go
+++ b/internal/daemon/worker_classify.go
@@ -60,6 +60,7 @@ func isClassifierConfigError(err error) bool {
 	msg := err.Error()
 	return strings.Contains(msg, "not registered") ||
 		strings.Contains(msg, "not installed") ||
+		strings.Contains(msg, "no schema-capable classifier agents available") ||
 		strings.Contains(msg, "not a SchemaAgent") ||
 		strings.Contains(msg, "lost SchemaAgent capability")
 }
@@ -111,50 +112,61 @@ func (wp *WorkerPool) processClassifyJob(ctx context.Context, workerID string, j
 		wp.completeClassifyAsSkip(workerID, job, "classifier unavailable", err.Error())
 		return
 	}
+	defaultedPrimary := classifyAgentDefaulted(job.RepoPath, cfg)
 	backup, backupErr := config.ResolveBackupClassifyAgent(job.RepoPath, cfg)
 	if backupErr != nil {
 		log.Printf("[%s] classifier backup agent invalid (%v); ignoring", workerID, backupErr)
 		backup = ""
 	}
 
-	tryAgent := func(name, model string) (bool, string, error) {
-		// Use Get (NOT GetAvailable). GetAvailable falls back to a
-		// hardcoded chain of installed agents when the requested name is
-		// missing — for the classifier, that would silently route
-		// untrusted commit text through a different model than the user
-		// configured. Classify must fail closed when the configured
-		// agent isn't usable; the explicit classify_backup_agent is the
-		// only acceptable fallback.
-		ag, err := agent.Get(name)
+	tryAgent := func(name, model string) (bool, string, string, error) {
+		// Explicit classify_agent values fail closed: do not silently
+		// route classifier input through an unrelated agent. The built-in
+		// default is different; it should behave like normal roborev
+		// agent selection and only run an installed schema-capable agent.
+		var ag agent.SchemaAgent
+		var err error
+		if defaultedPrimary && agent.CanonicalName(name) == agent.CanonicalName(primary) {
+			ag, err = agent.GetAvailableSchemaWithConfig(primary, cfg, backup)
+		} else {
+			ag, err = agent.GetAvailableSchemaExactWithConfig(name, cfg)
+		}
 		if err != nil {
-			return false, "", fmt.Errorf("classifier %q not registered: %w", name, err)
+			return false, "", "", err
 		}
-		if !agent.IsAvailable(name) {
-			return false, "", fmt.Errorf("classifier %q not installed (CLI not on PATH)", name)
-		}
-		sa, ok := ag.(agent.SchemaAgent)
-		if !ok {
-			return false, "", fmt.Errorf("classify_agent %q is not a SchemaAgent", name)
+		selectedName := ag.Name()
+		if defaultedPrimary && agent.CanonicalName(name) == agent.CanonicalName(primary) {
+			resolvedName := agent.CanonicalName(selectedName)
+			switch {
+			case backup != "" && resolvedName == agent.CanonicalName(backup):
+				model = config.ResolveBackupClassifyModel(job.RepoPath, cfg)
+			case resolvedName != agent.CanonicalName(primary):
+				model = ""
+			}
 		}
 		level := agent.ParseReasoningLevel(config.ResolveClassifyReasoning("", job.RepoPath, cfg))
-		ag = sa.WithReasoning(level)
+		configured := ag.WithReasoning(level)
 		if model != "" {
-			ag = ag.WithModel(model)
+			configured = configured.WithModel(model)
 		}
-		sa, ok = ag.(agent.SchemaAgent)
+		sa, ok := configured.(agent.SchemaAgent)
 		if !ok {
-			return false, "", fmt.Errorf("classify_agent %q lost SchemaAgent capability after WithReasoning/WithModel", name)
+			return false, "", selectedName, fmt.Errorf("classify_agent %q lost SchemaAgent capability after WithReasoning/WithModel", name)
 		}
-		return newClassifierAdapter(sa, maxBytes).Decide(classifyCtx, in)
+		yes, reason, err := newClassifierAdapter(sa, maxBytes).Decide(classifyCtx, in)
+		return yes, reason, selectedName, err
 	}
 
 	primaryModel := config.ResolveClassifyModel("", job.RepoPath, cfg)
-	yes, reason, err := tryAgent(primary, primaryModel)
-	if err != nil && backup != "" && backup != primary {
+	yes, reason, selected, err := tryAgent(primary, primaryModel)
+	if err != nil &&
+		backup != "" &&
+		agent.CanonicalName(backup) != agent.CanonicalName(primary) &&
+		agent.CanonicalName(selected) != agent.CanonicalName(backup) {
 		backupModel := config.ResolveBackupClassifyModel(job.RepoPath, cfg)
 		log.Printf("[%s] classifier primary %q (model=%q) failed (%v); trying backup %q (model=%q)",
 			workerID, primary, primaryModel, err, backup, backupModel)
-		yes, reason, err = tryAgent(backup, backupModel)
+		yes, reason, _, err = tryAgent(backup, backupModel)
 	}
 	if err != nil {
 		log.Printf("[%s] classifier error for job %d: %v", workerID, job.ID, err)
@@ -164,6 +176,13 @@ func (wp *WorkerPool) processClassifyJob(ctx context.Context, workerID string, j
 		return
 	}
 	wp.applyClassifyVerdict(workerID, job, yes, reason)
+}
+
+func classifyAgentDefaulted(repoPath string, globalCfg *config.Config) bool {
+	if repoCfg, err := config.LoadRepoConfig(repoPath); err == nil && repoCfg != nil && repoCfg.ClassifyAgent != "" {
+		return false
+	}
+	return globalCfg == nil || globalCfg.ClassifyAgent == ""
 }
 
 // applyClassifyVerdict converts the classify row in place — a separate

--- a/internal/daemon/worker_classify_test.go
+++ b/internal/daemon/worker_classify_test.go
@@ -3,11 +3,14 @@ package daemon
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testutil"
 )
@@ -23,6 +26,7 @@ func TestPublicClassifierSkipReason(t *testing.T) {
 		{"wrapped timeout", errors.New("x: " + context.DeadlineExceeded.Error()), "classifier failed"},
 		{"not registered", errors.New(`classifier "fake" not registered: no such agent`), "classifier unavailable"},
 		{"not installed", errors.New(`classifier "claude-code" not installed (CLI not on PATH)`), "classifier unavailable"},
+		{"no schema agents available", errors.New(`no schema-capable classifier agents available (install one of: claude-code)`), "classifier unavailable"},
 		{"not a schema agent", errors.New(`classify_agent "gemini" is not a SchemaAgent`), "classifier unavailable"},
 		{"schema lost", errors.New(`classify_agent "claude-code" lost SchemaAgent capability after WithReasoning/WithModel`), "classifier unavailable"},
 		{"exec stderr leak", errors.New(`/nix/store/abc/bin/claude: not found: /home/user/creds`), "classifier failed"},
@@ -66,6 +70,26 @@ func TestComposeClassifyErrorDetail(t *testing.T) {
 		assert.Empty(t, composeClassifyErrorDetail(nil, nil))
 		assert.Empty(t, composeClassifyErrorDetail(nil, backupCfg),
 			"no primary error means no failure to report")
+	})
+}
+
+func TestClassifyAgentDefaulted(t *testing.T) {
+	t.Run("default when unset", func(t *testing.T) {
+		assert.True(t, classifyAgentDefaulted(t.TempDir(), &config.Config{}))
+	})
+
+	t.Run("global classify agent is explicit", func(t *testing.T) {
+		assert.False(t, classifyAgentDefaulted(t.TempDir(), &config.Config{
+			ClassifyAgent: "claude-code",
+		}))
+	})
+
+	t.Run("repo classify agent is explicit", func(t *testing.T) {
+		repoPath := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(repoPath, ".roborev.toml"),
+			[]byte("classify_agent = \"claude-code\"\n"), 0o644))
+
+		assert.False(t, classifyAgentDefaulted(repoPath, &config.Config{}))
 	})
 }
 


### PR DESCRIPTION
## Summary
- add config-aware availability resolution for schema-capable classifier agents
- preserve fail-closed behavior for explicit classify_agent settings
- let the built-in claude-code classifier default fall back to installed schema-capable agents and honor command overrides
- support `classify_agent = "pi"` via pinned `@nqbao/pi-json-schema@0.1.1` with builtin tools, skills, prompt templates, themes, context-file discovery, extension discovery, and sessions disabled
- allow overriding the Pi schema extension source with `[agent.pi] jsonschemaextension = "..."` for vendored or mirrored extension paths

## Validation
- pi --no-session --no-extensions --no-builtin-tools --no-skills --no-prompt-templates --no-themes --no-context-files --extension npm:@nqbao/pi-json-schema@0.1.1 ...
- go test ./internal/config
- go test ./internal/agent
- go test ./cmd/roborev -run Config
- go test ./internal/daemon -run 'Classify|Classifier'
- go fmt ./...
- go test ./...
- go vet ./...
