### PR TITLE
feat(tui): toggle full command line in log and prompt views

### DIFF
--- a/cmd/roborev/tui/command_header_test.go
+++ b/cmd/roborev/tui/command_header_test.go
@@ -1,0 +1,152 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"go.kenn.io/roborev/internal/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+// cmdHeaderLine returns the rendered "Command:" header line from a full view,
+// or "" if none is present. Used to assert on the command header in isolation
+// from the rest of the rendered screen.
+func cmdHeaderLine(view string) string {
+	for ln := range strings.SplitSeq(view, "\n") {
+		if strings.Contains(ln, "Command:") {
+			return ln
+		}
+	}
+	return ""
+}
+
+func TestCommandHeaderLinesCollapsedTruncates(t *testing.T) {
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.width = 12 // narrower than "Command: test" (13)
+	m.cmdExpanded = false
+
+	job := makeJob(1, withAgent("test"))
+	lines := m.commandHeaderLines(&job)
+
+	assert.Len(t, lines, 1)
+	assert.Contains(t, lines[0], "…")
+}
+
+func TestCommandHeaderLinesExpandedWraps(t *testing.T) {
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.width = 12
+	m.cmdExpanded = true
+
+	job := makeJob(1, withAgent("test"))
+	lines := m.commandHeaderLines(&job)
+
+	assert.Greater(t, len(lines), 1, "expanded command should wrap to multiple lines")
+	joined := strings.Join(lines, " ")
+	assert.Contains(t, joined, "Command:")
+	assert.Contains(t, joined, "test")
+	for _, ln := range lines {
+		assert.NotContains(t, ln, "…", "wrapped lines must not be truncated")
+	}
+}
+
+func TestCommandHeaderLinesEmptyForNoCommand(t *testing.T) {
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.width = 80
+
+	job := makeJob(1, withAgent("")) // no agent -> no command line
+	assert.Empty(t, m.commandHeaderLines(&job))
+}
+
+func TestCommandHeaderLinesFitsWithoutTruncation(t *testing.T) {
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.width = 80
+	m.cmdExpanded = false
+
+	job := makeJob(1, withAgent("test"))
+	lines := m.commandHeaderLines(&job)
+
+	assert.Len(t, lines, 1)
+	assert.NotContains(t, lines[0], "…")
+	assert.Contains(t, lines[0], "Command: test")
+}
+
+func TestLogVisibleLinesShrinksWhenCommandExpanded(t *testing.T) {
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.height = 30
+	m.width = 12 // forces the command to wrap when expanded
+	m.logJobID = 1
+	m.jobs = []storage.ReviewJob{makeJob(1, withAgent("test"))}
+
+	collapsed := m.logVisibleLines()
+	m.cmdExpanded = true
+	expanded := m.logVisibleLines()
+
+	assert.Greater(t, collapsed, expanded,
+		"expanding a wrapped command must reserve more header lines")
+}
+
+func TestLogViewTogglesCommandExpand(t *testing.T) {
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.currentView = viewLog
+	m.logJobID = 1
+	m.logFromView = viewQueue
+	m.height = 30
+	m.width = 80
+	m.jobs = []storage.ReviewJob{makeJob(1, withAgent("test"))}
+
+	assert.False(t, m.cmdExpanded)
+
+	m2, _ := pressKey(m, 'i')
+	assert.True(t, m2.cmdExpanded, "i should expand the command in the log view")
+
+	m3, _ := pressKey(m2, 'i')
+	assert.False(t, m3.cmdExpanded, "i should collapse the command again")
+}
+
+func TestPromptViewTogglesCommandExpand(t *testing.T) {
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.currentView = viewKindPrompt
+	m.height = 30
+	m.width = 80
+	job := makeJob(1, withAgent("test"))
+	m.currentReview = &storage.Review{
+		ID:     1,
+		JobID:  1,
+		Agent:  "test",
+		Prompt: "hello",
+		Job:    &job,
+	}
+
+	m2, _ := pressKey(m, 'i')
+	assert.True(t, m2.cmdExpanded, "i should expand the command in the prompt view")
+}
+
+func TestQueueViewIgnoresCommandExpandKey(t *testing.T) {
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.currentView = viewQueue
+	m.height = 30
+	m.width = 80
+	m.jobs = []storage.ReviewJob{makeJob(1, withAgent("test"))}
+	m.selectedIdx = 0
+
+	m2, _ := pressKey(m, 'i')
+	assert.False(t, m2.cmdExpanded, "i should not toggle command expand outside log/prompt views")
+}
+
+func TestLogViewRendersFullCommandWhenExpanded(t *testing.T) {
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.currentView = viewLog
+	m.logJobID = 1
+	m.logFromView = viewQueue
+	m.height = 30
+	m.width = 12 // forces truncation when collapsed
+	m.jobs = []storage.ReviewJob{makeJob(1, withAgent("test"))}
+	m.logLines = []logLine{{text: "out"}}
+
+	collapsed := cmdHeaderLine(m.View())
+	assert.Contains(t, collapsed, "…", "collapsed command header should be truncated")
+
+	m.cmdExpanded = true
+	expanded := cmdHeaderLine(m.View())
+	assert.NotContains(t, expanded, "…", "expanded command header line should not be truncated")
+}

--- a/cmd/roborev/tui/handlers.go
+++ b/cmd/roborev/tui/handlers.go
@@ -115,6 +115,12 @@ func (m model) handleGlobalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handlePageDownKey()
 	case "p":
 		return m.handlePromptKey()
+	case "i":
+		if m.currentView == viewKindPrompt {
+			m.cmdExpanded = !m.cmdExpanded
+			return m, tea.ClearScreen
+		}
+		return m, nil
 	case "a":
 		return m.handleCloseKey()
 	case "x":

--- a/cmd/roborev/tui/handlers_modal.go
+++ b/cmd/roborev/tui/handlers_modal.go
@@ -323,6 +323,9 @@ func (m model) handleLogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handlePrevKey()
 	case "right":
 		return m.handleNextKey()
+	case "i":
+		m.cmdExpanded = !m.cmdExpanded
+		return m, tea.ClearScreen
 	case "?":
 		m.helpFromView = m.currentView
 		m.currentView = viewHelp

--- a/cmd/roborev/tui/nav.go
+++ b/cmd/roborev/tui/nav.go
@@ -150,12 +150,11 @@ func (m *model) logVisibleLines() int {
 	// title + separator + status + help(N)
 	helpRows := m.logHelpRows()
 	reserved := 3 + len(reflowHelpRows(helpRows, m.width))
-	if job := m.logViewLookupJob(); job != nil {
-		if commandLineForJob(job) != "" {
-			reserved++
-		}
-		reserved += len(classifyReasoningLines(job, m.width))
-	}
+	job := m.logViewLookupJob()
+	// Command header may span multiple lines when expanded; classify rows
+	// add their own reasoning header lines.
+	reserved += len(m.commandHeaderLines(job))
+	reserved += len(classifyReasoningLines(job, m.width))
 	return max(m.height-reserved, 1)
 }
 
@@ -163,6 +162,7 @@ func (m *model) logVisibleLines() int {
 func (m *model) logHelpRows() [][]helpItem {
 	helpRow := []helpItem{
 		{"↑/↓", "scroll"}, {"←/→", "prev/next"}, {"g", "toggle top/bottom"},
+		{"i", "expand cmd"},
 	}
 	if m.logStreaming {
 		helpRow = append(helpRow, helpItem{"x", "cancel"})

--- a/cmd/roborev/tui/render_log.go
+++ b/cmd/roborev/tui/render_log.go
@@ -8,6 +8,35 @@ import (
 	"go.kenn.io/roborev/internal/storage"
 )
 
+// commandHeaderLines renders the "Command: <cmd>" header for a job, honoring
+// the cmdExpanded toggle. Collapsed (default) returns a single line truncated
+// to the terminal width; expanded wraps the full command across as many lines
+// as needed. Returns nil when the job has no representative command line.
+// The length of the result is the header height, so the renderers and the
+// *VisibleLines helpers stay in agreement on layout.
+func (m model) commandHeaderLines(job *storage.ReviewJob) []string {
+	cmdLine := commandLineForJob(job)
+	if cmdLine == "" {
+		return nil
+	}
+	cmdText := "Command: " + cmdLine
+	if m.width <= 0 {
+		return []string{statusStyle.Render(cmdText)}
+	}
+	if m.cmdExpanded {
+		wrapped := wrapLine(cmdText, m.width)
+		lines := make([]string, len(wrapped))
+		for i, ln := range wrapped {
+			lines[i] = statusStyle.Render(ln)
+		}
+		return lines
+	}
+	if runewidth.StringWidth(cmdText) > m.width {
+		cmdText = runewidth.Truncate(cmdText, m.width, "…")
+	}
+	return []string{statusStyle.Render(cmdText)}
+}
+
 func (m model) renderLogView() string {
 	var b strings.Builder
 
@@ -31,14 +60,11 @@ func (m model) renderLogView() string {
 	b.WriteString(titleStyle.Render(title))
 	b.WriteString("\x1b[K\n")
 
-	// Show command line below title (dimmed, like Prompt view)
+	// Show command line below title (dimmed, like Prompt view). Collapsed by
+	// default; press i to expand the full command (wrapped) via cmdExpanded.
 	headerLines := 1
-	if cmdLine := commandLineForJob(job); cmdLine != "" {
-		cmdText := "Command: " + cmdLine
-		if m.width > 0 && runewidth.StringWidth(cmdText) > m.width {
-			cmdText = runewidth.Truncate(cmdText, m.width, "…")
-		}
-		b.WriteString(statusStyle.Render(cmdText))
+	for _, line := range m.commandHeaderLines(job) {
+		b.WriteString(line)
 		b.WriteString("\x1b[K\n")
 		headerLines++
 	}
@@ -59,7 +85,7 @@ func (m model) renderLogView() string {
 	// Calculate visible area (must match logVisibleLines())
 	logHelp := m.logHelpRows()
 	logHelpLines := len(reflowHelpRows(logHelp, m.width))
-	reservedLines := (2 + logHelpLines) + headerLines // title + cmd(0-1) + sep + status + help(N)
+	reservedLines := (2 + logHelpLines) + headerLines // title + cmd(N, in headerLines) + sep + status + help(N)
 	visibleLines := max(m.height-reservedLines, 1)
 
 	// Clamp scroll
@@ -299,6 +325,7 @@ func helpLines(tasksEnabled, noQuit bool) []string {
 				{"↑/↓", "Scroll content"},
 				{"←/→", "Previous / next prompt"},
 				{"PgUp/PgDn", "Page through content"},
+				{"i", "Expand/collapse command line"},
 				{"p", "Switch to review / back to queue"},
 				{"esc/q", "Back to queue"},
 			},
@@ -310,6 +337,7 @@ func helpLines(tasksEnabled, noQuit bool) []string {
 				{"←/→", "Previous / next log"},
 				{"PgUp/PgDn", "Page through output"},
 				{"g", "Toggle follow mode / jump to top"},
+				{"i", "Expand/collapse command line"},
 				{"x", "Cancel job"},
 				{"esc/q", "Back to queue"},
 			},

--- a/cmd/roborev/tui/render_review.go
+++ b/cmd/roborev/tui/render_review.go
@@ -277,14 +277,11 @@ func (m model) renderPromptView() string {
 	}
 	b.WriteString("\x1b[K\n") // Clear to end of line
 
-	// Show command line (computed from job params, dimmed, below title, truncated to fit)
+	// Show command line (computed from job params, dimmed, below title).
+	// Collapsed by default; press i to expand the full command via cmdExpanded.
 	headerLines := 1
-	if cmdLine := commandLineForJob(review.Job); cmdLine != "" {
-		cmdText := "Command: " + cmdLine
-		if m.width > 0 && runewidth.StringWidth(cmdText) > m.width {
-			cmdText = runewidth.Truncate(cmdText, m.width, "…")
-		}
-		b.WriteString(statusStyle.Render(cmdText))
+	for _, line := range m.commandHeaderLines(review.Job) {
+		b.WriteString(line)
 		b.WriteString("\x1b[K\n")
 		headerLines++
 	}
@@ -300,9 +297,9 @@ func (m model) renderPromptView() string {
 		lines = sanitizeLines(wrapText(review.Prompt, wrapWidth))
 	}
 
-	// Reserve: title + command(0-1) + scroll indicator(1) + help(N) + margin(1)
+	// Reserve: title + command(N, headerLines) + scroll indicator(1) + help(N) + margin(1)
 	promptHelpRows := [][]helpItem{
-		{{"↑/↓", "scroll"}, {"←/→", "prev/next"}, {"p", "toggle prompt/review"}, {"?", "commands"}, {"esc", "back"}},
+		{{"↑/↓", "scroll"}, {"←/→", "prev/next"}, {"i", "expand cmd"}, {"p", "toggle prompt/review"}, {"?", "commands"}, {"esc", "back"}},
 	}
 	promptHelpLines := len(reflowHelpRows(promptHelpRows, m.width))
 	visibleLines := max(m.height-(2+promptHelpLines)-headerLines, 1)

--- a/cmd/roborev/tui/tui.go
+++ b/cmd/roborev/tui/tui.go
@@ -395,6 +395,11 @@ type model struct {
 	logLoading        bool                 // True while a fetch is in-flight
 	logFetchSeq       uint64               // Monotonic seq to drop stale responses
 
+	// cmdExpanded toggles full (wrapped) display of the agent command-line
+	// header shown in the Log and Prompt views. Collapsed (default) shows a
+	// single line truncated to the terminal width.
+	cmdExpanded bool
+
 	// Glamour markdown render cache (pointer so View's value receiver can update it)
 	mdCache *markdownCache
 


### PR DESCRIPTION
## Summary

- The agent command line shown below the title in the Log and Prompt views was truncated to a single terminal row with `…`, so the full invocation could not be read.
- Add an `i` keybind that toggles `cmdExpanded`: collapsed (default) keeps the one-line truncated view; expanded wraps the full command across as many lines as needed.
- Introduce a shared `commandHeaderLines` helper that renders the `Command:` header for both views and reports its height, so `logVisibleLines` and the prompt scroll math stay correct when the header grows.
- Advertise the key as `i expand cmd` in both view help bars and `Expand/collapse command line` in the full help screen.