### PR TITLE
Fix hook binary resolution for managed installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ git commit -m "..."   # Reviews happen automatically
 roborev tui           # View reviews in interactive UI
 ```
 
+If roborev is managed by a version manager, `roborev init` tries to
+install hooks with the stable shim/symlink. You can also choose the exact
+binary path with `roborev init --binary ~/.local/share/mise/shims/roborev`.
+
 ![roborev review](https://raw.githubusercontent.com/roborev-dev/roborev-docs/main/public/tui-review.svg)
 
 ## Features

--- a/cmd/roborev/hook.go
+++ b/cmd/roborev/hook.go
@@ -12,6 +12,7 @@ import (
 
 func installHookCmd() *cobra.Command {
 	var force bool
+	var hookBinary string
 
 	cmd := &cobra.Command{
 		Use:   "install-hook",
@@ -34,11 +35,22 @@ func installHookCmd() *cobra.Command {
 				return fmt.Errorf("create hooks directory: %w", err)
 			}
 
-			return githook.InstallAll(hooksDir, force)
+			binaryResolution, err := githook.ResolveRoborevPath(hookBinary)
+			if err != nil {
+				return fmt.Errorf("resolve hook binary: %w", err)
+			}
+			if binaryResolution.Notice != "" {
+				fmt.Println(binaryResolution.Notice)
+			}
+			return githook.InstallAllWithOptions(hooksDir, githook.InstallOptions{
+				Force:      force,
+				BinaryPath: binaryResolution.Path,
+			})
 		},
 	}
 
 	cmd.Flags().BoolVar(&force, "force", false, "overwrite existing hook")
+	cmd.Flags().StringVar(&hookBinary, "binary", "", "roborev binary path to bake into git hooks (for version-manager shims)")
 
 	return cmd
 }

--- a/cmd/roborev/hook_test.go
+++ b/cmd/roborev/hook_test.go
@@ -478,6 +478,29 @@ func TestInitNoDaemonEnsuresDefaultSnapshotDirGitignored(t *testing.T) {
 	require.NoError(t, check.Run())
 }
 
+func TestInitNoDaemonWithBinaryInstallsHooksUsingSpecifiedBinary(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on Windows due to shell script stubs")
+	}
+
+	repo := initNoDaemonSetup(t)
+	binPath := filepath.Join(t.TempDir(), "roborev")
+	require.NoError(t, os.WriteFile(binPath, []byte("#!/bin/sh\nexit 0\n"), 0755))
+	setupMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	})
+
+	cmd := initCmd()
+	cmd.SetArgs([]string{"--no-daemon", "--binary", binPath})
+	require.NoError(t, cmd.Execute())
+
+	for _, hookName := range []string{"post-commit", "post-rewrite"} {
+		content, err := os.ReadFile(filepath.Join(repo.HooksDir, hookName))
+		require.NoError(t, err)
+		assert.Contains(t, string(content), fmt.Sprintf("ROBOREV=%q", binPath))
+	}
+}
+
 func TestInitNoDaemonEnsuresConfiguredSnapshotDirGitignored(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on Windows due to shell script stubs")

--- a/cmd/roborev/init_cmd.go
+++ b/cmd/roborev/init_cmd.go
@@ -14,6 +14,7 @@ import (
 func initCmd() *cobra.Command {
 	var agent string
 	var noDaemon bool
+	var hookBinary string
 
 	cmd := &cobra.Command{
 		Use:   "init",
@@ -80,7 +81,16 @@ func initCmd() *cobra.Command {
 			if err := os.MkdirAll(hooksDir, 0755); err != nil {
 				return fmt.Errorf("create hooks directory: %w", err)
 			}
-			if err := githook.InstallAll(hooksDir, false); err != nil {
+			binaryResolution, err := githook.ResolveRoborevPath(hookBinary)
+			if err != nil {
+				return fmt.Errorf("resolve hook binary: %w", err)
+			}
+			if binaryResolution.Notice != "" {
+				fmt.Printf("  %s\n", binaryResolution.Notice)
+			}
+			if err := githook.InstallAllWithOptions(hooksDir, githook.InstallOptions{
+				BinaryPath: binaryResolution.Path,
+			}); err != nil {
 				if githook.HasRealErrors(err) {
 					return fmt.Errorf("install hooks: %w", err)
 				}
@@ -135,6 +145,7 @@ func initCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&agent, "agent", "", "default agent (codex, claude-code, gemini, copilot, opencode, cursor, kiro, kilo)")
 	cmd.Flags().BoolVar(&noDaemon, "no-daemon", false, "skip auto-starting daemon (useful with systemd/launchd)")
+	cmd.Flags().StringVar(&hookBinary, "binary", "", "roborev binary path to bake into git hooks (for version-manager shims)")
 	registerAgentCompletion(cmd)
 
 	cmd.AddCommand(ghActionCmd())

--- a/internal/githook/githook.go
+++ b/internal/githook/githook.go
@@ -458,40 +458,33 @@ func InstallWithOptions(hooksDir, hookName string, opts InstallOptions) error {
 				generateEmbeddableWithBinary(hookName, resolution.Path),
 			)
 		} else if strings.Contains(existingStr, versionMarker) {
-			fmt.Printf(
-				"%s hook already installed (current)\n",
-				hookName,
-			)
-			return nil
+			if !hookUsesBinary(existingStr, resolution.Path) {
+				hookContent, err = renderUpdatedHookContent(
+					hookPath,
+					hookName,
+					existingStr,
+					resolution.Path,
+				)
+				if err != nil {
+					return err
+				}
+			} else {
+				fmt.Printf(
+					"%s hook already installed (current)\n",
+					hookName,
+				)
+				return nil
+			}
 		} else {
-			// Upgrade: remove old snippet, embed new one
-			if !isShellHook(existingStr) {
-				return fmt.Errorf(
-					"%s hook: %w; add the roborev snippet "+
-						"manually or use --force to overwrite",
-					hookName, ErrNonShellHook)
+			hookContent, err = renderUpdatedHookContent(
+				hookPath,
+				hookName,
+				existingStr,
+				resolution.Path,
+			)
+			if err != nil {
+				return err
 			}
-			if rmErr := Uninstall(hookPath); rmErr != nil {
-				return fmt.Errorf(
-					"upgrade %s: %w", hookName, rmErr,
-				)
-			}
-			updated, readErr := ReadFile(hookPath)
-			if readErr != nil && !os.IsNotExist(readErr) {
-				return fmt.Errorf(
-					"re-read %s after cleanup: %w",
-					hookName, readErr,
-				)
-			}
-			if readErr == nil {
-				remaining := string(updated)
-				hookContent = embedSnippet(
-					remaining,
-					generateEmbeddableWithBinary(hookName, resolution.Path),
-				)
-			}
-			// If file was deleted (snippet-only), hookContent
-			// is the fresh standalone content.
 		}
 	}
 
@@ -502,6 +495,39 @@ func InstallWithOptions(hooksDir, hookName string, opts InstallOptions) error {
 	}
 	fmt.Printf("Installed %s hook at %s\n", hookName, hookPath)
 	return nil
+}
+
+func hookUsesBinary(content, roborevPath string) bool {
+	return strings.Contains(content, fmt.Sprintf("ROBOREV=%q", roborevPath))
+}
+
+func renderUpdatedHookContent(
+	hookPath, hookName, existingStr, roborevPath string,
+) (string, error) {
+	if !isShellHook(existingStr) {
+		return "", fmt.Errorf(
+			"%s hook: %w; add the roborev snippet "+
+				"manually or use --force to overwrite",
+			hookName, ErrNonShellHook)
+	}
+	if rmErr := Uninstall(hookPath); rmErr != nil {
+		return "", fmt.Errorf("upgrade %s: %w", hookName, rmErr)
+	}
+	updated, readErr := ReadFile(hookPath)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		return "", fmt.Errorf(
+			"re-read %s after cleanup: %w",
+			hookName, readErr,
+		)
+	}
+	if readErr == nil {
+		return embedSnippet(
+			string(updated),
+			generateEmbeddableWithBinary(hookName, roborevPath),
+		), nil
+	}
+	// If the old roborev block was the whole file, Uninstall removes it.
+	return generateContentWithBinary(hookName, roborevPath), nil
 }
 
 // InstallAll installs both post-commit and post-rewrite hooks.

--- a/internal/githook/githook.go
+++ b/internal/githook/githook.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"go.kenn.io/roborev/internal/git"
@@ -18,6 +19,32 @@ import (
 // ErrNonShellHook is returned when a hook uses a non-shell
 // interpreter and cannot be safely modified.
 var ErrNonShellHook = errors.New("non-shell interpreter")
+
+// BinaryResolution describes the roborev binary path to bake into hooks.
+type BinaryResolution struct {
+	Path   string
+	Notice string
+}
+
+// InstallOptions configures hook installation.
+type InstallOptions struct {
+	Force      bool
+	BinaryPath string
+}
+
+type binaryResolverDeps struct {
+	executable  func() (string, error)
+	lookPath    func(string) (string, error)
+	userHomeDir func() (string, error)
+}
+
+func defaultBinaryResolverDeps() binaryResolverDeps {
+	return binaryResolverDeps{
+		executable:  os.Executable,
+		lookPath:    exec.LookPath,
+		userHomeDir: os.UserHomeDir,
+	}
+}
 
 // HasRealErrors returns true if err contains any error that
 // is not ErrNonShellHook. Use this instead of errors.Is when
@@ -123,26 +150,164 @@ func Missing(repoPath, hookName string) bool {
 	)
 }
 
-// resolveRoborevPath returns the absolute path to the running
-// roborev binary, falling back to a PATH lookup.
-func resolveRoborevPath() string {
-	roborevPath, err := os.Executable()
-	if err == nil {
-		if resolved, err := filepath.EvalSymlinks(roborevPath); err == nil {
-			roborevPath = resolved
+// ResolveRoborevPath returns the roborev path to bake into git hooks.
+// When override is empty, it lightly probes common version managers and
+// prefers their stable shim/symlink over a versioned install path.
+func ResolveRoborevPath(override string) (BinaryResolution, error) {
+	return resolveRoborevPathWithDeps(override, defaultBinaryResolverDeps())
+}
+
+func resolveRoborevPathWithDeps(override string, deps binaryResolverDeps) (BinaryResolution, error) {
+	override = strings.TrimSpace(override)
+	if override != "" {
+		path, err := normalizeOverridePath(override, deps)
+		if err != nil {
+			return BinaryResolution{}, err
 		}
-		return roborevPath
+		return BinaryResolution{Path: path}, nil
 	}
-	roborevPath, _ = exec.LookPath("roborev")
+
+	current, err := deps.executable()
+	roborevPath, _ := deps.lookPath("roborev")
+	if err != nil {
+		if roborevPath == "" {
+			roborevPath = "roborev"
+		}
+		return BinaryResolution{Path: roborevPath}, nil
+	}
+
+	if roborevPath != "" {
+		if manager, ok := managedBinaryShim(current, roborevPath); ok {
+			return BinaryResolution{
+				Path: roborevPath,
+				Notice: fmt.Sprintf(
+					"Detected roborev managed by %s; installing hooks with %s instead of versioned binary %s",
+					manager, roborevPath, current,
+				),
+			}, nil
+		}
+	}
+
+	if manager := versionedManagerInstall(current); manager != "" {
+		return BinaryResolution{
+			Path: current,
+			Notice: fmt.Sprintf(
+				"Warning: roborev appears to be running from a versioned %s install (%s); use --binary to install hooks with a stable shim if available",
+				manager, current,
+			),
+		}, nil
+	}
+
+	return BinaryResolution{Path: current}, nil
+}
+
+// resolveRoborevPath returns the path to use in generated hooks. It is kept
+// for callers that only need the legacy default behavior.
+func resolveRoborevPath() string {
+	resolution, err := ResolveRoborevPath("")
+	if err == nil {
+		return resolution.Path
+	}
+	roborevPath, _ := exec.LookPath("roborev")
 	if roborevPath == "" {
 		roborevPath = "roborev"
 	}
 	return roborevPath
 }
 
+func normalizeOverridePath(raw string, deps binaryResolverDeps) (string, error) {
+	path := expandHome(raw, deps)
+	if !hasPathSeparator(path) {
+		resolved, err := deps.lookPath(path)
+		if err != nil {
+			return "", fmt.Errorf("find %s on PATH: %w", path, err)
+		}
+		path = resolved
+	} else if !filepath.IsAbs(path) {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return "", fmt.Errorf("resolve %s: %w", raw, err)
+		}
+		path = abs
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("stat %s: %w", path, err)
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("%s is a directory, not a binary", path)
+	}
+	if runtime.GOOS != "windows" && info.Mode()&0111 == 0 {
+		return "", fmt.Errorf("%s is not executable", path)
+	}
+	return path, nil
+}
+
+func expandHome(path string, deps binaryResolverDeps) string {
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		home, err := deps.userHomeDir()
+		if err == nil && home != "" {
+			if path == "~" {
+				return home
+			}
+			return filepath.Join(home, path[2:])
+		}
+	}
+	return path
+}
+
+func hasPathSeparator(path string) bool {
+	return strings.ContainsRune(path, os.PathSeparator) ||
+		(os.PathSeparator != '/' && strings.ContainsRune(path, '/'))
+}
+
+func managedBinaryShim(current, pathRoborev string) (string, bool) {
+	current = filepath.ToSlash(current)
+	pathRoborev = filepath.ToSlash(pathRoborev)
+	switch {
+	case isMiseManagedRoborev(current) &&
+		strings.Contains(pathRoborev, "/mise/shims/roborev"):
+		return "mise", true
+	case strings.Contains(current, "/Cellar/roborev/") &&
+		isHomebrewBin(pathRoborev):
+		return "Homebrew", true
+	default:
+		return "", false
+	}
+}
+
+func versionedManagerInstall(current string) string {
+	current = filepath.ToSlash(current)
+	switch {
+	case isMiseManagedRoborev(current):
+		return "mise"
+	case strings.Contains(current, "/Cellar/roborev/"):
+		return "Homebrew"
+	default:
+		return ""
+	}
+}
+
+func isMiseManagedRoborev(path string) bool {
+	return strings.Contains(path, "/mise/installs/") &&
+		strings.HasSuffix(path, "/roborev")
+}
+
+func isHomebrewBin(path string) bool {
+	return strings.HasSuffix(path, "/bin/roborev") &&
+		(strings.HasPrefix(path, "/opt/homebrew/") ||
+			strings.HasPrefix(path, "/usr/local/") ||
+			strings.HasPrefix(path, "/home/linuxbrew/.linuxbrew/"))
+}
+
 // GeneratePostCommit returns a standalone post-commit hook
 // (with shebang, suitable for fresh installs).
 func GeneratePostCommit() string {
+	return GeneratePostCommitWithBinary(resolveRoborevPath())
+}
+
+// GeneratePostCommitWithBinary returns a post-commit hook using roborevPath.
+func GeneratePostCommitWithBinary(roborevPath string) string {
 	return fmt.Sprintf(`#!/bin/sh
 # roborev %s - auto-reviews every commit
 ROBOREV=%q
@@ -151,12 +316,17 @@ if [ ! -x "$ROBOREV" ]; then
     [ -z "$ROBOREV" ] || [ ! -x "$ROBOREV" ] && exit 0
 fi
 "$ROBOREV" post-commit 2>/dev/null
-`, PostCommitVersionMarker, resolveRoborevPath())
+`, PostCommitVersionMarker, roborevPath)
 }
 
 // GeneratePostRewrite returns a standalone post-rewrite hook
 // (with shebang, suitable for fresh installs).
 func GeneratePostRewrite() string {
+	return GeneratePostRewriteWithBinary(resolveRoborevPath())
+}
+
+// GeneratePostRewriteWithBinary returns a post-rewrite hook using roborevPath.
+func GeneratePostRewriteWithBinary(roborevPath string) string {
 	return fmt.Sprintf(`#!/bin/sh
 # roborev %s - remaps reviews after rebase/amend
 ROBOREV=%q
@@ -165,7 +335,7 @@ if [ ! -x "$ROBOREV" ]; then
     [ -z "$ROBOREV" ] || [ ! -x "$ROBOREV" ] && exit 0
 fi
 "$ROBOREV" remap --quiet 2>/dev/null
-`, PostRewriteVersionMarker, resolveRoborevPath())
+`, PostRewriteVersionMarker, roborevPath)
 }
 
 // generateEmbeddablePostCommit returns a function-wrapped
@@ -173,6 +343,10 @@ fi
 // Uses return instead of exit so it doesn't terminate the
 // parent script.
 func generateEmbeddablePostCommit() string {
+	return generateEmbeddablePostCommitWithBinary(resolveRoborevPath())
+}
+
+func generateEmbeddablePostCommitWithBinary(roborevPath string) string {
 	return fmt.Sprintf(`# roborev %s - auto-reviews every commit
 _roborev_hook() {
 ROBOREV=%q
@@ -183,12 +357,16 @@ fi
 "$ROBOREV" post-commit 2>/dev/null
 }
 _roborev_hook
-`, PostCommitVersionMarker, resolveRoborevPath())
+`, PostCommitVersionMarker, roborevPath)
 }
 
 // generateEmbeddablePostRewrite returns a function-wrapped
 // snippet without shebang, for embedding in existing hooks.
 func generateEmbeddablePostRewrite() string {
+	return generateEmbeddablePostRewriteWithBinary(resolveRoborevPath())
+}
+
+func generateEmbeddablePostRewriteWithBinary(roborevPath string) string {
 	return fmt.Sprintf(`# roborev %s - remaps reviews after rebase/amend
 _roborev_remap() {
 ROBOREV=%q
@@ -199,30 +377,26 @@ fi
 "$ROBOREV" remap --quiet 2>/dev/null
 }
 _roborev_remap
-`, PostRewriteVersionMarker, resolveRoborevPath())
+`, PostRewriteVersionMarker, roborevPath)
 }
 
-// generateContent returns the standalone hook content for the
-// given hook name.
-func generateContent(hookName string) string {
+func generateContentWithBinary(hookName, roborevPath string) string {
 	switch hookName {
 	case "post-commit":
-		return GeneratePostCommit()
+		return GeneratePostCommitWithBinary(roborevPath)
 	case "post-rewrite":
-		return GeneratePostRewrite()
+		return GeneratePostRewriteWithBinary(roborevPath)
 	default:
 		return ""
 	}
 }
 
-// generateEmbeddable returns the embeddable snippet for the
-// given hook name.
-func generateEmbeddable(hookName string) string {
+func generateEmbeddableWithBinary(hookName, roborevPath string) string {
 	switch hookName {
 	case "post-commit":
-		return generateEmbeddablePostCommit()
+		return generateEmbeddablePostCommitWithBinary(roborevPath)
 	case "post-rewrite":
-		return generateEmbeddablePostRewrite()
+		return generateEmbeddablePostRewriteWithBinary(roborevPath)
 	default:
 		return ""
 	}
@@ -252,12 +426,23 @@ func embedSnippet(existing, snippet string) string {
 //   - Existing with old version: remove old, embed new
 //   - force=true: overwrite unconditionally
 func Install(hooksDir, hookName string, force bool) error {
+	return InstallWithOptions(hooksDir, hookName, InstallOptions{
+		Force: force,
+	})
+}
+
+// InstallWithOptions installs or upgrades a single hook with options.
+func InstallWithOptions(hooksDir, hookName string, opts InstallOptions) error {
 	hookPath := filepath.Join(hooksDir, hookName)
 	versionMarker := VersionMarker(hookName)
-	hookContent := generateContent(hookName)
+	resolution, err := ResolveRoborevPath(opts.BinaryPath)
+	if err != nil {
+		return err
+	}
+	hookContent := generateContentWithBinary(hookName, resolution.Path)
 
 	existing, err := os.ReadFile(hookPath)
-	if err == nil && !force {
+	if err == nil && !opts.Force {
 		existingStr := string(existing)
 		if !strings.Contains(
 			strings.ToLower(existingStr), "roborev",
@@ -270,7 +455,7 @@ func Install(hooksDir, hookName string, force bool) error {
 			}
 			hookContent = embedSnippet(
 				existingStr,
-				generateEmbeddable(hookName),
+				generateEmbeddableWithBinary(hookName, resolution.Path),
 			)
 		} else if strings.Contains(existingStr, versionMarker) {
 			fmt.Printf(
@@ -302,7 +487,7 @@ func Install(hooksDir, hookName string, force bool) error {
 				remaining := string(updated)
 				hookContent = embedSnippet(
 					remaining,
-					generateEmbeddable(hookName),
+					generateEmbeddableWithBinary(hookName, resolution.Path),
 				)
 			}
 			// If file was deleted (snippet-only), hookContent
@@ -322,9 +507,17 @@ func Install(hooksDir, hookName string, force bool) error {
 // InstallAll installs both post-commit and post-rewrite hooks.
 // It attempts all hooks and returns a joined error if any fail.
 func InstallAll(hooksDir string, force bool) error {
+	return InstallAllWithOptions(hooksDir, InstallOptions{
+		Force: force,
+	})
+}
+
+// InstallAllWithOptions installs both post-commit and post-rewrite hooks.
+// It attempts all hooks and returns a joined error if any fail.
+func InstallAllWithOptions(hooksDir string, opts InstallOptions) error {
 	var errs []error
 	for _, name := range []string{"post-commit", "post-rewrite"} {
-		if err := Install(hooksDir, name, force); err != nil {
+		if err := InstallWithOptions(hooksDir, name, opts); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/internal/githook/githook_test.go
+++ b/internal/githook/githook_test.go
@@ -764,6 +764,60 @@ func TestInstall(t *testing.T) {
 	})
 }
 
+func TestInstallWithOptionsUpdatesCurrentHookBinary(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("test checks Unix exec bits")
+	}
+
+	newBinary := filepath.Join(t.TempDir(), "roborev")
+	require.NoError(t, os.WriteFile(newBinary, []byte("#!/bin/sh\nexit 0\n"), 0755))
+
+	t.Run("standalone hook", func(t *testing.T) {
+		t.Parallel()
+		repo := setupHooksRepo(t)
+		hookPath := filepath.Join(repo.HooksDir, hookPostCommit)
+		require.NoError(t, os.WriteFile(
+			hookPath,
+			[]byte(GeneratePostCommitWithBinary("/old/roborev")),
+			0755,
+		))
+
+		err := InstallWithOptions(repo.HooksDir, hookPostCommit, InstallOptions{
+			BinaryPath: newBinary,
+		})
+		require.NoError(t, err)
+
+		assertFileContains(t, hookPath, fmt.Sprintf("ROBOREV=%q", newBinary))
+		assertFileNotContains(t, hookPath, `ROBOREV="/old/roborev"`)
+	})
+
+	t.Run("embedded hook preserves user content", func(t *testing.T) {
+		t.Parallel()
+		repo := setupHooksRepo(t)
+		hookPath := filepath.Join(repo.HooksDir, hookPostCommit)
+		require.NoError(t, os.WriteFile(
+			hookPath,
+			[]byte(shebang+
+				generateEmbeddablePostCommitWithBinary("/old/roborev")+
+				"echo 'user code'\n"),
+			0755,
+		))
+
+		err := InstallWithOptions(repo.HooksDir, hookPostCommit, InstallOptions{
+			BinaryPath: newBinary,
+		})
+		require.NoError(t, err)
+
+		assertFileContains(t, hookPath,
+			fmt.Sprintf("ROBOREV=%q", newBinary),
+			"echo 'user code'",
+			"_roborev_hook() {",
+		)
+		assertFileNotContains(t, hookPath, `ROBOREV="/old/roborev"`)
+	})
+}
+
 func assertInstallResult(t *testing.T, hookPath string, tc installTestCase) {
 	t.Helper()
 	if tc.expectExact != "" {

--- a/internal/githook/githook_test.go
+++ b/internal/githook/githook_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -95,6 +96,128 @@ func TestGeneratePostRewrite(t *testing.T) {
 	assert.True(t, strings.HasPrefix(content, shebang), "hook should start with #!/bin/sh")
 	assert.Contains(t, content, PostRewriteVersionMarker, "hook should contain version marker")
 	assert.Contains(t, content, "remap --quiet", "hook should call remap --quiet")
+}
+
+func TestResolveRoborevPathPrefersVersionManagerShim(t *testing.T) {
+	tests := []struct {
+		name        string
+		executable  string
+		pathRoborev string
+		manager     string
+	}{
+		{
+			name:        "mise go backend",
+			executable:  "/Users/alice/.local/share/mise/installs/go-go-kenn-io-roborev-cmd-roborev/1.2.3/bin/roborev",
+			pathRoborev: "/Users/alice/.local/share/mise/shims/roborev",
+			manager:     "mise",
+		},
+		{
+			name:        "mise registry backend",
+			executable:  "/Users/alice/.local/share/mise/installs/roborev/1.2.3/bin/roborev",
+			pathRoborev: "/Users/alice/.local/share/mise/shims/roborev",
+			manager:     "mise",
+		},
+		{
+			name:        "mise github backend",
+			executable:  "/Users/alice/.local/share/mise/installs/github-roborev-dev-roborev/1.2.3/roborev",
+			pathRoborev: "/Users/alice/.local/share/mise/shims/roborev",
+			manager:     "mise",
+		},
+		{
+			name:        "homebrew macos",
+			executable:  "/opt/homebrew/Cellar/roborev/1.2.3/bin/roborev",
+			pathRoborev: "/opt/homebrew/bin/roborev",
+			manager:     "Homebrew",
+		},
+		{
+			name:        "homebrew linux",
+			executable:  "/home/linuxbrew/.linuxbrew/Cellar/roborev/1.2.3/bin/roborev",
+			pathRoborev: "/home/linuxbrew/.linuxbrew/bin/roborev",
+			manager:     "Homebrew",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deps := stubRoborevPathDeps(t, tt.executable, tt.pathRoborev)
+
+			resolution, err := resolveRoborevPathWithDeps("", deps)
+			require.NoError(t, err)
+			assert.Equal(t, tt.pathRoborev, resolution.Path)
+			assert.Contains(t, resolution.Notice, tt.manager)
+			assert.Contains(t, resolution.Notice, "versioned binary")
+		})
+	}
+}
+
+func TestResolveRoborevPathWarnsForVersionedInstallWithoutShim(t *testing.T) {
+	current := "/Users/alice/.local/share/mise/installs/go-go-kenn-io-roborev-cmd-roborev/1.2.3/bin/roborev"
+	deps := stubRoborevPathDeps(t, current, "")
+
+	resolution, err := resolveRoborevPathWithDeps("", deps)
+	require.NoError(t, err)
+	assert.Equal(t, current, resolution.Path)
+	assert.Contains(t, resolution.Notice, "Warning")
+	assert.Contains(t, resolution.Notice, "mise")
+	assert.Contains(t, resolution.Notice, "--binary")
+}
+
+func TestResolveRoborevPathDoesNotGuessUnsupportedManagers(t *testing.T) {
+	tests := []struct {
+		name        string
+		executable  string
+		pathRoborev string
+	}{
+		{
+			name:        "rtx has no standard roborev plugin",
+			executable:  "/Users/alice/.local/share/rtx/installs/roborev/1.2.3/bin/roborev",
+			pathRoborev: "/Users/alice/.local/share/rtx/shims/roborev",
+		},
+		{
+			name:        "asdf has no standard roborev plugin",
+			executable:  "/Users/alice/.asdf/installs/roborev/1.2.3/bin/roborev",
+			pathRoborev: "/Users/alice/.asdf/shims/roborev",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deps := stubRoborevPathDeps(t, tt.executable, tt.pathRoborev)
+
+			resolution, err := resolveRoborevPathWithDeps("", deps)
+			require.NoError(t, err)
+			assert.Equal(t, tt.executable, resolution.Path)
+			assert.Empty(t, resolution.Notice)
+		})
+	}
+}
+
+func TestResolveRoborevPathUsesExplicitBinary(t *testing.T) {
+	binPath := filepath.Join(t.TempDir(), "roborev")
+	require.NoError(t, os.WriteFile(binPath, []byte("#!/bin/sh\nexit 0\n"), 0755))
+
+	resolution, err := ResolveRoborevPath(binPath)
+	require.NoError(t, err)
+	assert.Equal(t, binPath, resolution.Path)
+	assert.Empty(t, resolution.Notice)
+}
+
+func stubRoborevPathDeps(t *testing.T, current, pathRoborev string) binaryResolverDeps {
+	t.Helper()
+
+	return binaryResolverDeps{
+		executable: func() (string, error) {
+			return current, nil
+		},
+		lookPath: func(file string) (string, error) {
+			require.Equal(t, "roborev", file)
+			if pathRoborev == "" {
+				return "", exec.ErrNotFound
+			}
+			return pathRoborev, nil
+		},
+		userHomeDir: os.UserHomeDir,
+	}
 }
 
 func TestGenerateEmbeddablePostCommit(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `--binary` to `roborev init` and `install-hook` so users can explicitly choose the roborev executable baked into git hooks
- resolve stable shim/symlink paths for empirically verified mise and Homebrew installs instead of pinning hooks to versioned binaries
- cover mise Go backend, mise GitHub Releases backend, Homebrew/Linuxbrew, explicit binary overrides, and unsupported-manager non-guesses in tests

## Validation
- `go fmt ./...`
- `go test ./internal/githook`
- `go vet ./...`
- `go test ./...`
- `make lint`
- Docker probes for mise Go backend, mise GitHub backend, Homebrew/Linuxbrew, rtx, and asdf
