### PR TITLE
chore(lint): enable gci+gofumpt and fix violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,9 +38,21 @@ issues:
   max-issues-per-linter: 0
   max-same-issues: 0
 formatters:
+  enable:
+    - gci
+    - gofumpt
   exclusions:
     generated: lax
     paths:
       - third_party$
       - builtin$
       - examples$
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(go.kenn.io/roborev)
+    gofumpt:
+      # extra-rules collapses same-type params (a, b string); keep them explicit.
+      extra-rules: false

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ See [configuration guide](https://roborev.io/configuration/) for all options.
 |----------|-------------|
 | `ROBOREV_DATA_DIR` | Override default data directory (`~/.roborev`) |
 | `ROBOREV_COLOR_MODE` | TUI color theme: `auto` (default), `dark`, `light`, `none` |
+| `ROBOREV_SYNC_CURSOR_LOOKBACK` | PostgreSQL sync cursor overlap duration (default `5m`) |
 | `NO_COLOR` | Set to any value to disable all color output ([no-color.org](https://no-color.org)) |
 
 ## Supported Agents

--- a/cmd/roborev/analyze.go
+++ b/cmd/roborev/analyze.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/daemon"

--- a/cmd/roborev/analyze_integration_test.go
+++ b/cmd/roborev/analyze_integration_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/prompt/analyze"
 	"go.kenn.io/roborev/internal/storage"
 )

--- a/cmd/roborev/analyze_test.go
+++ b/cmd/roborev/analyze_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/prompt/analyze"
@@ -300,7 +301,7 @@ func TestMarkJobClosed(t *testing.T) {
 
 func TestRunFixAgent(t *testing.T) {
 	tmpDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o755); err != nil {
 		require.NoError(t, err, "MkdirAll: %v")
 	}
 
@@ -548,7 +549,7 @@ func TestGetBranchFiles(t *testing.T) {
 	t.Run("reads from git not working tree", func(t *testing.T) {
 		repo := setupBranchTestRepo(t)
 		// Modify working tree — should NOT affect branch analysis
-		_ = os.WriteFile(filepath.Join(repo.Dir, "new.go"), []byte("DIRTY"), 0644)
+		_ = os.WriteFile(filepath.Join(repo.Dir, "new.go"), []byte("DIRTY"), 0o644)
 
 		files, err := getBranchFiles(cmd, repo.Dir, analyzeOptions{
 			branch:     "HEAD",

--- a/cmd/roborev/backfill.go
+++ b/cmd/roborev/backfill.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 

--- a/cmd/roborev/backfill_tokens.go
+++ b/cmd/roborev/backfill_tokens.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/tokens"
 )

--- a/cmd/roborev/backfill_tokens_test.go
+++ b/cmd/roborev/backfill_tokens_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 

--- a/cmd/roborev/check_agents.go
+++ b/cmd/roborev/check_agents.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/agent"
 )
 

--- a/cmd/roborev/ci.go
+++ b/cmd/roborev/ci.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/git"
 	ghpkg "go.kenn.io/roborev/internal/github"

--- a/cmd/roborev/ci_test.go
+++ b/cmd/roborev/ci_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/config"
 )
 
@@ -22,7 +23,7 @@ func installFakeGHAuthToken(t *testing.T, token string) {
 	dir := t.TempDir()
 	scriptPath := filepath.Join(dir, "gh")
 	script := "#!/bin/sh\nif [ \"$1\" = \"auth\" ] && [ \"$2\" = \"token\" ]; then\n  printf '%s\\n' " + "'" + token + "'\n  exit 0\nfi\nexit 1\n"
-	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0755))
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o755))
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
@@ -91,7 +92,7 @@ func setupFakeGitHubEvent(t *testing.T, event map[string]any) {
 	t.Helper()
 	eventFile := filepath.Join(t.TempDir(), "event.json")
 	data, _ := json.Marshal(event)
-	if err := os.WriteFile(eventFile, data, 0644); err != nil {
+	if err := os.WriteFile(eventFile, data, 0o644); err != nil {
 		require.NoError(t, err)
 	}
 	t.Setenv("GITHUB_EVENT_PATH", eventFile)
@@ -120,7 +121,6 @@ func TestDetectGitRef_NoEnv(t *testing.T) {
 
 	_, err := detectGitRef()
 	require.Error(t, err)
-
 }
 
 func TestDetectPRNumber_EventJSON(t *testing.T) {
@@ -152,7 +152,6 @@ func TestDetectPRNumber_NoEnv(t *testing.T) {
 
 	_, err := detectPRNumber()
 	require.Error(t, err)
-
 }
 
 func TestExtractHeadSHA(t *testing.T) {

--- a/cmd/roborev/client_test.go
+++ b/cmd/roborev/client_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -113,7 +114,6 @@ func TestGetCommentsForJob(t *testing.T) {
 
 		_, err := getCommentsForJob(42)
 		require.Error(t, err)
-
 	})
 }
 
@@ -265,7 +265,7 @@ func TestFindJobForCommit(t *testing.T) {
 			setupTest: func(t *testing.T) (string, []MockStep) {
 				tmpDir := normalizeTestPath(t, t.TempDir())
 				repoPath := filepath.Join(tmpDir, "repo")
-				if err := os.MkdirAll(repoPath, 0755); err != nil {
+				if err := os.MkdirAll(repoPath, 0o755); err != nil {
 					require.NoError(t, err)
 				}
 				return repoPath, []MockStep{

--- a/cmd/roborev/comment.go
+++ b/cmd/roborev/comment.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/git"
 )
 

--- a/cmd/roborev/comment_test.go
+++ b/cmd/roborev/comment_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -60,7 +61,6 @@ func TestCommentJobFlag(t *testing.T) {
 			if !tt.wantErr {
 				daemonFromHandler(t, mockCommentHandler(t, &receivedJobID))
 			} else {
-
 				_ = mockCommentHandler(t, nil)
 			}
 

--- a/cmd/roborev/compact.go
+++ b/cmd/roborev/compact.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/daemon"
@@ -655,12 +656,12 @@ func writeCompactMetadata(consolidatedJobID int64, sourceJobIDs []int64) error {
 	}
 
 	dataDir := config.DataDir()
-	if err := os.MkdirAll(dataDir, 0755); err != nil {
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
 		return fmt.Errorf("create data directory: %w", err)
 	}
 
 	path := filepath.Join(dataDir, getCompactMetadataFilename(consolidatedJobID))
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	if err := os.WriteFile(path, data, 0o644); err != nil {
 		return fmt.Errorf("write metadata file: %w", err)
 	}
 

--- a/cmd/roborev/compact_test.go
+++ b/cmd/roborev/compact_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 

--- a/cmd/roborev/completions.go
+++ b/cmd/roborev/completions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 )

--- a/cmd/roborev/config_cmd.go
+++ b/cmd/roborev/config_cmd.go
@@ -9,6 +9,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/git"
 )
@@ -22,9 +23,7 @@ const (
 	scopeLocal
 )
 
-var (
-	errNotGitRepository = errors.New("not in a git repository")
-)
+var errNotGitRepository = errors.New("not in a git repository")
 
 // RepoResolver provides filesystem and git context.
 type RepoResolver interface {

--- a/cmd/roborev/config_cmd_test.go
+++ b/cmd/roborev/config_cmd_test.go
@@ -113,7 +113,7 @@ func (s *stubRepoResolver) SetWorkingDirError(err error) {
 func createFakeGitRepo(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
-	err := os.Mkdir(filepath.Join(dir, ".git"), 0755)
+	err := os.Mkdir(filepath.Join(dir, ".git"), 0o755)
 	require.NoError(t, err, "create .git dir: %v", err)
 	return dir
 }
@@ -131,13 +131,13 @@ func setupConfigEnv(t *testing.T, globalTOML, localTOML string) configEnv {
 
 	if globalTOML != "" {
 		globalPath := filepath.Join(dataDir, "config.toml")
-		require.NoError(t, os.WriteFile(globalPath, []byte(globalTOML), 0644), "write global config")
+		require.NoError(t, os.WriteFile(globalPath, []byte(globalTOML), 0o644), "write global config")
 	}
 
 	repoDir := createFakeGitRepo(t)
 	if localTOML != "" {
 		localPath := filepath.Join(repoDir, ".roborev.toml")
-		require.NoError(t, os.WriteFile(localPath, []byte(localTOML), 0644), "write local config")
+		require.NoError(t, os.WriteFile(localPath, []byte(localTOML), 0o644), "write local config")
 	}
 
 	resolver := &stubRepoResolver{}
@@ -206,7 +206,7 @@ func TestRepoRoot(t *testing.T) {
 	t.Run("falls back to filesystem when git resolver fails", func(t *testing.T) {
 		repoDir := createFakeGitRepo(t)
 		nestedDir := filepath.Join(repoDir, "nested", "deeper")
-		require.NoError(t, os.MkdirAll(nestedDir, 0755), "create nested dir")
+		require.NoError(t, os.MkdirAll(nestedDir, 0o755), "create nested dir")
 
 		resolver := &stubRepoResolver{}
 		resolver.SetGitError(errors.New(errGitStub))
@@ -253,7 +253,7 @@ func TestGetValueForScopeMergedPrefersLocal(t *testing.T) {
 	env := setupConfigEnv(t, "review_agent = \"global-agent\"\n", "review_agent = \"local-agent\"\n")
 
 	nestedDir := filepath.Join(env.RepoDir, "a", "b")
-	require.NoError(t, os.MkdirAll(nestedDir, 0755), "create nested dir")
+	require.NoError(t, os.MkdirAll(nestedDir, 0o755), "create nested dir")
 
 	env.Resolver.SetGitError(errors.New(errGitStub))
 	env.Resolver.SetWorkingDir(nestedDir)

--- a/cmd/roborev/daemon_client.go
+++ b/cmd/roborev/daemon_client.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/storage"
 )

--- a/cmd/roborev/daemon_cmd.go
+++ b/cmd/roborev/daemon_cmd.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/storage"

--- a/cmd/roborev/daemon_integration_test.go
+++ b/cmd/roborev/daemon_integration_test.go
@@ -6,16 +6,17 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.kenn.io/roborev/internal/daemon"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/daemon"
 )
 
 func TestDaemonRunStartsAndShutdownsCleanly(t *testing.T) {
@@ -127,7 +128,7 @@ func setupTestDaemon(t *testing.T) (string, string) {
 	t.Setenv("ROBOREV_DATA_DIR", tmpDir)
 
 	// Write minimal config
-	if err := os.WriteFile(configPath, []byte(`max_workers = 1`), 0644); err != nil {
+	if err := os.WriteFile(configPath, []byte(`max_workers = 1`), 0o644); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "write config: %v", err)
@@ -327,7 +328,6 @@ func TestDaemonSignalCleanup(t *testing.T) {
 				return false
 			}, "expected signal.Stop (cleanup) to be"+
 				" called after signal shutdown")
-
 		}
 	case <-time.After(5 * time.Second):
 		require.Condition(t, func() bool {

--- a/cmd/roborev/daemon_lifecycle_test.go
+++ b/cmd/roborev/daemon_lifecycle_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/version"
 )

--- a/cmd/roborev/fix.go
+++ b/cmd/roborev/fix.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/daemon"
@@ -1027,7 +1028,7 @@ func fixSingleJob(cmd *cobra.Command, repoRoot string, jobID int64, opts fixOpti
 	}
 
 	// Set up output
-	var underlying = io.Discard
+	underlying := io.Discard
 	var fmtr *streamfmt.Formatter
 	if !opts.quiet {
 		fmtr = streamfmt.New(cmd.OutOrStdout(), streamfmt.WriterIsTerminal(cmd.OutOrStdout()))
@@ -1335,7 +1336,7 @@ func processFixBatch(ctx context.Context, cmd *cobra.Command, roots currentRepoR
 
 		prompt := buildBatchFixPrompt(batch, minSev)
 
-		var underlying = io.Discard
+		underlying := io.Discard
 		var fmtr *streamfmt.Formatter
 		if !opts.quiet {
 			fmtr = streamfmt.New(cmd.OutOrStdout(), streamfmt.WriterIsTerminal(cmd.OutOrStdout()))
@@ -1430,8 +1431,10 @@ func processFixBatch(ctx context.Context, cmd *cobra.Command, roots currentRepoR
 // batchPromptOverhead is the fixed size of the batch prompt header + footer.
 var batchPromptOverhead = len(batchPromptHeader + batchPromptFooter)
 
-const batchPromptHeader = "# Batch Fix Request\n\nThe following reviews found issues that need to be fixed.\nAddress all findings across all reviews in a single pass.\n\n"
-const batchPromptFooter = "## Instructions\n\nPlease apply fixes for all the findings above.\nFocus on the highest priority items first.\nAfter making changes, verify the code compiles/passes linting,\nrun relevant tests, and create a git commit summarizing all changes.\n"
+const (
+	batchPromptHeader = "# Batch Fix Request\n\nThe following reviews found issues that need to be fixed.\nAddress all findings across all reviews in a single pass.\n\n"
+	batchPromptFooter = "## Instructions\n\nPlease apply fixes for all the findings above.\nFocus on the highest priority items first.\nAfter making changes, verify the code compiles/passes linting,\nrun relevant tests, and create a git commit summarizing all changes.\n"
+)
 
 // batchEntrySize returns the size of a single entry in the batch prompt.
 // The index parameter is the 1-based position in the batch.

--- a/cmd/roborev/fix_integration_test.go
+++ b/cmd/roborev/fix_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/storage"
 )
@@ -254,15 +255,19 @@ func (a *failOnNthAgent) Review(ctx context.Context, repoPath, commitSHA, prompt
 	}
 	return a.inner.Review(ctx, repoPath, commitSHA, prompt, output)
 }
+
 func (a *failOnNthAgent) WithReasoning(level agent.ReasoningLevel) agent.Agent {
 	return &failOnNthAgent{inner: a.inner.WithReasoning(level).(*agent.TestAgent), failOn: a.failOn, calls: a.calls}
 }
+
 func (a *failOnNthAgent) WithAgentic(agentic bool) agent.Agent {
 	return a
 }
+
 func (a *failOnNthAgent) WithModel(model string) agent.Agent {
 	return a
 }
+
 func (a *failOnNthAgent) WithSessionID(id string) agent.Agent {
 	return &failOnNthAgent{inner: a.inner.WithSessionID(id).(*agent.TestAgent), failOn: a.failOn, calls: a.calls}
 }
@@ -281,12 +286,15 @@ func (a *namedAgent) Name() string { return a.name }
 func (a *namedAgent) Review(ctx context.Context, repoPath, commitSHA, prompt string, output io.Writer) (string, error) {
 	return a.inner.Review(ctx, repoPath, commitSHA, prompt, output)
 }
+
 func (a *namedAgent) WithReasoning(level agent.ReasoningLevel) agent.Agent {
 	return &namedAgent{name: a.name, inner: a.inner.WithReasoning(level)}
 }
+
 func (a *namedAgent) WithAgentic(agentic bool) agent.Agent {
 	return &namedAgent{name: a.name, inner: a.inner.WithAgentic(agentic)}
 }
+
 func (a *namedAgent) WithModel(model string) agent.Agent {
 	return &namedAgent{name: a.name, inner: a.inner.WithModel(model)}
 }
@@ -301,12 +309,15 @@ type namedSessionAgent struct {
 func (a *namedSessionAgent) WithReasoning(level agent.ReasoningLevel) agent.Agent {
 	return &namedSessionAgent{namedAgent: namedAgent{name: a.name, inner: a.inner.WithReasoning(level)}}
 }
+
 func (a *namedSessionAgent) WithAgentic(agentic bool) agent.Agent {
 	return &namedSessionAgent{namedAgent: namedAgent{name: a.name, inner: a.inner.WithAgentic(agentic)}}
 }
+
 func (a *namedSessionAgent) WithModel(model string) agent.Agent {
 	return &namedSessionAgent{namedAgent: namedAgent{name: a.name, inner: a.inner.WithModel(model)}}
 }
+
 func (a *namedSessionAgent) WithSessionID(id string) agent.Agent {
 	if sa, ok := a.inner.(agent.SessionAgent); ok {
 		return &namedSessionAgent{namedAgent: namedAgent{name: a.name, inner: sa.WithSessionID(id)}}

--- a/cmd/roborev/fix_mock_test.go
+++ b/cmd/roborev/fix_mock_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 

--- a/cmd/roborev/fix_session_test.go
+++ b/cmd/roborev/fix_session_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/agent"
 )
 

--- a/cmd/roborev/fix_test.go
+++ b/cmd/roborev/fix_test.go
@@ -22,9 +22,9 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/daemon"
@@ -573,7 +573,7 @@ func TestFixSingleJobRecoversPostFixDaemonCalls(t *testing.T) {
 		NameStr: "test",
 		ReviewFn: func(_ context.Context, repoPath, _, _ string, _ io.Writer) (string, error) {
 			fixPath := filepath.Join(repoPath, "fix.txt")
-			if err := os.WriteFile(fixPath, []byte("fixed\n"), 0644); err != nil {
+			if err := os.WriteFile(fixPath, []byte("fixed\n"), 0o644); err != nil {
 				return "", fmt.Errorf("write fix: %w", err)
 			}
 			cmd := exec.Command("git", "add", "fix.txt")
@@ -1161,6 +1161,7 @@ func TestRunFixOpenOrdering(t *testing.T) {
 		assert.Contains(t, out, "[30 20 10]")
 	})
 }
+
 func TestRunFixOpenRequery(t *testing.T) {
 	repo := createTestRepo(t, map[string]string{"f.txt": "x"})
 	repoBranch := strings.TrimSpace(repo.Run("rev-parse", "--abbrev-ref", "HEAD"))
@@ -1362,7 +1363,7 @@ func TestFixJobDirectUnbornHead(t *testing.T) {
 			NameStr: "test",
 			ReviewFn: func(ctx context.Context, repoPath, commitSHA, prompt string, output io.Writer) (string, error) {
 				// Simulate agent creating the first commit
-				if err := os.WriteFile(filepath.Join(repoPath, "fix.txt"), []byte("fixed"), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(repoPath, "fix.txt"), []byte("fixed"), 0o644); err != nil {
 					return "", fmt.Errorf("write file: %w", err)
 				}
 				c := exec.Command("git", "add", ".")
@@ -1605,7 +1606,6 @@ func TestSplitIntoBatches(t *testing.T) {
 			}, "severity filter should not reduce batch count: "+
 				"without=%d, with=%d",
 				len(batchesNoSev), len(batchesWithSev))
-
 		}
 		// Verify the prompt respects the size estimate
 		for i, batch := range batchesWithSev {
@@ -1615,7 +1615,6 @@ func TestSplitIntoBatches(t *testing.T) {
 					return false
 				}, "batch %d prompt size %d exceeds limit 1200",
 					i, len(p))
-
 			}
 		}
 	})
@@ -2087,6 +2086,7 @@ func TestRunFixList(t *testing.T) {
 		assert.False(t, gotIDs[0] != 30 || gotIDs[1] != 20 || gotIDs[2] != 10)
 	})
 }
+
 func TestTruncateString(t *testing.T) {
 	tests := []struct {
 		s      string
@@ -2697,7 +2697,7 @@ func TestResolveFixAgentSkipsDefaultModel(t *testing.T) {
 	if err := os.WriteFile(cfgPath, []byte(`
 default_agent = "codex"
 default_model = "gpt-5.4"
-`), 0644); err != nil {
+`), 0o644); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -2765,7 +2765,7 @@ func TestResolveFixAgentUsesWorkflowModel(t *testing.T) {
 default_agent = "codex"
 default_model = "gpt-5.4"
 fix_model = "gemini-2.5-pro"
-`), 0644); err != nil {
+`), 0o644); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -2786,7 +2786,6 @@ fix_model = "gemini-2.5-pro"
 
 		"expected workflow-specific model 'gemini-2.5-pro', got %q",
 		modelStr)
-
 }
 
 func TestResolveFixAgentSkipsDefaultModelForConfiguredFixAgent(t *testing.T) {
@@ -2801,7 +2800,7 @@ func TestResolveFixAgentSkipsDefaultModelForConfiguredFixAgent(t *testing.T) {
 default_agent = "codex"
 default_model = "gpt-5.4"
 fix_agent = "claude"
-`), 0644); err != nil {
+`), 0o644); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -2824,7 +2823,7 @@ func TestResolveFixAgentFallbackUsesDefaultModelForActualAgent(t *testing.T) {
 default_agent = "codex"
 default_model = "gpt-5.4"
 fix_agent = "claude"
-`), 0644); err != nil {
+`), 0o644); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -2848,7 +2847,7 @@ func TestResolveFixAgentUsesRepoWorkflowModel(t *testing.T) {
 	if err := os.WriteFile(cfgPath, []byte(`
 default_agent = "codex"
 default_model = "gpt-5.4"
-`), 0644); err != nil {
+`), 0o644); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -2857,7 +2856,7 @@ default_model = "gpt-5.4"
 	repoConfigPath := filepath.Join(repoDir, ".roborev.toml")
 	if err := os.WriteFile(repoConfigPath, []byte(`
 fix_model_fast = "claude-sonnet"
-`), 0644); err != nil {
+`), 0o644); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -2875,7 +2874,7 @@ fix_model_fast = "claude-sonnet"
 	repoConfigPath2 := filepath.Join(repoDir, ".roborev.toml")
 	if err := os.WriteFile(repoConfigPath2, []byte(`
 model = "repo-default"
-`), 0644); err != nil {
+`), 0o644); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -2884,7 +2883,6 @@ model = "repo-default"
 
 		"expected empty model (repo generic should be skipped), got %q",
 		modelStr)
-
 }
 
 func TestResolveFixAgentSameAsDefault(t *testing.T) {
@@ -2928,7 +2926,7 @@ func TestResolveFixAgentSameAsDefault(t *testing.T) {
 				"default_agent = %q\ndefault_model = \"gpt-5.4\"\n",
 				tt.defaultAgent,
 			)
-			if err := os.WriteFile(cfgPath, []byte(cfgContent), 0644); err != nil {
+			if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o644); err != nil {
 				require.NoError(t, err)
 			}
 			cfg, err := config.LoadGlobal()
@@ -3123,24 +3121,33 @@ func TestFilterReachableJobs(t *testing.T) {
 		{
 			name: "range ref matching branch included",
 			jobs: []storage.ReviewJob{
-				{ID: 5, GitRef: otherSHA + ".." + mainSHA,
-					Branch: defaultBranch},
+				{
+					ID:     5,
+					GitRef: otherSHA + ".." + mainSHA,
+					Branch: defaultBranch,
+				},
 			},
 			wantIDs: []int64{5},
 		},
 		{
 			name: "range ref unreachable end different branch excluded",
 			jobs: []storage.ReviewJob{
-				{ID: 5, GitRef: mainSHA + ".." + otherSHA,
-					Branch: "other-branch"},
+				{
+					ID:     5,
+					GitRef: mainSHA + ".." + otherSHA,
+					Branch: "other-branch",
+				},
 			},
 			wantIDs: nil,
 		},
 		{
 			name: "range ref unreachable end same branch included (rebase)",
 			jobs: []storage.ReviewJob{
-				{ID: 5, GitRef: mainSHA + ".." + otherSHA,
-					Branch: defaultBranch},
+				{
+					ID:     5,
+					GitRef: mainSHA + ".." + otherSHA,
+					Branch: defaultBranch,
+				},
 			},
 			wantIDs: []int64{5},
 		},
@@ -3161,24 +3168,33 @@ func TestFilterReachableJobs(t *testing.T) {
 		{
 			name: "task ref matching branch included",
 			jobs: []storage.ReviewJob{
-				{ID: 7, GitRef: "run", Branch: defaultBranch,
-					JobType: storage.JobTypeTask},
+				{
+					ID:     7,
+					GitRef: "run", Branch: defaultBranch,
+					JobType: storage.JobTypeTask,
+				},
 			},
 			wantIDs: []int64{7},
 		},
 		{
 			name: "task ref different branch excluded",
 			jobs: []storage.ReviewJob{
-				{ID: 8, GitRef: "analyze", Branch: "other-branch",
-					JobType: storage.JobTypeTask},
+				{
+					ID:     8,
+					GitRef: "analyze", Branch: "other-branch",
+					JobType: storage.JobTypeTask,
+				},
 			},
 			wantIDs: nil,
 		},
 		{
 			name: "task ref no branch excluded",
 			jobs: []storage.ReviewJob{
-				{ID: 9, GitRef: "custom-label",
-					JobType: storage.JobTypeTask},
+				{
+					ID:      9,
+					GitRef:  "custom-label",
+					JobType: storage.JobTypeTask,
+				},
 			},
 			wantIDs: nil,
 		},
@@ -3337,7 +3353,7 @@ func TestRunFixOpenFiltersUnreachableJobs(t *testing.T) {
 	cmd.Dir = worktreeDir
 	_ = cmd.Run()
 	wtFile := filepath.Join(worktreeDir, "wt-file.txt")
-	require.NoError(t, os.WriteFile(wtFile, []byte("wt"), 0644))
+	require.NoError(t, os.WriteFile(wtFile, []byte("wt"), 0o644))
 	cmd = exec.Command("git", "add", "wt-file.txt")
 	cmd.Dir = worktreeDir
 	require.NoError(t, cmd.Run())

--- a/cmd/roborev/ghaction.go
+++ b/cmd/roborev/ghaction.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/ghaction"
 	"go.kenn.io/roborev/internal/git"

--- a/cmd/roborev/ghaction_test.go
+++ b/cmd/roborev/ghaction_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/testutil"
 )
@@ -94,7 +95,7 @@ func TestGhActionCmd(t *testing.T) {
 			repo, outPath := setupGhActionTest(t)
 
 			if tt.repoConfig != "" {
-				require.NoError(t, os.WriteFile(filepath.Join(repo.Root, ".roborev.toml"), []byte(tt.repoConfig), 0644), "failed to write repo config")
+				require.NoError(t, os.WriteFile(filepath.Join(repo.Root, ".roborev.toml"), []byte(tt.repoConfig), 0o644), "failed to write repo config")
 				_ = repo // Avoid unused variable warning
 			}
 
@@ -136,8 +137,8 @@ func TestGhActionCmd_ForceOverwrite(t *testing.T) {
 
 	_, outPath := setupGhActionTest(t)
 
-	require.NoError(t, os.MkdirAll(filepath.Dir(outPath), 0755), "failed to create directory")
-	require.NoError(t, os.WriteFile(outPath, []byte("existing content"), 0644), "failed to write existing content")
+	require.NoError(t, os.MkdirAll(filepath.Dir(outPath), 0o755), "failed to create directory")
+	require.NoError(t, os.WriteFile(outPath, []byte("existing content"), 0o644), "failed to write existing content")
 
 	// Without --force should fail
 	cmd := ghActionCmd()

--- a/cmd/roborev/helpers.go
+++ b/cmd/roborev/helpers.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/githook"
 	"go.kenn.io/roborev/internal/storage"

--- a/cmd/roborev/helpers_test.go
+++ b/cmd/roborev/helpers_test.go
@@ -109,9 +109,9 @@ func (r *TestGitRepo) Run(args ...string) string {
 func (r *TestGitRepo) CommitFile(name, content, msg string) string {
 	r.t.Helper()
 	fullPath := filepath.Join(r.Dir, name)
-	err := os.MkdirAll(filepath.Dir(fullPath), 0755)
+	err := os.MkdirAll(filepath.Dir(fullPath), 0o755)
 	require.NoError(r.t, err)
-	err = os.WriteFile(fullPath, []byte(content), 0644)
+	err = os.WriteFile(fullPath, []byte(content), 0o644)
 	require.NoError(r.t, err)
 	r.Run("add", name)
 	r.Run("commit", "-m", msg)
@@ -167,9 +167,9 @@ func writeFiles(t *testing.T, dir string, files map[string]string) {
 	t.Helper()
 	for path, content := range files {
 		fullPath := filepath.Join(dir, path)
-		err := os.MkdirAll(filepath.Dir(fullPath), 0755)
+		err := os.MkdirAll(filepath.Dir(fullPath), 0o755)
 		require.NoError(t, err, "mkdir: %v")
-		err = os.WriteFile(fullPath, []byte(content), 0644)
+		err = os.WriteFile(fullPath, []byte(content), 0o644)
 		require.NoError(t, err, "write %s: %v", path, err)
 	}
 }

--- a/cmd/roborev/hook.go
+++ b/cmd/roborev/hook.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/githook"
 )
@@ -31,7 +32,7 @@ func installHookCmd() *cobra.Command {
 				return fmt.Errorf("get hooks path: %w", err)
 			}
 
-			if err := os.MkdirAll(hooksDir, 0755); err != nil {
+			if err := os.MkdirAll(hooksDir, 0o755); err != nil {
 				return fmt.Errorf("create hooks directory: %w", err)
 			}
 

--- a/cmd/roborev/hook_integration_test.go
+++ b/cmd/roborev/hook_integration_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/githook"
 	"go.kenn.io/roborev/internal/testutil"
 )
@@ -78,7 +79,7 @@ func TestInitCmdCreatesHooksDirectory(t *testing.T) {
 
 	info, err := os.Stat(repo.HookPath)
 	require.NoError(t, err)
-	assert.NotZero(t, info.Mode()&0111, "post-commit hook is not executable")
+	assert.NotZero(t, info.Mode()&0o111, "post-commit hook is not executable")
 }
 
 func TestInitCmdUpgradesOutdatedHook(t *testing.T) {

--- a/cmd/roborev/hook_test.go
+++ b/cmd/roborev/hook_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/githook"
 	"go.kenn.io/roborev/internal/testutil"
 )
@@ -121,11 +122,11 @@ func TestUninstallHookCmd(t *testing.T) {
 			}
 
 			if len(tt.initialHooks) > 0 {
-				err := os.MkdirAll(repo.HooksDir, 0755)
+				err := os.MkdirAll(repo.HooksDir, 0o755)
 				require.NoError(t, err)
 				for name, content := range tt.initialHooks {
 					path := filepath.Join(repo.HooksDir, name)
-					err = os.WriteFile(path, []byte(content), 0755)
+					err = os.WriteFile(path, []byte(content), 0o755)
 					require.NoError(t, err)
 				}
 			}
@@ -309,9 +310,9 @@ func TestInitNoDaemon(t *testing.T) {
 				w.WriteHeader(200)
 			},
 			setupFiles: func(t *testing.T, repo *testutil.TestRepo) {
-				err := os.MkdirAll(repo.HooksDir, 0755)
+				err := os.MkdirAll(repo.HooksDir, 0o755)
 				require.NoError(t, err)
-				err = os.WriteFile(filepath.Join(repo.HooksDir, "post-commit"), []byte(githook.GeneratePostCommit()), 0755)
+				err = os.WriteFile(filepath.Join(repo.HooksDir, "post-commit"), []byte(githook.GeneratePostCommit()), 0o755)
 				require.NoError(t, err)
 			},
 			postCheck: func(t *testing.T, repo *testutil.TestRepo) {
@@ -328,11 +329,11 @@ func TestInitNoDaemon(t *testing.T) {
 				w.WriteHeader(200)
 			},
 			setupFiles: func(t *testing.T, repo *testutil.TestRepo) {
-				os.MkdirAll(repo.HooksDir, 0755)
+				os.MkdirAll(repo.HooksDir, 0o755)
 				os.WriteFile(
 					filepath.Join(repo.HooksDir, "post-commit"),
 					[]byte("#!/usr/bin/env python3\nprint('hello')\n"),
-					0755,
+					0o755,
 				)
 			},
 			expectContains: []string{
@@ -346,9 +347,9 @@ func TestInitNoDaemon(t *testing.T) {
 				w.WriteHeader(200)
 			},
 			setupFiles: func(t *testing.T, repo *testutil.TestRepo) {
-				os.MkdirAll(repo.HooksDir, 0755)
-				os.Chmod(repo.HooksDir, 0555)
-				t.Cleanup(func() { os.Chmod(repo.HooksDir, 0755) })
+				os.MkdirAll(repo.HooksDir, 0o755)
+				os.Chmod(repo.HooksDir, 0o555)
+				t.Cleanup(func() { os.Chmod(repo.HooksDir, 0o755) })
 			},
 			expectError:   true,
 			errorContains: "install hooks",
@@ -359,14 +360,14 @@ func TestInitNoDaemon(t *testing.T) {
 				w.WriteHeader(200)
 			},
 			setupFiles: func(t *testing.T, repo *testutil.TestRepo) {
-				os.MkdirAll(repo.HooksDir, 0755)
+				os.MkdirAll(repo.HooksDir, 0o755)
 				os.WriteFile(
 					filepath.Join(repo.HooksDir, "post-commit"),
 					[]byte("#!/usr/bin/env python3\nprint('hello')\n"),
-					0755,
+					0o755,
 				)
 				// Create post-rewrite as a directory so writing it fails.
-				os.MkdirAll(filepath.Join(repo.HooksDir, "post-rewrite"), 0755)
+				os.MkdirAll(filepath.Join(repo.HooksDir, "post-rewrite"), 0o755)
 			},
 			expectError:   true,
 			errorContains: "install hooks",
@@ -626,13 +627,14 @@ func TestInstallHookFromLinkedWorktree(t *testing.T) {
 	// no hooks installed yet.
 	repo := testutil.NewTestRepoWithCommit(t)
 	customHooks := filepath.Join(repo.Root, ".githooks")
-	require.NoError(t, os.MkdirAll(customHooks, 0755))
+	require.NoError(t, os.MkdirAll(customHooks, 0o755))
 
 	runGit := func(dir string, args ...string) string {
 		t.Helper()
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
-		cmd.Env = append(os.Environ(),
+		cmd.Env = append(
+			os.Environ(),
 			"GIT_AUTHOR_NAME=Test",
 			"GIT_AUTHOR_EMAIL=test@test.com",
 			"GIT_COMMITTER_NAME=Test",
@@ -677,13 +679,14 @@ func TestUninstallHookFromLinkedWorktree(t *testing.T) {
 	// installed hooks.
 	repo := testutil.NewTestRepoWithCommit(t)
 	customHooks := filepath.Join(repo.Root, ".githooks")
-	require.NoError(t, os.MkdirAll(customHooks, 0755))
+	require.NoError(t, os.MkdirAll(customHooks, 0o755))
 
 	runGit := func(dir string, args ...string) string {
 		t.Helper()
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
-		cmd.Env = append(os.Environ(),
+		cmd.Env = append(
+			os.Environ(),
 			"GIT_AUTHOR_NAME=Test",
 			"GIT_AUTHOR_EMAIL=test@test.com",
 			"GIT_COMMITTER_NAME=Test",
@@ -705,7 +708,8 @@ func TestUninstallHookFromLinkedWorktree(t *testing.T) {
 		}
 		require.NoError(t, os.WriteFile(
 			filepath.Join(customHooks, name),
-			[]byte(content), 0755))
+			[]byte(content), 0o755,
+		))
 	}
 
 	// Create a linked worktree.

--- a/cmd/roborev/hook_test.go
+++ b/cmd/roborev/hook_test.go
@@ -486,7 +486,7 @@ func TestInitNoDaemonWithBinaryInstallsHooksUsingSpecifiedBinary(t *testing.T) {
 
 	repo := initNoDaemonSetup(t)
 	binPath := filepath.Join(t.TempDir(), "roborev")
-	require.NoError(t, os.WriteFile(binPath, []byte("#!/bin/sh\nexit 0\n"), 0755))
+	require.NoError(t, os.WriteFile(binPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
 	setupMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 	})

--- a/cmd/roborev/init_cmd.go
+++ b/cmd/roborev/init_cmd.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/githook"
@@ -35,7 +36,7 @@ func initCmd() *cobra.Command {
 
 			// 2. Create config directory and default config
 			configDir := config.DataDir()
-			if err := os.MkdirAll(configDir, 0755); err != nil {
+			if err := os.MkdirAll(configDir, 0o755); err != nil {
 				return fmt.Errorf("create config dir: %w", err)
 			}
 
@@ -78,7 +79,7 @@ func initCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get hooks path: %w", err)
 			}
-			if err := os.MkdirAll(hooksDir, 0755); err != nil {
+			if err := os.MkdirAll(hooksDir, 0o755); err != nil {
 				return fmt.Errorf("create hooks directory: %w", err)
 			}
 			binaryResolution, err := githook.ResolveRoborevPath(hookBinary)

--- a/cmd/roborev/insights.go
+++ b/cmd/roborev/insights.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/storage"

--- a/cmd/roborev/insights_test.go
+++ b/cmd/roborev/insights_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/storage"
 )

--- a/cmd/roborev/job_helpers_test.go
+++ b/cmd/roborev/job_helpers_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 

--- a/cmd/roborev/list.go
+++ b/cmd/roborev/list.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/storage"
 )

--- a/cmd/roborev/list_test.go
+++ b/cmd/roborev/list_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 

--- a/cmd/roborev/local_review_integration_test.go
+++ b/cmd/roborev/local_review_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/agent"
 )
 

--- a/cmd/roborev/local_review_test.go
+++ b/cmd/roborev/local_review_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/testutil"
 )
 
@@ -36,7 +36,7 @@ func newReviewHarness(t *testing.T) *reviewHarness {
 func (h *reviewHarness) writeConfig(content string) {
 	h.t.Helper()
 	path := filepath.Join(h.Dir, ".roborev.toml")
-	err := os.WriteFile(path, []byte(content), 0644)
+	err := os.WriteFile(path, []byte(content), 0o644)
 	require.NoError(h.t, err)
 }
 
@@ -135,7 +135,7 @@ func TestLocalReviewWithDirtyDiff(t *testing.T) {
 
 	// Create a new file to make the repo dirty
 	newFile := filepath.Join(h.Dir, "newfile.go")
-	err := os.WriteFile(newFile, []byte("package main\nfunc test() {}"), 0644)
+	err := os.WriteFile(newFile, []byte("package main\nfunc test() {}"), 0o644)
 	require.NoError(t, err)
 
 	err = h.run(runOpts{Dirty: true, Agent: "test", Reasoning: "fast"})
@@ -271,5 +271,4 @@ func TestLocalReviewSkipsDaemon(t *testing.T) {
 
 	err := h.run(runOpts{Agent: "test", Reasoning: "fast"})
 	require.NoError(t, err, "Expected --local to work without daemon, got: %v")
-
 }

--- a/cmd/roborev/log_cmd.go
+++ b/cmd/roborev/log_cmd.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/streamfmt"
 )

--- a/cmd/roborev/log_cmd_test.go
+++ b/cmd/roborev/log_cmd_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/streamfmt"
 )
 
@@ -87,10 +88,10 @@ func TestLogCmd_RawFlag(t *testing.T) {
 
 	// Create a log file at the expected path.
 	logDir := filepath.Join(dir, "logs", "jobs")
-	os.MkdirAll(logDir, 0755)
+	os.MkdirAll(logDir, 0o755)
 	logPath := filepath.Join(logDir, "42.log")
 	rawContent := `{"type":"assistant"}` + "\n"
-	os.WriteFile(logPath, []byte(rawContent), 0644)
+	os.WriteFile(logPath, []byte(rawContent), 0o644)
 
 	var buf bytes.Buffer
 	cmd := logCmd()

--- a/cmd/roborev/main_integration_test.go
+++ b/cmd/roborev/main_integration_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/storage"
@@ -227,7 +228,7 @@ func TestRunRefineBranchReviewUsesEmptyAgent(t *testing.T) {
 func TestRefineLoopStaysOnFailedFixChain(t *testing.T) {
 	repoDir, _ := setupRefineRepo(t)
 
-	if err := os.WriteFile(filepath.Join(repoDir, "second.txt"), []byte("second"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(repoDir, "second.txt"), []byte("second"), 0o644); err != nil {
 		require.NoError(t, err)
 	}
 	execGit(t, repoDir, "add", "second.txt")
@@ -255,7 +256,7 @@ func TestRefineLoopStaysOnFailedFixChain(t *testing.T) {
 	agent.Register(&functionalMockAgent{nameVal: "test", reviewFunc: func(ctx context.Context, repoPath, commitSHA, prompt string, output io.Writer) (string, error) {
 		changeCount++
 		change := fmt.Sprintf("fix %d", changeCount)
-		if err := os.WriteFile(filepath.Join(repoPath, "fix.txt"), []byte(change), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(repoPath, "fix.txt"), []byte(change), 0o644); err != nil {
 			return "", err
 		}
 		if output != nil {

--- a/cmd/roborev/main_test.go
+++ b/cmd/roborev/main_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/git"
@@ -782,7 +783,7 @@ func TestDaemonStopInvalidPID(t *testing.T) {
 	// Port 59999 is unlikely to be in use and will get connection refused quickly
 	daemonInfo := daemon.RuntimeInfo{PID: 0, Addr: "127.0.0.1:59999"}
 	data, _ := json.Marshal(daemonInfo)
-	if err := os.WriteFile(filepath.Join(tmpDir, "daemon.json"), data, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "daemon.json"), data, 0o644); err != nil {
 		require.NoError(t, err, "write daemon.json: %v")
 	}
 
@@ -802,7 +803,7 @@ func TestDaemonStopCorruptedFile(t *testing.T) {
 	tmpDir := setupIsolatedDataDir(t)
 
 	// Create corrupted daemon.json
-	if err := os.WriteFile(filepath.Join(tmpDir, "daemon.json"), []byte("not valid json"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "daemon.json"), []byte("not valid json"), 0o644); err != nil {
 		require.NoError(t, err, "write daemon.json: %v")
 	}
 
@@ -821,7 +822,7 @@ func TestDaemonStopTruncatedFile(t *testing.T) {
 
 	// Create truncated daemon.json (partial JSON that triggers io.ErrUnexpectedEOF)
 	// A JSON object that ends abruptly mid-string causes io.ErrUnexpectedEOF
-	if err := os.WriteFile(filepath.Join(tmpDir, "daemon.json"), []byte(`{"pid": 123, "addr": "127.0.0.1:7373`), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "daemon.json"), []byte(`{"pid": 123, "addr": "127.0.0.1:7373`), 0o644); err != nil {
 		require.NoError(t, err, "write daemon.json: %v")
 	}
 
@@ -848,16 +849,16 @@ func TestDaemonStopUnreadableFileSkipped(t *testing.T) {
 	daemonInfo := daemon.RuntimeInfo{PID: 12345, Addr: "127.0.0.1:7373"}
 	data, _ := json.Marshal(daemonInfo)
 	daemonPath := filepath.Join(tmpDir, "daemon.json")
-	if err := os.WriteFile(daemonPath, data, 0644); err != nil {
+	if err := os.WriteFile(daemonPath, data, 0o644); err != nil {
 		require.NoError(t, err, "write daemon.json: %v")
 	}
 
 	// Remove read permission
-	if err := os.Chmod(daemonPath, 0000); err != nil {
+	if err := os.Chmod(daemonPath, 0o000); err != nil {
 		require.NoError(t, err, "chmod daemon.json: %v")
 	}
 	// Restore permission for cleanup
-	defer func() { _ = os.Chmod(daemonPath, 0644) }()
+	defer func() { _ = os.Chmod(daemonPath, 0o644) }()
 
 	// Probe whether chmod 0000 actually blocks reads on this filesystem
 	// (some filesystems like Windows or certain ACL-based systems may not enforce this)

--- a/cmd/roborev/main_test_helpers_test.go
+++ b/cmd/roborev/main_test_helpers_test.go
@@ -56,8 +56,8 @@ func (r *GitTestRepo) Run(args ...string) string {
 func (r *GitTestRepo) CommitFile(name, content, msg string) string {
 	r.t.Helper()
 	path := filepath.Join(r.Dir, name)
-	require.NoError(r.t, os.MkdirAll(filepath.Dir(path), 0755))
-	require.NoError(r.t, os.WriteFile(path, []byte(content), 0644))
+	require.NoError(r.t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(r.t, os.WriteFile(path, []byte(content), 0o644))
 	r.Run("add", name)
 	r.Run("commit", "-m", msg)
 	return r.Run("rev-parse", "HEAD")
@@ -170,12 +170,12 @@ func NewMockDaemon(t *testing.T, hooks MockRefineHooks) *MockDaemon {
 	tmpDir := t.TempDir()
 	t.Setenv("ROBOREV_DATA_DIR", tmpDir)
 
-	require.NoError(t, os.MkdirAll(tmpDir, 0755), "failed to create data dir")
+	require.NoError(t, os.MkdirAll(tmpDir, 0o755), "failed to create data dir")
 	mockAddr := ts.URL[7:] // strip "http://"
 	daemonInfo := daemon.RuntimeInfo{Addr: mockAddr, PID: os.Getpid(), Version: version.Version}
 	data, err := json.Marshal(daemonInfo)
 	require.NoError(t, err, "failed to marshal daemon.json")
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "daemon.json"), data, 0644), "failed to write daemon.json")
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "daemon.json"), data, 0o644), "failed to write daemon.json")
 
 	origServerAddr := serverAddr
 	origGetAnyRunningDaemon := getAnyRunningDaemon

--- a/cmd/roborev/mock_daemon_test.go
+++ b/cmd/roborev/mock_daemon_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/version"
 )
@@ -26,7 +27,6 @@ func TestCreateMockRefineHandler_MethodEnforcement(t *testing.T) {
 		wantMethod string
 		wantStatus int
 	}{
-
 		{
 			name:       "GET /api/status returns 200",
 			method:     http.MethodGet,
@@ -127,7 +127,6 @@ func TestCreateMockRefineHandler_MethodEnforcement(t *testing.T) {
 			w := httptest.NewRecorder()
 			handler.ServeHTTP(w, req)
 			assert.Equal(t, tt.wantStatus, w.Code, "got status %d, want %d", w.Code, tt.wantStatus)
-
 		})
 	}
 }
@@ -152,11 +151,9 @@ func TestCreateMockRefineHandler_405ResponseBody(t *testing.T) {
 
 		"got error %q, want %q",
 		resp["error"], "method not allowed")
-
 }
 
 func TestNewMockDaemon_ServerWiring(t *testing.T) {
-
 	md := NewMockDaemon(t, MockRefineHooks{})
 	defer md.Close()
 
@@ -434,7 +431,6 @@ func (b *MockDaemonBuilder) WithJobs(jobs []storage.ReviewJob) *MockDaemonBuilde
 }
 
 func (b *MockDaemonBuilder) Build() *httptest.Server {
-
 	if _, ok := b.handlers["/api/review"]; !ok && len(b.reviews) > 0 {
 		b.handlers["/api/review"] = func(w http.ResponseWriter, r *http.Request) {
 			jobIDStr := r.URL.Query().Get("job_id")
@@ -447,7 +443,6 @@ func (b *MockDaemonBuilder) Build() *httptest.Server {
 			if review, ok := b.reviews[jobID]; ok {
 				json.NewEncoder(w).Encode(review)
 			} else {
-
 				http.Error(w, fmt.Sprintf("review for job %d not found", jobID), http.StatusNotFound)
 			}
 		}

--- a/cmd/roborev/mock_server_test.go
+++ b/cmd/roborev/mock_server_test.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMockServerHandler_HandleEnqueue_MethodRouting(t *testing.T) {

--- a/cmd/roborev/postcommit.go
+++ b/cmd/roborev/postcommit.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/git"
@@ -174,17 +175,17 @@ func hookLog(repo, outcome, message string) {
 	}
 	data = append(data, '\n')
 
-	if err := os.MkdirAll(filepath.Dir(logPath), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o700); err != nil {
 		return
 	}
 	f, err := os.OpenFile(
-		logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600,
+		logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600,
 	)
 	if err != nil {
 		return
 	}
 	defer f.Close()
-	_ = f.Chmod(0600)
+	_ = f.Chmod(0o600)
 	_, _ = f.Write(data)
 }
 

--- a/cmd/roborev/postcommit_test.go
+++ b/cmd/roborev/postcommit_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/githook"
@@ -134,7 +135,6 @@ func TestPostCommitRejectsPositionalArgs(t *testing.T) {
 func TestEnqueueRejectsPositionalArgs(t *testing.T) {
 	_, _, err := executeEnqueueAliasCmd("abc123")
 	require.Error(t, err)
-
 }
 
 func TestPostCommitLogsSuccess(t *testing.T) {
@@ -188,7 +188,7 @@ func TestPostCommitLogsSkipRebase(t *testing.T) {
 		gitDir = filepath.Join(repo.Dir, gitDir)
 	}
 	require.NoError(t, os.MkdirAll(
-		filepath.Join(gitDir, "rebase-merge"), 0755))
+		filepath.Join(gitDir, "rebase-merge"), 0o755))
 
 	_, _, err := executePostCommitCmd("--repo", repo.Dir)
 	require.NoError(t, err)
@@ -300,7 +300,6 @@ func TestPostCommitTimesOutOnSlowDaemon(t *testing.T) {
 
 		"command took %v; should return promptly via timeout",
 		elapsed)
-
 }
 
 func TestEnqueueAliasIsHidden(t *testing.T) {
@@ -427,7 +426,7 @@ func TestPostCommitSkipsEnqueueDuringRebase(t *testing.T) {
 				gitDir = filepath.Join(r.repo.Dir, gitDir)
 			}
 			require.NoError(t, os.MkdirAll(
-				filepath.Join(gitDir, tt.sentinel), 0755))
+				filepath.Join(gitDir, tt.sentinel), 0o755))
 
 			_, _, err := executePostCommitCmd("--repo", r.repo.Dir)
 			require.NoError(t, err)
@@ -457,7 +456,7 @@ esac
 `, marker)
 	require.NoError(t, os.WriteFile(
 		filepath.Join(binDir, "roborev"),
-		[]byte(script), 0755))
+		[]byte(script), 0o755))
 	return binDir
 }
 
@@ -467,7 +466,7 @@ func installMockHook(t *testing.T, repoDir, mockBinDir string) {
 	t.Helper()
 	hooksDir, err := git.GetHooksPath(repoDir)
 	require.NoError(t, err)
-	require.NoError(t, os.MkdirAll(hooksDir, 0755))
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
 
 	hookContent := githook.GeneratePostCommit()
 	mockBin := filepath.Join(mockBinDir, "roborev")
@@ -480,7 +479,7 @@ func installMockHook(t *testing.T, repoDir, mockBinDir string) {
 	}
 	require.NoError(t, os.WriteFile(
 		filepath.Join(hooksDir, "post-commit"),
-		[]byte(strings.Join(lines, "\n")), 0755))
+		[]byte(strings.Join(lines, "\n")), 0o755))
 }
 
 // TestPostCommitDoesNotEnqueueDuringRebase runs a real clean git rebase with
@@ -552,7 +551,7 @@ func TestPostCommitDoesNotEnqueueDuringRebase(t *testing.T) {
 			// Create 3 feature commits with actual file changes.
 			for i := 1; i <= 3; i++ {
 				f := filepath.Join(r.repo.Dir, fmt.Sprintf("branch%d.txt", i))
-				require.NoError(t, os.WriteFile(f, fmt.Appendf(nil, "content %d", i), 0644))
+				require.NoError(t, os.WriteFile(f, fmt.Appendf(nil, "content %d", i), 0o644))
 				gitCmd("add", f)
 				gitCmd("commit", "-m", fmt.Sprintf("feature commit %d", i))
 			}

--- a/cmd/roborev/processcheck_common_test.go
+++ b/cmd/roborev/processcheck_common_test.go
@@ -3,9 +3,9 @@ package main
 import (
 	"encoding/binary"
 	"testing"
+	"unicode/utf16"
 
 	"github.com/stretchr/testify/require"
-	"unicode/utf16"
 )
 
 func TestIsRoborevDaemonCommandForUpdate(t *testing.T) {

--- a/cmd/roborev/refine.go
+++ b/cmd/roborev/refine.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/daemon"

--- a/cmd/roborev/refine_integration_test.go
+++ b/cmd/roborev/refine_integration_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/testutil"
 )
 
@@ -143,7 +144,6 @@ func TestValidateRefineContext(t *testing.T) {
 			assert.NotEmpty(t, repoPath, "expected non-empty repoPath")
 			assert.Equal(t, tt.wantBr, currentBranch, "expected branch %q", tt.wantBr)
 			assert.Equal(t, expectedBase, mergeBase, "expected merge base %q", expectedBase)
-
 		})
 	}
 }

--- a/cmd/roborev/refine_test.go
+++ b/cmd/roborev/refine_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/daemon"
@@ -149,7 +150,6 @@ func (m *mockDaemonClient) WithJob(id int64, gitRef string, status storage.JobSt
 var _ daemon.Client = (*mockDaemonClient)(nil)
 
 func TestSelectRefineAgentCodexFallback(t *testing.T) {
-
 	t.Setenv("PATH", "")
 
 	_, err := selectRefineAgent("", nil, "codex", agent.ReasoningFast, "")
@@ -160,7 +160,6 @@ func TestSelectRefineAgentCodexFallback(t *testing.T) {
 }
 
 func TestResolveAllowUnsafeAgents(t *testing.T) {
-
 	boolTrue := true
 	boolFalse := false
 
@@ -775,7 +774,7 @@ fi
 exit 0
 `)
 
-	if err := os.WriteFile(filepath.Join(repo.Root, "new.txt"), []byte("hello"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(repo.Root, "new.txt"), []byte("hello"), 0o644); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -799,7 +798,7 @@ func TestCommitWithHookRetryExhausted(t *testing.T) {
 	repo.WriteNamedHook("pre-commit",
 		"#!/bin/sh\necho 'always fails' >&2\nexit 1\n")
 
-	if err := os.WriteFile(filepath.Join(repo.Root, "new.txt"), []byte("hello"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(repo.Root, "new.txt"), []byte("hello"), 0o644); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -833,12 +832,12 @@ func TestCommitWithHookRetrySkipsAddPhaseError(t *testing.T) {
 
 	repo.WriteNamedHook("pre-commit", "#!/bin/sh\nexit 0\n")
 
-	if err := os.WriteFile(filepath.Join(repo.Root, "new.txt"), []byte("hello"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(repo.Root, "new.txt"), []byte("hello"), 0o644); err != nil {
 		require.NoError(t, err)
 	}
 
 	lockFile := filepath.Join(repo.Root, ".git", "index.lock")
-	if err := os.WriteFile(lockFile, []byte(""), 0644); err != nil {
+	if err := os.WriteFile(lockFile, []byte(""), 0o644); err != nil {
 		require.NoError(t, err)
 	}
 	defer os.Remove(lockFile)
@@ -915,7 +914,6 @@ func TestResolveReasoningWithFast(t *testing.T) {
 }
 
 func TestApplyModelForAgent_BackupKeepsOwnModel(t *testing.T) {
-
 	t.Cleanup(testutil.MockExecutableIsolated(t, "codex", 0))
 
 	selected, err := selectRefineAgent(
@@ -966,7 +964,6 @@ func TestApplyModelForAgent_EmptyModelPreservesAgentDefault(t *testing.T) {
 	codexAgent, ok := result.(*agent.CodexAgent)
 	assert.True(t, ok)
 	assert.Equal(t, "o3", codexAgent.Model, "agent model should remain %q, got %q", "o3", codexAgent.Model)
-
 }
 
 func TestApplyModelForAgent_SameAgentPrimaryAndBackup(t *testing.T) {
@@ -996,7 +993,6 @@ func TestApplyModelForAgent_SameAgentPrimaryAndBackup(t *testing.T) {
 
 	assert.Equal(t, "primary-model", model)
 	assert.Equal(t, "primary-model", codexAgent.Model, "expected agent model %q, got %q", "primary-model", codexAgent.Model)
-
 }
 
 func TestApplyModelForAgentFallbackUsesDefaultModelForActualAgent(t *testing.T) {

--- a/cmd/roborev/remap.go
+++ b/cmd/roborev/remap.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/git"
 )

--- a/cmd/roborev/remap_test.go
+++ b/cmd/roborev/remap_test.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io"
 	"reflect"
 	"strings"
 	"testing"
 	"testing/iotest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRemapStdinParsing(t *testing.T) {

--- a/cmd/roborev/repo.go
+++ b/cmd/roborev/repo.go
@@ -9,6 +9,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/storage"

--- a/cmd/roborev/repo_test.go
+++ b/cmd/roborev/repo_test.go
@@ -40,13 +40,13 @@ func TestResolveRepoIdentifier(t *testing.T) {
 
 		tmpDir := t.TempDir()
 		orgDir := filepath.Join(tmpDir, "org")
-		require.NoError(t, os.Mkdir(orgDir, 0755), "Failed to create org dir")
+		require.NoError(t, os.Mkdir(orgDir, 0o755), "Failed to create org dir")
 
 		// Ensure we are in a safe directory (tmpDir) before modifying permissions of orgDir
 		chdir(t, tmpDir)
 
-		require.NoError(t, os.Chmod(orgDir, 0000), "Failed to chmod")
-		defer func() { _ = os.Chmod(orgDir, 0755) }()
+		require.NoError(t, os.Chmod(orgDir, 0o000), "Failed to chmod")
+		defer func() { _ = os.Chmod(orgDir, 0o755) }()
 
 		// The test expects "org/project" because it can't stat "org" to see if it's a repo,
 		// so it treats it as a name string.
@@ -58,7 +58,7 @@ func TestResolveRepoIdentifier(t *testing.T) {
 		root := newTestGitRepo(t).Dir
 		// Create common structure: root/sub/dir
 		subDir := filepath.Join(root, "sub", "dir")
-		require.NoError(t, os.MkdirAll(subDir, 0755))
+		require.NoError(t, os.MkdirAll(subDir, 0o755))
 
 		// Also create a non-git temp dir for that one case
 		nonGitDir := t.TempDir()

--- a/cmd/roborev/review.go
+++ b/cmd/roborev/review.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/daemon"
@@ -460,7 +461,7 @@ func runLocalReview(cmd *cobra.Command, repoPath, gitRef, diffContent, agentName
 	}
 
 	// Use consistent output writer, respecting --quiet
-	var out = cmd.OutOrStdout()
+	out := cmd.OutOrStdout()
 	if quiet {
 		out = io.Discard
 	}

--- a/cmd/roborev/review_test.go
+++ b/cmd/roborev/review_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -565,7 +566,7 @@ func writeRoborevConfig(t *testing.T, repo *TestGitRepo, content string) {
 	t.Helper()
 	err := os.WriteFile(
 		filepath.Join(repo.Dir, ".roborev.toml"),
-		[]byte(content), 0644,
+		[]byte(content), 0o644,
 	)
 	require.NoError(t, err, "write .roborev.toml: %v")
 }
@@ -849,23 +850,23 @@ func TestFindChildGitRepos(t *testing.T) {
 	parent := t.TempDir()
 
 	regularRepo := filepath.Join(parent, "regular")
-	os.Mkdir(regularRepo, 0755)
-	os.Mkdir(filepath.Join(regularRepo, ".git"), 0755)
+	os.Mkdir(regularRepo, 0o755)
+	os.Mkdir(filepath.Join(regularRepo, ".git"), 0o755)
 
 	worktreeRepo := filepath.Join(parent, "worktree")
-	os.Mkdir(worktreeRepo, 0755)
+	os.Mkdir(worktreeRepo, 0o755)
 	os.WriteFile(
 		filepath.Join(worktreeRepo, ".git"),
 		[]byte("gitdir: /some/main/.git/worktrees/wt"),
-		0644,
+		0o644,
 	)
 
 	plainDir := filepath.Join(parent, "plain")
-	os.Mkdir(plainDir, 0755)
+	os.Mkdir(plainDir, 0o755)
 
 	hiddenDir := filepath.Join(parent, ".hidden")
-	os.Mkdir(hiddenDir, 0755)
-	os.Mkdir(filepath.Join(hiddenDir, ".git"), 0755)
+	os.Mkdir(hiddenDir, 0o755)
+	os.Mkdir(filepath.Join(hiddenDir, ".git"), 0o755)
 
 	repos := findChildGitRepos(parent)
 
@@ -885,8 +886,8 @@ func TestFindChildGitReposHintPaths(t *testing.T) {
 	parent := t.TempDir()
 
 	repoDir := filepath.Join(parent, "my-repo")
-	os.Mkdir(repoDir, 0755)
-	os.Mkdir(filepath.Join(repoDir, ".git"), 0755)
+	os.Mkdir(repoDir, 0o755)
+	os.Mkdir(filepath.Join(repoDir, ".git"), 0o755)
 
 	_, _, err := executeReviewCmd("--repo", parent)
 	require.Error(t, err, "Expected error for non-git directory")

--- a/cmd/roborev/run.go
+++ b/cmd/roborev/run.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/git"

--- a/cmd/roborev/run_test.go
+++ b/cmd/roborev/run_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/version"
@@ -25,7 +26,7 @@ func createRepoWithConfig(t *testing.T, configContent string) string {
 	t.Helper()
 	repoPath := t.TempDir()
 	if configContent != "" {
-		if err := os.WriteFile(filepath.Join(repoPath, ".roborev.toml"), []byte(configContent), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(repoPath, ".roborev.toml"), []byte(configContent), 0o644); err != nil {
 			require.NoError(t, err)
 		}
 	}

--- a/cmd/roborev/show.go
+++ b/cmd/roborev/show.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/tokens"

--- a/cmd/roborev/show_test.go
+++ b/cmd/roborev/show_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 

--- a/cmd/roborev/skills.go
+++ b/cmd/roborev/skills.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/skills"
 )
 

--- a/cmd/roborev/status.go
+++ b/cmd/roborev/status.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/githook"
 	"go.kenn.io/roborev/internal/storage"

--- a/cmd/roborev/status_test.go
+++ b/cmd/roborev/status_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/version"
 )

--- a/cmd/roborev/stream.go
+++ b/cmd/roborev/stream.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/git"
 )
 

--- a/cmd/roborev/summary.go
+++ b/cmd/roborev/summary.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/storage"
 )

--- a/cmd/roborev/summary_test.go
+++ b/cmd/roborev/summary_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 

--- a/cmd/roborev/sync.go
+++ b/cmd/roborev/sync.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
 )

--- a/cmd/roborev/tui/action_test.go
+++ b/cmd/roborev/tui/action_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mattn/go-runewidth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -60,7 +61,6 @@ func TestTUIToggleClosedNoReview(t *testing.T) {
 
 	errMsg := assertMsgType[errMsg](t, msg)
 	assert.Equal(t, "no review for this job", errMsg.Error(), "Expected 'no review for this job', got: %v", errMsg)
-
 }
 
 func TestTUICloseFromReviewView_Navigation(t *testing.T) {
@@ -78,7 +78,6 @@ func TestTUICloseFromReviewView_Navigation(t *testing.T) {
 			initialIdx:   1,
 			initialJobID: 2,
 			actions: func(m model) model {
-
 				m2, _ := pressKey(m, 'a')
 
 				assertSelection(t, m2, 1, 2)
@@ -346,7 +345,6 @@ func TestTUIClosedSuccessNoRollback(t *testing.T) {
 		}
 	}
 	require.NoError(t, m.err, "Expected no error, got %v", m.err)
-
 }
 
 func TestTUIClosedToggleMovesSelectionWithHideActive(t *testing.T) {
@@ -368,7 +366,6 @@ func TestTUIClosedToggleMovesSelectionWithHideActive(t *testing.T) {
 
 	prevIdx := m.findPrevVisibleJob(m.selectedIdx)
 	assert.Equal(t, 2, prevIdx, "Expected prev visible job at index 2, got %d", prevIdx)
-
 }
 
 func TestTUIClosedRollbackRestoresSelectionAfterHideClosedMove(t *testing.T) {
@@ -838,11 +835,9 @@ func TestTUICancelJobNotFound(t *testing.T) {
 		"expected not-found response to include error")
 	assert.Equal(t, storage.JobStatusQueued, result.oldState, "Expected oldState=queued for rollback, got %s", result.oldState)
 	assert.Nil(t, result.oldFinishedAt, "Expected oldFinishedAt=nil for queued job, got %v", result.oldFinishedAt)
-
 }
 
 func TestTUICancelRollbackOnError(t *testing.T) {
-
 	startTime := time.Now().Add(-5 * time.Minute)
 	m := setupTestModel([]storage.ReviewJob{
 		makeJob(42, withStatus(storage.JobStatusRunning), withStartedAt(startTime), withFinishedAt(nil)),
@@ -868,11 +863,9 @@ func TestTUICancelRollbackOnError(t *testing.T) {
 
 	require.Error(t, m2.err,
 		"expected cancel error on rollback")
-
 }
 
 func TestTUICancelRollbackWithNonNilFinishedAt(t *testing.T) {
-
 	startTime := time.Now().Add(-5 * time.Minute)
 	originalFinished := time.Now().Add(-2 * time.Minute)
 	m := setupTestModel([]storage.ReviewJob{
@@ -900,11 +893,9 @@ func TestTUICancelRollbackWithNonNilFinishedAt(t *testing.T) {
 		"expected finishedAt to be restored")
 	require.Error(t, m2.err,
 		"expected rollback error on save failure")
-
 }
 
 func TestTUICancelOptimisticUpdate(t *testing.T) {
-
 	startTime := time.Now().Add(-5 * time.Minute)
 	m := setupTestModel([]storage.ReviewJob{
 		makeJob(42, withStatus(storage.JobStatusRunning), withStartedAt(startTime), withFinishedAt(nil)),
@@ -920,11 +911,9 @@ func TestTUICancelOptimisticUpdate(t *testing.T) {
 
 	assert.NotNil(t, m2.jobs[0].FinishedAt, "expected optimistic cancel to set finishedAt")
 	assert.NotNil(t, cmd, "expected cancel command to be returned")
-
 }
 
 func TestTUICancelOnlyRunningOrQueued(t *testing.T) {
-
 	testCases := []storage.JobStatus{
 		storage.JobStatusDone,
 		storage.JobStatusFailed,
@@ -948,7 +937,6 @@ func TestTUICancelOnlyRunningOrQueued(t *testing.T) {
 				assert.True(t, m2.jobs[0].FinishedAt != nil && m2.jobs[0].FinishedAt.Equal(finishedAt), "Expected FinishedAt to remain unchanged")
 			}
 			assert.Nil(t, cmd, "Expected no command for non-cancellable job, got %v", cmd)
-
 		})
 	}
 }
@@ -991,7 +979,6 @@ func TestTUIRespondTextPreservation(t *testing.T) {
 		assert.Empty(t, m.commentText, "Expected text cleared for different job, got %q", m.commentText)
 	}
 	assert.Equal(t, int64(2), m.commentJobID, "Expected commentJobID=2, got %d", m.commentJobID)
-
 }
 
 func TestTUIRespondSuccessClearsOnlyMatchingJob(t *testing.T) {
@@ -1015,7 +1002,6 @@ func TestTUIRespondSuccessClearsOnlyMatchingJob(t *testing.T) {
 		assert.Empty(t, m.commentText, "Expected text cleared for matching job, got %q", m.commentText)
 	}
 	assert.Equal(t, int64(0), m.commentJobID, "Expected commentJobID=0 after success, got %d", m.commentJobID)
-
 }
 
 func TestTUIRespondBackspaceMultiByte(t *testing.T) {
@@ -1031,7 +1017,6 @@ func TestTUIRespondBackspaceMultiByte(t *testing.T) {
 
 	m, _ = pressSpecial(m, tea.KeyBackspace)
 	assert.Equal(t, "Hello ", m.commentText, "Expected commentText='Hello ' after second backspace, got %q", m.commentText)
-
 }
 
 func isValidUTF8(s string) bool {
@@ -1085,7 +1070,6 @@ func TestTUIRespondViewTruncationMultiByte(t *testing.T) {
 	}
 	assert.NotEqual(t, expectedWidth, 0,
 		"expected content area to produce visual width")
-
 }
 
 func TestTUIRespondViewTabExpansion(t *testing.T) {
@@ -1127,7 +1111,6 @@ func TestCancelKeyMovesSelectionWithHideClosed(t *testing.T) {
 			"selected index should move away from hidden canceled job")
 	assert.True(t, m2.isJobVisible(m2.jobs[m2.selectedIdx]),
 		"selected job should remain visible after selection move")
-
 }
 
 func TestClosedKeyUpdatesStatsOptimistically(t *testing.T) {
@@ -1192,13 +1175,11 @@ func assertSelection(t *testing.T, m model, idx int, jobID int64) {
 	t.Helper()
 	assert.Equal(t, idx, m.selectedIdx, "Expected selectedIdx=%d, got %d", idx, m.selectedIdx)
 	assert.Equal(t, jobID, m.selectedJobID, "Expected selectedJobID=%d, got %d", jobID, m.selectedJobID)
-
 }
 
 func assertView(t *testing.T, m model, view viewKind) {
 	t.Helper()
 	assert.Equal(t, view, m.currentView, "Expected view=%d, got %d", view, m.currentView)
-
 }
 
 func withStartedAt(t time.Time) func(*storage.ReviewJob) {
@@ -1245,5 +1226,4 @@ func assertJobStats(t *testing.T, m model, closed, open int) {
 	t.Helper()
 	require.Equal(t, m.jobStats.Closed, closed, "expected Closed=%d, got %d", closed, m.jobStats.Closed)
 	require.Equal(t, m.jobStats.Open, open, "expected Open=%d, got %d", open, m.jobStats.Open)
-
 }

--- a/cmd/roborev/tui/actions.go
+++ b/cmd/roborev/tui/actions.go
@@ -11,6 +11,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	godiff "github.com/sourcegraph/go-diff/diff"
+
 	daemonclient "go.kenn.io/roborev/internal/daemon_client"
 	"go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/storage"
@@ -317,8 +318,10 @@ func (m model) applyFixPatchInWorktree(jobID int64) tea.Cmd {
 		cmd := exec.Command("git", "-C", jobDetail.RepoPath, "worktree", "add", wtDir, jobDetail.Branch)
 		if out, cmdErr := cmd.CombinedOutput(); cmdErr != nil {
 			os.RemoveAll(wtDir)
-			return applyPatchResultMsg{jobID: jobID,
-				err: fmt.Errorf("git worktree add: %w: %s", cmdErr, out)}
+			return applyPatchResultMsg{
+				jobID: jobID,
+				err:   fmt.Errorf("git worktree add: %w: %s", cmdErr, out),
+			}
 		}
 
 		result := m.checkApplyCommitPatch(jobID, jobDetail, wtDir, patch)
@@ -359,12 +362,16 @@ func (m model) checkApplyCommitPatch(jobID int64, jobDetail *storage.ReviewJob, 
 	}
 	dirty, dirtyErr := dirtyPatchFiles(targetDir, patchedFiles)
 	if dirtyErr != nil {
-		return applyPatchResultMsg{jobID: jobID,
-			err: fmt.Errorf("checking dirty files: %w", dirtyErr)}
+		return applyPatchResultMsg{
+			jobID: jobID,
+			err:   fmt.Errorf("checking dirty files: %w", dirtyErr),
+		}
 	}
 	if len(dirty) > 0 {
-		return applyPatchResultMsg{jobID: jobID,
-			err: fmt.Errorf("uncommitted changes in patch files: %s — stash or commit first", strings.Join(dirty, ", "))}
+		return applyPatchResultMsg{
+			jobID: jobID,
+			err:   fmt.Errorf("uncommitted changes in patch files: %s — stash or commit first", strings.Join(dirty, ", ")),
+		}
 	}
 
 	// Dry-run check — only trigger rebase on actual merge conflicts
@@ -393,8 +400,10 @@ func (m model) checkApplyCommitPatch(jobID int64, jobDetail *storage.ReviewJob, 
 		commitMsg = fmt.Sprintf("fix: apply roborev fix for %s (job #%d)", ref, jobID)
 	}
 	if err := commitPatch(targetDir, patch, commitMsg); err != nil {
-		return applyPatchResultMsg{jobID: jobID, parentJobID: parentJobID, success: true,
-			commitFailed: true, err: fmt.Errorf("patch applied but commit failed: %w", err)}
+		return applyPatchResultMsg{
+			jobID: jobID, parentJobID: parentJobID, success: true,
+			commitFailed: true, err: fmt.Errorf("patch applied but commit failed: %w", err),
+		}
 	}
 
 	// Mark the fix job as applied on the server
@@ -406,8 +415,10 @@ func (m model) checkApplyCommitPatch(jobID int64, jobDetail *storage.ReviewJob, 
 		err = apiStatusError(resp.StatusCode(), resp.Status(), resp.Body)
 	}
 	if err != nil {
-		return applyPatchResultMsg{jobID: jobID, parentJobID: parentJobID, success: true,
-			err: fmt.Errorf("patch applied and committed but failed to mark applied: %w", err)}
+		return applyPatchResultMsg{
+			jobID: jobID, parentJobID: parentJobID, success: true,
+			err: fmt.Errorf("patch applied and committed but failed to mark applied: %w", err),
+		}
 	}
 
 	return applyPatchResultMsg{jobID: jobID, parentJobID: parentJobID, success: true}

--- a/cmd/roborev/tui/command_header_test.go
+++ b/cmd/roborev/tui/command_header_test.go
@@ -4,8 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"go.kenn.io/roborev/internal/storage"
 	"github.com/stretchr/testify/assert"
+
+	"go.kenn.io/roborev/internal/storage"
 )
 
 // cmdHeaderLine returns the rendered "Command:" header line from a full view,

--- a/cmd/roborev/tui/control.go
+++ b/cmd/roborev/tui/control.go
@@ -77,10 +77,10 @@ func isConnRefused(err error) bool {
 // This must only be called for managed directories (the
 // default data dir), never for arbitrary user-supplied paths.
 func ensureSocketDir(dir string) error {
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create socket directory: %w", err)
 	}
-	if err := os.Chmod(dir, 0700); err != nil {
+	if err := os.Chmod(dir, 0o700); err != nil {
 		return fmt.Errorf("chmod socket directory: %w", err)
 	}
 	return nil
@@ -92,7 +92,7 @@ func startControlListener(
 	// Ensure the parent directory exists for custom socket paths.
 	// Permission tightening is handled separately by ensureSocketDir
 	// for the default managed directory only.
-	if err := os.MkdirAll(filepath.Dir(socketPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0o755); err != nil {
 		return nil, fmt.Errorf("create socket directory: %w", err)
 	}
 
@@ -109,7 +109,7 @@ func startControlListener(
 	}
 
 	// Restrict socket permissions to owner-only.
-	if err := os.Chmod(socketPath, 0600); err != nil {
+	if err := os.Chmod(socketPath, 0o600); err != nil {
 		ln.Close()
 		return nil, fmt.Errorf("chmod socket: %w", err)
 	}

--- a/cmd/roborev/tui/control_handlers.go
+++ b/cmd/roborev/tui/control_handlers.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 

--- a/cmd/roborev/tui/control_runtime.go
+++ b/cmd/roborev/tui/control_runtime.go
@@ -31,7 +31,7 @@ func tuiRuntimePath(pid int) string {
 func WriteTUIRuntime(info TUIRuntimeInfo) error {
 	path := tuiRuntimePath(info.PID)
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
 
@@ -64,7 +64,7 @@ func WriteTUIRuntime(info TUIRuntimeInfo) error {
 	if err := os.Rename(tmpPath, path); err != nil {
 		return err
 	}
-	if err := os.Chmod(path, 0600); err != nil {
+	if err := os.Chmod(path, 0o600); err != nil {
 		return err
 	}
 

--- a/cmd/roborev/tui/control_test.go
+++ b/cmd/roborev/tui/control_test.go
@@ -15,6 +15,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -1134,7 +1135,7 @@ func TestRemoveStaleSocket_NonexistentPath(t *testing.T) {
 
 func TestRemoveStaleSocket_RegularFileRefused(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "file.txt")
-	require.NoError(t, os.WriteFile(path, []byte("data"), 0600))
+	require.NoError(t, os.WriteFile(path, []byte("data"), 0o600))
 
 	err := removeStaleSocket(path)
 	require.Error(t, err, "expected error for regular file")
@@ -1268,7 +1269,7 @@ func TestCleanupStaleTUIRuntimes_NonSocketPreserved(t *testing.T) {
 	// Write metadata pointing to a regular file (not a socket).
 	// Cleanup should remove the metadata but not the file.
 	filePath := filepath.Join(tmpDir, "tui.999999999.sock")
-	require.NoError(os.WriteFile(filePath, []byte{}, 0600))
+	require.NoError(os.WriteFile(filePath, []byte{}, 0o600))
 
 	info := TUIRuntimeInfo{
 		PID:        999999999,

--- a/cmd/roborev/tui/control_types.go
+++ b/cmd/roborev/tui/control_types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	tea "github.com/charmbracelet/bubbletea"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 

--- a/cmd/roborev/tui/control_unix_test.go
+++ b/cmd/roborev/tui/control_unix_test.go
@@ -33,7 +33,7 @@ func TestControlSocketPermissions(t *testing.T) {
 	assert.NotZero(t, info.Mode().Type()&os.ModeSocket,
 		"expected socket type, got %s", info.Mode().Type())
 	perm := info.Mode().Perm()
-	assert.Zero(t, perm&0077,
+	assert.Zero(t, perm&0o077,
 		"socket permissions %o allow group/other access", perm)
 }
 
@@ -41,13 +41,13 @@ func TestEnsureSocketDirTightensExistingDir(t *testing.T) {
 	socketDir := t.TempDir()
 
 	// Simulate a pre-existing data directory created with 0755.
-	require.NoError(t, os.Chmod(socketDir, 0755))
+	require.NoError(t, os.Chmod(socketDir, 0o755))
 
 	require.NoError(t, ensureSocketDir(socketDir))
 
 	di, err := os.Stat(socketDir)
 	require.NoError(t, err, "stat socket dir")
-	assert.Equal(t, os.FileMode(0700), di.Mode().Perm(),
+	assert.Equal(t, os.FileMode(0o700), di.Mode().Perm(),
 		"socket directory should be tightened to 0700")
 }
 

--- a/cmd/roborev/tui/fetch.go
+++ b/cmd/roborev/tui/fetch.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/daemon"
 	daemonclient "go.kenn.io/roborev/internal/daemon_client"
@@ -896,6 +897,7 @@ func (m model) fetchCommitMsg(job *storage.ReviewJob) tea.Cmd {
 		return commitMsgMsg{jobID: jobID, content: sanitizeForDisplay(content.String())}
 	}
 }
+
 func (m model) fetchPatch(jobID int64) tea.Cmd {
 	return func() tea.Msg {
 		patch, err := m.loadPatch(jobID)

--- a/cmd/roborev/tui/filter_queue_test.go
+++ b/cmd/roborev/tui/filter_queue_test.go
@@ -5,6 +5,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -107,7 +108,6 @@ func TestTUIMultiPathFilterStatusCounts(t *testing.T) {
 }
 
 func TestTUIBranchFilterApplied(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 
 	m.jobs = []storage.ReviewJob{
@@ -130,7 +130,6 @@ func TestTUIBranchFilterApplied(t *testing.T) {
 }
 
 func TestTUIBranchFilterNone(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 
 	m.jobs = []storage.ReviewJob{
@@ -152,7 +151,6 @@ func TestTUIBranchFilterNone(t *testing.T) {
 }
 
 func TestTUIBranchFilterCombinedWithRepoFilter(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 
 	m.jobs = []storage.ReviewJob{
@@ -174,7 +172,6 @@ func TestTUIBranchFilterCombinedWithRepoFilter(t *testing.T) {
 }
 
 func TestTUINavigateDownNoLoadMoreWhenBranchFiltered(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 
 	m.jobs = []storage.ReviewJob{makeJob(1, withBranch("feature"))}
@@ -192,7 +189,6 @@ func TestTUINavigateDownNoLoadMoreWhenBranchFiltered(t *testing.T) {
 }
 
 func TestTUINavigateJKeyNoLoadMoreWhenBranchFiltered(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 
 	m.jobs = []storage.ReviewJob{makeJob(1, withBranch("feature"))}
@@ -210,7 +206,6 @@ func TestTUINavigateJKeyNoLoadMoreWhenBranchFiltered(t *testing.T) {
 }
 
 func TestTUIPageDownNoLoadMoreWhenBranchFiltered(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 
 	m.jobs = []storage.ReviewJob{makeJob(1, withBranch("feature"))}
@@ -229,7 +224,6 @@ func TestTUIPageDownNoLoadMoreWhenBranchFiltered(t *testing.T) {
 }
 
 func TestTUIBranchFilterClearTriggersRefetch(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 
 	m.currentView = viewQueue
@@ -424,7 +418,7 @@ func TestTUIAutoRepoFilterUsesRenamedRepoDisplayName(t *testing.T) {
 
 	m2, cmd := updateModel(t, m, repoNamesMsg{
 		names: map[string][]string{
-			"new-service": []string{oldRoot},
+			"new-service": {oldRoot},
 		},
 	})
 
@@ -447,10 +441,10 @@ func TestTUIAutoRepoFilterFallsBackToIdentity(t *testing.T) {
 
 	m2, cmd := updateModel(t, m, repoNamesMsg{
 		names: map[string][]string{
-			"old-service": []string{oldRoot},
+			"old-service": {oldRoot},
 		},
 		identities: map[string][]string{
-			identity: []string{oldRoot},
+			identity: {oldRoot},
 		},
 	})
 
@@ -474,10 +468,10 @@ func TestTUIAutoRepoFilterPrefersIdentityOverDisplayName(t *testing.T) {
 
 	m2, cmd := updateModel(t, m, repoNamesMsg{
 		names: map[string][]string{
-			"service": []string{wrongRoot},
+			"service": {wrongRoot},
 		},
 		identities: map[string][]string{
-			identity: []string{expectedRoot},
+			identity: {expectedRoot},
 		},
 	})
 
@@ -500,10 +494,10 @@ func TestTUIAutoRepoFilterKeepsTrackedCloneWithSharedIdentity(t *testing.T) {
 
 	m2, cmd := updateModel(t, m, repoNamesMsg{
 		names: map[string][]string{
-			"service": []string{currentRoot, otherRoot},
+			"service": {currentRoot, otherRoot},
 		},
 		identities: map[string][]string{
-			identity: []string{currentRoot, otherRoot},
+			identity: {currentRoot, otherRoot},
 		},
 	})
 

--- a/cmd/roborev/tui/filter_search_test.go
+++ b/cmd/roborev/tui/filter_search_test.go
@@ -158,7 +158,6 @@ func TestTUIFilterSearchByRepoPath(t *testing.T) {
 
 func TestTUIFilterSearchByDisplayName(t *testing.T) {
 	m := initFilterModel([]treeFilterNode{
-
 		{name: "My Project", rootPaths: []string{"/home/user/my-project-repo"}, count: 2},
 
 		{name: "frontend", rootPaths: []string{"/path/to/frontend"}, count: 1},

--- a/cmd/roborev/tui/filter_stack_test.go
+++ b/cmd/roborev/tui/filter_stack_test.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -30,7 +31,6 @@ func TestTUIFilterClearWithEsc(t *testing.T) {
 }
 
 func TestTUIFilterClearWithEscLayered(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 
 	m.jobs = []storage.ReviewJob{
@@ -55,7 +55,6 @@ func TestTUIFilterClearWithEscLayered(t *testing.T) {
 }
 
 func TestTUIFilterClearHideClosedOnly(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 
 	m.jobs = []storage.ReviewJob{
@@ -73,7 +72,6 @@ func TestTUIFilterClearHideClosedOnly(t *testing.T) {
 }
 
 func TestTUIFilterEscapeWhileLoadingFiresNewFetch(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 
 	m.jobs = []storage.ReviewJob{
@@ -99,7 +97,6 @@ func TestTUIFilterEscapeWhileLoadingFiresNewFetch(t *testing.T) {
 }
 
 func TestTUIFilterEscapeWhilePaginationDiscardsAppend(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 
 	m.jobs = []storage.ReviewJob{
@@ -222,7 +219,6 @@ func TestTUIFilterStackEscapeOrder(t *testing.T) {
 }
 
 func TestTUIFilterStackTitleBarOrder(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 
 	m.jobs = []storage.ReviewJob{
@@ -251,7 +247,7 @@ func TestTUIFilterStackTitleUsesRepoDisplayName(t *testing.T) {
 	m.activeRepoFilter = []string{"/workspace/old-service"}
 	m.filterStack = []string{"repo"}
 	m.repoNames = map[string][]string{
-		"new-service": []string{"/workspace/old-service"},
+		"new-service": {"/workspace/old-service"},
 	}
 
 	output := m.View()
@@ -261,7 +257,6 @@ func TestTUIFilterStackTitleUsesRepoDisplayName(t *testing.T) {
 }
 
 func TestTUIFilterStackReverseOrder(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 
 	m.jobs = []storage.ReviewJob{
@@ -332,7 +327,6 @@ func TestTUIReconnectClearsFetchFailed(t *testing.T) {
 }
 
 func TestTUILockedFilterModalBlocksAll(t *testing.T) {
-
 	nodes := []treeFilterNode{
 		makeNode("repo-a", 3),
 	}
@@ -351,7 +345,6 @@ func TestTUILockedFilterModalBlocksAll(t *testing.T) {
 }
 
 func TestTUIPopFilterSkipsLockedWalksBack(t *testing.T) {
-
 	m := initFilterModel(nil)
 	m.activeRepoFilter = []string{"/unlocked/repo"}
 	m.activeBranchFilter = "locked-branch"
@@ -367,7 +360,6 @@ func TestTUIPopFilterSkipsLockedWalksBack(t *testing.T) {
 }
 
 func TestTUIPopFilterAllLocked(t *testing.T) {
-
 	m := initFilterModel(nil)
 	m.activeRepoFilter = []string{"/locked/repo"}
 	m.activeBranchFilter = "locked-branch"
@@ -381,7 +373,6 @@ func TestTUIPopFilterAllLocked(t *testing.T) {
 }
 
 func TestTUIEscapeWithLockedFilters(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.currentView = viewQueue
 	m.jobs = []storage.ReviewJob{

--- a/cmd/roborev/tui/filter_test.go
+++ b/cmd/roborev/tui/filter_test.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -139,7 +140,6 @@ func TestTUIFilterPreselectsMultiPathReordered(t *testing.T) {
 }
 
 func TestTUIFilterAggregatedDisplayName(t *testing.T) {
-
 	m := initFilterModel([]treeFilterNode{
 		{name: "backend", rootPaths: []string{"/path/to/backend-dev", "/path/to/backend-prod"}, count: 2},
 		{name: "frontend", rootPaths: []string{"/path/to/frontend"}, count: 1},
@@ -256,7 +256,6 @@ func TestTUIFilterViewScrollWindow(t *testing.T) {
 }
 
 func TestTUIFilterLoadingRendersPaddedHeight(t *testing.T) {
-
 	m := initFilterModel(nil)
 	m.width = 100
 	m.height = 20
@@ -290,7 +289,6 @@ func TestTUIRightArrowRetriesAfterFailedLoad(t *testing.T) {
 }
 
 func TestTUIWindowResizeNoLoadMoreWhenMultiRepoFiltered(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 
 	m.jobs = []storage.ReviewJob{makeJob(1, withRepoPath("/repo1"))}

--- a/cmd/roborev/tui/filter_test_helpers.go
+++ b/cmd/roborev/tui/filter_test_helpers.go
@@ -1,9 +1,10 @@
 package tui
 
 import (
+	"testing"
+
 	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/storage"
-	"testing"
 )
 
 type testModelOption func(*model)

--- a/cmd/roborev/tui/filter_tree_test.go
+++ b/cmd/roborev/tui/filter_tree_test.go
@@ -8,6 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -440,7 +441,6 @@ func TestTUIManualExpandFailureDoesNotBlockSearch(t *testing.T) {
 }
 
 func TestTUITreeFilterSelectBranchTriggersRefetch(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.currentView = viewFilter
 	setupFilterTree(&m, []treeFilterNode{
@@ -470,7 +470,6 @@ func TestTUITreeFilterSelectBranchTriggersRefetch(t *testing.T) {
 }
 
 func TestTUIBranchBackfillDoneSetWhenNoNullsRemain(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.branchBackfillDone = false
 
@@ -482,7 +481,6 @@ func TestTUIBranchBackfillDoneSetWhenNoNullsRemain(t *testing.T) {
 }
 
 func TestTUIBranchBackfillDoneSetEvenWhenNullsRemain(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.branchBackfillDone = false
 
@@ -494,7 +492,6 @@ func TestTUIBranchBackfillDoneSetEvenWhenNullsRemain(t *testing.T) {
 }
 
 func TestTUIBranchBackfillIsOneTimeOperation(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.branchBackfillDone = false
 
@@ -512,7 +509,6 @@ func TestTUIBranchBackfillIsOneTimeOperation(t *testing.T) {
 }
 
 func TestTUIBranchBackfillDoneStaysTrueAfterNewJobs(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.branchBackfillDone = true
 
@@ -639,8 +635,12 @@ func TestTUIFilterEnterClearsBranchMode(t *testing.T) {
 	m.currentView = viewFilter
 	m.filterBranchMode = true
 	setupFilterTree(&m, []treeFilterNode{
-		{name: "repo-a", rootPaths: []string{"/path/to/repo-a"}, count: 5,
-			children: []branchFilterItem{{name: "main", count: 3}}},
+		{
+			name:      "repo-a",
+			rootPaths: []string{"/path/to/repo-a"},
+			count:     5,
+			children:  []branchFilterItem{{name: "main", count: 3}},
+		},
 	})
 
 	m.filterSelectedIdx = 1
@@ -652,7 +652,6 @@ func TestTUIFilterEnterClearsBranchMode(t *testing.T) {
 }
 
 func TestTUILockedBranchPreservedOnRepoSelect(t *testing.T) {
-
 	nodes := []treeFilterNode{
 		makeNode("repo-a", 3),
 	}
@@ -667,11 +666,9 @@ func TestTUILockedBranchPreservedOnRepoSelect(t *testing.T) {
 
 		"Locked branch filter changed: got %q, want %q",
 		m2.activeBranchFilter, "locked-branch")
-
 }
 
 func TestTUILockedRepoPreservedOnBranchSelect(t *testing.T) {
-
 	node := makeNode("repo-a", 2)
 	node.children = []branchFilterItem{
 		{name: "feature-x", count: 2},
@@ -689,5 +686,4 @@ func TestTUILockedRepoPreservedOnBranchSelect(t *testing.T) {
 
 		"Locked repo filter changed: got %v, want [/locked/repo]",
 		m2.activeRepoFilter)
-
 }

--- a/cmd/roborev/tui/handlers.go
+++ b/cmd/roborev/tui/handlers.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/streamfmt"
 )

--- a/cmd/roborev/tui/handlers_modal.go
+++ b/cmd/roborev/tui/handlers_modal.go
@@ -9,6 +9,7 @@ import (
 	"unicode"
 
 	tea "github.com/charmbracelet/bubbletea"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 

--- a/cmd/roborev/tui/handlers_msg.go
+++ b/cmd/roborev/tui/handlers_msg.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/streamfmt"
 	"go.kenn.io/roborev/internal/version"

--- a/cmd/roborev/tui/handlers_queue.go
+++ b/cmd/roborev/tui/handlers_queue.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -232,8 +233,7 @@ func (m model) handleColumnOptionsInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "j":
 		// Move current column down in order
 		if isColumn(m.colOptionsIdx) && isColumn(m.colOptionsIdx+1) {
-			m.colOptionsList[m.colOptionsIdx], m.colOptionsList[m.colOptionsIdx+1] =
-				m.colOptionsList[m.colOptionsIdx+1], m.colOptionsList[m.colOptionsIdx]
+			m.colOptionsList[m.colOptionsIdx], m.colOptionsList[m.colOptionsIdx+1] = m.colOptionsList[m.colOptionsIdx+1], m.colOptionsList[m.colOptionsIdx]
 			m.colOptionsIdx++
 			m.syncColumnOrderFromOptions()
 			m.colOptionsDirty = true
@@ -244,8 +244,7 @@ func (m model) handleColumnOptionsInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "k":
 		// Move current column up in order
 		if isColumn(m.colOptionsIdx) && isColumn(m.colOptionsIdx-1) {
-			m.colOptionsList[m.colOptionsIdx], m.colOptionsList[m.colOptionsIdx-1] =
-				m.colOptionsList[m.colOptionsIdx-1], m.colOptionsList[m.colOptionsIdx]
+			m.colOptionsList[m.colOptionsIdx], m.colOptionsList[m.colOptionsIdx-1] = m.colOptionsList[m.colOptionsIdx-1], m.colOptionsList[m.colOptionsIdx]
 			m.colOptionsIdx--
 			m.syncColumnOrderFromOptions()
 			m.colOptionsDirty = true

--- a/cmd/roborev/tui/handlers_review.go
+++ b/cmd/roborev/tui/handlers_review.go
@@ -6,6 +6,7 @@ import (
 	"unicode"
 
 	tea "github.com/charmbracelet/bubbletea"
+
 	"go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/storage"
 )

--- a/cmd/roborev/tui/helpers.go
+++ b/cmd/roborev/tui/helpers.go
@@ -11,6 +11,7 @@ import (
 	xansi "github.com/charmbracelet/x/ansi"
 	"github.com/mattn/go-runewidth"
 	"github.com/muesli/termenv"
+
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/streamfmt"
 )

--- a/cmd/roborev/tui/helpers_test.go
+++ b/cmd/roborev/tui/helpers_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -448,7 +449,6 @@ func TestRenderMarkdownLinesNoColor(t *testing.T) {
 }
 
 func TestReflowHelpRows(t *testing.T) {
-
 	tests := []struct {
 		name     string
 		items    []helpItem
@@ -490,7 +490,6 @@ func TestReflowHelpRows(t *testing.T) {
 }
 
 func TestRenderHelpTableLinesWithinWidth(t *testing.T) {
-
 	// Real help row sets used by the TUI views.
 	helpSets := map[string][][]helpItem{
 		"queue": {

--- a/cmd/roborev/tui/nav.go
+++ b/cmd/roborev/tui/nav.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -161,7 +162,9 @@ func (m *model) logVisibleLines() int {
 // logHelpRows returns the help row items for the log view.
 func (m *model) logHelpRows() [][]helpItem {
 	helpRow := []helpItem{
-		{"↑/↓", "scroll"}, {"←/→", "prev/next"}, {"g", "toggle top/bottom"},
+		{"↑/↓", "scroll"},
+		{"←/→", "prev/next"},
+		{"g", "toggle top/bottom"},
 		{"i", "expand cmd"},
 	}
 	if m.logStreaming {

--- a/cmd/roborev/tui/queue_test.go
+++ b/cmd/roborev/tui/queue_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
 )
@@ -500,7 +501,6 @@ func TestTUITasksViewShowsQueuedColumn(t *testing.T) {
 }
 
 func TestTUIQueueNavigationBoundaries(t *testing.T) {
-
 	m := newQueueTestModel(
 		withQueueTestJobs(makeJob(1), makeJob(2), makeJob(3)),
 		withQueueTestSelection(0),
@@ -523,7 +523,6 @@ func TestTUIQueueNavigationBoundaries(t *testing.T) {
 }
 
 func TestTUIQueueNavigationBoundariesWithFilter(t *testing.T) {
-
 	m := newQueueTestModel(
 		withQueueTestJobs(makeJob(1, withRepoPath("/repo1")), makeJob(2, withRepoPath("/repo2"))),
 		withQueueTestSelection(1),
@@ -537,7 +536,6 @@ func TestTUIQueueNavigationBoundariesWithFilter(t *testing.T) {
 }
 
 func TestTUINavigateDownTriggersLoadMore(t *testing.T) {
-
 	m := newQueueTestModel(
 		withQueueTestJobs(makeJob(1)),
 		withQueueTestSelection(0),
@@ -551,7 +549,6 @@ func TestTUINavigateDownTriggersLoadMore(t *testing.T) {
 }
 
 func TestTUINavigateDownNoLoadMoreWhenFiltered(t *testing.T) {
-
 	m := newQueueTestModel(
 		withQueueTestJobs(makeJob(1, withRepoPath("/path/to/repo"))),
 		withQueueTestSelection(0),
@@ -679,7 +676,6 @@ func TestTUIQueueShowsCostColumnByDefault(t *testing.T) {
 }
 
 func TestTUIQueueTableRendersWithinWidth(t *testing.T) {
-
 	widths := []int{80, 100, 120, 200}
 	for _, w := range widths {
 		t.Run(fmt.Sprintf("width=%d", w), func(t *testing.T) {
@@ -710,7 +706,6 @@ func TestTUIQueueTableRendersWithinWidth(t *testing.T) {
 }
 
 func TestStatusColumnAutoWidth(t *testing.T) {
-
 	tests := []struct {
 		name      string
 		statuses  []storage.JobStatus
@@ -893,7 +888,6 @@ func TestTUIPageDownBlockedWhileLoadingJobs(t *testing.T) {
 }
 
 func TestTUIPageUpDownMovesSelection(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.currentView = viewQueue
 	m.hideClosed = true
@@ -1110,7 +1104,6 @@ func TestTUIJobsMsgHideClosedFilledViewportDoesNotAutoPaginate(t *testing.T) {
 }
 
 func TestTUIEmptyQueueRendersPaddedHeight(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.width = 100
 	m.height = 20
@@ -1127,7 +1120,6 @@ func TestTUIEmptyQueueRendersPaddedHeight(t *testing.T) {
 }
 
 func TestTUIEmptyQueueWithFilterRendersPaddedHeight(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.width = 100
 	m.height = 20
@@ -1144,7 +1136,6 @@ func TestTUIEmptyQueueWithFilterRendersPaddedHeight(t *testing.T) {
 }
 
 func TestTUILoadingJobsShowsLoadingMessage(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.width = 100
 	m.height = 20
@@ -1159,7 +1150,6 @@ func TestTUILoadingJobsShowsLoadingMessage(t *testing.T) {
 }
 
 func TestTUILoadingShowsForLoadingMore(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.width = 100
 	m.height = 20
@@ -1173,7 +1163,6 @@ func TestTUILoadingShowsForLoadingMore(t *testing.T) {
 }
 
 func TestTUIQueueNoScrollIndicatorPads(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.width = 100
 	m.height = 30
@@ -1448,7 +1437,6 @@ func TestTUIClosedHideClosedStats(t *testing.T) {
 }
 
 func TestTUIQueueNavigationSequences(t *testing.T) {
-
 	threeJobs := []storage.ReviewJob{
 		makeJob(1),
 		makeJob(2),
@@ -1521,7 +1509,6 @@ func assertFlashMessage(t *testing.T, m model, view viewKind, msg string) {
 }
 
 func TestTUIQueueNarrowWidthFlexAllocation(t *testing.T) {
-
 	for _, w := range []int{20, 30, 40} {
 		t.Run(fmt.Sprintf("width=%d", w), func(t *testing.T) {
 			m := newModel(localhostEndpoint, withExternalIODisabled())
@@ -1539,7 +1526,6 @@ func TestTUIQueueNarrowWidthFlexAllocation(t *testing.T) {
 }
 
 func TestTUIQueueLongCellContent(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.width = 80
 	m.height = 20
@@ -1566,7 +1552,6 @@ func TestTUIQueueLongCellContent(t *testing.T) {
 }
 
 func TestTUIQueueLongAgentName(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.width = 100
 	m.height = 20
@@ -1592,7 +1577,6 @@ func TestTUIQueueLongAgentName(t *testing.T) {
 }
 
 func TestTUIQueueWideCharacterWidth(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.width = 100
 	m.height = 20
@@ -1619,7 +1603,6 @@ func TestTUIQueueWideCharacterWidth(t *testing.T) {
 }
 
 func TestTUIQueueAgentColumnCapped(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.width = 120
 	m.height = 20
@@ -1653,7 +1636,6 @@ func TestTUIQueueAgentColumnCapped(t *testing.T) {
 }
 
 func TestTUITasksFlexOvershootHandled(t *testing.T) {
-
 	m := newTuiModel("http://localhost")
 	m.currentView = tuiViewTasks
 	m.width = 50
@@ -1680,7 +1662,6 @@ func TestTUITasksFlexOvershootHandled(t *testing.T) {
 }
 
 func TestTUIQueueFlexOvershootHandled(t *testing.T) {
-
 	tests := []struct {
 		name   string
 		width  int
@@ -1722,7 +1703,6 @@ func TestTUIQueueFlexOvershootHandled(t *testing.T) {
 }
 
 func TestTUIQueueFlexColumnsGetContentWidth(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.width = 120
 	m.height = 20
@@ -1751,7 +1731,6 @@ func TestTUIQueueFlexColumnsGetContentWidth(t *testing.T) {
 }
 
 func TestTUITasksStaleSelectionNoPanic(t *testing.T) {
-
 	m := newTuiModel("http://localhost")
 	m.currentView = tuiViewTasks
 	m.width = 120
@@ -1767,7 +1746,6 @@ func TestTUITasksStaleSelectionNoPanic(t *testing.T) {
 }
 
 func TestTUITasksNarrowWidthFlexAllocation(t *testing.T) {
-
 	for _, w := range []int{20, 30, 40} {
 		t.Run(fmt.Sprintf("width=%d", w), func(t *testing.T) {
 			m := newTuiModel("http://localhost")
@@ -1977,7 +1955,6 @@ func TestColumnBordersRendered(t *testing.T) {
 }
 
 func TestQueueColWidthCacheColdStart(t *testing.T) {
-
 	m := newTuiModel("http://localhost")
 	m.width = 120
 	m.height = 24
@@ -2312,7 +2289,6 @@ func TestMigrateColumnConfig(t *testing.T) {
 }
 
 func TestParseColumnOrderAppendsMissing(t *testing.T) {
-
 	oldCustom := []string{"repo", "ref", "agent", "status", "queued", "elapsed", "branch", "closed"}
 	got := parseColumnOrder(oldCustom)
 
@@ -2339,7 +2315,6 @@ func TestParseColumnOrderAppendsMissing(t *testing.T) {
 }
 
 func TestDefaultColumnOrderDetection(t *testing.T) {
-
 	defaultOrder := make([]int, len(toggleableColumns))
 	copy(defaultOrder, toggleableColumns)
 

--- a/cmd/roborev/tui/render_log.go
+++ b/cmd/roborev/tui/render_log.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/mattn/go-runewidth"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -405,6 +406,7 @@ func helpLines(tasksEnabled, noQuit bool) []string {
 	}
 	return lines
 }
+
 func (m model) helpMaxScroll() int {
 	reservedLines := 3 // title + blank + help hint
 	visibleLines := max(m.height-reservedLines, 5)
@@ -414,6 +416,7 @@ func (m model) helpMaxScroll() int {
 	}
 	return maxScroll
 }
+
 func (m model) renderHelpView() string {
 	var b strings.Builder
 

--- a/cmd/roborev/tui/render_log_classify_test.go
+++ b/cmd/roborev/tui/render_log_classify_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mattn/go-runewidth"
 	"github.com/muesli/ansi"
 	"github.com/stretchr/testify/assert"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 

--- a/cmd/roborev/tui/render_queue.go
+++ b/cmd/roborev/tui/render_queue.go
@@ -10,6 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
+
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
@@ -29,10 +30,16 @@ func (m model) getVisibleJobs() []storage.ReviewJob {
 	}
 	return visible
 }
+
 func (m model) queueHelpRows() [][]helpItem {
 	row1 := []helpItem{
-		{"x", "cancel"}, {"r", "rerun"}, {"l", "log"}, {"p", "prompt"},
-		{"c", "comment"}, {"y", "copy"}, {"m", "commit"},
+		{"x", "cancel"},
+		{"r", "rerun"},
+		{"l", "log"},
+		{"p", "prompt"},
+		{"c", "comment"},
+		{"y", "copy"},
+		{"m", "commit"},
 	}
 	if m.tasksWorkflowEnabled() {
 		row1 = append(row1, helpItem{"F", "fix"})
@@ -60,6 +67,7 @@ func (m model) queueHelpRows() [][]helpItem {
 	}
 	return [][]helpItem{row1, row2}
 }
+
 func (m model) queueHelpLines() int {
 	return len(reflowHelpRows(m.queueHelpRows(), m.width))
 }
@@ -81,10 +89,12 @@ func (m model) queueVisibleRows() int {
 	visibleRows := max(m.height-reserved, 3)
 	return visibleRows
 }
+
 func (m model) canPaginate() bool {
 	return m.hasMore && !m.loadingMore && !m.loadingJobs &&
 		len(m.activeRepoFilter) <= 1 && m.activeBranchFilter != branchNone
 }
+
 func (m model) getVisibleSelectedIdx() int {
 	if m.selectedIdx < 0 {
 		return -1
@@ -813,11 +823,15 @@ func migrateColumnConfig(cfg *config.Config) bool {
 	// Old default orders → reset
 	oldDefaults := [][]string{
 		// status before queued (pre-rename)
-		{"ref", "branch", "repo", "agent",
-			"status", "queued", "elapsed", "closed"},
+		{
+			"ref", "branch", "repo", "agent",
+			"status", "queued", "elapsed", "closed",
+		},
 		// combined status without pf column
-		{"ref", "branch", "repo", "agent",
-			"queued", "elapsed", "status", "closed"},
+		{
+			"ref", "branch", "repo", "agent",
+			"queued", "elapsed", "status", "closed",
+		},
 	}
 	for _, old := range oldDefaults {
 		if slices.Equal(cfg.ColumnOrder, old) {

--- a/cmd/roborev/tui/render_review.go
+++ b/cmd/roborev/tui/render_review.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	xansi "github.com/charmbracelet/x/ansi"
 	"github.com/mattn/go-runewidth"
+
 	"go.kenn.io/roborev/internal/tokens"
 )
 
@@ -262,6 +263,7 @@ func (m model) renderReviewView() string {
 
 	return b.String()
 }
+
 func (m model) renderPromptView() string {
 	var b strings.Builder
 
@@ -342,6 +344,7 @@ func (m model) renderPromptView() string {
 
 	return b.String()
 }
+
 func (m model) renderRespondView() string {
 	var b strings.Builder
 
@@ -416,6 +419,7 @@ func (m model) renderRespondView() string {
 
 	return b.String()
 }
+
 func (m model) renderCommitMsgView() string {
 	var b strings.Builder
 

--- a/cmd/roborev/tui/render_tasks.go
+++ b/cmd/roborev/tui/render_tasks.go
@@ -2,14 +2,16 @@ package tui
 
 import (
 	"fmt"
-	"github.com/charmbracelet/lipgloss"
-	"github.com/charmbracelet/lipgloss/table"
-	"github.com/mattn/go-runewidth"
-	"go.kenn.io/roborev/internal/storage"
 	"maps"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
+	"github.com/mattn/go-runewidth"
+
+	"go.kenn.io/roborev/internal/storage"
 )
 
 // Task view column constants (prefixed tcol to avoid collision with queue's col constants).
@@ -413,6 +415,7 @@ func (m model) renderTasksView() string {
 
 	return b.String()
 }
+
 func (m model) renderTasksHelpOverlay(b *strings.Builder) string {
 	help := []string{
 		"",
@@ -450,6 +453,7 @@ func (m model) renderTasksHelpOverlay(b *strings.Builder) string {
 	b.WriteString("\x1b[K\x1b[J")
 	return b.String()
 }
+
 func (m model) renderPatchView() string {
 	var b strings.Builder
 
@@ -522,6 +526,7 @@ func (m model) renderPatchView() string {
 	b.WriteString("\x1b[K\x1b[J")
 	return b.String()
 }
+
 func (m model) renderWorktreeConfirmView() string {
 	var b strings.Builder
 

--- a/cmd/roborev/tui/review_addressed_test.go
+++ b/cmd/roborev/tui/review_addressed_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 

--- a/cmd/roborev/tui/review_branch_test.go
+++ b/cmd/roborev/tui/review_branch_test.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 

--- a/cmd/roborev/tui/review_clipboard_test.go
+++ b/cmd/roborev/tui/review_clipboard_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -111,7 +112,6 @@ func TestTUIYankCopyShowsFriendlyMessageWhenNoClipboardTool(t *testing.T) {
 }
 
 func TestTUIYankFlashViewNotAffectedByViewChange(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.currentView = viewQueue
 	m.width = 80
@@ -197,7 +197,6 @@ func TestTUIFetchReviewAndCopyIncludesComments(t *testing.T) {
 }
 
 func TestTUIFetchReviewAndCopy404(t *testing.T) {
-
 	_, m := mockServerModel(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	})

--- a/cmd/roborev/tui/review_fetch_test.go
+++ b/cmd/roborev/tui/review_fetch_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 

--- a/cmd/roborev/tui/review_fix_panel_test.go
+++ b/cmd/roborev/tui/review_fix_panel_test.go
@@ -7,6 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 

--- a/cmd/roborev/tui/review_log_test.go
+++ b/cmd/roborev/tui/review_log_test.go
@@ -8,6 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/streamfmt"
 )
@@ -40,7 +41,6 @@ func hasMsgType(msgs []tea.Msg, typeName string) bool {
 }
 
 func TestTUILogVisibleLinesWithCommandHeader(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.height = 30
 	m.logJobID = 1
@@ -59,7 +59,6 @@ func TestTUILogVisibleLinesWithCommandHeader(t *testing.T) {
 }
 
 func TestTUILogPagingUsesLogVisibleLines(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.currentView = viewLog
 	m.logJobID = 1
@@ -98,7 +97,6 @@ func TestTUILogPagingUsesLogVisibleLines(t *testing.T) {
 }
 
 func TestTUILogPagingNoHeader(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.currentView = viewLog
 	m.logJobID = 1
@@ -126,7 +124,6 @@ func TestTUILogPagingNoHeader(t *testing.T) {
 }
 
 func TestTUILogLoadingGuard(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.currentView = viewLog
 	m.logJobID = 1
@@ -141,7 +138,6 @@ func TestTUILogLoadingGuard(t *testing.T) {
 }
 
 func TestTUILogErrorDroppedOutsideLogView(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.currentView = viewQueue
 	m.logFetchSeq = 3
@@ -159,7 +155,6 @@ func TestTUILogErrorDroppedOutsideLogView(t *testing.T) {
 }
 
 func TestTUILogViewLookupFixJob(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.currentView = viewLog
 	m.logJobID = 42
@@ -184,7 +179,6 @@ func TestTUILogViewLookupFixJob(t *testing.T) {
 }
 
 func TestTUILogCancelFixJob(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.currentView = viewLog
 	m.logJobID = 42
@@ -209,7 +203,6 @@ func TestTUILogCancelFixJob(t *testing.T) {
 }
 
 func TestTUILogVisibleLinesFixJob(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.currentView = viewLog
 	m.logJobID = 42
@@ -238,11 +231,9 @@ func TestTUILogVisibleLinesFixJob(t *testing.T) {
 	}
 	visWithout := m.logVisibleLines()
 	assert.Equal(t, visWithout-1, visWithCmd, "logVisibleLines mismatch: with cmd=%d, without=%d (expected difference of 1)", visWithCmd, visWithout)
-
 }
 
 func TestTUILogNavFromTasks(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.currentView = viewLog
 	m.logJobID = 20
@@ -271,7 +262,6 @@ func TestTUILogNavFromTasks(t *testing.T) {
 	m3, cmd := pressSpecial(m, tea.KeyRight)
 	require.NotNil(t, cmd, "expected command from right arrow nav")
 	assert.Equal(t, 0, m3.fixSelectedIdx, "fixSelectedIdx should be 0, got %d", m3.fixSelectedIdx)
-
 }
 
 func TestTUILogOutputTable(t *testing.T) {
@@ -514,7 +504,6 @@ func TestTUILogOutputTable(t *testing.T) {
 }
 
 func TestMouseDisabledInContentViews(t *testing.T) {
-
 	contentViews := []struct {
 		name     string
 		view     viewKind
@@ -651,7 +640,6 @@ func TestMouseDisabledInContentViews(t *testing.T) {
 }
 
 func TestMouseNotToggledWithinContentViews(t *testing.T) {
-
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.currentView = viewReview
 	m.height = 30

--- a/cmd/roborev/tui/review_navigation_test.go
+++ b/cmd/roborev/tui/review_navigation_test.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 

--- a/cmd/roborev/tui/review_render_test.go
+++ b/cmd/roborev/tui/review_render_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 

--- a/cmd/roborev/tui/review_test_helpers_test.go
+++ b/cmd/roborev/tui/review_test_helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 

--- a/cmd/roborev/tui/review_views_test.go
+++ b/cmd/roborev/tui/review_views_test.go
@@ -1,11 +1,13 @@
 package tui
 
 import (
+	"testing"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
-	"testing"
 )
 
 func TestTUIEscapeFromReviewTriggersRefreshWithHideClosed(t *testing.T) {

--- a/cmd/roborev/tui/sse.go
+++ b/cmd/roborev/tui/sse.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+
 	"go.kenn.io/roborev/internal/daemon"
 )
 

--- a/cmd/roborev/tui/sse_test.go
+++ b/cmd/roborev/tui/sse_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/daemon"
 )
 

--- a/cmd/roborev/tui/tui.go
+++ b/cmd/roborev/tui/tui.go
@@ -19,6 +19,7 @@ import (
 	"github.com/charmbracelet/lipgloss/table"
 	"github.com/mattn/go-runewidth"
 	"github.com/muesli/termenv"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/daemon"
 	daemonclient "go.kenn.io/roborev/internal/daemon_client"

--- a/cmd/roborev/tui/tui_test.go
+++ b/cmd/roborev/tui/tui_test.go
@@ -4,17 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/stretchr/testify/assert"
-	"go.kenn.io/roborev/internal/config"
-	"go.kenn.io/roborev/internal/daemon"
-	"go.kenn.io/roborev/internal/storage"
-	"go.kenn.io/roborev/internal/version"
-
-	// testServerAddr is a placeholder address used in tests that don't make real HTTP calls.
-	// Tests that need actual HTTP should use httptest.NewServer and pass ts.URL.
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -25,8 +14,19 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/config"
+	"go.kenn.io/roborev/internal/daemon"
+	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/version"
 )
 
+// testServerAddr is a placeholder address used in tests that don't make real HTTP calls.
+// Tests that need actual HTTP should use httptest.NewServer and pass ts.URL.
 const testServerAddr = "http://test.invalid:9999"
 
 // testEndpoint is a DaemonEndpoint parsed from testServerAddr.
@@ -616,7 +616,7 @@ func TestTUIHideClosedMalformedConfigNotOverwritten(t *testing.T) {
 	// Write malformed TOML that LoadGlobal will fail to parse
 	malformed := []byte(`this is not valid toml {{{`)
 	configPath := filepath.Join(tmpDir, "config.toml")
-	if err := os.WriteFile(configPath, malformed, 0644); err != nil {
+	if err := os.WriteFile(configPath, malformed, 0o644); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "write malformed config: %v", err)
@@ -1235,14 +1235,12 @@ func TestHandleFixKeyRejectsFixJob(t *testing.T) {
 			return false
 		}, "Expected flash 'Cannot fix a fix job', got %q",
 			updated.flashMessage)
-
 	}
 	if updated.currentView != viewQueue {
 		assert.Condition(t, func() bool {
 			return false
 		}, "Expected view to stay on queue, got %d",
 			updated.currentView)
-
 	}
 }
 
@@ -1560,7 +1558,7 @@ func TestNewModelLoadsMouseDisabledFromConfig(t *testing.T) {
 	tmpDir := setupTuiTestEnv(t)
 
 	configPath := filepath.Join(tmpDir, "config.toml")
-	if err := os.WriteFile(configPath, []byte("mouse_enabled = false\n"), 0644); err != nil {
+	if err := os.WriteFile(configPath, []byte("mouse_enabled = false\n"), 0o644); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "write config: %v", err)
@@ -1578,6 +1576,7 @@ func TestNewModelLoadsMouseDisabledFromConfig(t *testing.T) {
 		}, "expected startup options without mouse capture when disabled, got %d options", len(programOptionsForModel(m)))
 	}
 }
+
 func TestTUISelection(t *testing.T) {
 	t.Run("MaintainedOnInsert", func(t *testing.T) {
 		m := newModel(testEndpoint, withExternalIODisabled())
@@ -1598,7 +1597,6 @@ func TestTUISelection(t *testing.T) {
 
 		// Should still be on job ID=2, now at index 3
 		assertSelection(t, m, 3, 2)
-
 	})
 	t.Run("ClampsOnRemoval", func(t *testing.T) {
 		m := newModel(testEndpoint, withExternalIODisabled())
@@ -1619,7 +1617,6 @@ func TestTUISelection(t *testing.T) {
 
 		// Should clamp to last valid index and update selectedJobID
 		assertSelection(t, m, 1, 2)
-
 	})
 	t.Run("FirstJobOnEmpty", func(t *testing.T) {
 		m := newModel(testEndpoint, withExternalIODisabled())
@@ -1638,7 +1635,6 @@ func TestTUISelection(t *testing.T) {
 
 		// Should select first job
 		assertSelection(t, m, 0, 5)
-
 	})
 	t.Run("EmptyList", func(t *testing.T) {
 		m := newModel(testEndpoint, withExternalIODisabled())
@@ -1654,7 +1650,6 @@ func TestTUISelection(t *testing.T) {
 
 		// Empty list should have selectedIdx=-1 (no valid selection)
 		assertSelection(t, m, -1, 0)
-
 	})
 	t.Run("MaintainedOnLargeBatch", func(t *testing.T) {
 		m := newModel(testEndpoint, withExternalIODisabled())
@@ -1675,7 +1670,6 @@ func TestTUISelection(t *testing.T) {
 
 		// Should still follow job ID=1, now at index 30
 		assertSelection(t, m, 30, 1)
-
 	})
 }
 
@@ -1684,7 +1678,7 @@ func TestTUIHideClosed(t *testing.T) {
 		tmpDir := setupTuiTestEnv(t)
 
 		configPath := filepath.Join(tmpDir, "config.toml")
-		if err := os.WriteFile(configPath, []byte("hide_addressed_by_default = true\n"), 0644); err != nil {
+		if err := os.WriteFile(configPath, []byte("hide_addressed_by_default = true\n"), 0o644); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, "write config: %v", err)
@@ -1696,7 +1690,6 @@ func TestTUIHideClosed(t *testing.T) {
 				return false
 			}, "hideClosed should be true when config sets hide_addressed_by_default = true")
 		}
-
 	})
 	t.Run("Toggle", func(t *testing.T) {
 		m := newModel(testEndpoint, withExternalIODisabled())
@@ -1726,7 +1719,6 @@ func TestTUIHideClosed(t *testing.T) {
 				return false
 			}, "hideClosed should be false after pressing 'h' again")
 		}
-
 	})
 	t.Run("FiltersJobs", func(t *testing.T) {
 		m := newModel(testEndpoint, withExternalIODisabled())
@@ -1780,7 +1772,6 @@ func TestTUIHideClosed(t *testing.T) {
 				return false
 			}, "Expected visible jobs 2 and 5, got %d and %d", visible[0].ID, visible[1].ID)
 		}
-
 	})
 	t.Run("SelectionMovesToVisible", func(t *testing.T) {
 		m := newModel(testEndpoint, withExternalIODisabled())
@@ -1801,7 +1792,6 @@ func TestTUIHideClosed(t *testing.T) {
 
 		// Selection should move to first visible job (ID=2)
 		assertSelection(t, m2, 1, 2)
-
 	})
 	t.Run("RefreshRevalidatesSelection", func(t *testing.T) {
 		m := newModel(testEndpoint, withExternalIODisabled())
@@ -1827,7 +1817,6 @@ func TestTUIHideClosed(t *testing.T) {
 
 		// Selection should move to job 2 since job 1 is now hidden
 		assertSelection(t, m2, 1, 2)
-
 	})
 	t.Run("RefreshPreservesSelectionInReviewView", func(t *testing.T) {
 		// When in review view, a job refresh should NOT move selectedIdx
@@ -1891,7 +1880,6 @@ func TestTUIHideClosed(t *testing.T) {
 		m2, _ := pressKey(m, 'j')
 
 		assertSelection(t, m2, 3, 4)
-
 	})
 	t.Run("withRepoFilter", func(t *testing.T) {
 		m := newModel(testEndpoint, withExternalIODisabled())
@@ -1918,7 +1906,6 @@ func TestTUIHideClosed(t *testing.T) {
 				return false
 			}, "Expected visible job ID=1, got %d", visible[0].ID)
 		}
-
 	})
 	t.Run("ClearRepoFilterRefetches", func(t *testing.T) {
 		// Scenario: hide closed enabled, then filter by repo, then press escape
@@ -1980,7 +1967,6 @@ func TestTUIHideClosed(t *testing.T) {
 				return false
 			}, "loadingJobs should be set when refetching after clearing repo filter")
 		}
-
 	})
 	t.Run("EnableTriggersRefetch", func(t *testing.T) {
 		m := newModel(testEndpoint, withExternalIODisabled())
@@ -2009,7 +1995,6 @@ func TestTUIHideClosed(t *testing.T) {
 				return false
 			}, "Command should be returned to fetch all jobs when enabling hideClosed")
 		}
-
 	})
 	t.Run("DisableRefetches", func(t *testing.T) {
 		m := newModel(testEndpoint, withExternalIODisabled())
@@ -2038,7 +2023,6 @@ func TestTUIHideClosed(t *testing.T) {
 				return false
 			}, "Expected a refetch command when disabling hideClosed")
 		}
-
 	})
 	t.Run("ValidConfigNotMutated", func(t *testing.T) {
 		tmpDir := setupTuiTestEnv(t)
@@ -2046,7 +2030,7 @@ func TestTUIHideClosed(t *testing.T) {
 		// Write a valid config with the hide-closed default enabled
 		validConfig := []byte("hide_addressed_by_default = true\n")
 		configPath := filepath.Join(tmpDir, "config.toml")
-		if err := os.WriteFile(configPath, validConfig, 0644); err != nil {
+		if err := os.WriteFile(configPath, validConfig, 0o644); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, "write config: %v", err)
@@ -2090,7 +2074,6 @@ func TestTUIHideClosed(t *testing.T) {
 				return false
 			}, "valid config was mutated:\n  before: %q\n  after:  %q", validConfig, got)
 		}
-
 	})
 }
 
@@ -2110,7 +2093,6 @@ func TestTUIFlashMessage(t *testing.T) {
 				return false
 			}, "Expected flash message to appear in queue view")
 		}
-
 	})
 	t.Run("NotShownInDifferentView", func(t *testing.T) {
 		m := newModel(testEndpoint, withExternalIODisabled())
@@ -2128,7 +2110,6 @@ func TestTUIFlashMessage(t *testing.T) {
 				return false
 			}, "Flash message should not appear when viewing different view than where it was triggered")
 		}
-
 	})
 }
 

--- a/cmd/roborev/tui/types.go
+++ b/cmd/roborev/tui/types.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/atotto/clipboard"
 	osc52 "github.com/aymanbagabas/go-osc52/v2"
+
 	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/streamfmt"
@@ -121,14 +122,17 @@ type logTickMsg struct{}
 // displayTickMsg triggers a local repaint without polling the daemon.
 type displayTickMsg struct{}
 
-type tickMsg time.Time
-type jobsMsg struct {
-	jobs    []storage.ReviewJob
-	hasMore bool
-	append  bool             // true to append to existing jobs, false to replace
-	seq     int              // fetch sequence number — stale responses (seq < model.fetchSeq) are discarded
-	stats   storage.JobStats // aggregate counts from server
-}
+type (
+	tickMsg time.Time
+	jobsMsg struct {
+		jobs    []storage.ReviewJob
+		hasMore bool
+		append  bool             // true to append to existing jobs, false to replace
+		seq     int              // fetch sequence number — stale responses (seq < model.fetchSeq) are discarded
+		stats   storage.JobStats // aggregate counts from server
+	}
+)
+
 type statusMsg struct {
 	status storage.DaemonStatus
 	gen    uint64 // fetch generation — discard if < model.fetchGen
@@ -143,17 +147,20 @@ type promptMsg struct {
 	review *storage.Review
 	jobID  int64 // The job ID that was requested (for stale response detection)
 }
-type closedMsg bool
-type closedResultMsg struct {
-	jobID            int64 // job ID for queue view rollback
-	reviewID         int64 // review ID for review view rollback
-	reviewView       bool  // true if from review view (rollback currentReview)
-	restoreSelection bool
-	oldState         bool
-	newState         bool   // the requested state (for pendingClosed validation)
-	seq              uint64 // request sequence number (for distinguishing same-state rapid toggles)
-	err              error
-}
+type (
+	closedMsg       bool
+	closedResultMsg struct {
+		jobID            int64 // job ID for queue view rollback
+		reviewID         int64 // review ID for review view rollback
+		reviewView       bool  // true if from review view (rollback currentReview)
+		restoreSelection bool
+		oldState         bool
+		newState         bool   // the requested state (for pendingClosed validation)
+		seq              uint64 // request sequence number (for distinguishing same-state rapid toggles)
+		err              error
+	}
+)
+
 type cancelResultMsg struct {
 	jobID            int64
 	oldState         storage.JobStatus
@@ -171,16 +178,22 @@ type rerunResultMsg struct {
 	oldVerdict    *string
 	err           error
 }
-type errMsg error
-type statusErrMsg struct {
-	err error
-	gen uint64
-}
-type configSaveErrMsg struct{ err error }
-type jobsErrMsg struct {
-	err error
-	seq int // fetch sequence number for staleness check
-}
+type (
+	errMsg       error
+	statusErrMsg struct {
+		err error
+		gen uint64
+	}
+)
+
+type (
+	configSaveErrMsg struct{ err error }
+	jobsErrMsg       struct {
+		err error
+		seq int // fetch sequence number for staleness check
+	}
+)
+
 type paginationErrMsg struct {
 	err error
 	seq int // fetch sequence number for staleness check

--- a/cmd/roborev/tui_cmd.go
+++ b/cmd/roborev/tui_cmd.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/cmd/roborev/tui"
 	"go.kenn.io/roborev/internal/daemon"
 )

--- a/cmd/roborev/update.go
+++ b/cmd/roborev/update.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/skills"
 	"go.kenn.io/roborev/internal/update"
 	"go.kenn.io/roborev/internal/version"

--- a/cmd/roborev/version.go
+++ b/cmd/roborev/version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/version"
 )
 

--- a/cmd/roborev/wait.go
+++ b/cmd/roborev/wait.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/spf13/cobra"
+
 	"go.kenn.io/roborev/internal/git"
 )
 

--- a/cmd/roborev/wait_test.go
+++ b/cmd/roborev/wait_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -298,7 +299,6 @@ func TestWaitMultipleJobIDs(t *testing.T) {
 
 	_, err := runWait(t, "--job", "10", "20")
 	require.NoError(t, err)
-
 }
 
 func TestWaitMultipleJobIDsOneFails(t *testing.T) {

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/storage"

--- a/internal/agent/acp_agent.go
+++ b/internal/agent/acp_agent.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	acp "github.com/coder/acp-go-sdk"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/version"
 )
@@ -129,7 +130,6 @@ func (a *ACPAgent) WithReasoning(level ReasoningLevel) Agent {
 }
 
 func (a *ACPAgent) WithAgentic(agentic bool) Agent {
-
 	// Set the appropriate mode based on agentic flag
 	mode := a.ReadOnlyMode
 	if agentic && a.AutoApproveMode != "" {

--- a/internal/agent/acp_auth_test.go
+++ b/internal/agent/acp_auth_test.go
@@ -376,7 +376,7 @@ func TestACPAuthEdgeCases(t *testing.T) {
 	t.Run("Path validation blocks writes to symlinks escaping repo root", func(t *testing.T) {
 		externalDir := t.TempDir()
 		externalTarget := filepath.Join(externalDir, "outside.txt")
-		if err := os.WriteFile(externalTarget, []byte("outside"), 0644); err != nil {
+		if err := os.WriteFile(externalTarget, []byte("outside"), 0o644); err != nil {
 			require.NoError(t, err, "Failed to create external target: %v", err)
 		}
 
@@ -392,7 +392,7 @@ func TestACPAuthEdgeCases(t *testing.T) {
 
 	t.Run("Path validation allows writes to symlinks that resolve inside repo root", func(t *testing.T) {
 		internalTarget := filepath.Join(tempDir, "inside.txt")
-		if err := os.WriteFile(internalTarget, []byte("inside"), 0644); err != nil {
+		if err := os.WriteFile(internalTarget, []byte("inside"), 0o644); err != nil {
 			require.NoError(t, err, "Failed to create internal target: %v", err)
 		}
 		defer os.Remove(internalTarget)
@@ -410,7 +410,7 @@ func TestACPAuthEdgeCases(t *testing.T) {
 
 	t.Run("Path validation allows valid paths", func(t *testing.T) {
 		validFile := filepath.Join(tempDir, "valid.txt")
-		err := os.WriteFile(validFile, []byte("test"), 0644)
+		err := os.WriteFile(validFile, []byte("test"), 0o644)
 		require.NoError(t, err, "Failed to create test file: %v", err)
 		defer os.Remove(validFile)
 

--- a/internal/agent/acp_client_files.go
+++ b/internal/agent/acp_client_files.go
@@ -7,11 +7,12 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	acp "github.com/coder/acp-go-sdk"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	acp "github.com/coder/acp-go-sdk"
 )
 
 func readTextFileWindow(path string, startLine int, limit *int, maxBytes int) (string, error) {
@@ -202,7 +203,6 @@ func createTempFileWithPerm(parentDir, baseName string, perm os.FileMode) (*os.F
 }
 
 func (c *acpClient) ReadTextFile(ctx context.Context, params acp.ReadTextFileRequest) (acp.ReadTextFileResponse, error) {
-
 	// Validate session ID
 	if err := c.validateSessionID(params.SessionId); err != nil {
 		return acp.ReadTextFileResponse{}, err
@@ -253,7 +253,6 @@ func (c *acpClient) ReadTextFile(ctx context.Context, params acp.ReadTextFileReq
 }
 
 func (c *acpClient) WriteTextFile(ctx context.Context, params acp.WriteTextFileRequest) (acp.WriteTextFileResponse, error) {
-
 	// Validate session ID
 	if err := c.validateSessionID(params.SessionId); err != nil {
 		return acp.WriteTextFileResponse{}, err

--- a/internal/agent/acp_client_terminal.go
+++ b/internal/agent/acp_client_terminal.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	acp "github.com/coder/acp-go-sdk"
 	"io"
 	"os"
 	"os/exec"
@@ -13,6 +12,8 @@ import (
 	"sync"
 	"syscall"
 	"unicode/utf8"
+
+	acp "github.com/coder/acp-go-sdk"
 )
 
 type acpTerminal struct {
@@ -270,7 +271,6 @@ func (bw *boundedWriter) trimToMaxSizeLocked() {
 }
 
 func (c *acpClient) CreateTerminal(ctx context.Context, params acp.CreateTerminalRequest) (acp.CreateTerminalResponse, error) {
-
 	// Validate session ID
 	if err := c.validateSessionID(params.SessionId); err != nil {
 		return acp.CreateTerminalResponse{}, err
@@ -425,7 +425,6 @@ func (c *acpClient) CreateTerminal(ctx context.Context, params acp.CreateTermina
 }
 
 func (c *acpClient) KillTerminal(ctx context.Context, params acp.KillTerminalRequest) (acp.KillTerminalResponse, error) {
-
 	// Validate session ID
 	if err := c.validateSessionID(params.SessionId); err != nil {
 		return acp.KillTerminalResponse{}, err
@@ -445,7 +444,6 @@ func (c *acpClient) KillTerminal(ctx context.Context, params acp.KillTerminalReq
 }
 
 func (c *acpClient) TerminalOutput(ctx context.Context, params acp.TerminalOutputRequest) (acp.TerminalOutputResponse, error) {
-
 	// Validate session ID
 	if err := c.validateSessionID(params.SessionId); err != nil {
 		return acp.TerminalOutputResponse{}, err
@@ -479,7 +477,6 @@ func (c *acpClient) TerminalOutput(ctx context.Context, params acp.TerminalOutpu
 }
 
 func (c *acpClient) ReleaseTerminal(ctx context.Context, params acp.ReleaseTerminalRequest) (acp.ReleaseTerminalResponse, error) {
-
 	// Validate session ID
 	if err := c.validateSessionID(params.SessionId); err != nil {
 		return acp.ReleaseTerminalResponse{}, err
@@ -500,7 +497,6 @@ func (c *acpClient) ReleaseTerminal(ctx context.Context, params acp.ReleaseTermi
 }
 
 func (c *acpClient) WaitForTerminalExit(ctx context.Context, params acp.WaitForTerminalExitRequest) (acp.WaitForTerminalExitResponse, error) {
-
 	// Validate session ID
 	if err := c.validateSessionID(params.SessionId); err != nil {
 		return acp.WaitForTerminalExitResponse{}, err

--- a/internal/agent/acp_integration_test.go
+++ b/internal/agent/acp_integration_test.go
@@ -5,14 +5,15 @@ package agent
 import (
 	"bytes"
 	"context"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/internal/agent/acp_resolution_test.go
+++ b/internal/agent/acp_resolution_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/config"
 )
 
@@ -53,7 +54,7 @@ func TestIsConfiguredACPAgentName(t *testing.T) {
 		content := `[acp]
 name = "repo-acp"
 `
-		err := os.WriteFile(configPath, []byte(content), 0644)
+		err := os.WriteFile(configPath, []byte(content), 0o644)
 		require.NoError(t, err)
 
 		// With repo config, should match repo-acp

--- a/internal/agent/acp_test.go
+++ b/internal/agent/acp_test.go
@@ -14,11 +14,11 @@ import (
 	"github.com/coder/acp-go-sdk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/config"
 )
 
 func TestACPAgent(t *testing.T) {
-
 	acpAgent := NewACPAgent("test-acp-agent")
 
 	assert.Equal(t, "acp", acpAgent.Name())
@@ -276,7 +276,6 @@ func terminalExists(client *acpClient, terminalID string) bool {
 }
 
 func TestACPAgentTerminalFunctionality(t *testing.T) {
-
 	agent := &ACPAgent{
 		SessionID:       "test-session",
 		ReadOnlyMode:    "read-only",
@@ -610,7 +609,6 @@ func TestACPAgentTerminalFunctionality(t *testing.T) {
 }
 
 func TestACPNoDoubleMutexUnlockPanics(t *testing.T) {
-
 	agent := &ACPAgent{
 		SessionID:       "test-session",
 		ReadOnlyMode:    "read-only",
@@ -629,7 +627,6 @@ func TestACPNoDoubleMutexUnlockPanics(t *testing.T) {
 	if err != nil {
 		t.Logf("Expected error for non-existent terminal: %v", err)
 	}
-
 }
 
 func TestBoundedWriter(t *testing.T) {
@@ -850,7 +847,6 @@ func TestReadTextFileWindow(t *testing.T) {
 			got, err := readTextFileWindow(testPath, tc.startLine, tc.limit, maxACPTextFileBytes)
 			require.NoError(t, err, "readTextFileWindow failed: %v")
 			require.Equal(t, tc.expected, got, "expected %q, got %q", tc.expected, got)
-
 		})
 	}
 
@@ -871,7 +867,6 @@ func TestReadTextFileWindow(t *testing.T) {
 }
 
 func TestACPAliasCollisionFixed(t *testing.T) {
-
 	fakeBin := t.TempDir()
 	agentBin := "agent"
 	if runtime.GOOS == "windows" {
@@ -929,7 +924,6 @@ func TestGetAvailableWithConfigPassesBackupsThrough(t *testing.T) {
 }
 
 func TestACPNameDoesNotMatchCanonicalRequest(t *testing.T) {
-
 	fakeBin := t.TempDir()
 	binName := "claude"
 	if runtime.GOOS == "windows" {

--- a/internal/agent/acp_validation_test.go
+++ b/internal/agent/acp_validation_test.go
@@ -17,7 +17,6 @@ func TestValidateSessionID(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Valid session ID matching agent session", func(t *testing.T) {
-
 		agent := &ACPAgent{
 			SessionID: "test-session-123",
 		}
@@ -32,7 +31,6 @@ func TestValidateSessionID(t *testing.T) {
 	})
 
 	t.Run("Invalid session ID not matching agent session", func(t *testing.T) {
-
 		agent := &ACPAgent{
 			SessionID: "test-session-123",
 		}
@@ -47,7 +45,6 @@ func TestValidateSessionID(t *testing.T) {
 	})
 
 	t.Run("Empty agent session ID rejects non-empty request session ID", func(t *testing.T) {
-
 		agent := &ACPAgent{
 			SessionID: "",
 		}
@@ -63,7 +60,6 @@ func TestValidateSessionID(t *testing.T) {
 	})
 
 	t.Run("Empty request session ID with non-empty agent session", func(t *testing.T) {
-
 		agent := &ACPAgent{
 			SessionID: "test-session-123",
 		}
@@ -79,7 +75,6 @@ func TestValidateSessionID(t *testing.T) {
 	})
 
 	t.Run("Both session IDs empty", func(t *testing.T) {
-
 		agent := &ACPAgent{
 			SessionID: "",
 		}
@@ -143,7 +138,6 @@ func TestValidateAndResolvePathUsesClientRepoRootPrecedence(t *testing.T) {
 
 	assert.True(t, pathWithinRoot(resolvedPath, resolvedClientRoot), "Expected resolved path %q to be under client repo root %q", resolvedPath, resolvedClientRoot)
 	assert.False(t, pathWithinRoot(resolvedPath, resolvedAgentRoot), "Expected resolved path %q to avoid agent repo root %q", resolvedPath, resolvedAgentRoot)
-
 }
 
 func TestValidateConfiguredSessionCapabilities(t *testing.T) {
@@ -226,7 +220,6 @@ func TestSessionUpdateValidatesSessionID(t *testing.T) {
 		require.NoError(t, err, "Expected valid SessionUpdate to succeed, got: %v")
 	}
 	assert.Equal(t, "hello", client.result.String(), "Expected session output to be appended, got: %q", client.result.String())
-
 }
 
 // TestSessionUpdateRejectsBeforeSessionEstablished verifies that an early

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -105,9 +105,11 @@ var (
 	registry   = make(map[string]Agent)
 )
 
-var allowUnsafeAgents atomic.Bool
-var codexSandboxDisabled atomic.Bool
-var anthropicAPIKey atomic.Value
+var (
+	allowUnsafeAgents    atomic.Bool
+	codexSandboxDisabled atomic.Bool
+	anthropicAPIKey      atomic.Value
+)
 
 func AllowUnsafeAgents() bool {
 	return allowUnsafeAgents.Load()

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/testenv"
 )

--- a/internal/agent/agent_test_cli_helpers_test.go
+++ b/internal/agent/agent_test_cli_helpers_test.go
@@ -50,7 +50,7 @@ func writeTempCommand(t *testing.T, script string) string {
 
 	tmpDir := t.TempDir()
 	path := filepath.Join(tmpDir, "cmd")
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
 	if err != nil {
 		t.Fatalf("write temp command: %v", err)
 	}
@@ -153,7 +153,7 @@ func mockAgentCLI(t *testing.T, opts MockCLIOpts) *MockCLIResult {
 
 	if opts.HelpOutput != "" {
 		helpFile := filepath.Join(tmpDir, "help_output.txt")
-		if err := os.WriteFile(helpFile, []byte(opts.HelpOutput), 0644); err != nil {
+		if err := os.WriteFile(helpFile, []byte(opts.HelpOutput), 0o644); err != nil {
 			t.Fatalf("write help output file: %v", err)
 		}
 		script.WriteString(fmt.Sprintf(`case "$*" in *--help*) cat %q; exit 0;; esac`, helpFile) + "\n")
@@ -180,7 +180,7 @@ func mockAgentCLI(t *testing.T, opts MockCLIOpts) *MockCLIResult {
 		if !strings.HasSuffix(content, "\n") {
 			content += "\n"
 		}
-		if err := os.WriteFile(stdoutFile, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(stdoutFile, []byte(content), 0o644); err != nil {
 			t.Fatalf("write stdout file: %v", err)
 		}
 		script.WriteString(fmt.Sprintf(`cat %q`, stdoutFile) + "\n")
@@ -192,7 +192,7 @@ func mockAgentCLI(t *testing.T, opts MockCLIOpts) *MockCLIResult {
 		if !strings.HasSuffix(content, "\n") {
 			content += "\n"
 		}
-		if err := os.WriteFile(stderrFile, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(stderrFile, []byte(content), 0o644); err != nil {
 			t.Fatalf("write stderr file: %v", err)
 		}
 		script.WriteString(fmt.Sprintf(`cat %q >&2`, stderrFile) + "\n")

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -24,12 +24,16 @@ type ClaudeAgent struct {
 	SessionID string         // Existing session ID to resume
 }
 
-const claudeDangerousFlag = "--dangerously-skip-permissions"
-const claudeEffortFlag = "--effort"
+const (
+	claudeDangerousFlag = "--dangerously-skip-permissions"
+	claudeEffortFlag    = "--effort"
+)
 
-var claudeDangerousSupport sync.Map
-var claudeEffortSupport sync.Map
-var claudeToolsSupport sync.Map
+var (
+	claudeDangerousSupport sync.Map
+	claudeEffortSupport    sync.Map
+	claudeToolsSupport     sync.Map
+)
 
 // NewClaudeAgent creates a new Claude Code agent
 func NewClaudeAgent(command string) *ClaudeAgent {
@@ -547,7 +551,8 @@ func (a *ClaudeAgent) classifyArgs(schema json.RawMessage) []string {
 	// or any other local file. The schema constraint pins output to
 	// {design_review, reason} regardless. Never pass
 	// --dangerously-skip-permissions.
-	args := []string{"-p", "--output-format", "stream-json", "--verbose",
+	args := []string{
+		"-p", "--output-format", "stream-json", "--verbose",
 		"--json-schema", string(schema),
 		"--tools", "",
 	}

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -23,15 +23,19 @@ type CodexAgent struct {
 	IgnoreUserConfig          bool           // Whether to pass --ignore-user-config
 }
 
-const codexDangerousFlag = "--dangerously-bypass-approvals-and-sandbox"
-const codexAutoApproveFlag = "--full-auto"
-const codexIgnoreUserConfigFlag = "--ignore-user-config"
-const codexDisableSkillsConfig = "skills.include_instructions=false"
-const codexReadOnlySandboxConfig = `sandbox_mode="read-only"`
+const (
+	codexDangerousFlag         = "--dangerously-bypass-approvals-and-sandbox"
+	codexAutoApproveFlag       = "--full-auto"
+	codexIgnoreUserConfigFlag  = "--ignore-user-config"
+	codexDisableSkillsConfig   = "skills.include_instructions=false"
+	codexReadOnlySandboxConfig = `sandbox_mode="read-only"`
+)
 
-var codexDangerousSupport sync.Map
-var codexAutoApproveSupport sync.Map
-var codexIgnoreUserConfigSupport sync.Map
+var (
+	codexDangerousSupport        sync.Map
+	codexAutoApproveSupport      sync.Map
+	codexIgnoreUserConfigSupport sync.Map
+)
 
 // errNoCodexJSON indicates no valid codex --json events were parsed.
 var errNoCodexJSON = errors.New("no valid codex --json events parsed from output")

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -11,8 +11,10 @@ import (
 	"sync"
 )
 
-var copilotAllowAllToolsSupport sync.Map
-var copilotStreamOffSupport sync.Map
+var (
+	copilotAllowAllToolsSupport sync.Map
+	copilotStreamOffSupport     sync.Map
+)
 
 // copilotSupportsAllowAllTools checks whether the copilot binary supports
 // the --allow-all-tools flag needed for non-interactive tool approval.

--- a/internal/agent/cursor_test.go
+++ b/internal/agent/cursor_test.go
@@ -2,10 +2,11 @@ package agent
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCursorBuildArgs_Table(t *testing.T) {
@@ -98,7 +99,6 @@ func TestCursorReviewPassesModelFlag(t *testing.T) {
 }
 
 func TestCursorParseStreamJSON(t *testing.T) {
-
 	tests := []struct {
 		name           string
 		input          string
@@ -128,7 +128,6 @@ func TestCursorParseStreamJSON(t *testing.T) {
 			res, err := cursor.parseStreamJSON(strings.NewReader(tt.input), nil)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedResult, res, "expected %q, got %q", tt.expectedResult, res)
-
 		})
 	}
 }
@@ -144,7 +143,6 @@ func TestCursorWithChaining(t *testing.T) {
 
 	assert.True(t, cursor.Agentic, "expected agentic true")
 	assert.Equal(t, "agent", cursor.Command, "expected command 'agent', got %q", cursor.Command)
-
 }
 
 func TestCursorReviewPipesPromptViaStdin(t *testing.T) {

--- a/internal/agent/droid_test.go
+++ b/internal/agent/droid_test.go
@@ -2,12 +2,13 @@ package agent
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDroidBuildArgs(t *testing.T) {
@@ -76,7 +77,6 @@ func TestDroidName(t *testing.T) {
 	a := NewDroidAgent("")
 	require.Equal(t, "droid", a.Name(), "expected name 'droid', got %s", a.Name())
 	require.Equal(t, "droid", a.CommandName(), "expected command name 'droid', got %s", a.CommandName())
-
 }
 
 func TestDroidWithAgentic(t *testing.T) {
@@ -86,7 +86,6 @@ func TestDroidWithAgentic(t *testing.T) {
 	a2 := a.WithAgentic(true).(*DroidAgent)
 	require.True(t, a2.Agentic, "expected agentic after WithAgentic(true)")
 	require.False(t, a.Agentic, "original should be unchanged")
-
 }
 
 func TestDroidReviewOutcomes(t *testing.T) {
@@ -137,7 +136,6 @@ func TestDroidReviewOutcomes(t *testing.T) {
 
 			if tt.exactMatch {
 				require.Equal(t, tt.wantResult, result, "expected exact result %q, got %q", tt.wantResult, result)
-
 			} else if !strings.Contains(result, tt.wantResult) {
 				require.Contains(t, result, tt.wantResult, "expected result to contain %q, got %q", tt.wantResult, result)
 			}

--- a/internal/agent/kilo_test.go
+++ b/internal/agent/kilo_test.go
@@ -6,11 +6,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestKiloReviewModelFlag(t *testing.T) {

--- a/internal/agent/kiro_test.go
+++ b/internal/agent/kiro_test.go
@@ -3,11 +3,12 @@ package agent
 import (
 	"bytes"
 	"context"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStripKiroOutput(t *testing.T) {
@@ -123,7 +124,6 @@ func TestKiroName(t *testing.T) {
 	a := NewKiroAgent("")
 	require.Equal(t, "kiro", a.Name(), "expected name 'kiro', got %s", a.Name())
 	require.Equal(t, "kiro-cli", a.CommandName(), "expected command name 'kiro-cli', got %s", a.CommandName())
-
 }
 
 func TestKiroCommandLine(t *testing.T) {
@@ -148,7 +148,6 @@ func TestKiroWithAgentic(t *testing.T) {
 	a2 := a.WithAgentic(true).(*KiroAgent)
 	require.True(t, a2.Agentic, "expected agentic after WithAgentic(true)")
 	require.False(t, a.Agentic, "original should be unchanged")
-
 }
 
 func TestKiroWithReasoning(t *testing.T) {
@@ -156,14 +155,12 @@ func TestKiroWithReasoning(t *testing.T) {
 	b := a.WithReasoning(ReasoningThorough).(*KiroAgent)
 	assert.Equal(t, ReasoningThorough, b.Reasoning, "expected thorough reasoning, got %q", b.Reasoning)
 	assert.Equal(t, ReasoningStandard, a.Reasoning, "original reasoning should be unchanged")
-
 }
 
 func TestKiroWithModelIsNoop(t *testing.T) {
 	a := NewKiroAgent("kiro-cli")
 	b := a.WithModel("some-model")
 	assert.Equal(t, a, b, "WithModel should return the same agent (kiro does not support model selection)")
-
 }
 
 func TestKiroReviewSuccess(t *testing.T) {
@@ -228,7 +225,6 @@ func TestKiroReviewEmptyOutput(t *testing.T) {
 	result, err := a.Review(context.Background(), t.TempDir(), "deadbeef", "review this commit", nil)
 	require.NoError(t, err)
 	require.Equal(t, "No review output generated", result, "unexpected result: %q", result)
-
 }
 
 func TestKiroPassesPromptAsArg(t *testing.T) {
@@ -426,5 +422,4 @@ func TestKiroWithChaining(t *testing.T) {
 
 	require.True(t, kiro.Agentic, "expected agentic true")
 	require.Equal(t, "kiro-cli", kiro.Command, "expected command 'kiro-cli', got %q", kiro.Command)
-
 }

--- a/internal/agent/model_resolution_test.go
+++ b/internal/agent/model_resolution_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/config"
 )
 

--- a/internal/agent/opencode_test.go
+++ b/internal/agent/opencode_test.go
@@ -6,12 +6,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenCodeReviewModelFlag(t *testing.T) {

--- a/internal/agent/pi_test.go
+++ b/internal/agent/pi_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/config"
 )
 

--- a/internal/agent/process.go
+++ b/internal/agent/process.go
@@ -79,7 +79,7 @@ func closeOnContextDone(ctx context.Context, c io.Closer) func() {
 }
 
 func contextProcessError(
-	ctx context.Context, tracker *subprocessTracker, runErr error, parseErr error,
+	ctx context.Context, tracker *subprocessTracker, runErr, parseErr error,
 ) error {
 	ctxErr := ctx.Err()
 	if ctxErr == nil {

--- a/internal/agent/process_test.go
+++ b/internal/agent/process_test.go
@@ -185,5 +185,4 @@ func TestConfigureSubprocessDoesNotMarkCanceledWhenProcessAlreadyExited(t *testi
 		require.ErrorIs(t, err, os.ErrProcessDone, "expected os.ErrProcessDone, got %v", err)
 	}
 	require.False(t, tracker.canceledByContext.Load(), "tracker should stay false when cancel runs after process exit")
-
 }

--- a/internal/agent/schema_agent_test.go
+++ b/internal/agent/schema_agent_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/config"
 )
 

--- a/internal/agent/spec.go
+++ b/internal/agent/spec.go
@@ -149,8 +149,10 @@ var allAgentSpecs = []agentSpec{
 	},
 }
 
-var agentSpecsByName = buildAgentSpecsByName()
-var fallbackAgentOrder = buildFallbackAgentOrder(allAgentSpecs)
+var (
+	agentSpecsByName   = buildAgentSpecsByName()
+	fallbackAgentOrder = buildFallbackAgentOrder(allAgentSpecs)
+)
 
 func buildAgentSpecsByName() map[string]agentSpec {
 	specs := make(map[string]agentSpec, len(allAgentSpecs))

--- a/internal/agent/spec_test.go
+++ b/internal/agent/spec_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/config"
 )
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	tomlv2 "github.com/pelletier/go-toml/v2"
+
 	"go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/review/autotype"
 )
@@ -515,8 +516,10 @@ func RegisterClassifyAgentValidator(fn func(name string) error) {
 	classifyAgentValidator = fn
 }
 
-const DefaultClassifyAgent = "claude-code"
-const DefaultClassifyReasoning = "fast"
+const (
+	DefaultClassifyAgent     = "claude-code"
+	DefaultClassifyReasoning = "fast"
+)
 
 // ResolveClassifyAgent returns the agent name to use for classification.
 // Priority: CLI flag > per-repo classify_agent > global classify_agent > default.
@@ -2138,9 +2141,11 @@ func ResolveModel(explicit string, repoPath string, globalCfg *Config) string {
 	return resolve("", strings.TrimSpace(explicit), repoVal, globalVal)
 }
 
-// DefaultMaxPromptSize is the default maximum prompt size in bytes (200KB)
-const DefaultMaxPromptSize = 200 * 1024
-const DefaultSnapshotDir = ".roborev"
+const (
+	// DefaultMaxPromptSize is the default maximum prompt size in bytes (200KB)
+	DefaultMaxPromptSize = 200 * 1024
+	DefaultSnapshotDir   = ".roborev"
+)
 
 // ResolveMaxPromptSize determines the maximum prompt size based on config priority:
 // 1. Per-repo config (max_prompt_size in .roborev.toml)
@@ -2438,7 +2443,7 @@ func SaveGlobal(cfg *Config) error {
 
 // SaveGlobalTo saves the global configuration to a specific path.
 func SaveGlobalTo(path string, cfg *Config) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
 
@@ -2461,7 +2466,7 @@ func SaveGlobalTo(path string, cfg *Config) error {
 	if err := f.Close(); err != nil {
 		return err
 	}
-	if err := os.Chmod(tmpPath, 0600); err != nil {
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
 		return err
 	}
 	return os.Rename(tmpPath, path)
@@ -2469,7 +2474,7 @@ func SaveGlobalTo(path string, cfg *Config) error {
 
 // SaveRepoConfigTo saves a per-repo configuration to a specific path.
 func SaveRepoConfigTo(path string, cfg *RepoConfig) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
 
@@ -2478,7 +2483,7 @@ func SaveRepoConfigTo(path string, cfg *RepoConfig) error {
 		return err
 	}
 
-	mode := os.FileMode(0644)
+	mode := os.FileMode(0o644)
 	if info, err := os.Stat(path); err == nil {
 		mode = info.Mode()
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,17 +2,18 @@ package config
 
 import (
 	"fmt"
-	"reflect"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.kenn.io/roborev/internal/testenv"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/testenv"
 )
 
 func TestMain(m *testing.M) {
@@ -36,7 +37,6 @@ func TestDefaultConfig(t *testing.T) {
 	assert.True(t, cfg.Agent.Codex.DisableReviewSkills, "expected Codex review skills to be disabled by default")
 	assert.True(t, cfg.Agent.Codex.IgnoreReviewUserConfig, "expected Codex review user config to be ignored by default")
 	assert.Equal(t, "npm:@nqbao/pi-json-schema@0.1.1", cfg.Agent.Pi.JSONSchemaExtension)
-
 }
 
 func TestDataDir(t *testing.T) {
@@ -107,7 +107,6 @@ func TestResolveAgent(t *testing.T) {
 	assert.Condition(t, func() bool {
 		return agent == "codex"
 	}, "Expected 'codex' (explicit), got '%s'", agent)
-
 }
 
 func TestSaveAndLoadGlobal(t *testing.T) {
@@ -132,7 +131,6 @@ func TestSaveAndLoadGlobal(t *testing.T) {
 	assert.Condition(t, func() bool {
 		return loaded.MaxWorkers == 8
 	}, "Expected MaxWorkers 8, got %d", loaded.MaxWorkers)
-
 }
 
 func TestLoadGlobalPiJSONSchemaExtension(t *testing.T) {
@@ -169,14 +167,13 @@ func TestSaveAndLoadGlobalAutoFilterBranch(t *testing.T) {
 	assert.Condition(t, func() bool {
 		return loaded.AutoFilterBranch
 	}, "AutoFilterBranch should be true after round-trip")
-
 }
 
 func TestLoadGlobalAutoFilterBranchFromTOML(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
 	{
-		err := os.WriteFile(path, []byte("auto_filter_branch = true\n"), 0644)
+		err := os.WriteFile(path, []byte("auto_filter_branch = true\n"), 0o644)
 		require.Condition(t, func() bool {
 			return err == nil
 		}, "write config: %v", err)
@@ -189,7 +186,6 @@ func TestLoadGlobalAutoFilterBranchFromTOML(t *testing.T) {
 	assert.Condition(t, func() bool {
 		return cfg.AutoFilterBranch
 	}, "AutoFilterBranch should be true when loaded from TOML")
-
 }
 
 func TestSaveAndLoadGlobalMouseEnabled(t *testing.T) {
@@ -212,14 +208,13 @@ func TestSaveAndLoadGlobalMouseEnabled(t *testing.T) {
 	assert.Condition(t, func() bool {
 		return !loaded.MouseEnabled
 	}, "MouseEnabled should be false after round-trip")
-
 }
 
 func TestLoadGlobalMouseEnabledFromTOML(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
 	{
-		err := os.WriteFile(path, []byte("mouse_enabled = false\n"), 0644)
+		err := os.WriteFile(path, []byte("mouse_enabled = false\n"), 0o644)
 		require.Condition(t, func() bool {
 			return err == nil
 		}, "write config: %v", err)
@@ -232,7 +227,6 @@ func TestLoadGlobalMouseEnabledFromTOML(t *testing.T) {
 	assert.Condition(t, func() bool {
 		return !cfg.MouseEnabled
 	}, "MouseEnabled should be false when loaded from TOML")
-
 }
 
 func TestLoadRepoConfigWithGuidelines(t *testing.T) {
@@ -261,7 +255,6 @@ All public APIs must have documentation comments.
 	assert.Condition(t, func() bool {
 		return strings.Contains(cfg.ReviewGuidelines, "composition over inheritance")
 	}, "Expected guidelines to contain 'composition over inheritance'")
-
 }
 
 func TestLoadRepoConfigNoGuidelines(t *testing.T) {
@@ -277,7 +270,6 @@ func TestLoadRepoConfigNoGuidelines(t *testing.T) {
 	assert.Condition(t, func() bool {
 		return cfg.ReviewGuidelines == ""
 	}, "Expected empty guidelines, got '%s'", cfg.ReviewGuidelines)
-
 }
 
 func TestLoadRepoConfigMissing(t *testing.T) {
@@ -291,7 +283,6 @@ func TestLoadRepoConfigMissing(t *testing.T) {
 	assert.Condition(t, func() bool {
 		return cfg == nil
 	}, "Expected nil config when file doesn't exist")
-
 }
 
 func TestResolveJobTimeout(t *testing.T) {
@@ -538,7 +529,6 @@ func TestFixEmptyReasoningSelectsStandardAgent(t *testing.T) {
 	assert.Condition(t, func() bool {
 		return model == ""
 	}, "expected empty model (none configured), got %q", model)
-
 }
 
 func TestIsBranchExcluded(t *testing.T) {
@@ -827,7 +817,6 @@ func TestAllCommitMessagesExcluded(t *testing.T) {
 					return false
 				}, "AllCommitMessagesExcluded() = %v, want %v",
 					got, tt.want)
-
 			}
 		})
 	}
@@ -1010,7 +999,7 @@ postgres_url = "postgres://roborev:pass@localhost:5432/roborev"
 interval = "10m"
 machine_name = "test-machine"
 connect_timeout = "10s"
-`), 0644)
+`), 0o644)
 		require.Condition(t, func() bool {
 			return err == nil
 		}, "Failed to write config: %v", err)
@@ -1035,7 +1024,6 @@ connect_timeout = "10s"
 	assert.Condition(t, func() bool {
 		return cfg.Sync.ConnectTimeout == "10s"
 	}, "Expected ConnectTimeout '10s', got '%s'", cfg.Sync.ConnectTimeout)
-
 }
 
 func TestGetDisplayName(t *testing.T) {
@@ -1140,7 +1128,7 @@ func TestReadRoborevID(t *testing.T) {
 
 	t.Run("valid file", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		if err := os.WriteFile(filepath.Join(tmpDir, ".roborev-id"), []byte("my-project\n"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tmpDir, ".roborev-id"), []byte("my-project\n"), 0o644); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, err)
@@ -1160,7 +1148,7 @@ func TestReadRoborevID(t *testing.T) {
 
 	t.Run("valid file with whitespace", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		if err := os.WriteFile(filepath.Join(tmpDir, ".roborev-id"), []byte("  my-project  \n\n"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tmpDir, ".roborev-id"), []byte("  my-project  \n\n"), 0o644); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, err)
@@ -1180,7 +1168,7 @@ func TestReadRoborevID(t *testing.T) {
 
 	t.Run("invalid file content", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		if err := os.WriteFile(filepath.Join(tmpDir, ".roborev-id"), []byte(".invalid-start"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tmpDir, ".roborev-id"), []byte(".invalid-start"), 0o644); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, err)
@@ -1200,7 +1188,7 @@ func TestReadRoborevID(t *testing.T) {
 
 	t.Run("empty file", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		if err := os.WriteFile(filepath.Join(tmpDir, ".roborev-id"), []byte(""), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tmpDir, ".roborev-id"), []byte(""), 0o644); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, err)
@@ -1222,7 +1210,7 @@ func TestReadRoborevID(t *testing.T) {
 func TestResolveRepoIdentity(t *testing.T) {
 	t.Run("uses roborev-id when present", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		if err := os.WriteFile(filepath.Join(tmpDir, ".roborev-id"), []byte("my-custom-id"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tmpDir, ".roborev-id"), []byte("my-custom-id"), 0o644); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, err)
@@ -1303,7 +1291,7 @@ func TestResolveRepoIdentity(t *testing.T) {
 	t.Run("skips invalid roborev-id and uses remote", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		// Write invalid content (starts with dot)
-		if err := os.WriteFile(filepath.Join(tmpDir, ".roborev-id"), []byte(".invalid"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tmpDir, ".roborev-id"), []byte(".invalid"), 0o644); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, err)
@@ -1754,7 +1742,8 @@ func TestResolveWorkflowModel(t *testing.T) {
 		// Skips generic repo model
 		{
 			"skips repo generic model",
-			M{"model": "gpt-5.4"}, nil,
+			M{"model": "gpt-5.4"},
+			nil,
 			"fix", "fast", "",
 		},
 		// Uses workflow-specific model from global config
@@ -1778,13 +1767,15 @@ func TestResolveWorkflowModel(t *testing.T) {
 		// Uses workflow-specific model from repo config
 		{
 			"repo fix_model",
-			M{"model": "gpt-5.4", "fix_model": "gemini-2.5-pro"}, nil,
+			M{"model": "gpt-5.4", "fix_model": "gemini-2.5-pro"},
+			nil,
 			"fix", "fast", "gemini-2.5-pro",
 		},
 		// Uses level-specific model from repo config
 		{
 			"repo fix_model_fast",
-			M{"fix_model_fast": "claude-3"}, nil,
+			M{"fix_model_fast": "claude-3"},
+			nil,
 			"fix", "fast", "claude-3",
 		},
 		// Repo beats global for workflow-specific
@@ -1797,7 +1788,8 @@ func TestResolveWorkflowModel(t *testing.T) {
 		// Review workflow isolation
 		{
 			"review workflow uses review_model",
-			M{"fix_model": "fix-only", "review_model": "review-only"}, nil,
+			M{"fix_model": "fix-only", "review_model": "review-only"},
+			nil,
 			"review", "standard", "review-only",
 		},
 		// Skips both global default_model and repo generic model
@@ -2033,7 +2025,7 @@ enabled = true
 repos = ["myorg/*", "other/repo"]
 exclude_repos = ["myorg/archived-*", "myorg/internal-*"]
 max_repos = 50
-`), 0644); err != nil {
+`), 0o644); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, err)
@@ -2310,7 +2302,7 @@ github_app_private_key = "~/.roborev/app.pem"
 [ci.github_app_installations]
 Wesm = 111111
 RoboRev-Dev = 222222
-`), 0644)
+`), 0o644)
 		require.Condition(t, func() bool {
 			return err == nil
 		}, err)
@@ -2334,7 +2326,6 @@ RoboRev-Dev = 222222
 			return got == 222222
 		}, "got %d, want 222222 for normalized 'roborev-dev'", got)
 	}
-
 }
 
 func TestGitHubAppConfigured_MultiInstall(t *testing.T) {
@@ -2395,7 +2386,7 @@ func TestGitHubAppPrivateKeyResolved_TildeExpansion(t *testing.T) {
 	pemFile := filepath.Join(dir, "test.pem")
 	pemContent := "-----BEGIN RSA PRIVATE KEY-----\nfakekey\n-----END RSA PRIVATE KEY-----"
 	{
-		err := os.WriteFile(pemFile, []byte(pemContent), 0600)
+		err := os.WriteFile(pemFile, []byte(pemContent), 0o600)
 		require.Condition(t, func() bool {
 			return err == nil
 		}, err)
@@ -2438,12 +2429,12 @@ func TestGitHubAppPrivateKeyResolved_TildeExpansion(t *testing.T) {
 		t.Setenv("USERPROFILE", fakeHome) // Windows compatibility
 
 		fakePem := filepath.Join(fakeHome, ".roborev", "test.pem")
-		if err := os.MkdirAll(filepath.Dir(fakePem), 0700); err != nil {
+		if err := os.MkdirAll(filepath.Dir(fakePem), 0o700); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, err)
 		}
-		if err := os.WriteFile(fakePem, []byte(pemContent), 0600); err != nil {
+		if err := os.WriteFile(fakePem, []byte(pemContent), 0o600); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, err)
@@ -2567,7 +2558,6 @@ func TestHideClosedDefaultPersistence(t *testing.T) {
 	assert.Condition(t, func() bool {
 		return !reloaded.HideClosedByDefault
 	}, "Expected HideClosedByDefault to be false")
-
 }
 
 func TestAdvancedTasksEnabledPersistence(t *testing.T) {
@@ -2605,7 +2595,6 @@ func TestAdvancedTasksEnabledPersistence(t *testing.T) {
 	assert.Condition(t, func() bool {
 		return !reloaded.Advanced.TasksEnabled
 	}, "Expected Advanced.TasksEnabled to be false")
-
 }
 
 func TestSaveGlobalWritesDocumentedSettings(t *testing.T) {
@@ -2641,7 +2630,6 @@ func TestSaveGlobalWritesDocumentedSettings(t *testing.T) {
 		require.Condition(t, func() bool {
 			return strings.Contains(got, want)
 		}, "saved config missing documented setting %q:\n%s", want, got)
-
 	}
 }
 
@@ -2651,14 +2639,14 @@ func TestHideAddressedDeprecatedMigration(t *testing.T) {
 	// Write a config using the deprecated hide_addressed_by_default key
 	cfgPath := GlobalConfigPath()
 	{
-		err := os.MkdirAll(filepath.Dir(cfgPath), 0755)
+		err := os.MkdirAll(filepath.Dir(cfgPath), 0o755)
 		require.Condition(t, func() bool {
 			return err == nil
 		}, "mkdir failed: %v", err)
 	}
 	{
 
-		err := os.WriteFile(cfgPath, []byte("hide_addressed_by_default = true\n"), 0644)
+		err := os.WriteFile(cfgPath, []byte("hide_addressed_by_default = true\n"), 0o644)
 		require.Condition(t, func() bool {
 			return err == nil
 		}, "WriteFile failed: %v", err)
@@ -2675,7 +2663,6 @@ func TestHideAddressedDeprecatedMigration(t *testing.T) {
 	assert.Condition(t, func() bool {
 		return !loaded.HideAddressedByDefault
 	}, "Expected HideAddressedByDefault to be cleared after migration")
-
 }
 
 func TestHideAddressedDoesNotOverrideExplicitNewKey(t *testing.T) {
@@ -2684,7 +2671,7 @@ func TestHideAddressedDoesNotOverrideExplicitNewKey(t *testing.T) {
 	// Both deprecated and new key set — explicit new key should win
 	cfgPath := GlobalConfigPath()
 	{
-		err := os.MkdirAll(filepath.Dir(cfgPath), 0755)
+		err := os.MkdirAll(filepath.Dir(cfgPath), 0o755)
 		require.Condition(t, func() bool {
 			return err == nil
 		}, "mkdir failed: %v", err)
@@ -2692,7 +2679,7 @@ func TestHideAddressedDoesNotOverrideExplicitNewKey(t *testing.T) {
 
 	content := "hide_addressed_by_default = true\nhide_closed_by_default = false\n"
 	{
-		err := os.WriteFile(cfgPath, []byte(content), 0644)
+		err := os.WriteFile(cfgPath, []byte(content), 0o644)
 		require.Condition(t, func() bool {
 			return err == nil
 		}, "WriteFile failed: %v", err)
@@ -2708,16 +2695,15 @@ func TestHideAddressedDoesNotOverrideExplicitNewKey(t *testing.T) {
 	assert.Condition(t, func() bool {
 		return !loaded.HideAddressedByDefault
 	}, "Expected HideAddressedByDefault to be cleared after migration")
-
 }
 
 func TestHiddenColumnsExplicitEmptyBecomesSentinel(t *testing.T) {
 	testenv.SetDataDir(t)
 
 	cfgPath := GlobalConfigPath()
-	require.NoError(t, os.MkdirAll(filepath.Dir(cfgPath), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(cfgPath), 0o755))
 	require.NoError(t, os.WriteFile(cfgPath,
-		[]byte("hidden_columns = []\n"), 0644))
+		[]byte("hidden_columns = []\n"), 0o644))
 
 	loaded, err := LoadGlobal()
 	require.NoError(t, err)
@@ -2730,9 +2716,9 @@ func TestHiddenColumnsRenamedOnlyDoesNotBecomeSentinel(t *testing.T) {
 	testenv.SetDataDir(t)
 
 	cfgPath := GlobalConfigPath()
-	require.NoError(t, os.MkdirAll(filepath.Dir(cfgPath), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(cfgPath), 0o755))
 	require.NoError(t, os.WriteFile(cfgPath,
-		[]byte("hidden_columns = [\"handled\"]\n"), 0644))
+		[]byte("hidden_columns = [\"handled\"]\n"), 0o644))
 
 	loaded, err := LoadGlobal()
 	require.NoError(t, err)
@@ -2746,14 +2732,12 @@ func TestIsDefaultReviewType(t *testing.T) {
 		assert.Condition(t, func() bool {
 			return IsDefaultReviewType(rt)
 		}, "expected %q to be default review type", rt)
-
 	}
 	nonDefaults := []string{"security", "design", "bogus"}
 	for _, rt := range nonDefaults {
 		assert.Condition(t, func() bool {
 			return !IsDefaultReviewType(rt)
 		}, "expected %q to NOT be default review type", rt)
-
 	}
 }
 
@@ -2924,7 +2908,6 @@ func TestResolvedReviewMatrix(t *testing.T) {
 					return false
 				}, "matrix[%d] = %v, want %v",
 					i, got, want[i])
-
 			}
 		}
 	})
@@ -2963,7 +2946,6 @@ func TestResolvedReviewMatrix(t *testing.T) {
 					return false
 				}, "matrix[%d] = %v, want %v",
 					i, got, want[i])
-
 			}
 		}
 	})
@@ -3273,7 +3255,6 @@ func TestResolvedThrottleInterval(t *testing.T) {
 					return false
 				}, "ResolvedThrottleInterval() = %v, want %v",
 					got, tt.want)
-
 			}
 		})
 	}
@@ -3291,7 +3272,7 @@ throttle_interval = "30m"
 [ci.reviews]
 codex = ["security", "default"]
 gemini = ["default"]
-`), 0644)
+`), 0o644)
 		require.Condition(t, func() bool {
 			return err == nil
 		}, err)
@@ -3316,7 +3297,6 @@ gemini = ["default"]
 			codexTypes[0] == "security" &&
 			codexTypes[1] == "default"
 	}, "got codex types %v", codexTypes)
-
 }
 
 func TestIsThrottleBypassed(t *testing.T) {
@@ -3344,7 +3324,6 @@ func TestIsThrottleBypassed(t *testing.T) {
 					return false
 				}, "IsThrottleBypassed(%q) = %v, want %v",
 					tt.login, got, tt.want)
-
 			}
 		})
 	}
@@ -3378,7 +3357,6 @@ gemini = ["default"]
 		return len(cfg.CI.Reviews) == 2
 	}, "got %d review entries, want 2",
 		len(cfg.CI.Reviews))
-
 }
 
 func TestResolveMinSeverity(t *testing.T) {
@@ -3479,7 +3457,6 @@ func TestSeverityInstruction(t *testing.T) {
 						return false
 					}, "SeverityInstruction(%q) = %q, want empty",
 						tt.minSeverity, got)
-
 				}
 				return
 			}
@@ -3488,21 +3465,18 @@ func TestSeverityInstruction(t *testing.T) {
 					return false
 				}, "SeverityInstruction(%q) = empty, want non-empty",
 					tt.minSeverity)
-
 			}
 			if !strings.Contains(got, tt.wantSubstr) {
 				assert.Condition(t, func() bool {
 					return false
 				}, "SeverityInstruction(%q) = %q, missing %q",
 					tt.minSeverity, got, tt.wantSubstr)
-
 			}
 			if !strings.Contains(got, SeverityThresholdMarker) {
 				assert.Condition(t, func() bool {
 					return false
 				}, "SeverityInstruction(%q) missing threshold marker %q",
 					tt.minSeverity, SeverityThresholdMarker)
-
 			}
 		})
 	}

--- a/internal/config/config_test_helpers_test.go
+++ b/internal/config/config_test_helpers_test.go
@@ -44,7 +44,7 @@ func writeRepoConfig(t *testing.T, dir string, cfg map[string]string) {
 // writeTestFile writes content to a file in the given directory.
 func writeTestFile(t *testing.T, dir, filename, content string) {
 	t.Helper()
-	err := os.WriteFile(filepath.Join(dir, filename), []byte(content), 0644)
+	err := os.WriteFile(filepath.Join(dir, filename), []byte(content), 0o644)
 	require.NoError(t, err, "failed to write %s", filename)
 }
 

--- a/internal/daemon/activity_handler_test.go
+++ b/internal/daemon/activity_handler_test.go
@@ -2,11 +2,12 @@ package daemon
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type activityResponse struct {
@@ -38,7 +39,6 @@ func TestHandleActivity_MethodNotAllowed(t *testing.T) {
 	w := requestActivity(s, http.MethodPost, "")
 	assert.Equal(t, http.StatusMethodNotAllowed, w.Code,
 		"assertion failed", "expected 405, got %d", w.Code)
-
 }
 
 func TestHandleActivity_Limits(t *testing.T) {
@@ -86,5 +86,4 @@ func TestHandleActivity_NilActivityLog(t *testing.T) {
 	resp := decodeActivityResponse(t, w)
 	assert.Empty(t, resp.Entries,
 		"assertion failed", "expected 0 entries with nil log, got %d", len(resp.Entries))
-
 }

--- a/internal/daemon/activitylog.go
+++ b/internal/daemon/activitylog.go
@@ -51,7 +51,7 @@ func NewActivityLog(path string) (*ActivityLog, error) {
 
 func newActivityLogWithConfig(path string, maxSize int64, checkInterval int) (*ActivityLog, error) {
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, err
 	}
 
@@ -60,7 +60,7 @@ func newActivityLogWithConfig(path string, maxSize int64, checkInterval int) (*A
 	}
 
 	file, err := os.OpenFile(
-		path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644,
+		path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644,
 	)
 	if err != nil {
 		return nil, err
@@ -181,13 +181,13 @@ func (a *ActivityLog) maybeRotate() {
 
 	a.file.Close()
 	f, err := os.OpenFile(
-		a.path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644,
+		a.path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644,
 	)
 	if err != nil {
 		log.Printf("Activity log: rotate reopen failed, retrying append: %v", err)
 		// Fall back to append mode so logging isn't permanently disabled
 		f, err = os.OpenFile(
-			a.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644,
+			a.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644,
 		)
 		if err != nil {
 			log.Printf("Activity log: fallback reopen also failed: %v", err)

--- a/internal/daemon/activitylog_test.go
+++ b/internal/daemon/activitylog_test.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"maps"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func createTestActivityLog(t *testing.T) (*ActivityLog, string) {
@@ -70,7 +71,6 @@ func TestActivityLog_RecentN(t *testing.T) {
 	got = al.RecentN(100)
 	assert.Len(t, got, 10,
 		"expected 10 entries, got %d", len(got))
-
 }
 
 func TestActivityLog_RingBuffer(t *testing.T) {
@@ -90,7 +90,6 @@ func TestActivityLog_RingBuffer(t *testing.T) {
 	oldest := recent[activityLogCapacity-1]
 	want := fmt.Sprintf("msg %d", total-activityLogCapacity)
 	assert.Equal(t, want, oldest.Message, "oldest = %q, want %q", oldest.Message, want)
-
 }
 
 func TestActivityLog_FileFormat(t *testing.T) {
@@ -169,7 +168,6 @@ func TestActivityLog_DetailsCopied(t *testing.T) {
 	assert.Equal(t, "original", again[0].Details["key"],
 		"ring buffer mutated via returned entry: got %q, want %q",
 		again[0].Details["key"], "original")
-
 }
 
 func TestActivityLog_RecentN_Negative(t *testing.T) {
@@ -183,7 +181,6 @@ func TestActivityLog_RecentN_Negative(t *testing.T) {
 	got = al.RecentN(0)
 	assert.Nil(t, got,
 		"RecentN(0) = %v, want nil", got)
-
 }
 
 func TestActivityLog_FileTruncation(t *testing.T) {
@@ -191,7 +188,7 @@ func TestActivityLog_FileTruncation(t *testing.T) {
 	path := filepath.Join(dir, "activity.log")
 
 	data := make([]byte, maxActivityLogSize+1)
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	if err := os.WriteFile(path, data, 0o644); err != nil {
 		require.NoError(t, err, "write seed file: %v")
 	}
 
@@ -209,7 +206,6 @@ func TestActivityLog_FileTruncation(t *testing.T) {
 	assert.LessOrEqual(t, info.Size(), int64(1024),
 		"file should be small after truncation, got %d bytes",
 		info.Size())
-
 }
 
 func TestActivityLog_RuntimeRotation(t *testing.T) {
@@ -240,11 +236,9 @@ func TestActivityLog_RuntimeRotation(t *testing.T) {
 
 			"file should be under cap after rotation, got %d bytes",
 			info.Size())
-
 }
 
 func TestActivityLog_RotationRecovery(t *testing.T) {
-
 	dir := t.TempDir()
 	path := filepath.Join(dir, "activity.log")
 

--- a/internal/daemon/broadcaster_test.go
+++ b/internal/daemon/broadcaster_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/testutil"
 )
 
@@ -34,7 +35,6 @@ func assertEventFields(t *testing.T, got Event, expected Event) {
 	assert.Equal(t, expected.SHA, got.SHA, "event sha")
 	assert.Equal(t, expected.Agent, got.Agent, "event agent")
 	assert.Equal(t, expected.Verdict, got.Verdict, "event verdict")
-
 }
 
 func assertNoEventWithin(t *testing.T, ch <-chan Event, duration time.Duration) {

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -20,6 +20,7 @@ import (
 	"unicode/utf8"
 
 	googlegithub "github.com/google/go-github/v84/github"
+
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 	gitpkg "go.kenn.io/roborev/internal/git"

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -6,19 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	googlegithub "github.com/google/go-github/v84/github"
-	ghpkg "go.kenn.io/roborev/internal/github"
 	"net/http"
 	"net/http/httptest"
-
-	"github.com/stretchr/testify/assert"
-	"go.kenn.io/roborev/internal/config"
-	"go.kenn.io/roborev/internal/review"
-	"go.kenn.io/roborev/internal/storage"
-	"go.kenn.io/roborev/internal/testutil"
-
-	// ciPollerHarness bundles DB, repo, config, and poller for CI poller tests.
-	"github.com/stretchr/testify/require"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,8 +15,19 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	googlegithub "github.com/google/go-github/v84/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/config"
+	ghpkg "go.kenn.io/roborev/internal/github"
+	"go.kenn.io/roborev/internal/review"
+	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/testutil"
 )
 
+// ciPollerHarness bundles DB, repo, config, and poller for CI poller tests.
 type ciPollerHarness struct {
 	DB       *storage.DB
 	RepoPath string
@@ -44,7 +44,7 @@ func installFakeGHAuthToken(t *testing.T, token string) {
 	dir := t.TempDir()
 	scriptPath := filepath.Join(dir, "gh")
 	script := "#!/bin/sh\nif [ \"$1\" = \"auth\" ] && [ \"$2\" = \"token\" ]; then\n  printf '%s\\n' " + "'" + token + "'\n  exit 0\nfi\nexit 1\n"
-	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0755))
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o755))
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
@@ -993,7 +993,7 @@ func TestCIPollerProcessPR_WhitespaceReasoning(t *testing.T) {
 	h.stubProcessPRGit()
 	h.Poller.mergeBaseFn = func(_, _, _ string) (string, error) { return "base-sha", nil }
 
-	if err := os.WriteFile(h.RepoPath+"/.roborev.toml", []byte("[ci]\nreasoning = \"   \"\n"), 0644); err != nil {
+	if err := os.WriteFile(h.RepoPath+"/.roborev.toml", []byte("[ci]\nreasoning = \"   \"\n"), 0o644); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "write .roborev.toml: %v", err)
@@ -1034,7 +1034,7 @@ func TestCIPollerProcessPR_InvalidReasoning(t *testing.T) {
 	h.stubProcessPRGit()
 	h.Poller.mergeBaseFn = func(_, _, _ string) (string, error) { return "base-sha", nil }
 
-	if err := os.WriteFile(h.RepoPath+"/.roborev.toml", []byte("[ci]\nreasoning = \"invalid\"\n"), 0644); err != nil {
+	if err := os.WriteFile(h.RepoPath+"/.roborev.toml", []byte("[ci]\nreasoning = \"invalid\"\n"), 0o644); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "write .roborev.toml: %v", err)
@@ -1932,7 +1932,6 @@ func TestCIPollerFindOrCloneRepo_AutoClones(t *testing.T) {
 			return false
 		}, "expected same repo ID on reuse: got %d, want %d",
 			repo2.ID, repo.ID)
-
 	}
 }
 
@@ -1990,7 +1989,6 @@ func TestCIPollerFindOrCloneRepo_ReusesExistingDir(t *testing.T) {
 		assert.Condition(t, func() bool {
 			return false
 		}, "repo.RootPath=%q, want %q", repo.RootPath, filepath.ToSlash(clonePath))
-
 	}
 }
 
@@ -2286,7 +2284,6 @@ func TestCloneRemoteMatches(t *testing.T) {
 				return false
 			}, "expected nil error for missing config, got: %v",
 				err)
-
 		}
 		if ok {
 			assert.Condition(t, func() bool {
@@ -2427,7 +2424,6 @@ func TestOwnerRepoFromURL(t *testing.T) {
 					return false
 				}, "ownerRepoFromURL(%q) = %q, want %q",
 					tt.url, got, tt.want)
-
 			}
 		})
 	}
@@ -2454,7 +2450,6 @@ func TestCIPollerEnsureClone_RejectsMalformedRepo(t *testing.T) {
 			assert.Condition(t, func() bool {
 				return false
 			}, "ensureClone(%q) should have failed", input)
-
 		}
 	}
 }
@@ -2631,7 +2626,7 @@ func TestCIPollerProcessPR_RepoOverrides(t *testing.T) {
 	h.stubProcessPRGit()
 	h.Poller.mergeBaseFn = func(_, _, _ string) (string, error) { return "base-sha", nil }
 
-	if err := os.WriteFile(h.RepoPath+"/.roborev.toml", []byte("[ci]\nagents = [\"codex\"]\nreview_types = [\"review\"]\nreasoning = \"fast\"\n"), 0644); err != nil {
+	if err := os.WriteFile(h.RepoPath+"/.roborev.toml", []byte("[ci]\nagents = [\"codex\"]\nreview_types = [\"review\"]\nreasoning = \"fast\"\n"), 0o644); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "write .roborev.toml: %v", err)
@@ -2867,7 +2862,7 @@ func TestResolveMinSeverity(t *testing.T) {
 				dir = t.TempDir()
 			}
 			if tt.repoConfig != "" && dir != "" {
-				if err := os.WriteFile(filepath.Join(dir, ".roborev.toml"), []byte(tt.repoConfig), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(dir, ".roborev.toml"), []byte(tt.repoConfig), 0o644); err != nil {
 					require.Condition(t, func() bool {
 						return false
 					}, "write config: %v", err)
@@ -2909,7 +2904,7 @@ func initGitRepoWithOrigin(t *testing.T) (dir string, runGit func(args ...string
 	runGit("init", "-b", "main")
 	runGit("config", "user.email", "test@test.com")
 	runGit("config", "user.name", "Test")
-	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("init"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("init"), 0o644); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "write README.md: %v", err)
@@ -2927,7 +2922,7 @@ func TestLoadCIRepoConfig_LoadsFromDefaultBranch(t *testing.T) {
 
 	// Commit .roborev.toml on main with CI agents override
 	if err := os.WriteFile(filepath.Join(dir, ".roborev.toml"),
-		[]byte("[ci]\nagents = [\"claude\"]\n"), 0644); err != nil {
+		[]byte("[ci]\nagents = [\"claude\"]\n"), 0o644); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "write .roborev.toml: %v", err)
@@ -2951,7 +2946,7 @@ func TestLoadCIRepoConfig_FallsBackWhenNoConfigOnDefaultBranch(t *testing.T) {
 
 	// No .roborev.toml on origin/main, but put one in the working tree
 	if err := os.WriteFile(filepath.Join(dir, ".roborev.toml"),
-		[]byte("[ci]\nagents = [\"codex\"]\n"), 0644); err != nil {
+		[]byte("[ci]\nagents = [\"codex\"]\n"), 0o644); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "write .roborev.toml: %v", err)
@@ -2972,7 +2967,7 @@ func TestLoadCIRepoConfig_PropagatesParseError(t *testing.T) {
 
 	// Commit invalid TOML on main
 	if err := os.WriteFile(filepath.Join(dir, ".roborev.toml"),
-		[]byte("this is not valid toml [[["), 0644); err != nil {
+		[]byte("this is not valid toml [[["), 0o644); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "write .roborev.toml: %v", err)
@@ -2983,7 +2978,7 @@ func TestLoadCIRepoConfig_PropagatesParseError(t *testing.T) {
 
 	// Also put valid config in working tree -- should NOT be used
 	if err := os.WriteFile(filepath.Join(dir, ".roborev.toml"),
-		[]byte("[ci]\nagents = [\"codex\"]\n"), 0644); err != nil {
+		[]byte("[ci]\nagents = [\"codex\"]\n"), 0o644); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "write .roborev.toml: %v", err)
@@ -3812,7 +3807,7 @@ func TestCIPollerProcessPR_RepoReviewsMapOverride(
 		"codex = [\"security\"]\n"
 	if err := os.WriteFile(
 		filepath.Join(h.RepoPath, ".roborev.toml"),
-		[]byte(repoConfig), 0644,
+		[]byte(repoConfig), 0o644,
 	); err != nil {
 		require.Condition(t, func() bool {
 			return false
@@ -3885,7 +3880,7 @@ func TestCIPollerProcessPR_RepoEmptyReviewsDisables(
 		"[ci.reviews]\n"
 	if err := os.WriteFile(
 		filepath.Join(h.RepoPath, ".roborev.toml"),
-		[]byte(repoConfig), 0644,
+		[]byte(repoConfig), 0o644,
 	); err != nil {
 		require.Condition(t, func() bool {
 			return false
@@ -3920,7 +3915,6 @@ func TestCIPollerProcessPR_RepoEmptyReviewsDisables(
 			return false
 		}, "expected no batch when repo disables reviews "+
 			"via empty [ci.reviews]")
-
 	}
 }
 
@@ -4101,13 +4095,11 @@ func TestCIPollerPollRepo_SkipsCancelWhenPRStillOpen(t *testing.T) {
 		assert.Condition(t, func() bool {
 			return false
 		}, "batch for still-open PR #99 should not be canceled")
-
 	}
 	if len(canceledJobs) != 0 {
 		assert.Condition(t, func() bool {
 			return false
 		}, "expected 0 jobs canceled, got %d", len(canceledJobs))
-
 	}
 
 	_ = batch99
@@ -4235,7 +4227,6 @@ func TestCIPollerProcessPR_EmptyMatrixStillCancelsSuperseded(t *testing.T) {
 			return false
 		}, "expected 1 superseded job canceled, got %d",
 			len(canceledJobs))
-
 	}
 
 	// No new batch should have been created
@@ -4249,7 +4240,6 @@ func TestCIPollerProcessPR_EmptyMatrixStillCancelsSuperseded(t *testing.T) {
 		require.Condition(t, func() bool {
 			return false
 		}, "expected no batch for empty matrix after supersede")
-
 	}
 }
 
@@ -4306,7 +4296,6 @@ func TestCIPollerProcessPR_AgentFailureSetsErrorStatus(t *testing.T) {
 		require.Condition(t, func() bool {
 			return false
 		}, "expected 1 status call, got %d", len(*statuses))
-
 	}
 	sc := (*statuses)[0]
 	if sc.State != "error" {
@@ -4323,7 +4312,6 @@ func TestCIPollerProcessPR_AgentFailureSetsErrorStatus(t *testing.T) {
 		assert.Condition(t, func() bool {
 			return false
 		}, "desc=%q, want substring 'agent'", sc.Desc)
-
 	}
 }
 

--- a/internal/daemon/ci_repo_resolver_test.go
+++ b/internal/daemon/ci_repo_resolver_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/config"
 )
 

--- a/internal/daemon/classifier_test.go
+++ b/internal/daemon/classifier_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/review/autotype"
 )

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -25,7 +26,7 @@ func createTestGitRepo(t *testing.T) (string, func(args ...string)) {
 		tmpDir = resolved
 	}
 	repoDir := filepath.Join(tmpDir, "repo")
-	require.NoError(t, os.MkdirAll(repoDir, 0755))
+	require.NoError(t, os.MkdirAll(repoDir, 0o755))
 	run := func(args ...string) {
 		t.Helper()
 		cmd := exec.Command("git", args...)
@@ -37,7 +38,7 @@ func createTestGitRepo(t *testing.T) (string, func(args ...string)) {
 	run("config", "user.email", "test@test.com")
 	run("config", "user.name", "Test")
 	testFile := filepath.Join(repoDir, "test.txt")
-	require.NoError(t, os.WriteFile(testFile, []byte("test"), 0644))
+	require.NoError(t, os.WriteFile(testFile, []byte("test"), 0o644))
 	run("add", ".")
 	run("commit", "-m", "initial")
 	return repoDir, run
@@ -145,7 +146,6 @@ func TestHTTPClientWaitForReviewUsesJobID(t *testing.T) {
 }
 
 func TestFindJobForCommit(t *testing.T) {
-
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}

--- a/internal/daemon/compact_test.go
+++ b/internal/daemon/compact_test.go
@@ -63,7 +63,7 @@ func TestReadCompactMetadata(t *testing.T) {
 
 			if tt.mockFile != nil {
 				path := compactMetadataPath(tt.jobID)
-				if err := os.WriteFile(path, tt.mockFile, 0644); err != nil {
+				if err := os.WriteFile(path, tt.mockFile, 0o644); err != nil {
 					require.NoError(t, err, "Setup failed: %v")
 				}
 			}
@@ -90,7 +90,7 @@ func TestDeleteCompactMetadata(t *testing.T) {
 
 		// Create a metadata file
 		path := compactMetadataPath(jobID)
-		if err := os.WriteFile(path, []byte(`{"source_job_ids":[1,2,3]}`), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(`{"source_job_ids":[1,2,3]}`), 0o644); err != nil {
 			require.NoError(t, err, "Failed to write metadata file: %v")
 		}
 

--- a/internal/daemon/config_watcher.go
+++ b/internal/daemon/config_watcher.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 )

--- a/internal/daemon/config_watcher_test.go
+++ b/internal/daemon/config_watcher_test.go
@@ -2,18 +2,18 @@ package daemon
 
 import (
 	"context"
-
-	"github.com/stretchr/testify/assert"
-	"go.kenn.io/roborev/internal/config"
-
-	// configWatcherHarness encapsulates the watcher, broadcaster, temp paths, and event channel.
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/config"
 )
 
+// configWatcherHarness encapsulates the watcher, broadcaster, temp paths, and event channel.
 type configWatcherHarness struct {
 	Watcher     *ConfigWatcher
 	Broadcaster Broadcaster
@@ -101,7 +101,7 @@ func (h *configWatcherHarness) waitForReload(t *testing.T) {
 
 func writeTestFile(t *testing.T, path, content string) {
 	t.Helper()
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "Failed to write %s: %v", filepath.Base(path), err)

--- a/internal/daemon/e2e_auto_design_test.go
+++ b/internal/daemon/e2e_auto_design_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testutil"

--- a/internal/daemon/e2e_ci_auto_design_test.go
+++ b/internal/daemon/e2e_ci_auto_design_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testutil"

--- a/internal/daemon/errorlog.go
+++ b/internal/daemon/errorlog.go
@@ -37,12 +37,12 @@ type ErrorLog struct {
 func NewErrorLog(path string) (*ErrorLog, error) {
 	// Ensure directory exists
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, err
 	}
 
 	// Open file in append mode
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/daemon/errorlog_test.go
+++ b/internal/daemon/errorlog_test.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"path/filepath"
@@ -14,6 +12,9 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func createTestErrorLog(t *testing.T) (*ErrorLog, string) {

--- a/internal/daemon/githubapp_test.go
+++ b/internal/daemon/githubapp_test.go
@@ -7,14 +7,15 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -333,6 +334,7 @@ func TestTokenCaching(t *testing.T) {
 		}, "expected still 1 server call (cached), got %d", mock.callCount)
 	}
 }
+
 func TestTokenRefreshOnExpiry(t *testing.T) {
 	mock := &mockServer{
 		t: t,
@@ -386,6 +388,7 @@ func TestTokenRefreshOnExpiry(t *testing.T) {
 		}, "expected 2 server calls (refresh), got %d", mock.callCount)
 	}
 }
+
 func TestTokenExchangeError(t *testing.T) {
 	tp, _ := setupMockProvider(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)

--- a/internal/daemon/health_test.go
+++ b/internal/daemon/health_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
 )

--- a/internal/daemon/hooks_test.go
+++ b/internal/daemon/hooks_test.go
@@ -5,12 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-
-	"github.com/stretchr/testify/assert"
-	"go.kenn.io/roborev/internal/config"
-
-	// quote wraps a string in platform-appropriate shell quoting (matches shellEscape output).
-	"github.com/stretchr/testify/require"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -22,8 +16,14 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/config"
 )
 
+// quote wraps a string in platform-appropriate shell quoting (matches shellEscape output).
 func quote(s string) string {
 	return shellEscape(s)
 }
@@ -459,7 +459,6 @@ func TestResolveCommand(t *testing.T) {
 }
 
 func TestHookRunnerFiresHooks(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	markerFile := filepath.Join(tmpDir, "hook-fired")
 
@@ -489,7 +488,6 @@ func TestHookRunnerFiresHooks(t *testing.T) {
 }
 
 func TestHookRunnerWorkingDirectory(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	markerFile := filepath.Join(tmpDir, "pwd-test")
 
@@ -540,7 +538,6 @@ func TestHookRunnerWorkingDirectory(t *testing.T) {
 }
 
 func TestHookRunnerNoMatchDoesNotFire(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	markerFile := filepath.Join(tmpDir, "should-not-exist")
 
@@ -791,7 +788,6 @@ func TestRedactURLError(t *testing.T) {
 }
 
 func TestHooksSliceNotAliased(t *testing.T) {
-
 	// Verify that repo hooks don't leak into the global config's Hooks slice
 	tmpDir := t.TempDir()
 	markerGlobal := filepath.Join(tmpDir, "global-fired")
@@ -837,7 +833,6 @@ command = "`+touchCmd(markerRepo)+`"
 }
 
 func TestHookRunnerGlobalAndRepoHooksBothFire(t *testing.T) {
-
 	// Both global and per-repo hooks should fire for the same event
 	globalDir := t.TempDir()
 	repoDir := t.TempDir()
@@ -873,7 +868,6 @@ command = "`+touchCmd(repoMarker)+`"
 }
 
 func TestHookRunnerRepoOnlyHooks(t *testing.T) {
-
 	// Repo hooks fire even when there are no global hooks
 	repoDir := t.TempDir()
 	markerFile := filepath.Join(repoDir, "repo-only")
@@ -902,7 +896,6 @@ command = "`+touchCmd(markerFile)+`"
 }
 
 func TestHookRunnerRepoHookDoesNotFireForOtherRepo(t *testing.T) {
-
 	// A repo's hooks should not fire for events from a different repo
 	repoA := t.TempDir()
 	repoB := t.TempDir()
@@ -967,7 +960,7 @@ func TestHookRunnerStopUnsubscribes(t *testing.T) {
 // writeRepoConfig writes a .roborev.toml file into repoDir, failing the test on error.
 func writeRepoConfig(t *testing.T, repoDir, content string) {
 	t.Helper()
-	if err := os.WriteFile(filepath.Join(repoDir, ".roborev.toml"), []byte(content), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(repoDir, ".roborev.toml"), []byte(content), 0o644); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "failed to write .roborev.toml: %v", err)

--- a/internal/daemon/insights_test.go
+++ b/internal/daemon/insights_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	gitpkg "go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testutil"

--- a/internal/daemon/joblog.go
+++ b/internal/daemon/joblog.go
@@ -31,20 +31,20 @@ func JobLogPath(jobID int64) string {
 
 func openJobLogFile(jobID int64, flags int) (*os.File, error) {
 	dir := JobLogDir()
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("create job log dir %s: %w", dir, err)
 	}
 	// Tighten pre-existing directories from older installs.
-	if err := os.Chmod(dir, 0700); err != nil {
+	if err := os.Chmod(dir, 0o700); err != nil {
 		log.Printf("Warning: cannot chmod job log dir: %v", err)
 	}
 	path := JobLogPath(jobID)
-	f, err := os.OpenFile(path, flags, 0600)
+	f, err := os.OpenFile(path, flags, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("open job log file for job %d: %w", jobID, err)
 	}
 	// Tighten pre-existing files from older installs.
-	if err := f.Chmod(0600); err != nil {
+	if err := f.Chmod(0o600); err != nil {
 		log.Printf("Warning: cannot chmod job log file: %v", err)
 	}
 	return f, nil

--- a/internal/daemon/joblog_test.go
+++ b/internal/daemon/joblog_test.go
@@ -81,9 +81,9 @@ func TestOpenJobLog_TightensPermissivePerms(t *testing.T) {
 	// Pre-create dir and file with permissive modes, simulating
 	// an install upgraded from a version that used 0755/0644.
 	dir := JobLogDir()
-	require.NoError(os.MkdirAll(dir, 0755))
+	require.NoError(os.MkdirAll(dir, 0o755))
 	path := JobLogPath(500)
-	require.NoError(os.WriteFile(path, []byte("old"), 0644))
+	require.NoError(os.WriteFile(path, []byte("old"), 0o644))
 
 	f := openJobLog(500)
 	require.NotNil(f, "openJobLog returned nil")
@@ -95,7 +95,7 @@ func TestOpenJobLog_TightensPermissivePerms(t *testing.T) {
 
 func createLogFile(t *testing.T, path, content string, mtime time.Time) {
 	t.Helper()
-	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 	require.NoError(t, os.Chtimes(path, mtime, mtime))
 }
 
@@ -107,7 +107,7 @@ func TestCleanJobLogs(t *testing.T) {
 		setupTestEnv(t)
 
 		dir := JobLogDir()
-		require.NoError(os.MkdirAll(dir, 0755))
+		require.NoError(os.MkdirAll(dir, 0o755))
 
 		// Create an "old" log file by writing and then back-dating its mtime
 		oldPath := filepath.Join(dir, "1.log")
@@ -197,12 +197,12 @@ func TestJobLogWriter(t *testing.T) {
 		})
 
 		logsDir := filepath.Join(filepath.Dir(JobLogDir()))
-		if err := os.MkdirAll(logsDir, 0700); err != nil {
+		if err := os.MkdirAll(logsDir, 0o700); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, "MkdirAll: %v", err)
 		}
-		if err := os.WriteFile(JobLogDir(), []byte("blocked"), 0600); err != nil {
+		if err := os.WriteFile(JobLogDir(), []byte("blocked"), 0o600); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, "WriteFile: %v", err)
@@ -254,12 +254,12 @@ func TestJobLogWriter(t *testing.T) {
 		})
 
 		logsDir := filepath.Join(filepath.Dir(JobLogDir()))
-		if err := os.MkdirAll(logsDir, 0700); err != nil {
+		if err := os.MkdirAll(logsDir, 0o700); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, "MkdirAll: %v", err)
 		}
-		if err := os.WriteFile(JobLogDir(), []byte("blocked"), 0600); err != nil {
+		if err := os.WriteFile(JobLogDir(), []byte("blocked"), 0o600); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, "WriteFile: %v", err)

--- a/internal/daemon/normalize_test.go
+++ b/internal/daemon/normalize_test.go
@@ -207,7 +207,6 @@ func TestGetNormalizer(t *testing.T) {
 			if tc.wantType != "" {
 				assert.Equal(t, tc.wantType, result.Type, "Normalizer for %q: got type %q, want %q", tc.agent, result.Type, tc.wantType)
 			}
-
 		})
 	}
 }

--- a/internal/daemon/remap_integration_test.go
+++ b/internal/daemon/remap_integration_test.go
@@ -4,17 +4,18 @@ package daemon
 
 import (
 	"encoding/json"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	gitpkg "go.kenn.io/roborev/internal/git"
-	"go.kenn.io/roborev/internal/storage"
-	"go.kenn.io/roborev/internal/testutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	gitpkg "go.kenn.io/roborev/internal/git"
+	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/testutil"
 )
 
 type remapContext struct {

--- a/internal/daemon/routes_test.go
+++ b/internal/daemon/routes_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testutil"
 )

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -72,7 +72,7 @@ func WriteRuntime(ep DaemonEndpoint, version string) error {
 
 	path := RuntimePath()
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
 
@@ -112,7 +112,7 @@ func WriteRuntime(ep DaemonEndpoint, version string) error {
 	// Set permissions to 0644 explicitly. This intentionally ignores umask
 	// because the runtime file must be readable by other processes (CLI commands
 	// discovering the daemon). The file contains only PID/port/version, not secrets.
-	if err := os.Chmod(path, 0644); err != nil {
+	if err := os.Chmod(path, 0o644); err != nil {
 		return err
 	}
 

--- a/internal/daemon/runtime_integration_test.go
+++ b/internal/daemon/runtime_integration_test.go
@@ -3,11 +3,12 @@
 package daemon
 
 import (
-	"github.com/stretchr/testify/assert"
 	"math"
 	"net/http"
 	"sync/atomic"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestKillDaemonMakesHTTPForLoopback(t *testing.T) {

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -3,10 +3,6 @@ package daemon
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.kenn.io/roborev/internal/testenv"
 	"math"
 	"net"
 	"net/http"
@@ -17,6 +13,11 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/testenv"
 )
 
 const (
@@ -50,7 +51,7 @@ func createRuntimeFile(t *testing.T, dir string, pid int, data *runtimeData) str
 		}, "Failed to marshal runtime data: %v", err)
 	}
 	path := filepath.Join(dir, fmt.Sprintf("daemon.%d.json", pid))
-	if err := os.WriteFile(path, bytes, 0644); err != nil {
+	if err := os.WriteFile(path, bytes, 0o644); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "Failed to write runtime file: %v", err)
@@ -261,8 +262,8 @@ func TestListAllRuntimesSkipsUnreadableFiles(t *testing.T) {
 		PID:  math.MaxInt32 - 1,
 		Addr: "127.0.0.1:7374",
 	})
-	os.Chmod(unreadablePath, 0000)
-	t.Cleanup(func() { os.Chmod(unreadablePath, 0644) })
+	os.Chmod(unreadablePath, 0o000)
+	t.Cleanup(func() { os.Chmod(unreadablePath, 0o644) })
 
 	// Probe whether chmod 0000 actually blocks reads on this filesystem
 	if f, probeErr := os.Open(unreadablePath); probeErr == nil {
@@ -533,7 +534,7 @@ func TestCleanupZombieDaemonsPreservesTargetSocket(t *testing.T) {
 	require.NoError(t, err)
 	runtimePath := filepath.Join(
 		dataDir, fmt.Sprintf("daemon.%d.json", stalePID))
-	require.NoError(t, os.WriteFile(runtimePath, runtimeJSON, 0644))
+	require.NoError(t, os.WriteFile(runtimePath, runtimeJSON, 0o644))
 
 	mockIdentifyProcess(t, func(pid int) processIdentity {
 		return processNotRoborev
@@ -583,7 +584,7 @@ func TestListAllRuntimesWithGlobMetacharacters(t *testing.T) {
 	tmpDir := t.TempDir()
 	// Create a subdirectory with brackets (glob metacharacter)
 	dataDir := filepath.Join(tmpDir, "data[test]")
-	if err := os.Mkdir(dataDir, 0755); err != nil {
+	if err := os.Mkdir(dataDir, 0o755); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "Failed to create test directory: %v", err)

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -180,13 +180,13 @@ func (s *Server) Start(ctx context.Context) error {
 		if ep.IsUnix() {
 			socketPath := ep.Address
 			socketDir := filepath.Dir(socketPath)
-			if err := os.MkdirAll(socketDir, 0700); err != nil {
+			if err := os.MkdirAll(socketDir, 0o700); err != nil {
 				s.configWatcher.Stop()
 				return fmt.Errorf("create socket directory: %w", err)
 			}
 			// Verify the parent directory has safe permissions (owner-only)
 			if fi, err := os.Stat(socketDir); err == nil {
-				if perm := fi.Mode().Perm(); perm&0077 != 0 {
+				if perm := fi.Mode().Perm(); perm&0o077 != 0 {
 					s.configWatcher.Stop()
 					return fmt.Errorf("socket directory %s has unsafe permissions %o (must not be group/world accessible)", socketDir, perm)
 				}
@@ -198,7 +198,7 @@ func (s *Server) Start(ctx context.Context) error {
 				s.configWatcher.Stop()
 				return fmt.Errorf("listen on %s: %w", ep, err)
 			}
-			if err := os.Chmod(socketPath, 0600); err != nil {
+			if err := os.Chmod(socketPath, 0o600); err != nil {
 				_ = listener.Close()
 				s.configWatcher.Stop()
 				return fmt.Errorf("chmod socket: %w", err)
@@ -409,7 +409,7 @@ func getSystemdListener() (net.Listener, DaemonEndpoint, error) {
 			_ = listener.Close()
 			return nil, ep, fmt.Errorf("socket activation: %w", err)
 		}
-		if perm := fi.Mode().Perm(); perm&0077 != 0 {
+		if perm := fi.Mode().Perm(); perm&0o077 != 0 {
 			_ = listener.Close()
 			return nil, ep, fmt.Errorf(
 				"socket activation: socket %q has unsafe permissions: %04o",
@@ -2717,6 +2717,7 @@ func (s *Server) humaStreamEvents(
 		}
 	}}, nil
 }
+
 func rawJSONOutput(status int, body any) (*RawJSONOutput, error) {
 	return &RawJSONOutput{
 		Status: status,

--- a/internal/daemon/server_actions_test.go
+++ b/internal/daemon/server_actions_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"

--- a/internal/daemon/server_auto_design_test.go
+++ b/internal/daemon/server_auto_design_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testutil"

--- a/internal/daemon/server_integration_test.go
+++ b/internal/daemon/server_integration_test.go
@@ -3,15 +3,17 @@
 package daemon
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.kenn.io/roborev/internal/storage"
-	"go.kenn.io/roborev/internal/testutil"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/testutil"
 )
 
 func TestHandleEnqueueReviewTypeNormalization(t *testing.T) {

--- a/internal/daemon/server_jobs_test.go
+++ b/internal/daemon/server_jobs_test.go
@@ -2,14 +2,6 @@ package daemon
 
 import (
 	"fmt"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.kenn.io/roborev/internal/config"
-	gitpkg "go.kenn.io/roborev/internal/git"
-	"go.kenn.io/roborev/internal/storage"
-	"go.kenn.io/roborev/internal/testenv"
-	"go.kenn.io/roborev/internal/testutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -20,6 +12,15 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/config"
+	gitpkg "go.kenn.io/roborev/internal/git"
+	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/testenv"
+	"go.kenn.io/roborev/internal/testutil"
 )
 
 // listJobsResponse is the JSON shape returned by GET /api/jobs.
@@ -191,7 +192,7 @@ func TestHandleEnqueueExcludedBranch(t *testing.T) {
 	// Create .roborev.toml with excluded_branches
 	repoConfig := filepath.Join(repoDir, ".roborev.toml")
 	configContent := `excluded_branches = ["wip-feature", "draft"]`
-	if err := os.WriteFile(repoConfig, []byte(configContent), 0644); err != nil {
+	if err := os.WriteFile(repoConfig, []byte(configContent), 0o644); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "Failed to write repo config: %v", err)
@@ -278,7 +279,7 @@ func TestHandleEnqueueExcludedCommitPattern(t *testing.T) {
 	// Write repo config with excluded_commit_patterns
 	repoConfig := filepath.Join(repoDir, ".roborev.toml")
 	configContent := `excluded_commit_patterns = ["[skip review]", "[wip]"]`
-	if err := os.WriteFile(repoConfig, []byte(configContent), 0644); err != nil {
+	if err := os.WriteFile(repoConfig, []byte(configContent), 0o644); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "Failed to write repo config: %v", err)
@@ -714,7 +715,7 @@ func TestFindReusableSessionIDRejectsReusedBranchNameFromUnrelatedHistory(t *tes
 		}, "git rm failed: %v\n%s", err, out)
 	}
 	unrelatedFile := filepath.Join(repoDir, "unrelated.txt")
-	if err := os.WriteFile(unrelatedFile, []byte("unrelated\n"), 0644); err != nil {
+	if err := os.WriteFile(unrelatedFile, []byte("unrelated\n"), 0o644); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "WriteFile failed: %v", err)
@@ -848,7 +849,7 @@ func TestFindReusableSessionIDRejectsCandidateThatIsTooOldOnBranch(t *testing.T)
 
 	for i := range 51 {
 		nextFile := filepath.Join(repoDir, fmt.Sprintf("commit-%02d.txt", i))
-		if err := os.WriteFile(nextFile, fmt.Appendf(nil, "%d\n", i), 0644); err != nil {
+		if err := os.WriteFile(nextFile, fmt.Appendf(nil, "%d\n", i), 0o644); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, "WriteFile failed: %v", err)
@@ -948,7 +949,7 @@ func TestFindReusableSessionIDFallsBackToOlderValidCandidate(t *testing.T) {
 		}, "git rm failed: %v\n%s", err, out)
 	}
 	unrelatedFile := filepath.Join(repoDir, "unrelated-newer.txt")
-	if err := os.WriteFile(unrelatedFile, []byte("unrelated newer\n"), 0644); err != nil {
+	if err := os.WriteFile(unrelatedFile, []byte("unrelated newer\n"), 0o644); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "WriteFile failed: %v", err)
@@ -1093,7 +1094,7 @@ func TestFindReusableSessionIDUsesConfigurableLookback(t *testing.T) {
 		}
 
 		unrelatedFile := filepath.Join(repoDir, fmt.Sprintf("unrelated-%02d.txt", i))
-		if err := os.WriteFile(unrelatedFile, fmt.Appendf(nil, "unrelated %02d\n", i), 0644); err != nil {
+		if err := os.WriteFile(unrelatedFile, fmt.Appendf(nil, "unrelated %02d\n", i), 0o644); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, "WriteFile failed: %v", err)
@@ -1869,14 +1870,14 @@ func TestHandleEnqueueAgentAvailability(t *testing.T) {
 	gitOnlyDir := t.TempDir()
 	if runtime.GOOS == "windows" {
 		wrapper := fmt.Sprintf("@\"%s\" %%*\r\n", gitPath)
-		if err := os.WriteFile(filepath.Join(gitOnlyDir, "git.cmd"), []byte(wrapper), 0755); err != nil {
+		if err := os.WriteFile(filepath.Join(gitOnlyDir, "git.cmd"), []byte(wrapper), 0o755); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, err)
 		}
 	} else {
 		wrapper := fmt.Sprintf("#!/bin/sh\nexec '%s' \"$@\"\n", gitPath)
-		if err := os.WriteFile(filepath.Join(gitOnlyDir, "git"), []byte(wrapper), 0755); err != nil {
+		if err := os.WriteFile(filepath.Join(gitOnlyDir, "git"), []byte(wrapper), 0o755); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, err)
@@ -1975,7 +1976,7 @@ func TestHandleEnqueueAgentAvailability(t *testing.T) {
 					name = bin + ".cmd"
 					content = "@exit /b 0\r\n"
 				}
-				if err := os.WriteFile(filepath.Join(mockDir, name), []byte(content), 0755); err != nil {
+				if err := os.WriteFile(filepath.Join(mockDir, name), []byte(content), 0o755); err != nil {
 					require.Condition(t, func() bool {
 						return false
 					}, err)
@@ -2041,7 +2042,7 @@ func TestHandleEnqueueWorktreeGitDirIsolation(t *testing.T) {
 
 	// Make a new commit in the worktree so HEAD differs (commit B)
 	wtFile := filepath.Join(worktreeDir, "worktree-file.txt")
-	if err := os.WriteFile(wtFile, []byte("worktree content"), 0644); err != nil {
+	if err := os.WriteFile(wtFile, []byte("worktree content"), 0o644); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "write file: %v", err)
@@ -2137,7 +2138,7 @@ func TestHandleEnqueueRangeFromRootCommit(t *testing.T) {
 
 	// Add a second commit so we have a range
 	testFile := filepath.Join(repoDir, "second.txt")
-	if err := os.WriteFile(testFile, []byte("second"), 0644); err != nil {
+	if err := os.WriteFile(testFile, []byte("second"), 0o644); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, err)
@@ -2309,7 +2310,6 @@ func TestHandleListJobsJobTypeFilter(t *testing.T) {
 			assert.Condition(t, func() bool {
 				return false
 			}, "Expected job_type 'fix', got %q", resp.Jobs[0].JobType)
-
 		}
 	})
 
@@ -2733,7 +2733,6 @@ func TestHandleEnqueueCompactReasoning(t *testing.T) {
 			return false
 		}, "compact job reasoning = %q, want %q (fix default)",
 			job.Reasoning, "standard")
-
 	}
 }
 
@@ -2896,7 +2895,6 @@ func TestHandleListJobsSlashNormalization(t *testing.T) {
 				return false
 			}, "Expected 3 jobs with forward-slash prefix, got %d",
 				len(resp.Jobs))
-
 		}
 		for _, j := range resp.Jobs {
 			if !strings.HasPrefix(j.RepoPath, ws+"/") {
@@ -2904,7 +2902,6 @@ func TestHandleListJobsSlashNormalization(t *testing.T) {
 					return false
 				}, "Job %d repo_path %q should be under %s",
 					j.ID, j.RepoPath, ws)
-
 			}
 		}
 	})

--- a/internal/daemon/server_ops_test.go
+++ b/internal/daemon/server_ops_test.go
@@ -4,12 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.kenn.io/roborev/internal/config"
-	"go.kenn.io/roborev/internal/storage"
-	"go.kenn.io/roborev/internal/testutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -19,6 +13,13 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/config"
+	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/testutil"
 )
 
 func TestHandleBatchJobs(t *testing.T) {
@@ -149,7 +150,7 @@ func TestHandleRemap(t *testing.T) {
 
 	// Set up a git repo so the remap route can resolve paths.
 	repoDir := filepath.Join(tmpDir, "remap-repo")
-	if err := os.MkdirAll(repoDir, 0755); err != nil {
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, err)
@@ -256,7 +257,7 @@ func TestHandleRemap(t *testing.T) {
 	t.Run("remap with unregistered repo returns 404", func(t *testing.T) {
 		// Create a valid git repo that is NOT registered in the DB
 		unregistered := filepath.Join(tmpDir, "unregistered-repo")
-		if err := os.MkdirAll(unregistered, 0755); err != nil {
+		if err := os.MkdirAll(unregistered, 0o755); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, err)
@@ -491,7 +492,6 @@ func TestHandleGetReviewJobIDParsing(t *testing.T) {
 					return false
 				}, "expected status %d, got %d: %s",
 					tt.wantStatus, w.Code, w.Body.String())
-
 			}
 		})
 	}
@@ -931,7 +931,6 @@ func TestHandleFixJobStaleValidation(t *testing.T) {
 						return false
 					}, "Expected job %d status %s, got %s",
 						fixJob.ID, status, got.Status)
-
 				}
 
 				req := testutil.MakeJSONRequest(
@@ -1129,14 +1128,14 @@ func TestHandleFixJobAgentAvailability(t *testing.T) {
 	gitOnlyDir := t.TempDir()
 	if runtime.GOOS == "windows" {
 		wrapper := fmt.Sprintf("@\"%s\" %%*\r\n", gitPath)
-		if err := os.WriteFile(filepath.Join(gitOnlyDir, "git.cmd"), []byte(wrapper), 0755); err != nil {
+		if err := os.WriteFile(filepath.Join(gitOnlyDir, "git.cmd"), []byte(wrapper), 0o755); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, err)
 		}
 	} else {
 		wrapper := fmt.Sprintf("#!/bin/sh\nexec '%s' \"$@\"\n", gitPath)
-		if err := os.WriteFile(filepath.Join(gitOnlyDir, "git"), []byte(wrapper), 0755); err != nil {
+		if err := os.WriteFile(filepath.Join(gitOnlyDir, "git"), []byte(wrapper), 0o755); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, err)
@@ -1180,7 +1179,7 @@ func TestHandleFixJobAgentAvailability(t *testing.T) {
 					name = bin + ".cmd"
 					content = "@exit /b 0\r\n"
 				}
-				if err := os.WriteFile(filepath.Join(mockDir, name), []byte(content), 0755); err != nil {
+				if err := os.WriteFile(filepath.Join(mockDir, name), []byte(content), 0o755); err != nil {
 					require.Condition(t, func() bool {
 						return false
 					}, err)

--- a/internal/daemon/server_output_test.go
+++ b/internal/daemon/server_output_test.go
@@ -2,11 +2,6 @@ package daemon
 
 import (
 	"fmt"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.kenn.io/roborev/internal/storage"
-	"go.kenn.io/roborev/internal/testutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,6 +9,12 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/testutil"
 )
 
 // jobOutputResponse covers the union of fields returned by GET /api/job/output
@@ -187,14 +188,14 @@ func TestHandleJobLog(t *testing.T) {
 	t.Run("returns log content with headers", func(t *testing.T) {
 		// Create a log file
 		logDir := JobLogDir()
-		if err := os.MkdirAll(logDir, 0755); err != nil {
+		if err := os.MkdirAll(logDir, 0o755); err != nil {
 			require.Condition(t, func() bool {
 				return false
 			}, "MkdirAll: %v", err)
 		}
 		logContent := `{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}` + "\n"
 		if err := os.WriteFile(
-			JobLogPath(job.ID), []byte(logContent), 0644,
+			JobLogPath(job.ID), []byte(logContent), 0o644,
 		); err != nil {
 			require.Condition(t, func() bool {
 				return false
@@ -311,7 +312,7 @@ func TestHandleJobLogOffset(t *testing.T) {
 	}
 
 	logDir := JobLogDir()
-	if err := os.MkdirAll(logDir, 0755); err != nil {
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "MkdirAll: %v", err)
@@ -320,7 +321,7 @@ func TestHandleJobLogOffset(t *testing.T) {
 	line2 := `{"type":"assistant","message":{"content":[{"type":"text","text":"second"}]}}` + "\n"
 	logContent := line1 + line2
 	if err := os.WriteFile(
-		JobLogPath(job.ID), []byte(logContent), 0644,
+		JobLogPath(job.ID), []byte(logContent), 0o644,
 	); err != nil {
 		require.Condition(t, func() bool {
 			return false
@@ -348,7 +349,6 @@ func TestHandleJobLogOffset(t *testing.T) {
 				return false
 			}, "expected full content, got %q",
 				w.Body.String())
-
 		}
 
 		// X-Log-Offset should equal file size.
@@ -364,7 +364,6 @@ func TestHandleJobLogOffset(t *testing.T) {
 				return false
 			}, "X-Log-Offset = %d, want %d",
 				offset, len(logContent))
-
 		}
 	})
 
@@ -391,7 +390,6 @@ func TestHandleJobLogOffset(t *testing.T) {
 				return false
 			}, "expected second line only, got %q",
 				w.Body.String())
-
 		}
 	})
 
@@ -418,7 +416,6 @@ func TestHandleJobLogOffset(t *testing.T) {
 				return false
 			}, "expected empty body, got %q",
 				w.Body.String())
-
 		}
 	})
 
@@ -463,7 +460,6 @@ func TestHandleJobLogOffset(t *testing.T) {
 				return false
 			}, "expected full content after clamp, got %q",
 				w.Body.String())
-
 		}
 	})
 
@@ -500,7 +496,7 @@ func TestHandleJobLogOffset(t *testing.T) {
 		if err := os.WriteFile(
 			JobLogPath(job2.ID),
 			[]byte(completeLine+partialLine),
-			0644,
+			0o644,
 		); err != nil {
 			require.Condition(t, func() bool {
 				return false
@@ -530,7 +526,6 @@ func TestHandleJobLogOffset(t *testing.T) {
 				return false
 			}, "expected only complete line, got %q",
 				body)
-
 		}
 
 		// X-Log-Offset should point past the newline.
@@ -546,7 +541,6 @@ func TestHandleJobLogOffset(t *testing.T) {
 				return false
 			}, "X-Log-Offset = %d, want %d",
 				offset, len(completeLine))
-
 		}
 	})
 }

--- a/internal/daemon/server_repos_test.go
+++ b/internal/daemon/server_repos_test.go
@@ -2,17 +2,18 @@ package daemon
 
 import (
 	"encoding/json"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.kenn.io/roborev/internal/storage"
-	"go.kenn.io/roborev/internal/testutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/testutil"
 )
 
 func TestHandleListRepos(t *testing.T) {
@@ -393,7 +394,6 @@ func TestHandleListReposSlashNormalization(t *testing.T) {
 				return false
 			}, "Expected 2 repos with forward-slash prefix, got %d",
 				len(response.Repos))
-
 		}
 		if response.TotalCount != 3 {
 			assert.Condition(t, func() bool {

--- a/internal/daemon/server_stream_test.go
+++ b/internal/daemon/server_stream_test.go
@@ -5,14 +5,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // startStreamHandler starts the stream handler in a goroutine and waits for subscription.

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -4,14 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.kenn.io/roborev/internal/agent"
-	"go.kenn.io/roborev/internal/config"
-	"go.kenn.io/roborev/internal/storage"
-	"go.kenn.io/roborev/internal/testenv"
-	"go.kenn.io/roborev/internal/testutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -20,6 +12,15 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/agent"
+	"go.kenn.io/roborev/internal/config"
+	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/testenv"
+	"go.kenn.io/roborev/internal/testutil"
 )
 
 // safeRecorder wraps httptest.ResponseRecorder with mutex protection for concurrent access

--- a/internal/daemon/stream_integration_test.go
+++ b/internal/daemon/stream_integration_test.go
@@ -3,16 +3,18 @@
 package daemon
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.kenn.io/roborev/internal/config"
-	"go.kenn.io/roborev/internal/storage"
-	"go.kenn.io/roborev/internal/testutil"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/config"
+	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/testutil"
 )
 
 func waitForEventType(t *testing.T, ch <-chan Event, eventType string, timeout time.Duration) Event {

--- a/internal/daemon/worker_classify_test.go
+++ b/internal/daemon/worker_classify_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testutil"

--- a/internal/daemon/worker_integration_test.go
+++ b/internal/daemon/worker_integration_test.go
@@ -3,16 +3,17 @@
 package daemon
 
 import (
-	"github.com/stretchr/testify/assert"
-	"go.kenn.io/roborev/internal/storage"
-	"go.kenn.io/roborev/internal/testutil"
-
-	// waitForJobStatus polls until the job reaches one of the given statuses.
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/testutil"
 )
 
+// waitForJobStatus polls until the job reaches one of the given statuses.
 func (c *workerTestContext) waitForJobStatus(t *testing.T, jobID int64, statuses ...storage.JobStatus) *storage.ReviewJob {
 	t.Helper()
 

--- a/internal/daemon/worker_snapshot_test.go
+++ b/internal/daemon/worker_snapshot_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/agent"
 	gitpkg "go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/storage"

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -5,14 +5,21 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 	gitpkg "go.kenn.io/roborev/internal/git"
@@ -20,18 +27,11 @@ import (
 	"go.kenn.io/roborev/internal/review"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testutil"
-
-	// workerTestContext encapsulates the common setup for worker pool tests.
-	"github.com/stretchr/testify/require"
-	"io"
-	"strings"
-	"sync/atomic"
-	"testing"
-	"time"
 )
 
 const testWorkerID = "test-worker"
 
+// workerTestContext encapsulates the common setup for worker pool tests.
 type workerTestContext struct {
 	DB          *storage.DB
 	TmpDir      string
@@ -1113,7 +1113,6 @@ func TestResolveBackupAgent_AliasMatchesPrimary(t *testing.T) {
 			return false
 		}, "resolveBackupAgent() = %q, want empty (alias match)",
 			got)
-
 	}
 }
 

--- a/internal/ghaction/ghaction.go
+++ b/internal/ghaction/ghaction.go
@@ -238,13 +238,13 @@ func WriteWorkflow(
 	}
 
 	dir := filepath.Dir(outputPath)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf(
 			"create directory %s: %w", dir, err)
 	}
 
 	if err := os.WriteFile(
-		outputPath, []byte(content), 0644); err != nil {
+		outputPath, []byte(content), 0o644); err != nil {
 		return fmt.Errorf("write workflow: %w", err)
 	}
 

--- a/internal/ghaction/ghaction_test.go
+++ b/internal/ghaction/ghaction_test.go
@@ -407,7 +407,7 @@ func TestWriteWorkflow_ExistingFile_NoForce(t *testing.T) {
 	outPath := filepath.Join(dir, "roborev.yml")
 
 	if err := os.WriteFile(
-		outPath, []byte("existing"), 0644); err != nil {
+		outPath, []byte("existing"), 0o644); err != nil {
 		require.NoError(t, err)
 	}
 
@@ -426,7 +426,7 @@ func TestWriteWorkflow_ExistingFile_Force(t *testing.T) {
 	outPath := filepath.Join(dir, "roborev.yml")
 
 	if err := os.WriteFile(
-		outPath, []byte("existing"), 0644); err != nil {
+		outPath, []byte("existing"), 0o644); err != nil {
 		require.NoError(t, err)
 	}
 

--- a/internal/git/git_integration_test.go
+++ b/internal/git/git_integration_test.go
@@ -3,11 +3,12 @@
 package git
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetMainRepoRoot(t *testing.T) {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/testenv"
 )
 
@@ -74,9 +75,9 @@ func (r *TestRepo) CommitAll(msg string) {
 func (r *TestRepo) WriteFile(filename, content string) {
 	r.T.Helper()
 	path := filepath.Join(r.Dir, filename)
-	err := os.MkdirAll(filepath.Dir(path), 0755)
+	err := os.MkdirAll(filepath.Dir(path), 0o755)
 	require.NoError(r.T, err)
-	err = os.WriteFile(path, []byte(content), 0644)
+	err = os.WriteFile(path, []byte(content), 0o644)
 	require.NoError(r.T, err)
 }
 
@@ -100,10 +101,10 @@ func (r *TestRepo) AddWorktree(branchName string) *TestRepo {
 func (r *TestRepo) InstallHook(name, script string) {
 	r.T.Helper()
 	hooksDir := filepath.Join(r.Dir, ".git", "hooks")
-	err := os.MkdirAll(hooksDir, 0755)
+	err := os.MkdirAll(hooksDir, 0o755)
 	require.NoError(r.T, err)
 	hookPath := filepath.Join(hooksDir, name)
-	err = os.WriteFile(hookPath, []byte(script), 0755)
+	err = os.WriteFile(hookPath, []byte(script), 0o755)
 	require.NoError(r.T, err)
 }
 
@@ -174,7 +175,6 @@ func TestNormalizeMSYSPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := normalizeMSYSPath(tt.input)
 			assert.Equal(t, tt.expected, result, "Expected %s, got %s", tt.expected, result)
-
 		})
 	}
 }
@@ -379,7 +379,7 @@ func TestEnsureAbsoluteHooksPath(t *testing.T) {
 			t.Setenv("GIT_CONFIG_GLOBAL", globalCfg)
 			err := os.WriteFile(globalCfg, []byte(
 				"[core]\n\thooksPath = .githooks\n",
-			), 0644)
+			), 0o644)
 			require.NoError(t, err)
 
 			repo := NewTestRepo(t)
@@ -496,7 +496,6 @@ func TestGetCommitInfo(t *testing.T) {
 
 		assert.Empty(t, info.Body, "expected empty body, got '%s'", info.Body)
 		assert.Equal(t, "Test Author", info.Author, "expected author 'Test Author', got '%s'", info.Author)
-
 	})
 
 	t.Run("commit with subject and body", func(t *testing.T) {
@@ -1752,7 +1751,7 @@ func TestCommitErrorHookFailedFalseForGPGSigningFailure(t *testing.T) {
 		repo.WriteFile("fail-gpg.bat", "@echo off\nexit /b 1\n")
 	} else {
 		repo.WriteFile("fail-gpg", "#!/bin/sh\nexit 1\n")
-		err := os.Chmod(dummyGPG, 0755)
+		err := os.Chmod(dummyGPG, 0o755)
 		require.NoError(t, err, "failed to chmod fail-gpg")
 	}
 
@@ -1786,7 +1785,6 @@ func TestHasCommitHooksIgnoresDirectories(t *testing.T) {
 	err = os.MkdirAll(filepath.Join(hooksDir, "pre-commit"), 0o755)
 	require.NoError(t, err, "failed to create pre-commit directory")
 	require.False(t, hasCommitHooks(repo.Dir), "expected directory named pre-commit not to be treated as hook file")
-
 }
 
 func setupAncestorTest(t *testing.T) (*TestRepo, string, string, string) {
@@ -1848,7 +1846,6 @@ func TestIsAncestor(t *testing.T) {
 		repo, _, _, _ := setupAncestorTest(t)
 		_, err := IsAncestor(repo.Dir, "badbadbadbadbadbadbadbadbadbadbadbadbad", "HEAD")
 		require.Error(t, err, "bad object should return error")
-
 	})
 }
 
@@ -1875,7 +1872,6 @@ func TestGetPatchID(t *testing.T) {
 
 		assert.NotEqual(t, sha1, sha2, "SHAs should differ after rebase")
 		assert.Equal(t, patchID1, patchID2, "patch-ids should match: %s != %s", patchID1, patchID2)
-
 	})
 
 	t.Run("different for modified commits", func(t *testing.T) {
@@ -2008,7 +2004,6 @@ func TestWorktreePathForBranch(t *testing.T) {
 	t.Run("returns error for invalid repo path", func(t *testing.T) {
 		_, _, err := WorktreePathForBranch("/nonexistent/repo", "main")
 		require.Error(t, err, "expected error for invalid repo path, got nil")
-
 	})
 
 	t.Run("git worktree add succeeds on pre-existing empty directory", func(t *testing.T) {

--- a/internal/githook/githook.go
+++ b/internal/githook/githook.go
@@ -239,7 +239,7 @@ func normalizeOverridePath(raw string, deps binaryResolverDeps) (string, error) 
 	if info.IsDir() {
 		return "", fmt.Errorf("%s is a directory, not a binary", path)
 	}
-	if runtime.GOOS != "windows" && info.Mode()&0111 == 0 {
+	if runtime.GOOS != "windows" && info.Mode()&0o111 == 0 {
 		return "", fmt.Errorf("%s is not executable", path)
 	}
 	return path, nil

--- a/internal/githook/githook.go
+++ b/internal/githook/githook.go
@@ -69,8 +69,10 @@ func HasRealErrors(err error) bool {
 // Version markers identify the current hook template version.
 // Bump these when the hook template changes to trigger
 // upgrade warnings and auto-upgrades.
-const PostCommitVersionMarker = "post-commit hook v4"
-const PostRewriteVersionMarker = "post-rewrite hook v2"
+const (
+	PostCommitVersionMarker  = "post-commit hook v4"
+	PostRewriteVersionMarker = "post-rewrite hook v2"
+)
 
 // VersionMarker returns the current version marker for a hook.
 func VersionMarker(hookName string) string {
@@ -451,7 +453,8 @@ func InstallWithOptions(hooksDir, hookName string, opts InstallOptions) error {
 				return fmt.Errorf(
 					"%s hook: %w; add the roborev snippet "+
 						"manually or use --force to overwrite",
-					hookName, ErrNonShellHook)
+					hookName, ErrNonShellHook,
+				)
 			}
 			hookContent = embedSnippet(
 				existingStr,
@@ -489,7 +492,7 @@ func InstallWithOptions(hooksDir, hookName string, opts InstallOptions) error {
 	}
 
 	if err := os.WriteFile(
-		hookPath, []byte(hookContent), 0755,
+		hookPath, []byte(hookContent), 0o755,
 	); err != nil {
 		return fmt.Errorf("write %s hook: %w", hookName, err)
 	}
@@ -637,7 +640,7 @@ func Uninstall(hookPath string) error {
 			newContent += "\n"
 		}
 		if err := os.WriteFile(
-			hookPath, []byte(newContent), 0755,
+			hookPath, []byte(newContent), 0o755,
 		); err != nil {
 			return fmt.Errorf("write %s: %w", hookName, err)
 		}

--- a/internal/githook/githook_test.go
+++ b/internal/githook/githook_test.go
@@ -195,7 +195,7 @@ func TestResolveRoborevPathDoesNotGuessUnsupportedManagers(t *testing.T) {
 
 func TestResolveRoborevPathUsesExplicitBinary(t *testing.T) {
 	binPath := filepath.Join(t.TempDir(), "roborev")
-	require.NoError(t, os.WriteFile(binPath, []byte("#!/bin/sh\nexit 0\n"), 0755))
+	require.NoError(t, os.WriteFile(binPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
 
 	resolution, err := ResolveRoborevPath(binPath)
 	require.NoError(t, err)
@@ -770,7 +770,7 @@ func TestInstallWithOptionsUpdatesCurrentHookBinary(t *testing.T) {
 	}
 
 	newBinary := filepath.Join(t.TempDir(), "roborev")
-	require.NoError(t, os.WriteFile(newBinary, []byte("#!/bin/sh\nexit 0\n"), 0755))
+	require.NoError(t, os.WriteFile(newBinary, []byte("#!/bin/sh\nexit 0\n"), 0o755))
 
 	t.Run("standalone hook", func(t *testing.T) {
 		t.Parallel()
@@ -779,7 +779,7 @@ func TestInstallWithOptionsUpdatesCurrentHookBinary(t *testing.T) {
 		require.NoError(t, os.WriteFile(
 			hookPath,
 			[]byte(GeneratePostCommitWithBinary("/old/roborev")),
-			0755,
+			0o755,
 		))
 
 		err := InstallWithOptions(repo.HooksDir, hookPostCommit, InstallOptions{
@@ -800,7 +800,7 @@ func TestInstallWithOptionsUpdatesCurrentHookBinary(t *testing.T) {
 			[]byte(shebang+
 				generateEmbeddablePostCommitWithBinary("/old/roborev")+
 				"echo 'user code'\n"),
-			0755,
+			0o755,
 		))
 
 		err := InstallWithOptions(repo.HooksDir, hookPostCommit, InstallOptions{

--- a/internal/githook/githook_test.go
+++ b/internal/githook/githook_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/testutil"
 )
 
@@ -286,7 +287,6 @@ func TestEmbedSnippet(t *testing.T) {
 				return false
 			}, "snippet should come right after shebang, got:\n%s",
 				result)
-
 		}
 		if !strings.Contains(result, "echo 'user code'") {
 			assert.Condition(t, func() bool {
@@ -319,7 +319,6 @@ func TestEmbedSnippet(t *testing.T) {
 				return false
 			}, "snippet should be prepended, got:\n%s",
 				result)
-
 		}
 	})
 
@@ -333,7 +332,6 @@ func TestEmbedSnippet(t *testing.T) {
 				return false
 			}, "shebang should get trailing newline, got:\n%q",
 				result)
-
 		}
 		if !strings.Contains(result, "SNIPPET") {
 			assert.Condition(t, func() bool {
@@ -410,7 +408,7 @@ func TestNeedsUpgrade(t *testing.T) {
 			filepath.Join(repo.HooksDir, hookPostRewrite),
 			[]byte("#!/bin/sh\n# roborev hook\n"+
 				"roborev remap\n"),
-			0755,
+			0o755,
 		)
 		if !NeedsUpgrade(
 			repo.Root, hookPostRewrite,
@@ -430,7 +428,7 @@ func TestNeedsUpgrade(t *testing.T) {
 			[]byte("#!/bin/sh\n# roborev "+
 				PostRewriteVersionMarker+
 				"\nroborev remap\n"),
-			0755,
+			0o755,
 		)
 		if NeedsUpgrade(
 			repo.Root, hookPostRewrite,
@@ -477,7 +475,8 @@ func TestNotInstalled(t *testing.T) {
 		}
 	})
 
-	t.Run("non-ENOENT read error returns false",
+	t.Run(
+		"non-ENOENT read error returns false",
 		func(t *testing.T) {
 			t.Parallel()
 			repo := testutil.NewTestRepo(t)
@@ -486,13 +485,12 @@ func TestNotInstalled(t *testing.T) {
 			hookPath := filepath.Join(
 				repo.Root, ".git", "hooks", hookPostCommit,
 			)
-			os.MkdirAll(hookPath, 0755)
+			os.MkdirAll(hookPath, 0o755)
 			if NotInstalled(repo.Root, hookPostCommit) {
 				assert.Condition(t, func() bool {
 					return false
 				}, "non-ENOENT error should not report "+
 					"as not installed")
-
 			}
 		},
 	)
@@ -500,7 +498,8 @@ func TestNotInstalled(t *testing.T) {
 
 func TestMissing(t *testing.T) {
 	t.Parallel()
-	t.Run("missing post-rewrite with roborev post-commit",
+	t.Run(
+		"missing post-rewrite with roborev post-commit",
 		func(t *testing.T) {
 			t.Parallel()
 			repo := testutil.NewTestRepo(t)
@@ -541,7 +540,7 @@ func TestMissing(t *testing.T) {
 			[]byte("#!/bin/sh\n# roborev "+
 				PostRewriteVersionMarker+
 				"\nroborev remap\n"),
-			0755,
+			0o755,
 		)
 		if Missing(repo.Root, hookPostRewrite) {
 			assert.Condition(t, func() bool {
@@ -561,7 +560,8 @@ func TestMissing(t *testing.T) {
 		}
 	})
 
-	t.Run("non-ENOENT read error returns false",
+	t.Run(
+		"non-ENOENT read error returns false",
 		func(t *testing.T) {
 			t.Parallel()
 			if runtime.GOOS == "windows" {
@@ -578,12 +578,11 @@ func TestMissing(t *testing.T) {
 			prPath := filepath.Join(
 				repo.Root, ".git", "hooks", hookPostRewrite,
 			)
-			os.MkdirAll(prPath, 0755)
+			os.MkdirAll(prPath, 0o755)
 			if Missing(repo.Root, hookPostRewrite) {
 				assert.Condition(t, func() bool {
 					return false
 				}, "non-ENOENT error should return false")
-
 			}
 		},
 	)
@@ -706,7 +705,7 @@ func TestInstall(t *testing.T) {
 			hookPath := filepath.Join(repo.HooksDir, tc.hookName)
 
 			if tc.initialContent != "" {
-				if err := os.WriteFile(hookPath, []byte(tc.initialContent), 0755); err != nil {
+				if err := os.WriteFile(hookPath, []byte(tc.initialContent), 0o755); err != nil {
 					require.Condition(t, func() bool {
 						return false
 					}, err)
@@ -751,7 +750,7 @@ func TestInstall(t *testing.T) {
 				repo := setupHooksRepo(t)
 				hookPath := filepath.Join(repo.HooksDir, hookPostCommit)
 				existing := shebang + "\necho 'custom'\n"
-				os.WriteFile(hookPath, []byte(existing), 0755)
+				os.WriteFile(hookPath, []byte(existing), 0o755)
 
 				if err := Install(repo.HooksDir, hookPostCommit, false); err != nil {
 					require.Condition(t, func() bool {
@@ -851,7 +850,7 @@ func TestInstall_ReReadError(t *testing.T) {
 		"# roborev post-commit hook\n" +
 		"ROBOREV=\"/usr/local/bin/roborev\"\n" +
 		"\"$ROBOREV\" enqueue --quiet 2>/dev/null\n"
-	os.WriteFile(hookPath, []byte(outdated), 0755)
+	os.WriteFile(hookPath, []byte(outdated), 0o755)
 
 	origReadFile := ReadFile
 	ReadFile = func(string) ([]byte, error) {
@@ -906,7 +905,6 @@ func TestInstallAll(t *testing.T) {
 			assert.Condition(t, func() bool {
 				return false
 			}, "%s should contain version marker", name)
-
 		}
 	}
 }
@@ -1005,7 +1003,7 @@ func TestUninstall(t *testing.T) {
 			repo := setupHooksRepo(t)
 			hookPath := filepath.Join(repo.HooksDir, tc.hookName)
 
-			if err := os.WriteFile(hookPath, []byte(tc.initialContent), 0755); err != nil {
+			if err := os.WriteFile(hookPath, []byte(tc.initialContent), 0o755); err != nil {
 				require.Condition(t, func() bool {
 					return false
 				}, err)
@@ -1182,7 +1180,7 @@ func TestIsRoborevSnippetLine(t *testing.T) {
 func setupHooksRepo(t *testing.T) *testutil.TestRepo {
 	t.Helper()
 	repo := testutil.NewTestRepo(t)
-	if err := os.MkdirAll(repo.HooksDir, 0755); err != nil {
+	if err := os.MkdirAll(repo.HooksDir, 0o755); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, err)

--- a/internal/github/comment.go
+++ b/internal/github/comment.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	googlegithub "github.com/google/go-github/v84/github"
+
 	"go.kenn.io/roborev/internal/review"
 )
 

--- a/internal/github/comment_test.go
+++ b/internal/github/comment_test.go
@@ -13,6 +13,7 @@ import (
 	googlegithub "github.com/google/go-github/v84/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/review"
 )
 

--- a/internal/prompt/golden_test.go
+++ b/internal/prompt/golden_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testutil"

--- a/internal/prompt/insights_test.go
+++ b/internal/prompt/insights_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -1360,7 +1360,7 @@ func SplitResponses(responses []storage.Response) (toolAttempts, userComments []
 			userComments = append(userComments, r)
 		}
 	}
-	return
+	return toolAttempts, userComments
 }
 
 func FormatToolAttempts(attempts []storage.Response) string {

--- a/internal/prompt/prompt_body_templates_test.go
+++ b/internal/prompt/prompt_body_templates_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -396,6 +397,7 @@ func mustParsePromptTestTime(t *testing.T, value string) time.Time {
 	require.NoError(t, err)
 	return parsed
 }
+
 func TestRenderAddressPromptOmitsOptionalSectionsWhenEmpty(t *testing.T) {
 	body, err := renderAddressPrompt(addressPromptView{ReviewFindings: "finding", JobID: 1})
 	require.NoError(t, err)

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/config"
 	gitpkg "go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/storage"
@@ -196,7 +197,7 @@ func TestBuildPromptWithNoParentCommits(t *testing.T) {
 	// Create a repo with just one commit
 	r := newTestRepo(t)
 
-	if err := os.WriteFile(filepath.Join(r.dir, "file.txt"), []byte("content"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(r.dir, "file.txt"), []byte("content"), 0o644); err != nil {
 		require.NoError(t, err)
 	}
 	r.git("add", "file.txt")
@@ -258,7 +259,7 @@ All public APIs must have documentation comments.
 """
 `
 	configPath := filepath.Join(repoPath, ".roborev.toml")
-	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+	if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
 		require.NoError(t, err, "Failed to write config: %v", err)
 	}
 
@@ -285,7 +286,7 @@ func TestBuildPromptWithoutProjectGuidelines(t *testing.T) {
 	// Create .roborev.toml WITHOUT review guidelines
 	configContent := `agent = "codex"`
 	configPath := filepath.Join(repoPath, ".roborev.toml")
-	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+	if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
 		require.NoError(t, err, "Failed to write config: %v", err)
 	}
 
@@ -320,7 +321,7 @@ func TestBuildPromptGuidelinesOrder(t *testing.T) {
 	// Create .roborev.toml with review guidelines
 	configContent := `review_guidelines = "Test guideline"`
 	configPath := filepath.Join(repoPath, ".roborev.toml")
-	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+	if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
 		require.NoError(t, err, "Failed to write config: %v", err)
 	}
 
@@ -1631,7 +1632,7 @@ func TestLoadGuidelines(t *testing.T) {
 			setupFilesystem: func(t *testing.T, dir string) {
 				t.Helper()
 				if err := os.WriteFile(filepath.Join(dir, ".roborev.toml"),
-					[]byte("review_guidelines = \"Filesystem rule.\"\n"), 0644); err != nil {
+					[]byte("review_guidelines = \"Filesystem rule.\"\n"), 0o644); err != nil {
 					require.NoError(t, err, "write .roborev.toml: %v", err)
 				}
 			},
@@ -1643,7 +1644,7 @@ func TestLoadGuidelines(t *testing.T) {
 			setupGit: func(t *testing.T, r *testRepo) {
 				t.Helper()
 				if err := os.WriteFile(filepath.Join(r.dir, ".roborev.toml"),
-					[]byte("review_guidelines = INVALID[[["), 0644); err != nil {
+					[]byte("review_guidelines = INVALID[[["), 0o644); err != nil {
 					require.NoError(t, err, "write .roborev.toml: %v", err)
 				}
 				r.git("add", "-A")
@@ -1655,7 +1656,7 @@ func TestLoadGuidelines(t *testing.T) {
 			setupFilesystem: func(t *testing.T, dir string) {
 				t.Helper()
 				if err := os.WriteFile(filepath.Join(dir, ".roborev.toml"),
-					[]byte("review_guidelines = \"Filesystem guideline\"\n"), 0644); err != nil {
+					[]byte("review_guidelines = \"Filesystem guideline\"\n"), 0o644); err != nil {
 					require.NoError(t, err, "write .roborev.toml: %v", err)
 				}
 			},
@@ -1667,7 +1668,7 @@ func TestLoadGuidelines(t *testing.T) {
 			setupGit: func(t *testing.T, r *testRepo) {
 				t.Helper()
 				if err := os.WriteFile(filepath.Join(r.dir, ".roborev.toml"),
-					[]byte("review_guidelines = \"From main\"\n"), 0644); err != nil {
+					[]byte("review_guidelines = \"From main\"\n"), 0o644); err != nil {
 					require.NoError(t, err, "write .roborev.toml: %v", err)
 				}
 				r.git("add", "-A")
@@ -1682,17 +1683,17 @@ func TestLoadGuidelines(t *testing.T) {
 				blobSHA := r.git("rev-parse", "HEAD:.roborev.toml")
 				objPath := filepath.Join(r.dir, ".git", "objects",
 					blobSHA[:2], blobSHA[2:])
-				if err := os.Chmod(objPath, 0644); err != nil {
+				if err := os.Chmod(objPath, 0o644); err != nil {
 					require.NoError(t, err, "chmod: %v", err)
 				}
-				if err := os.WriteFile(objPath, []byte("corrupt"), 0444); err != nil {
+				if err := os.WriteFile(objPath, []byte("corrupt"), 0o444); err != nil {
 					require.NoError(t, err, "write corrupt blob: %v", err)
 				}
 			},
 			setupFilesystem: func(t *testing.T, dir string) {
 				t.Helper()
 				if err := os.WriteFile(filepath.Join(dir, ".roborev.toml"),
-					[]byte("review_guidelines = \"Filesystem fallback.\"\n"), 0644); err != nil {
+					[]byte("review_guidelines = \"Filesystem fallback.\"\n"), 0o644); err != nil {
 					require.NoError(t, err, "write .roborev.toml: %v", err)
 				}
 			},

--- a/internal/prompt/test_helpers_test.go
+++ b/internal/prompt/test_helpers_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testutil"
 )
@@ -86,7 +87,7 @@ func setupTestRepo(t *testing.T) (string, []string) {
 	for i := 1; i <= 6; i++ {
 		filename := filepath.Join(r.dir, "file.txt")
 		content := strings.Repeat("x", i) // Different content each time
-		require.NoError(t, os.WriteFile(filename, []byte(content), 0644))
+		require.NoError(t, os.WriteFile(filename, []byte(content), 0o644))
 		r.git("add", "file.txt")
 		r.git("commit", "-m", "commit "+string(rune('0'+i)))
 
@@ -370,9 +371,9 @@ func setupGuidelinesRepo(t *testing.T, defaultBranch, baseGuidelines, branchGuid
 	// Initial commit with base guidelines
 	if baseGuidelines != "" {
 		toml := `review_guidelines = """` + "\n" + baseGuidelines + "\n" + `"""` + "\n"
-		require.NoError(t, os.WriteFile(filepath.Join(r.dir, ".roborev.toml"), []byte(toml), 0644), "write .roborev.toml")
+		require.NoError(t, os.WriteFile(filepath.Join(r.dir, ".roborev.toml"), []byte(toml), 0o644), "write .roborev.toml")
 	} else {
-		require.NoError(t, os.WriteFile(filepath.Join(r.dir, "README.md"), []byte("init"), 0644), "write README.md")
+		require.NoError(t, os.WriteFile(filepath.Join(r.dir, "README.md"), []byte("init"), 0o644), "write README.md")
 	}
 	r.git("add", "-A")
 	r.git("commit", "-m", "initial")
@@ -389,7 +390,7 @@ func setupGuidelinesRepo(t *testing.T, defaultBranch, baseGuidelines, branchGuid
 	if branchGuidelines != "" {
 		r.git("checkout", "-b", "feature-branch")
 		toml := `review_guidelines = """` + "\n" + branchGuidelines + "\n" + `"""` + "\n"
-		require.NoError(t, os.WriteFile(filepath.Join(r.dir, ".roborev.toml"), []byte(toml), 0644), "write .roborev.toml")
+		require.NoError(t, os.WriteFile(filepath.Join(r.dir, ".roborev.toml"), []byte(toml), 0o644), "write .roborev.toml")
 		r.git("add", ".roborev.toml")
 		r.git("commit", "-m", "update guidelines on branch")
 		featureSHA = r.git("rev-parse", "HEAD")

--- a/internal/review/batch_test.go
+++ b/internal/review/batch_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/testutil"
@@ -35,19 +36,23 @@ func (m *mockAgent) Review(
 	}
 	return out, m.err
 }
+
 func (m *mockAgent) WithReasoning(
 	_ agent.ReasoningLevel,
 ) agent.Agent {
 	return m
 }
+
 func (m *mockAgent) WithAgentic(_ bool) agent.Agent {
 	return m
 }
+
 func (m *mockAgent) WithModel(model string) agent.Agent {
 	c := *m
 	c.model = model
 	return &c
 }
+
 func (m *mockAgent) CommandLine() string {
 	return m.name
 }
@@ -384,6 +389,7 @@ func (p *promptCapture) Review(
 	p.lastPrompt = prompt
 	return "ok", nil
 }
+
 func (p *promptCapture) WithReasoning(
 	_ agent.ReasoningLevel,
 ) agent.Agent {

--- a/internal/review/result_test.go
+++ b/internal/review/result_test.go
@@ -1,9 +1,10 @@
 package review
 
 import (
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTrimPartialRune(t *testing.T) {

--- a/internal/review/synthesis_test.go
+++ b/internal/review/synthesis_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/testenv"
 )
 

--- a/internal/review/synthesize_test.go
+++ b/internal/review/synthesize_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 )

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -265,7 +265,7 @@ func installAgent(spec agentSpec) (InstallResult, error) {
 	}
 
 	skillsDir := agentSkillsDir(home, spec)
-	if err := os.MkdirAll(skillsDir, 0755); err != nil {
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
 		return result, fmt.Errorf("create skills dir: %w", err)
 	}
 
@@ -278,14 +278,14 @@ func installAgent(spec agentSpec) (InstallResult, error) {
 		skillName := skill.DirName
 		skillDir := filepath.Join(skillsDir, skillName)
 
-		if err := os.MkdirAll(skillDir, 0755); err != nil {
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
 			return result, fmt.Errorf("create %s dir: %w", skillName, err)
 		}
 
 		destPath := filepath.Join(skillDir, "SKILL.md")
 		existed := fileExists(destPath)
 
-		if err := os.WriteFile(destPath, skill.Content, 0644); err != nil {
+		if err := os.WriteFile(destPath, skill.Content, 0o644); err != nil {
 			return result, fmt.Errorf("write %s/SKILL.md: %w", skillName, err)
 		}
 

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -37,8 +37,8 @@ func setupTestEnv(t *testing.T) string {
 func createMockSkill(t *testing.T, homeDir string, agent Agent, skill string) {
 	t.Helper()
 	dir := filepath.Join(homeDir, "."+string(agent), "skills", skill)
-	require.NoError(t, os.MkdirAll(dir, 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("old"), 0644))
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("old"), 0o644))
 }
 
 func expectedSkillDirNames(t *testing.T) []string {
@@ -107,7 +107,7 @@ func TestInstallWhenDirExists(t *testing.T) {
 		t.Run(tc.displayName, func(t *testing.T) {
 			tmpHome := setupTestEnv(t)
 			agentDir := filepath.Join(tmpHome, tc.configDir)
-			require.NoError(t, os.MkdirAll(agentDir, 0755))
+			require.NoError(t, os.MkdirAll(agentDir, 0o755))
 
 			results, err := Install()
 			require.NoError(t, err, "Install failed")
@@ -227,7 +227,7 @@ func TestInstallRemovesLegacySkills(t *testing.T) {
 		t.Run(tc.displayName, func(t *testing.T) {
 			tmpHome := setupTestEnv(t)
 
-			require.NoError(t, os.MkdirAll(filepath.Join(tmpHome, tc.configDir), 0755))
+			require.NoError(t, os.MkdirAll(filepath.Join(tmpHome, tc.configDir), 0o755))
 			createMockSkill(t, tmpHome, tc.agent, "roborev-address")
 
 			_, err := Install()
@@ -250,8 +250,8 @@ func TestUpdateRemovesLegacySkills(t *testing.T) {
 
 	// Plant the legacy skill
 	legacyDir := filepath.Join(tmpHome, ".claude", "skills", "roborev-address")
-	require.NoError(t, os.MkdirAll(legacyDir, 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(legacyDir, "SKILL.md"), []byte("old"), 0644))
+	require.NoError(t, os.MkdirAll(legacyDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(legacyDir, "SKILL.md"), []byte("old"), 0o644))
 
 	_, err := Update()
 	require.NoError(t, err)

--- a/internal/storage/ci_test.go
+++ b/internal/storage/ci_test.go
@@ -2,11 +2,12 @@ package storage
 
 import (
 	"database/sql"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -397,7 +398,6 @@ func TestIncrementBatchCompleted(t *testing.T) {
 	updated, err = db.IncrementBatchCompleted(batch.ID)
 	require.NoError(t, err, "IncrementBatchCompleted: %v")
 	assert.Equal(t, 2, updated.CompletedJobs, "got CompletedJobs=%d, want 2", updated.CompletedJobs)
-
 }
 
 func TestIncrementBatchFailed(t *testing.T) {
@@ -437,7 +437,6 @@ func TestIncrementBatchConcurrent(t *testing.T) {
 
 	finalBatch := getBatch(t, db, batch.ID)
 	assert.Equal(t, n, finalBatch.CompletedJobs, "got CompletedJobs=%d, want %d", finalBatch.CompletedJobs, n)
-
 }
 
 func TestGetBatchReviews(t *testing.T) {
@@ -492,7 +491,6 @@ func TestGetCIBatchByJobID(t *testing.T) {
 	notFound, err := db.GetCIBatchByJobID(99999)
 	require.NoError(t, err, "GetCIBatchByJobID: %v")
 	assert.Nil(t, notFound, "expected nil for unknown job ID")
-
 }
 
 func TestListCIBatchesByJobID_Multiple(t *testing.T) {
@@ -549,7 +547,6 @@ func TestClaimBatchForSynthesis(t *testing.T) {
 	require.NoError(t, err, "ClaimBatchForSynthesis (after unclaim): %v")
 
 	assert.True(t, claimed, "expected claim after unclaim to succeed")
-
 }
 
 func TestFinalizeBatch_PreventsStaleRepost(t *testing.T) {
@@ -599,7 +596,6 @@ func TestFinalizeBatch_PreventsStaleRepost(t *testing.T) {
 	claimed, err = db.ClaimBatchForSynthesis(batch.ID)
 	require.NoError(t, err)
 	assert.False(t, claimed, "should not be able to re-claim a finalized batch")
-
 }
 
 func TestGetStaleBatches_StaleClaim(t *testing.T) {
@@ -624,7 +620,6 @@ func TestGetStaleBatches_StaleClaim(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "stale claimed batch should appear in GetStaleBatches")
-
 }
 
 func TestUnclaimStaleBatchClaim_OnlyUnclaimsStillStaleClaims(t *testing.T) {
@@ -711,7 +706,6 @@ func TestCancelJob_ReturnsErrNoRowsForTerminalJobs(t *testing.T) {
 
 		err := db.CancelJob(job.ID)
 		require.ErrorIs(t, err, sql.ErrNoRows, "expected sql.ErrNoRows, got: %v", err)
-
 	})
 
 	t.Run("QueuedJob_Succeeds", func(t *testing.T) {
@@ -793,7 +787,6 @@ func TestLatestBatchTimeForPR(t *testing.T) {
 		ts, err := db.LatestBatchTimeForPR(testRepo, 99)
 		require.NoError(t, err, "LatestBatchTimeForPR: %v")
 		assert.True(t, ts.IsZero(), "expected zero time, got %v", ts)
-
 	})
 
 	t.Run("returns latest batch time", func(t *testing.T) {
@@ -834,7 +827,6 @@ func TestLatestBatchTimeForPR(t *testing.T) {
 		ts, err := db.LatestBatchTimeForPR(testRepo, 999)
 		require.NoError(t, err, "LatestBatchTimeForPR: %v")
 		assert.True(t, ts.IsZero(), "expected zero time for different PR, got %v", ts)
-
 	})
 }
 

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -11,8 +11,9 @@ import (
 	"strings"
 	"time"
 
-	"go.kenn.io/roborev/internal/config"
 	_ "modernc.org/sqlite"
+
+	"go.kenn.io/roborev/internal/config"
 )
 
 const schema = `
@@ -140,7 +141,7 @@ func DefaultDBPath() string {
 func Open(dbPath string) (*DB, error) {
 	// Ensure directory exists
 	dir := filepath.Dir(dbPath)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("create db directory: %w", err)
 	}
 

--- a/internal/storage/db_filter_test.go
+++ b/internal/storage/db_filter_test.go
@@ -2,11 +2,12 @@ package storage
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestJobCounts(t *testing.T) {
@@ -133,7 +134,6 @@ func TestListReposWithReviewCounts(t *testing.T) {
 	})
 
 	t.Run("counts include all job statuses", func(t *testing.T) {
-
 		claimed, _ := db.ClaimJob("worker-1")
 		if claimed != nil {
 			db.CompleteJob(claimed.ID, "codex", "prompt", "output")
@@ -441,7 +441,6 @@ func TestWithBranchOrEmpty(t *testing.T) {
 }
 
 func TestListJobsAndGetJobByIDReturnAgentic(t *testing.T) {
-
 	db := openTestDB(t)
 	defer db.Close()
 
@@ -558,7 +557,6 @@ func TestListReposWithReviewCountsByBranch(t *testing.T) {
 	})
 
 	t.Run("filter by (none) branch", func(t *testing.T) {
-
 		commit4 := createCommit(t, db, repo1.ID, "jkl012")
 		enqueueJob(t, db, repo1.ID, commit4.ID, "jkl012")
 
@@ -611,7 +609,6 @@ func TestListBranchesWithCounts(t *testing.T) {
 	})
 
 	t.Run("filter by single repo", func(t *testing.T) {
-
 		result, err := db.ListBranchesWithCounts([]string{repo1.RootPath})
 		require.NoError(t, err, "ListBranchesWithCounts failed: %v")
 
@@ -620,7 +617,6 @@ func TestListBranchesWithCounts(t *testing.T) {
 	})
 
 	t.Run("filter by multiple repos", func(t *testing.T) {
-
 		result, err := db.ListBranchesWithCounts([]string{repo1.RootPath, repo2.RootPath})
 		require.NoError(t, err, "ListBranchesWithCounts failed: %v")
 
@@ -638,7 +634,6 @@ func TestListBranchesWithCounts(t *testing.T) {
 }
 
 func TestListJobsVerdictForBranchRangeReview(t *testing.T) {
-
 	db := openTestDB(t)
 	defer db.Close()
 
@@ -939,7 +934,6 @@ func TestPrefixFilterWithSpecialChars(t *testing.T) {
 	})
 
 	t.Run("backslash prefix matches normalized Windows path", func(t *testing.T) {
-
 		createRepo(t, db, `C:\Users\dev\workspace\project-a`)
 		rA, _ := db.GetRepoByPath(`C:\Users\dev\workspace\project-a`)
 		cA := createCommit(t, db, rA.ID, "win-a")
@@ -965,7 +959,6 @@ func TestPrefixFilterWithSpecialChars(t *testing.T) {
 		require.NoError(t, err, "ListReposWithReviewCounts with backslash prefix should not error: %v")
 		assert.Len(t, repos, 1)
 		assert.Equal(t, 1, total)
-
 	})
 }
 

--- a/internal/storage/db_helper_test.go
+++ b/internal/storage/db_helper_test.go
@@ -46,7 +46,7 @@ func openTestDB(t *testing.T) *DB {
 	require.NoError(t, err, "Failed to read template DB: %v")
 
 	dbPath := filepath.Join(t.TempDir(), "test.db")
-	err = os.WriteFile(dbPath, data, 0644)
+	err = os.WriteFile(dbPath, data, 0o644)
 	require.NoError(t, err, "Failed to write test DB: %v")
 
 	db, err := Open(dbPath)
@@ -129,7 +129,6 @@ func backdateJobStart(t *testing.T, db *DB, jobID int64, d time.Duration) {
 	startTime := time.Now().Add(-d).UTC().Format(time.RFC3339)
 	_, err := db.Exec(`UPDATE review_jobs SET status = 'running', started_at = ? WHERE id = ?`, startTime, jobID)
 	require.NoError(t, err, "failed to backdate job: %v")
-
 }
 
 func backdateJobStartWithOffset(t *testing.T, db *DB, jobID int64, d time.Duration, loc *time.Location) {
@@ -137,14 +136,12 @@ func backdateJobStartWithOffset(t *testing.T, db *DB, jobID int64, d time.Durati
 	startTime := time.Now().Add(-d).In(loc).Format(time.RFC3339)
 	_, err := db.Exec(`UPDATE review_jobs SET status = 'running', started_at = ? WHERE id = ?`, startTime, jobID)
 	require.NoError(t, err, "failed to backdate job with offset: %v")
-
 }
 
 func setJobBranch(t *testing.T, db *DB, jobID int64, branch string) {
 	t.Helper()
 	_, err := db.Exec(`UPDATE review_jobs SET branch = ? WHERE id = ?`, branch, jobID)
 	require.NoError(t, err, "failed to set job branch: %v")
-
 }
 
 func createJobChain(t *testing.T, db *DB, repoPath, sha string) (*Repo, *Commit, *ReviewJob) {

--- a/internal/storage/db_repo_test.go
+++ b/internal/storage/db_repo_test.go
@@ -1,10 +1,11 @@
 package storage
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRepoOperations(t *testing.T) {

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -993,7 +993,7 @@ func (db *DB) GetJobByID(id int64) (*ReviewJob, error) {
 func (db *DB) GetJobCounts() (queued, running, done, failed, canceled, applied, rebased, skipped int, err error) {
 	rows, err := db.Query(`SELECT status, COUNT(*) FROM review_jobs GROUP BY status`)
 	if err != nil {
-		return
+		return queued, running, done, failed, canceled, applied, rebased, skipped, err
 	}
 	defer rows.Close()
 
@@ -1001,7 +1001,7 @@ func (db *DB) GetJobCounts() (queued, running, done, failed, canceled, applied, 
 		var status string
 		var count int
 		if err = rows.Scan(&status, &count); err != nil {
-			return
+			return queued, running, done, failed, canceled, applied, rebased, skipped, err
 		}
 		switch JobStatus(status) {
 		case JobStatusQueued:
@@ -1023,7 +1023,7 @@ func (db *DB) GetJobCounts() (queued, running, done, failed, canceled, applied, 
 		}
 	}
 	err = rows.Err()
-	return
+	return queued, running, done, failed, canceled, applied, rebased, skipped, err
 }
 
 // UpdateJobBranch sets the branch field for a job that doesn't have one.

--- a/internal/storage/models_test.go
+++ b/internal/storage/models_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testutil"
 )

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -15,12 +15,12 @@ import (
 )
 
 // PostgreSQL schema version - increment when schema changes
-const pgSchemaVersion = 13
+const pgSchemaVersion = 14
 
 // pgSchemaName is the PostgreSQL schema used to isolate roborev tables
 const pgSchemaName = "roborev"
 
-//go:embed schemas/postgres_v13.sql
+//go:embed schemas/postgres_v14.sql
 var pgSchemaSQL string
 
 // pgSchemaStatements returns the individual DDL statements for schema creation.
@@ -342,11 +342,32 @@ func (p *PgPool) EnsureSchema(ctx context.Context) error {
 				return fmt.Errorf("v13 migration (add retry_not_before): %w", err)
 			}
 		}
+		if currentVersion < 14 {
+			if _, err = p.pool.Exec(ctx, `ALTER TABLE responses ADD COLUMN IF NOT EXISTS inserted_at TIMESTAMP WITH TIME ZONE`); err != nil {
+				return fmt.Errorf("v14 migration (add inserted_at): %w", err)
+			}
+			if _, err = p.pool.Exec(ctx, `UPDATE responses SET inserted_at = created_at WHERE inserted_at IS NULL`); err != nil {
+				return fmt.Errorf("v14 migration (backfill inserted_at): %w", err)
+			}
+			if _, err = p.pool.Exec(ctx, `ALTER TABLE responses ALTER COLUMN inserted_at SET DEFAULT clock_timestamp()`); err != nil {
+				return fmt.Errorf("v14 migration (set inserted_at default): %w", err)
+			}
+			if _, err = p.pool.Exec(ctx, `ALTER TABLE responses ALTER COLUMN inserted_at SET NOT NULL`); err != nil {
+				return fmt.Errorf("v14 migration (set inserted_at not null): %w", err)
+			}
+			if _, err = p.pool.Exec(ctx, `CREATE INDEX IF NOT EXISTS idx_responses_inserted ON responses(inserted_at)`); err != nil {
+				return fmt.Errorf("v14 migration (add inserted_at index): %w", err)
+			}
+		}
 		// Update version
 		_, err = p.pool.Exec(ctx, `INSERT INTO schema_version (version) VALUES ($1) ON CONFLICT (version) DO NOTHING`, pgSchemaVersion)
 		if err != nil {
 			return fmt.Errorf("update schema version: %w", err)
 		}
+	}
+
+	if _, err := p.pool.Exec(ctx, `CREATE INDEX IF NOT EXISTS idx_responses_inserted ON responses(inserted_at)`); err != nil {
+		return fmt.Errorf("ensure response inserted_at index: %w", err)
 	}
 
 	// Auto-design dedup indexes are created unconditionally (with IF
@@ -643,7 +664,7 @@ func (p *PgPool) UpsertJob(ctx context.Context, j SyncableJob, pgRepoID int64, p
 			uuid, repo_id, commit_id, git_ref, session_id, agent, model, provider, requested_model, requested_provider, reasoning, job_type, review_type, patch_id, status, agentic,
 			enqueued_at, started_at, finished_at, prompt, diff_content, error, token_usage,
 			worktree_path, min_severity, source_machine_id, updated_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, NOW())
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, clock_timestamp())
 		ON CONFLICT (uuid) DO UPDATE SET
 			status = EXCLUDED.status,
 			finished_at = EXCLUDED.finished_at,
@@ -659,7 +680,7 @@ func (p *PgPool) UpsertJob(ctx context.Context, j SyncableJob, pgRepoID int64, p
 			token_usage = COALESCE(EXCLUDED.token_usage, review_jobs.token_usage),
 			worktree_path = COALESCE(EXCLUDED.worktree_path, review_jobs.worktree_path),
 			min_severity = EXCLUDED.min_severity,
-			updated_at = NOW()
+			updated_at = clock_timestamp()
 	`, j.UUID, pgRepoID, pgCommitID, j.GitRef, nullString(j.SessionID), j.Agent, nullString(j.Model), nullString(j.Provider), nullString(j.RequestedModel), nullString(j.RequestedProvider), nullString(j.Reasoning),
 		defaultStr(j.JobType, "review"), j.ReviewType, nullString(j.PatchID), j.Status, j.Agentic, j.EnqueuedAt, j.StartedAt, j.FinishedAt,
 		nullString(j.Prompt), j.DiffContent, nullString(j.Error), nullString(j.TokenUsage), nullString(j.WorktreePath), normalizeMinSeverityForWrite(j.MinSeverity), j.SourceMachineID)
@@ -672,11 +693,11 @@ func (p *PgPool) UpsertReview(ctx context.Context, r SyncableReview) error {
 		INSERT INTO reviews (
 			uuid, job_uuid, agent, prompt, output, closed,
 			updated_by_machine_id, created_at, updated_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, clock_timestamp())
 		ON CONFLICT (uuid) DO UPDATE SET
 			closed = EXCLUDED.closed,
 			updated_by_machine_id = EXCLUDED.updated_by_machine_id,
-			updated_at = NOW()
+			updated_at = clock_timestamp()
 	`, r.UUID, r.JobUUID, r.Agent, r.Prompt, r.Output, r.Closed,
 		r.UpdatedByMachineID, r.CreatedAt)
 	return err
@@ -886,45 +907,64 @@ type PulledResponse struct {
 	Response        string
 	SourceMachineID string
 	CreatedAt       time.Time
+	InsertedAt      time.Time
 }
 
-// PullResponses fetches responses from PostgreSQL created after the given ID cursor.
-func (p *PgPool) PullResponses(ctx context.Context, excludeMachineID string, afterID int64, limit int) ([]PulledResponse, int64, error) {
+// PullResponses fetches responses from PostgreSQL inserted after the given cursor.
+// Cursor format: "inserted_at id" (space-separated) or empty for first pull.
+func (p *PgPool) PullResponses(ctx context.Context, excludeMachineID string, cursor string, limit int) ([]PulledResponse, string, error) {
+	var cursorTime time.Time
+	var cursorID int64
+	if cursor != "" {
+		var ok bool
+		cursorTime, cursorID, ok = parseTimestampIDCursor(cursor)
+		if !ok {
+			cursor = ""
+		}
+	}
+
 	rows, err := p.pool.Query(ctx, `
 		SELECT
-			r.uuid, r.job_uuid, r.responder, r.response, r.source_machine_id, r.created_at, r.id
+			r.uuid, r.job_uuid, r.responder, r.response, r.source_machine_id, r.created_at, r.inserted_at, r.id
 		FROM responses r
 		WHERE (r.source_machine_id IS NULL OR r.source_machine_id != $1)
-		AND r.id > $2
-		ORDER BY r.id
-		LIMIT $3
-	`, excludeMachineID, afterID, limit)
+		AND (r.inserted_at > $2 OR (r.inserted_at = $2 AND r.id > $3))
+		ORDER BY r.inserted_at, r.id
+		LIMIT $4
+	`, excludeMachineID, cursorTime, cursorID, limit)
 	if err != nil {
-		return nil, afterID, fmt.Errorf("query responses: %w", err)
+		return nil, cursor, fmt.Errorf("query responses: %w", err)
 	}
 	defer rows.Close()
 
 	var responses []PulledResponse
-	var lastID = afterID
+	var lastInsertedAt time.Time
+	var lastID int64
 
 	for rows.Next() {
 		var r PulledResponse
 
 		err := rows.Scan(
-			&r.UUID, &r.JobUUID, &r.Responder, &r.Response, &r.SourceMachineID, &r.CreatedAt, &lastID,
+			&r.UUID, &r.JobUUID, &r.Responder, &r.Response, &r.SourceMachineID, &r.CreatedAt, &r.InsertedAt, &lastID,
 		)
 		if err != nil {
-			return nil, afterID, fmt.Errorf("scan response: %w", err)
+			return nil, cursor, fmt.Errorf("scan response: %w", err)
 		}
 
+		lastInsertedAt = r.InsertedAt
 		responses = append(responses, r)
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, afterID, fmt.Errorf("rows error: %w", err)
+		return nil, cursor, fmt.Errorf("rows error: %w", err)
 	}
 
-	return responses, lastID, nil
+	newCursor := cursor
+	if len(responses) > 0 {
+		newCursor = formatTimestampIDCursor(lastInsertedAt, lastID)
+	}
+
+	return responses, newCursor, nil
 }
 
 // nullString returns nil if s is empty, otherwise returns s
@@ -957,11 +997,11 @@ func (p *PgPool) BatchUpsertReviews(ctx context.Context, reviews []SyncableRevie
 			INSERT INTO reviews (
 				uuid, job_uuid, agent, prompt, output, closed,
 				updated_by_machine_id, created_at, updated_at
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, clock_timestamp())
 			ON CONFLICT (uuid) DO UPDATE SET
 				closed = EXCLUDED.closed,
 				updated_by_machine_id = EXCLUDED.updated_by_machine_id,
-				updated_at = NOW()
+				updated_at = clock_timestamp()
 		`, r.UUID, r.JobUUID, r.Agent, r.Prompt, r.Output, r.Closed,
 			r.UpdatedByMachineID, r.CreatedAt)
 	}
@@ -1044,7 +1084,7 @@ func (p *PgPool) BatchUpsertJobs(ctx context.Context, jobs []JobWithPgIDs) ([]bo
 				uuid, repo_id, commit_id, git_ref, session_id, agent, reasoning, job_type, review_type, patch_id, status, agentic,
 				enqueued_at, started_at, finished_at, prompt, diff_content, error, token_usage,
 				worktree_path, min_severity, source_machine_id, updated_at
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, NOW())
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, clock_timestamp())
 			ON CONFLICT (uuid) DO UPDATE SET
 				status = EXCLUDED.status,
 				finished_at = EXCLUDED.finished_at,
@@ -1056,7 +1096,7 @@ func (p *PgPool) BatchUpsertJobs(ctx context.Context, jobs []JobWithPgIDs) ([]bo
 				token_usage = COALESCE(EXCLUDED.token_usage, review_jobs.token_usage),
 				worktree_path = COALESCE(EXCLUDED.worktree_path, review_jobs.worktree_path),
 				min_severity = EXCLUDED.min_severity,
-				updated_at = NOW()
+				updated_at = clock_timestamp()
 		`, j.UUID, jw.PgRepoID, jw.PgCommitID, j.GitRef, nullString(j.SessionID), j.Agent, nullString(j.Reasoning),
 			defaultStr(j.JobType, "review"), j.ReviewType, nullString(j.PatchID), j.Status, j.Agentic, j.EnqueuedAt, j.StartedAt, j.FinishedAt,
 			nullString(j.Prompt), j.DiffContent, nullString(j.Error), nullString(j.TokenUsage), nullString(j.WorktreePath), normalizeMinSeverityForWrite(j.MinSeverity), j.SourceMachineID)

--- a/internal/storage/postgres_integration_test.go
+++ b/internal/storage/postgres_integration_test.go
@@ -376,6 +376,22 @@ func jobUUIDSet(jobs []ReviewJob) map[string]bool {
 	return uuids
 }
 
+func requireLocalJobByUUID(t *testing.T, db *DB, uuid string) ReviewJob {
+	t.Helper()
+	jobs, err := db.ListJobs("", "", 1000, 0)
+	require.NoError(t, err)
+	var found *ReviewJob
+	for _, job := range jobs {
+		if job.UUID == uuid {
+			j := job
+			found = &j
+			break
+		}
+	}
+	require.NotNil(t, found, "job UUID %s not found", uuid)
+	return *found
+}
+
 // TestIntegration_MigrationV6Idempotent verifies the v5→v6 migration
 // (addressed→closed rename) succeeds when the reviews table already
 // has the closed column. This happens when legacy schema_version
@@ -591,6 +607,45 @@ func TestIntegration_SyncPullsLateVisibleJobBeforeCursor(t *testing.T) {
 	jobs, err := nodeA.DB.ListJobs("", "", 1000, 0)
 	require.NoError(t, err)
 	assert.Contains(t, jobUUIDSet(jobs), lateUUID)
+}
+
+func TestIntegration_SyncLookbackDoesNotRevertAppliedFixJob(t *testing.T) {
+	t.Setenv(syncCursorLookbackEnv, "1h")
+	env := newIntegrationEnv(t, 30*time.Second)
+
+	repoIdentity := "git@github.com:test/lookback-applied.git"
+	nodeA := env.setupNode("lookback-applied-a", repoIdentity, "1h")
+	nodeB := env.setupNode("lookback-applied-b", repoIdentity, "1h")
+
+	commit, err := nodeB.DB.GetOrCreateCommit(nodeB.Repo.ID, "fix_01", "Bob", "Fix patch", time.Now())
+	require.NoError(t, err)
+	fixJob, err := nodeB.DB.EnqueueJob(EnqueueOpts{
+		RepoID:   nodeB.Repo.ID,
+		CommitID: commit.ID,
+		GitRef:   "fix_01",
+		Agent:    "test",
+		JobType:  JobTypeFix,
+	})
+	require.NoError(t, err)
+	_, err = nodeB.DB.Exec(`UPDATE review_jobs SET status = 'running', started_at = datetime('now') WHERE id = ?`, fixJob.ID)
+	require.NoError(t, err)
+	require.NoError(t, nodeB.DB.CompleteJob(fixJob.ID, "test", "prompt", "patch output"))
+
+	_, err = nodeB.Worker.SyncNow()
+	require.NoError(t, err)
+	_, err = nodeA.Worker.SyncNow()
+	require.NoError(t, err)
+
+	localFixJob := requireLocalJobByUUID(t, nodeA.DB, fixJob.UUID)
+	assert.Equal(t, JobStatusDone, localFixJob.Status)
+
+	require.NoError(t, nodeA.DB.MarkJobApplied(localFixJob.ID))
+
+	_, err = nodeA.Worker.SyncNow()
+	require.NoError(t, err)
+
+	localFixJob = requireLocalJobByUUID(t, nodeA.DB, fixJob.UUID)
+	assert.Equal(t, JobStatusApplied, localFixJob.Status)
 }
 
 func TestIntegration_SyncPullsLateVisibleResponseBeforeCursor(t *testing.T) {

--- a/internal/storage/postgres_integration_test.go
+++ b/internal/storage/postgres_integration_test.go
@@ -5,19 +5,19 @@ package storage
 import (
 	"context"
 	"fmt"
-
-	"github.com/stretchr/testify/assert"
-	"go.kenn.io/roborev/internal/config"
-
-	// getIntegrationPostgresURL returns the postgres URL for integration tests.
-	// Set via TEST_POSTGRES_URL environment variable or use default from docker-compose.test.yml
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/config"
 )
 
+// getIntegrationPostgresURL returns the postgres URL for integration tests.
+// Set via TEST_POSTGRES_URL environment variable or use default from docker-compose.test.yml
 func getIntegrationPostgresURL() string {
 	if url := os.Getenv("TEST_POSTGRES_URL"); url != "" {
 		return url
@@ -310,7 +310,6 @@ func startSyncWorkerNoSync(
 			return false
 		}, "SyncWorker.Start failed for %s: %v",
 			machineName, err)
-
 	}
 	t.Cleanup(func() { worker.Stop() })
 
@@ -367,6 +366,14 @@ func waitCondition(t *testing.T, timeout time.Duration, msg string, condition fu
 	require.Condition(t, func() bool {
 		return false
 	}, "Timeout waiting for: %s", msg)
+}
+
+func jobUUIDSet(jobs []ReviewJob) map[string]bool {
+	uuids := make(map[string]bool, len(jobs))
+	for _, job := range jobs {
+		uuids[job.UUID] = true
+	}
+	return uuids
 }
 
 // TestIntegration_MigrationV6Idempotent verifies the v5→v6 migration
@@ -544,6 +551,104 @@ func TestIntegration_PullFromRemote(t *testing.T) {
 			return false
 		}, "Expected job UUID '%s', got %s", remoteJobUUID, jobs[0].UUID)
 	}
+}
+
+func TestIntegration_SyncPullsLateVisibleJobBeforeCursor(t *testing.T) {
+	env := newIntegrationEnv(t, 30*time.Second)
+
+	repoIdentity := "git@github.com:test/late-visible.git"
+	nodeA := env.setupNode("late-visible-a", repoIdentity, "1h")
+	nodeB := env.setupNode("late-visible-b", repoIdentity, "1h")
+
+	createCompletedReview(t, nodeB.DB, nodeB.Repo.ID, "late_01", "Bob", "First", "prompt", "output")
+	createCompletedReview(t, nodeB.DB, nodeB.Repo.ID, "late_02", "Bob", "Second", "prompt", "output")
+	_, err := nodeB.Worker.SyncNow()
+	require.NoError(t, err)
+	_, err = nodeA.Worker.SyncNow()
+	require.NoError(t, err)
+
+	cursor, err := nodeA.DB.GetSyncState(SyncStateLastJobCursor)
+	require.NoError(t, err)
+	cursorTime, _, ok := parseTimestampIDCursor(cursor)
+	require.True(t, ok)
+
+	machineB, err := nodeB.DB.GetMachineID()
+	require.NoError(t, err)
+	pgRepoID, err := env.Pool.GetOrCreateRepo(env.Ctx, repoIdentity)
+	require.NoError(t, err)
+	lateUUID := "11111111-1111-1111-1111-111111111111"
+	_, err = env.Pool.pool.Exec(env.Ctx, `
+		INSERT INTO roborev.review_jobs (
+			uuid, repo_id, git_ref, agent, job_type, review_type, status,
+			enqueued_at, source_machine_id, updated_at
+		) VALUES ($1, $2, $3, 'test', 'review', '', 'done', $4, $5, $6)
+	`, lateUUID, pgRepoID, "late_stale", cursorTime.Add(-10*time.Second), machineB, cursorTime.Add(-10*time.Second))
+	require.NoError(t, err)
+
+	_, err = nodeA.Worker.SyncNow()
+	require.NoError(t, err)
+
+	jobs, err := nodeA.DB.ListJobs("", "", 1000, 0)
+	require.NoError(t, err)
+	assert.Contains(t, jobUUIDSet(jobs), lateUUID)
+}
+
+func TestIntegration_SyncPullsLateVisibleResponseBeforeCursor(t *testing.T) {
+	env := newIntegrationEnv(t, 30*time.Second)
+
+	repoIdentity := "git@github.com:test/late-response.git"
+	nodeA := env.setupNode("late-response-a", repoIdentity, "1h")
+	nodeB := env.setupNode("late-response-b", repoIdentity, "1h")
+
+	jobB, _ := createCompletedReview(t, nodeB.DB, nodeB.Repo.ID, "resp_01", "Bob", "First", "prompt", "output")
+	_, err := nodeB.Worker.SyncNow()
+	require.NoError(t, err)
+	_, err = nodeA.Worker.SyncNow()
+	require.NoError(t, err)
+
+	machineB, err := nodeB.DB.GetMachineID()
+	require.NoError(t, err)
+
+	tx, err := env.Pool.pool.Begin(env.Ctx)
+	require.NoError(t, err)
+	defer tx.Rollback(env.Ctx)
+
+	lateUUID := "33333333-3333-3333-3333-333333333333"
+	_, err = tx.Exec(env.Ctx, `
+		INSERT INTO roborev.responses (uuid, job_uuid, responder, response, source_machine_id, created_at)
+		VALUES ($1, $2, 'human', 'late response', $3, clock_timestamp())
+	`, lateUUID, jobB.UUID, machineB)
+	require.NoError(t, err)
+
+	highUUID := "44444444-4444-4444-4444-444444444444"
+	_, err = env.Pool.pool.Exec(env.Ctx, `
+		INSERT INTO roborev.responses (uuid, job_uuid, responder, response, source_machine_id, created_at)
+		VALUES ($1, $2, 'human', 'high response', $3, clock_timestamp())
+	`, highUUID, jobB.UUID, machineB)
+	require.NoError(t, err)
+
+	_, err = nodeA.Worker.SyncNow()
+	require.NoError(t, err)
+
+	err = tx.Commit(env.Ctx)
+	require.NoError(t, err)
+
+	_, err = nodeA.Worker.SyncNow()
+	require.NoError(t, err)
+
+	rows, err := nodeA.DB.Query(`SELECT uuid FROM responses WHERE uuid IN (?, ?)`, lateUUID, highUUID)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	uuids := map[string]bool{}
+	for rows.Next() {
+		var uuid string
+		require.NoError(t, rows.Scan(&uuid))
+		uuids[uuid] = true
+	}
+	require.NoError(t, rows.Err())
+	assert.Contains(t, uuids, highUUID)
+	assert.Contains(t, uuids, lateUUID)
 }
 
 func TestIntegration_FinalPush(t *testing.T) {
@@ -1436,7 +1541,6 @@ func TestIntegration_SyncNowWithProgressAbort(t *testing.T) {
 		}, "Expected partial push (abort after 1 batch), "+
 			"but pushed %d/%d jobs",
 			stats.PushedJobs, numJobs)
-
 	}
 
 	t.Logf("Progress abort test passed: pushed %d/%d jobs "+

--- a/internal/storage/postgres_migration_test.go
+++ b/internal/storage/postgres_migration_test.go
@@ -16,6 +16,9 @@ import (
 //go:embed schemas/postgres_v11.sql
 var postgresV11Schema string
 
+//go:embed schemas/postgres_v13.sql
+var postgresV13Schema string
+
 // openTestPgPoolRawAtVersion bootstraps a fresh Postgres test pool at the
 // given older schema version by running only the corresponding embedded
 // schema file and seeding schema_version. It deliberately does NOT call
@@ -34,13 +37,12 @@ func openTestPgPoolRawAtVersion(t *testing.T, version int) *PgPool {
 	_, err = pool.pool.Exec(ctx, `DROP SCHEMA IF EXISTS roborev CASCADE`)
 	require.NoError(t, err, "drop existing roborev schema")
 
-	var schemaSQL string
-	switch version {
-	case 11:
-		schemaSQL = postgresV11Schema
-	default:
-		t.Fatalf("openTestPgPoolRawAtVersion: no embedded schema for version %d", version)
+	schemas := map[int]string{
+		11: postgresV11Schema,
+		13: postgresV13Schema,
 	}
+	schemaSQL, ok := schemas[version]
+	require.Truef(t, ok, "openTestPgPoolRawAtVersion: no embedded schema for version %d", version)
 
 	for _, stmt := range strings.Split(schemaSQL, ";") {
 		s := strings.TrimSpace(stmt)
@@ -73,20 +75,25 @@ func openTestPgPoolRawAtVersion(t *testing.T, version int) *PgPool {
 func pgxPool(p *PgPool) *pgxpool.Pool { return p.pool }
 
 func TestPostgresMigration_SkipReasonAndClassify(t *testing.T) {
-	prevVersion := pgSchemaVersion - 1
-
-	oldPool := openTestPgPoolRawAtVersion(t, prevVersion)
+	oldPool := openTestPgPoolRawAtVersion(t, 11)
 	ctx := context.Background()
 
 	var repoID int
 	require.NoError(t, pgxPool(oldPool).QueryRow(ctx,
 		`INSERT INTO roborev.repos (identity) VALUES ($1) RETURNING id`,
 		"git@example.com:owner/test-repo.git").Scan(&repoID))
+	jobUUID := uuid.New().String()
 	_, err := pgxPool(oldPool).Exec(ctx, `
 		INSERT INTO roborev.review_jobs
 		  (uuid, repo_id, git_ref, agent, status, enqueued_at, source_machine_id)
 		VALUES ($1, $2, 'abc', 'test', 'done', NOW(), $3)
-	`, uuid.New().String(), repoID, uuid.New().String())
+	`, jobUUID, repoID, uuid.New().String())
+	require.NoError(t, err)
+	_, err = pgxPool(oldPool).Exec(ctx, `
+		INSERT INTO roborev.responses
+		  (uuid, job_uuid, responder, response, source_machine_id, created_at)
+		VALUES ($1, $2, 'human', 'legacy response', $3, NOW())
+	`, uuid.New().String(), jobUUID, uuid.New().String())
 	require.NoError(t, err)
 
 	pg := openTestPgPool(t)
@@ -95,6 +102,9 @@ func TestPostgresMigration_SkipReasonAndClassify(t *testing.T) {
 	var n int
 	require.NoError(t, pgxPool(pg).QueryRow(ctx,
 		`SELECT COUNT(*) FROM roborev.review_jobs WHERE git_ref = 'abc'`).Scan(&n))
+	require.Equal(t, 1, n)
+	require.NoError(t, pgxPool(pg).QueryRow(ctx,
+		`SELECT COUNT(*) FROM roborev.responses WHERE inserted_at IS NOT NULL`).Scan(&n))
 	require.Equal(t, 1, n)
 
 	machineID := uuid.New().String()
@@ -105,4 +115,44 @@ func TestPostgresMigration_SkipReasonAndClassify(t *testing.T) {
 		VALUES ($1, $2, 'after', 'test', 'review', 'design', 'skipped', NOW(), $3, 'trivial', 'auto_design')
 	`, uuid.New().String(), repoID, machineID)
 	require.NoError(t, err)
+}
+
+func TestPostgresMigration_ResponseInsertedAt(t *testing.T) {
+	oldPool := openTestPgPoolRawAtVersion(t, 13)
+	ctx := context.Background()
+
+	var repoID int
+	require.NoError(t, pgxPool(oldPool).QueryRow(ctx,
+		`INSERT INTO roborev.repos (identity) VALUES ($1) RETURNING id`,
+		"git@example.com:owner/response-migration.git").Scan(&repoID))
+	jobUUID := uuid.New().String()
+	_, err := pgxPool(oldPool).Exec(ctx, `
+		INSERT INTO roborev.review_jobs
+		  (uuid, repo_id, git_ref, agent, status, enqueued_at, source_machine_id)
+		VALUES ($1, $2, 'abc', 'test', 'done', NOW(), $3)
+	`, jobUUID, repoID, uuid.New().String())
+	require.NoError(t, err)
+	_, err = pgxPool(oldPool).Exec(ctx, `
+		INSERT INTO roborev.responses
+		  (uuid, job_uuid, responder, response, source_machine_id, created_at)
+		VALUES ($1, $2, 'human', 'legacy response', $3, NOW())
+	`, uuid.New().String(), jobUUID, uuid.New().String())
+	require.NoError(t, err)
+
+	pg := openTestPgPool(t)
+	defer pg.Close()
+
+	var n int
+	require.NoError(t, pgxPool(pg).QueryRow(ctx,
+		`SELECT COUNT(*) FROM roborev.responses WHERE inserted_at IS NOT NULL`).Scan(&n))
+	require.Equal(t, 1, n)
+
+	var indexExists bool
+	require.NoError(t, pgxPool(pg).QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM pg_indexes
+			WHERE schemaname = 'roborev' AND indexname = 'idx_responses_inserted'
+		)
+	`).Scan(&indexExists))
+	require.True(t, indexExists)
 }

--- a/internal/storage/repos_test.go
+++ b/internal/storage/repos_test.go
@@ -2,12 +2,13 @@ package storage
 
 import (
 	"database/sql"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // setupDBAndRepo is a helper that opens a test database and creates a repository.

--- a/internal/storage/schemas/postgres_v14.sql
+++ b/internal/storage/schemas/postgres_v14.sql
@@ -1,0 +1,117 @@
+-- PostgreSQL schema version 14
+-- Adds inserted_at to responses so response sync can use the same timestamp
+-- overlap strategy as jobs and reviews.
+-- Note: Version is managed by EnsureSchema(), not this file.
+
+CREATE SCHEMA IF NOT EXISTS roborev;
+
+CREATE TABLE IF NOT EXISTS roborev.schema_version (
+  version INTEGER PRIMARY KEY,
+  applied_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.machines (
+  id SERIAL PRIMARY KEY,
+  machine_id UUID UNIQUE NOT NULL,
+  name TEXT,
+  last_seen_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.repos (
+  id SERIAL PRIMARY KEY,
+  identity TEXT UNIQUE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.commits (
+  id SERIAL PRIMARY KEY,
+  repo_id INTEGER REFERENCES roborev.repos(id),
+  sha TEXT NOT NULL,
+  author TEXT NOT NULL,
+  subject TEXT NOT NULL,
+  timestamp TIMESTAMP WITH TIME ZONE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  UNIQUE(repo_id, sha)
+);
+
+CREATE TABLE IF NOT EXISTS roborev.review_jobs (
+  id SERIAL PRIMARY KEY,
+  uuid UUID UNIQUE NOT NULL,
+  repo_id INTEGER NOT NULL REFERENCES roborev.repos(id),
+  commit_id INTEGER REFERENCES roborev.commits(id),
+  git_ref TEXT NOT NULL,
+  branch TEXT,
+  session_id TEXT,
+  agent TEXT NOT NULL,
+  model TEXT,
+  provider TEXT,
+  requested_model TEXT,
+  requested_provider TEXT,
+  reasoning TEXT,
+  job_type TEXT NOT NULL DEFAULT 'review',
+  review_type TEXT NOT NULL DEFAULT '',
+  patch_id TEXT,
+  status TEXT NOT NULL CHECK(status IN ('queued', 'running', 'done', 'failed', 'canceled', 'applied', 'rebased', 'skipped')),
+  agentic BOOLEAN DEFAULT FALSE,
+  enqueued_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  started_at TIMESTAMP WITH TIME ZONE,
+  finished_at TIMESTAMP WITH TIME ZONE,
+  retry_not_before TIMESTAMP WITH TIME ZONE,
+  prompt TEXT,
+  diff_content TEXT,
+  error TEXT,
+  token_usage TEXT,
+  worktree_path TEXT,
+  min_severity TEXT NOT NULL DEFAULT '',
+  skip_reason TEXT,
+  source TEXT,
+  source_machine_id UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.reviews (
+  id SERIAL PRIMARY KEY,
+  uuid UUID UNIQUE NOT NULL,
+  job_uuid UUID NOT NULL REFERENCES roborev.review_jobs(uuid),
+  agent TEXT NOT NULL,
+  prompt TEXT NOT NULL,
+  output TEXT NOT NULL,
+  closed BOOLEAN NOT NULL DEFAULT FALSE,
+  updated_by_machine_id UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.responses (
+  id SERIAL PRIMARY KEY,
+  uuid UUID UNIQUE NOT NULL,
+  job_uuid UUID NOT NULL REFERENCES roborev.review_jobs(uuid),
+  responder TEXT NOT NULL,
+  response TEXT NOT NULL,
+  source_machine_id UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  inserted_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp()
+);
+
+CREATE INDEX IF NOT EXISTS idx_review_jobs_source ON roborev.review_jobs(source_machine_id);
+CREATE INDEX IF NOT EXISTS idx_review_jobs_updated ON roborev.review_jobs(updated_at);
+-- Note: idx_review_jobs_branch, idx_review_jobs_job_type, and
+-- idx_review_jobs_patch_id are created by migration code, not here
+-- (to support upgrades from older versions where those columns
+-- don't exist yet).
+CREATE INDEX IF NOT EXISTS idx_reviews_job_uuid ON roborev.reviews(job_uuid);
+CREATE INDEX IF NOT EXISTS idx_reviews_updated ON roborev.reviews(updated_at);
+CREATE INDEX IF NOT EXISTS idx_responses_job_uuid ON roborev.responses(job_uuid);
+CREATE INDEX IF NOT EXISTS idx_responses_id ON roborev.responses(id);
+-- idx_responses_inserted is created by EnsureSchema after migrations so
+-- upgrades from older schemas do not try to index a column before it exists.
+-- Partial unique indexes for auto-design dedup are created by EnsureSchema
+-- (fresh-init block + v12 migration step) — placing them here would break
+-- v1→v12 migrations where the source column doesn't yet exist when this
+-- schema is replayed.
+
+CREATE TABLE IF NOT EXISTS roborev.sync_metadata (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);

--- a/internal/storage/sync.go
+++ b/internal/storage/sync.go
@@ -643,6 +643,14 @@ func (db *DB) UpsertPulledJob(j PulledJob, repoID int64, commitID *int64) error 
 			min_severity = excluded.min_severity,
 			updated_at = excluded.updated_at,
 			synced_at = ?
+			WHERE review_jobs.status NOT IN ('applied', 'rebased')
+			OR datetime(
+				CASE WHEN review_jobs.updated_at GLOB '*[+-][0-9][0-9]:[0-9][0-9]' OR review_jobs.updated_at LIKE '%Z'
+					THEN review_jobs.updated_at ELSE review_jobs.updated_at || 'Z' END
+			) < datetime(
+				CASE WHEN excluded.updated_at GLOB '*[+-][0-9][0-9]:[0-9][0-9]' OR excluded.updated_at LIKE '%Z'
+					THEN excluded.updated_at ELSE excluded.updated_at || 'Z' END
+			)
 	`, j.UUID, repoID, commitID, j.GitRef, nullStr(j.SessionID), j.Agent, nullStr(j.Model), nullStr(j.Provider), nullStr(j.RequestedModel), nullStr(j.RequestedProvider), j.Reasoning, j.JobType,
 		j.ReviewType, nullStr(j.PatchID), j.Status, j.Agentic, j.EnqueuedAt.Format(time.RFC3339),
 		nullTimeStr(j.StartedAt), nullTimeStr(j.FinishedAt),
@@ -675,6 +683,13 @@ func (db *DB) UpsertPulledReview(r PulledReview) error {
 			updated_by_machine_id = excluded.updated_by_machine_id,
 			updated_at = excluded.updated_at,
 			synced_at = ?
+			WHERE datetime(
+				CASE WHEN reviews.updated_at GLOB '*[+-][0-9][0-9]:[0-9][0-9]' OR reviews.updated_at LIKE '%Z'
+					THEN reviews.updated_at ELSE reviews.updated_at || 'Z' END
+			) < datetime(
+				CASE WHEN excluded.updated_at GLOB '*[+-][0-9][0-9]:[0-9][0-9]' OR excluded.updated_at LIKE '%Z'
+					THEN excluded.updated_at ELSE excluded.updated_at || 'Z' END
+			)
 	`, r.UUID, jobID, r.Agent, r.Prompt, r.Output, r.Closed,
 		r.UpdatedByMachineID, r.CreatedAt.Format(time.RFC3339), r.UpdatedAt.Format(time.RFC3339), now, now)
 	return err

--- a/internal/storage/sync.go
+++ b/internal/storage/sync.go
@@ -15,7 +15,7 @@ const (
 	SyncStateMachineID        = "machine_id"
 	SyncStateLastJobCursor    = "last_job_cursor"    // ID of last synced job
 	SyncStateLastReviewCursor = "last_review_cursor" // Composite cursor for reviews (updated_at,id)
-	SyncStateLastResponseID   = "last_response_id"   // ID of last synced response
+	SyncStateLastResponseID   = "last_response_id"   // inserted_at/id cursor of last synced response
 	SyncStateSyncTargetID     = "sync_target_id"     // Database ID of last synced Postgres
 )
 

--- a/internal/storage/sync_identity_test.go
+++ b/internal/storage/sync_identity_test.go
@@ -1,11 +1,12 @@
 package storage
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"path/filepath"
 	"regexp"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetOrCreateRepoByIdentity(t *testing.T) {
@@ -296,7 +297,6 @@ func TestCommitsMigration_SameSHADifferentRepos(t *testing.T) {
 	// Verify duplicate in same repo is still rejected
 	_, err = db.Exec(`INSERT INTO commits (repo_id, sha, author, subject, timestamp) VALUES (1, 'abc123', 'Author', 'Subject', '2024-01-01T00:00:00Z')`)
 	require.Error(t, err, "Expected error inserting duplicate SHA in same repo, but got none")
-
 }
 
 func TestDuplicateRepoIdentity_MigrationSuccess(t *testing.T) {

--- a/internal/storage/sync_ordering_test.go
+++ b/internal/storage/sync_ordering_test.go
@@ -64,6 +64,27 @@ func TestUpsertPulledResponse_WithParentJob(t *testing.T) {
 	assert.Equal(t, 1, count)
 }
 
+func TestSyncCursorLookbackDefaultAndOverride(t *testing.T) {
+	t.Setenv(syncCursorLookbackEnv, "")
+	assert.Equal(t, defaultSyncCursorLookback, syncCursorLookback())
+
+	t.Setenv(syncCursorLookbackEnv, "30s")
+	assert.Equal(t, 30*time.Second, syncCursorLookback())
+
+	t.Setenv(syncCursorLookbackEnv, "bad")
+	assert.Equal(t, defaultSyncCursorLookback, syncCursorLookback())
+}
+
+func TestRewindResponseCursorRewindsTimestampAndResetsLegacyID(t *testing.T) {
+	cursorTime := time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC)
+	cursor := formatTimestampIDCursor(cursorTime, 42)
+
+	assert.Equal(t, formatTimestampIDCursor(cursorTime.Add(-30*time.Second), 42), rewindResponseCursor(cursor, 30*time.Second))
+	assert.Empty(t, rewindResponseCursor("42", 30*time.Second))
+	assert.Empty(t, responseCursorForMax("42"))
+	assert.Equal(t, cursor, responseCursorForMax(cursor))
+}
+
 // TestClearAllSyncedAt verifies that ClearAllSyncedAt clears synced_at
 // on all tables (jobs, reviews, responses).
 func TestClearAllSyncedAt(t *testing.T) {
@@ -204,15 +225,12 @@ func TestBatchMarkSynced(t *testing.T) {
 		// Empty slices should not error
 		if err := h.db.MarkJobsSynced([]int64{}); err != nil {
 			require.NoError(t, err)
-
 		}
 		if err := h.db.MarkReviewsSynced([]int64{}); err != nil {
 			require.NoError(t, err)
-
 		}
 		if err := h.db.MarkCommentsSynced([]int64{}); err != nil {
 			require.NoError(t, err)
-
 		}
 	})
 }

--- a/internal/storage/sync_ordering_test.go
+++ b/internal/storage/sync_ordering_test.go
@@ -85,6 +85,32 @@ func TestRewindResponseCursorRewindsTimestampAndResetsLegacyID(t *testing.T) {
 	assert.Equal(t, cursor, responseCursorForMax(cursor))
 }
 
+func TestUpsertPulledReviewSkipsStaleRemoteUpdate(t *testing.T) {
+	h := newSyncTestHelper(t)
+	job := h.createCompletedJob("stale-review-sha")
+	review, err := h.db.GetReviewByJobID(job.ID)
+	require.NoError(t, err)
+
+	require.NoError(t, h.db.MarkReviewClosed(review.ID, true))
+
+	err = h.db.UpsertPulledReview(PulledReview{
+		UUID:               review.UUID,
+		JobUUID:            job.UUID,
+		Agent:              review.Agent,
+		Prompt:             review.Prompt,
+		Output:             review.Output,
+		Closed:             false,
+		UpdatedByMachineID: GenerateUUID(),
+		CreatedAt:          review.CreatedAt,
+		UpdatedAt:          time.Now().Add(-time.Hour),
+	})
+	require.NoError(t, err)
+
+	review, err = h.db.GetReviewByJobID(job.ID)
+	require.NoError(t, err)
+	assert.True(t, review.Closed)
+}
+
 // TestClearAllSyncedAt verifies that ClearAllSyncedAt clears synced_at
 // on all tables (jobs, reviews, responses).
 func TestClearAllSyncedAt(t *testing.T) {

--- a/internal/storage/sync_queries_test.go
+++ b/internal/storage/sync_queries_test.go
@@ -21,7 +21,6 @@ func TestGetKnownJobUUIDs(t *testing.T) {
 	})
 
 	t.Run("returns UUIDs of jobs with UUIDs", func(t *testing.T) {
-
 		job1 := h.createPendingJob("abc123")
 		job2 := h.createPendingJob("def456")
 
@@ -325,7 +324,6 @@ func TestGetReviewsToSync_TimestampComparison(t *testing.T) {
 }
 
 func TestSessionID_SyncRoundTrip(t *testing.T) {
-
 	src := newSyncTestHelper(t)
 
 	job := src.createCompletedJob("session-sync-sha")
@@ -388,7 +386,6 @@ func TestSessionID_SyncRoundTrip(t *testing.T) {
 }
 
 func TestGetCommentsToSync_LegacyCommentsExcluded(t *testing.T) {
-
 	h := newSyncTestHelper(t)
 	job := h.createCompletedJob("legacy-resp-sha")
 
@@ -425,7 +422,6 @@ func TestGetCommentsToSync_LegacyCommentsExcluded(t *testing.T) {
 
 	assert.True(t, foundJobResp)
 	assert.False(t, foundLegacyResp, "Expected legacy response (job_id IS NULL) to be EXCLUDED from sync")
-
 }
 
 func TestGetJobsToSync_IncludesSkipped(t *testing.T) {

--- a/internal/storage/sync_state_test.go
+++ b/internal/storage/sync_state_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/config"
 )
 

--- a/internal/storage/syncworker.go
+++ b/internal/storage/syncworker.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strconv"
-	"strings"
+	"os"
 	"sync"
 	"time"
 
@@ -557,6 +556,14 @@ func (w *SyncWorker) doSync() error {
 // Smaller batches mean more frequent commits and better progress visibility.
 const syncBatchSize = 25
 
+// defaultSyncCursorLookback re-reads a timestamp overlap to avoid missing rows
+// whose transaction becomes visible after a newer timestamp has advanced the
+// local cursor. PostgreSQL NOW() is transaction-start time, so visible rows can
+// arrive behind the cursor when a transaction commits late.
+const defaultSyncCursorLookback = 5 * time.Minute
+
+const syncCursorLookbackEnv = "ROBOREV_SYNC_CURSOR_LOOKBACK"
+
 // pushChangesWithStats pushes local changes and returns statistics
 func (w *SyncWorker) pushChangesWithStats(ctx context.Context, pool *PgPool) (pushPullStats, error) {
 	stats := pushPullStats{}
@@ -706,9 +713,11 @@ func (w *SyncWorker) pullChangesWithStats(ctx context.Context, pool *PgPool) (pu
 	if err != nil {
 		return stats, fmt.Errorf("get job cursor: %w", err)
 	}
+	jobQueryCursor := rewindTimestampIDCursor(jobCursor, syncCursorLookback())
+	maxJobCursor := jobCursor
 
 	for {
-		jobs, newCursor, err := pool.PullJobs(ctx, machineID, jobCursor, 100)
+		jobs, newCursor, err := pool.PullJobs(ctx, machineID, jobQueryCursor, 100)
 		if err != nil {
 			return stats, fmt.Errorf("pull jobs: %w", err)
 		}
@@ -724,8 +733,9 @@ func (w *SyncWorker) pullChangesWithStats(ctx context.Context, pool *PgPool) (pu
 			stats.Jobs++
 		}
 
-		jobCursor = newCursor
-		if err := w.db.SetSyncState(SyncStateLastJobCursor, jobCursor); err != nil {
+		jobQueryCursor = newCursor
+		maxJobCursor = maxTimestampIDCursor(maxJobCursor, newCursor)
+		if err := w.db.SetSyncState(SyncStateLastJobCursor, maxJobCursor); err != nil {
 			return stats, fmt.Errorf("save job cursor: %w", err)
 		}
 
@@ -741,6 +751,8 @@ func (w *SyncWorker) pullChangesWithStats(ctx context.Context, pool *PgPool) (pu
 	if err != nil {
 		return stats, fmt.Errorf("get review cursor: %w", err)
 	}
+	reviewQueryCursor := rewindTimestampIDCursor(reviewCursor, syncCursorLookback())
+	maxReviewCursor := reviewCursor
 
 	knownJobUUIDs, err := w.db.GetKnownJobUUIDs()
 	if err != nil {
@@ -748,7 +760,7 @@ func (w *SyncWorker) pullChangesWithStats(ctx context.Context, pool *PgPool) (pu
 	}
 
 	for {
-		reviews, newCursor, err := pool.PullReviews(ctx, machineID, knownJobUUIDs, reviewCursor, 100)
+		reviews, newCursor, err := pool.PullReviews(ctx, machineID, knownJobUUIDs, reviewQueryCursor, 100)
 		if err != nil {
 			return stats, fmt.Errorf("pull reviews: %w", err)
 		}
@@ -775,8 +787,9 @@ func (w *SyncWorker) pullChangesWithStats(ctx context.Context, pool *PgPool) (pu
 			stats.Reviews++
 		}
 
-		reviewCursor = newCursor
-		if err := w.db.SetSyncState(SyncStateLastReviewCursor, reviewCursor); err != nil {
+		reviewQueryCursor = newCursor
+		maxReviewCursor = maxTimestampIDCursor(maxReviewCursor, newCursor)
+		if err := w.db.SetSyncState(SyncStateLastReviewCursor, maxReviewCursor); err != nil {
 			return stats, fmt.Errorf("save review cursor: %w", err)
 		}
 
@@ -790,20 +803,11 @@ func (w *SyncWorker) pullChangesWithStats(ctx context.Context, pool *PgPool) (pu
 	if err != nil {
 		return stats, fmt.Errorf("get response cursor: %w", err)
 	}
-	var responseID int64
-	if responseIDStr != "" {
-		parsed, err := strconv.ParseInt(
-			strings.TrimSpace(responseIDStr), 10, 64,
-		)
-		if err != nil {
-			log.Printf("Sync: malformed response cursor %q, resetting to 0", responseIDStr)
-		} else {
-			responseID = parsed
-		}
-	}
+	responseQueryCursor := rewindResponseCursor(responseIDStr, syncCursorLookback())
+	maxResponseCursor := responseCursorForMax(responseIDStr)
 
 	for {
-		responses, newID, err := pool.PullResponses(ctx, machineID, responseID, 100)
+		responses, newCursor, err := pool.PullResponses(ctx, machineID, responseQueryCursor, 100)
 		if err != nil {
 			return stats, fmt.Errorf("pull responses: %w", err)
 		}
@@ -827,8 +831,9 @@ func (w *SyncWorker) pullChangesWithStats(ctx context.Context, pool *PgPool) (pu
 			stats.Responses++
 		}
 
-		responseID = newID
-		if err := w.db.SetSyncState(SyncStateLastResponseID, fmt.Sprintf("%d", responseID)); err != nil {
+		responseQueryCursor = newCursor
+		maxResponseCursor = maxTimestampIDCursor(maxResponseCursor, newCursor)
+		if err := w.db.SetSyncState(SyncStateLastResponseID, maxResponseCursor); err != nil {
 			return stats, fmt.Errorf("save response cursor: %w", err)
 		}
 
@@ -842,6 +847,86 @@ func (w *SyncWorker) pullChangesWithStats(ctx context.Context, pool *PgPool) (pu
 	}
 
 	return stats, nil
+}
+
+func rewindTimestampIDCursor(cursor string, lookback time.Duration) string {
+	if cursor == "" || lookback <= 0 {
+		return cursor
+	}
+	cursorTime, cursorID, ok := parseTimestampIDCursor(cursor)
+	if !ok {
+		return cursor
+	}
+	return formatTimestampIDCursor(cursorTime.Add(-lookback), cursorID)
+}
+
+func syncCursorLookback() time.Duration {
+	raw := os.Getenv(syncCursorLookbackEnv)
+	if raw == "" {
+		return defaultSyncCursorLookback
+	}
+	lookback, err := time.ParseDuration(raw)
+	if err != nil || lookback < 0 {
+		return defaultSyncCursorLookback
+	}
+	return lookback
+}
+
+func rewindResponseCursor(cursor string, lookback time.Duration) string {
+	if cursor == "" {
+		return ""
+	}
+	if _, _, ok := parseTimestampIDCursor(cursor); !ok {
+		// Older versions stored response cursors as an ID only. Re-read from
+		// the beginning once so lower-ID late commits are not stranded.
+		return ""
+	}
+	return rewindTimestampIDCursor(cursor, lookback)
+}
+
+func responseCursorForMax(cursor string) string {
+	if _, _, ok := parseTimestampIDCursor(cursor); ok {
+		return cursor
+	}
+	return ""
+}
+
+func maxTimestampIDCursor(a, b string) string {
+	if a == "" {
+		return b
+	}
+	if b == "" {
+		return a
+	}
+	aTime, aID, aOK := parseTimestampIDCursor(a)
+	bTime, bID, bOK := parseTimestampIDCursor(b)
+	if !aOK {
+		return b
+	}
+	if !bOK {
+		return a
+	}
+	if bTime.After(aTime) || (bTime.Equal(aTime) && bID > aID) {
+		return b
+	}
+	return a
+}
+
+func parseTimestampIDCursor(cursor string) (time.Time, int64, bool) {
+	var ts string
+	var id int64
+	if _, err := fmt.Sscanf(cursor, "%s %d", &ts, &id); err != nil {
+		return time.Time{}, 0, false
+	}
+	cursorTime, err := time.Parse(time.RFC3339Nano, ts)
+	if err != nil {
+		return time.Time{}, 0, false
+	}
+	return cursorTime, id, true
+}
+
+func formatTimestampIDCursor(cursorTime time.Time, cursorID int64) string {
+	return fmt.Sprintf("%s %d", cursorTime.Format(time.RFC3339Nano), cursorID)
 }
 
 // pullJob inserts a pulled job into SQLite, creating repo/commit as needed

--- a/internal/streamfmt/render.go
+++ b/internal/streamfmt/render.go
@@ -172,7 +172,7 @@ func WrapText(text string, width int) []string {
 // Prose lines outside code blocks are left intact for glamour to
 // word-wrap naturally.
 func TruncateLongLines(
-	text string, maxWidth int, tabWidth int,
+	text string, maxWidth, tabWidth int,
 ) string {
 	if maxWidth <= 0 {
 		return text

--- a/internal/testenv/barrier_test.go
+++ b/internal/testenv/barrier_test.go
@@ -13,7 +13,7 @@ import (
 
 func appendToFile(t *testing.T, path, content string) {
 	t.Helper()
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	require.NoError(t, err, "failed to open file")
 	defer f.Close()
 	_, err = fmt.Fprintln(f, content)
@@ -36,7 +36,7 @@ func TestProdLogBarrierViolations(t *testing.T) {
 				logPath := filepath.Join(dir, "activity.log")
 				err := os.WriteFile(logPath, []byte(
 					`{"event":"job.completed","component":"worker"}`+"\n",
-				), 0644)
+				), 0o644)
 				require.NoError(t, err, "failed to write initial file")
 			},
 			mutate: func(t *testing.T, dir string) {
@@ -65,7 +65,7 @@ func TestProdLogBarrierViolations(t *testing.T) {
 				t.Helper()
 				runtimePath := filepath.Join(dir,
 					fmt.Sprintf("daemon.%d.json", os.Getpid()))
-				err := os.WriteFile(runtimePath, []byte("{}"), 0644)
+				err := os.WriteFile(runtimePath, []byte("{}"), 0o644)
 				require.NoError(t, err, "failed to write runtime file")
 			},
 			wantViolations: []string{
@@ -89,7 +89,7 @@ func TestProdLogBarrierViolations(t *testing.T) {
 				t.Helper()
 				runtimePath := filepath.Join(dir,
 					fmt.Sprintf("daemon.%d.json", os.Getpid()))
-				err := os.WriteFile(runtimePath, []byte("{}"), 0644)
+				err := os.WriteFile(runtimePath, []byte("{}"), 0o644)
 				require.NoError(t, err, "failed to write initial runtime file")
 			},
 		},
@@ -99,14 +99,14 @@ func TestProdLogBarrierViolations(t *testing.T) {
 				t.Helper()
 				runtimePath := filepath.Join(dir,
 					fmt.Sprintf("daemon.%d.json", os.Getpid()))
-				err := os.WriteFile(runtimePath, []byte("{}"), 0644)
+				err := os.WriteFile(runtimePath, []byte("{}"), 0o644)
 				require.NoError(t, err, "failed to write initial runtime file")
 			},
 			mutate: func(t *testing.T, dir string) {
 				t.Helper()
 				runtimePath := filepath.Join(dir,
 					fmt.Sprintf("daemon.%d.json", os.Getpid()))
-				err := os.WriteFile(runtimePath, []byte(`{"pid":999}`), 0644)
+				err := os.WriteFile(runtimePath, []byte(`{"pid":999}`), 0o644)
 				require.NoError(t, err, "failed to modify runtime file")
 			},
 			wantViolationCount: 1,
@@ -123,7 +123,7 @@ func TestProdLogBarrierViolations(t *testing.T) {
 				logPath := filepath.Join(dir, "activity.log")
 				err := os.WriteFile(logPath, []byte(
 					`{"event":"job.completed","component":"worker"}`+"\n",
-				), 0644)
+				), 0o644)
 				require.NoError(t, err, "failed to write initial file")
 			},
 			mutate: func(t *testing.T, dir string) {

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -49,11 +49,11 @@ func (r *TestRepo) WriteHook(content string) {
 // WriteNamedHook writes a hook with the given name and content.
 func (r *TestRepo) WriteNamedHook(name, content string) {
 	r.t.Helper()
-	if err := os.MkdirAll(r.HooksDir, 0755); err != nil {
+	if err := os.MkdirAll(r.HooksDir, 0o755); err != nil {
 		r.t.Fatal(err)
 	}
 	hookPath := filepath.Join(r.HooksDir, name)
-	if err := os.WriteFile(hookPath, []byte(content), 0755); err != nil {
+	if err := os.WriteFile(hookPath, []byte(content), 0o755); err != nil {
 		r.t.Fatal(err)
 	}
 }
@@ -93,7 +93,7 @@ func mockScriptInPath(t *testing.T, binName, scriptContent string, mode pathMode
 
 	path := filepath.Join(tmpBin, executableName(binName))
 	content := []byte(scriptContent)
-	if err := os.WriteFile(path, content, 0755); err != nil {
+	if err := os.WriteFile(path, content, 0o755); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -365,7 +365,7 @@ func (u *Updater) installBinary(srcPath, dstPath string) error {
 	}
 
 	if u.deps.GOOS != "windows" {
-		if err := os.Chmod(dstPath, 0755); err != nil {
+		if err := os.Chmod(dstPath, 0o755); err != nil {
 			return fmt.Errorf("chmod %s: %w", filepath.Base(dstPath), err)
 		}
 	}
@@ -513,14 +513,15 @@ func (u *Updater) downloadFile(url, dest string, totalSize int64, progressFn fun
 }
 
 func extractTarGz(archivePath, destDir string) error {
-	if err := os.MkdirAll(destDir, 0755); err != nil {
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		return err
 	}
 
-	absDestDir, err := filepath.Abs(destDir)
+	root, err := os.OpenRoot(destDir)
 	if err != nil {
-		return fmt.Errorf("resolve dest dir: %w", err)
+		return fmt.Errorf("open extraction root: %w", err)
 	}
+	defer root.Close()
 
 	file, err := os.Open(archivePath)
 	if err != nil {
@@ -543,7 +544,7 @@ func extractTarGz(archivePath, destDir string) error {
 		if err != nil {
 			return err
 		}
-		if err := extractTarEntry(tr, header, absDestDir); err != nil {
+		if err := extractTarEntry(tr, header, root); err != nil {
 			return err
 		}
 	}
@@ -551,8 +552,8 @@ func extractTarGz(archivePath, destDir string) error {
 	return nil
 }
 
-func extractTarEntry(tr *tar.Reader, header *tar.Header, destDir string) error {
-	target, err := sanitizeTarPath(destDir, header.Name)
+func extractTarEntry(tr *tar.Reader, header *tar.Header, root *os.Root) error {
+	name, err := sanitizeTarPath(header.Name)
 	if err != nil {
 		return fmt.Errorf("invalid tar entry %q: %w", header.Name, err)
 	}
@@ -563,12 +564,16 @@ func extractTarEntry(tr *tar.Reader, header *tar.Header, destDir string) error {
 
 	switch header.Typeflag {
 	case tar.TypeDir:
-		return os.MkdirAll(target, 0755)
+		return root.MkdirAll(name, 0o755)
 	case tar.TypeReg:
-		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
-			return err
+		parent := filepath.Dir(name)
+		if parent != "." {
+			if err := root.MkdirAll(parent, 0o755); err != nil {
+				return err
+			}
 		}
-		outFile, err := os.Create(target)
+		mode := os.FileMode(header.Mode).Perm()
+		outFile, err := root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
 		if err != nil {
 			return err
 		}
@@ -576,7 +581,7 @@ func extractTarEntry(tr *tar.Reader, header *tar.Header, destDir string) error {
 		if _, err := io.Copy(outFile, tr); err != nil {
 			return err
 		}
-		return os.Chmod(target, os.FileMode(header.Mode))
+		return root.Chmod(name, mode)
 	default:
 		return nil
 	}
@@ -587,33 +592,13 @@ func isTarLink(header *tar.Header) bool {
 }
 
 // sanitizeTarPath validates and sanitizes a tar entry path to prevent directory traversal.
-func sanitizeTarPath(destDir, name string) (string, error) {
-	if strings.HasPrefix(name, "/") {
-		return "", fmt.Errorf("absolute path not allowed")
-	}
-
+func sanitizeTarPath(name string) (string, error) {
 	cleanName := filepath.Clean(name)
-	if filepath.IsAbs(cleanName) {
-		return "", fmt.Errorf("absolute path not allowed")
-	}
-	if strings.HasPrefix(cleanName, "..") || strings.Contains(cleanName, string(filepath.Separator)+"..") {
-		return "", fmt.Errorf("path traversal not allowed")
-	}
-
-	target := filepath.Join(destDir, cleanName)
-	absTarget, err := filepath.Abs(target)
-	if err != nil {
-		return "", err
-	}
-	absDestDir, err := filepath.Abs(destDir)
-	if err != nil {
-		return "", err
-	}
-	if !strings.HasPrefix(absTarget, absDestDir+string(filepath.Separator)) && absTarget != absDestDir {
+	if !filepath.IsLocal(cleanName) {
 		return "", fmt.Errorf("path escapes destination directory")
 	}
 
-	return target, nil
+	return cleanName, nil
 }
 
 func copyFile(src, dst string) (err error) {
@@ -694,10 +679,10 @@ func (u *Updater) saveCache(version string) error {
 	}
 
 	cachePath := filepath.Join(u.deps.CacheDir(), cacheFileName)
-	if err := os.MkdirAll(filepath.Dir(cachePath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
 		return err
 	}
-	return os.WriteFile(cachePath, data, 0644)
+	return os.WriteFile(cachePath, data, 0o644)
 }
 
 func parseVersion(raw string) parsedVersion {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -49,8 +49,6 @@ func (r *testReporter) Progress(downloaded, total int64) {
 }
 
 func TestSanitizeTarPath(t *testing.T) {
-	destDir := t.TempDir()
-
 	tests := []struct {
 		name     string
 		path     string
@@ -73,7 +71,7 @@ func TestSanitizeTarPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			skipUnlessTargetOS(t, tt.targetOS)
 
-			_, err := sanitizeTarPath(destDir, tt.path)
+			_, err := sanitizeTarPath(tt.path)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -111,6 +109,28 @@ func TestExtractTarGzSymlinkSkipped(t *testing.T) {
 	require.NoError(t, extractTarGz(archivePath, extractDir))
 	requirePathExists(t, filepath.Join(extractDir, "normal.txt"))
 	requirePathMissing(t, filepath.Join(extractDir, "evil-link"))
+}
+
+func TestExtractTarGzExistingSymlinkDoesNotEscapeDestination(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "archive.tar.gz")
+	extractDir := filepath.Join(tmpDir, "extract")
+	outsideDir := filepath.Join(tmpDir, "outside")
+	outsideFile := filepath.Join(outsideDir, "pwned")
+
+	require.NoError(t, os.MkdirAll(extractDir, 0o755))
+	require.NoError(t, os.MkdirAll(outsideDir, 0o755))
+	require.NoError(t, os.Symlink(outsideDir, filepath.Join(extractDir, "link")))
+	createTestArchive(t, archivePath, []archiveEntry{
+		{Name: "link/pwned", Content: "owned"},
+	})
+
+	require.Error(t, extractTarGz(archivePath, extractDir))
+	requirePathMissing(t, outsideFile)
 }
 
 func TestExtractChecksum(t *testing.T) {
@@ -518,14 +538,14 @@ func TestUpdaterPerformUpdateInstallsBinary(t *testing.T) {
 	}
 
 	archiveData := createTestArchiveBytes(t, []archiveEntry{
-		{Name: binaryName, Content: "new-binary", Mode: 0755},
+		{Name: binaryName, Content: "new-binary", Mode: 0o755},
 	})
 	sum := sha256.Sum256(archiveData)
 	expectedChecksum := hex.EncodeToString(sum[:])
 
 	binDir := t.TempDir()
 	currentBinary := filepath.Join(binDir, binaryName)
-	require.NoError(t, os.WriteFile(currentBinary, []byte("old-binary"), 0755))
+	require.NoError(t, os.WriteFile(currentBinary, []byte("old-binary"), 0o755))
 
 	updater := NewUpdater(Deps{
 		Client: &http.Client{
@@ -563,7 +583,7 @@ func TestUpdaterPerformUpdateInstallsBinary(t *testing.T) {
 
 func createTestArchive(t *testing.T, path string, entries []archiveEntry) {
 	t.Helper()
-	require.NoError(t, os.WriteFile(path, createTestArchiveBytes(t, entries), 0644))
+	require.NoError(t, os.WriteFile(path, createTestArchiveBytes(t, entries), 0o644))
 }
 
 func createTestArchiveBytes(t *testing.T, entries []archiveEntry) []byte {
@@ -576,7 +596,7 @@ func createTestArchiveBytes(t *testing.T, entries []archiveEntry) []byte {
 	for _, entry := range entries {
 		mode := entry.Mode
 		if mode == 0 {
-			mode = 0644
+			mode = 0o644
 		}
 		typeFlag := entry.TypeFlag
 		if typeFlag == 0 {
@@ -632,7 +652,7 @@ func writeCachedCheck(t *testing.T, cacheDir string, cached cachedCheck) {
 	t.Helper()
 	data, err := json.Marshal(cached)
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, cacheFileName), data, 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, cacheFileName), data, 0o644))
 }
 
 func newHTTPResponse(statusCode int, body string) *http.Response {

--- a/internal/worktree/worktree_integration_test.go
+++ b/internal/worktree/worktree_integration_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/testutil"
 	"go.kenn.io/roborev/internal/worktree"
 )

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/roborev/internal/testenv"
 )
 
@@ -32,7 +33,7 @@ func runTestGit(t *testing.T, dir string, args ...string) string {
 
 func writeTestFile(t *testing.T, dir, name, content string) {
 	t.Helper()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0644), "failed to write %s", name)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644), "failed to write %s", name)
 }
 
 // setupGitRepo creates a minimal git repo with one commit and returns its path.
@@ -246,7 +247,7 @@ func TestGitmodulesUsesFileProtocol(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			gitmodulesPath := filepath.Join(t.TempDir(), ".gitmodules")
-			require.NoError(t, os.WriteFile(gitmodulesPath, fmt.Appendf(nil, tpl, tc.key, tc.url), 0644))
+			require.NoError(t, os.WriteFile(gitmodulesPath, fmt.Appendf(nil, tpl, tc.key, tc.url), 0o644))
 
 			usesFileProtocol, err := gitmodulesUsesFileProtocol(gitmodulesPath)
 			require.NoError(t, err)
@@ -264,7 +265,7 @@ func TestRepoUsesFileProtocolSubmodulesNested(t *testing.T) {
 	writeTestFile(t, dir, ".gitmodules", string(fmt.Appendf(nil, tpl, "https://example.com/repo.git")))
 
 	nestedPath := filepath.Join(dir, "sub", ".gitmodules")
-	if err := os.MkdirAll(filepath.Dir(nestedPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(nestedPath), 0o755); err != nil {
 		require.NoError(t, err, "mkdir nested: %v", err)
 	}
 	writeTestFile(t, dir, "sub/.gitmodules", string(fmt.Appendf(nil, tpl, "file:///tmp/repo")))
@@ -303,10 +304,10 @@ func TestFindGitmodulesPathsSkipsUnreadableNestedDir(t *testing.T) {
 	writeTestFile(t, dir, ".gitmodules", "[submodule]\n")
 
 	nested := filepath.Join(dir, "sub", "deep")
-	require.NoError(t, os.MkdirAll(nested, 0755))
+	require.NoError(t, os.MkdirAll(nested, 0o755))
 	writeTestFile(t, dir, "sub/deep/.gitmodules", "[submodule]\n")
-	require.NoError(t, os.Chmod(nested, 0000))
-	t.Cleanup(func() { os.Chmod(nested, 0755) })
+	require.NoError(t, os.Chmod(nested, 0o000))
+	t.Cleanup(func() { os.Chmod(nested, 0o755) })
 	requireUnreadable(t, nested)
 
 	paths, err := findGitmodulesPaths(dir)
@@ -319,9 +320,9 @@ func TestFindGitmodulesPathsErrorsOnUnreadableRoot(t *testing.T) {
 
 	dir := t.TempDir()
 	inner := filepath.Join(dir, "repo")
-	require.NoError(t, os.MkdirAll(inner, 0755))
-	require.NoError(t, os.Chmod(inner, 0000))
-	t.Cleanup(func() { os.Chmod(inner, 0755) })
+	require.NoError(t, os.MkdirAll(inner, 0o755))
+	require.NoError(t, os.Chmod(inner, 0o000))
+	t.Cleanup(func() { os.Chmod(inner, 0o755) })
 	requireUnreadable(t, inner)
 
 	_, err := findGitmodulesPaths(inner)
@@ -337,12 +338,12 @@ func TestRepoUsesFileProtocolSkipsUnreadableNestedGitmodules(t *testing.T) {
 		fmt.Sprintf(tpl, "https://example.com/repo.git"))
 
 	nested := filepath.Join(dir, "sub")
-	require.NoError(t, os.MkdirAll(nested, 0755))
+	require.NoError(t, os.MkdirAll(nested, 0o755))
 	nestedFile := filepath.Join(nested, ".gitmodules")
 	require.NoError(t, os.WriteFile(nestedFile,
-		fmt.Appendf(nil, tpl, "file:///tmp/repo"), 0644))
-	require.NoError(t, os.Chmod(nestedFile, 0000))
-	t.Cleanup(func() { os.Chmod(nestedFile, 0644) })
+		fmt.Appendf(nil, tpl, "file:///tmp/repo"), 0o644))
+	require.NoError(t, os.Chmod(nestedFile, 0o000))
+	t.Cleanup(func() { os.Chmod(nestedFile, 0o644) })
 	requireUnreadable(t, nestedFile)
 
 	usesFileProtocol, err := repoUsesFileProtocolSubmodules(dir)
@@ -355,9 +356,9 @@ func TestRepoUsesFileProtocolErrorsOnUnreadableTopLevel(t *testing.T) {
 
 	dir := t.TempDir()
 	topLevel := filepath.Join(dir, ".gitmodules")
-	require.NoError(t, os.WriteFile(topLevel, []byte("[submodule]\n"), 0644))
-	require.NoError(t, os.Chmod(topLevel, 0000))
-	t.Cleanup(func() { os.Chmod(topLevel, 0644) })
+	require.NoError(t, os.WriteFile(topLevel, []byte("[submodule]\n"), 0o644))
+	require.NoError(t, os.Chmod(topLevel, 0o000))
+	t.Cleanup(func() { os.Chmod(topLevel, 0o644) })
 	requireUnreadable(t, topLevel)
 
 	_, err := repoUsesFileProtocolSubmodules(dir)


### PR DESCRIPTION
## Summary

- Enable the `gci` and `gofumpt` formatters in golangci-lint and apply them repo-wide.
- Leave gofumpt `extra-rules` disabled so same-type parameters keep explicit types (`a string, b string` rather than `a, b string`), which reads more clearly and matches what code generators emit.
- Supersedes #757; the formatter-enablement commit keeps its original authorship.
