### PR TITLE
Use kit daemon lifecycle primitives

### DIFF
--- a/cmd/roborev/daemon_integration_test.go
+++ b/cmd/roborev/daemon_integration_test.go
@@ -124,7 +124,7 @@ func setupTestDaemon(t *testing.T) (string, string) {
 	dbPath := filepath.Join(tmpDir, "test.db")
 	configPath := filepath.Join(tmpDir, "config.toml")
 
-	// Isolate runtime dir to avoid writing to real ~/.roborev/daemon.json
+	// Isolate runtime dir to avoid writing to the real daemon runtime store.
 	t.Setenv("ROBOREV_DATA_DIR", tmpDir)
 
 	// Write minimal config
@@ -189,7 +189,7 @@ func TestDaemonShutdownBySignal(t *testing.T) {
 		"--config", configPath,
 		"--addr", "127.0.0.1:0",
 	)
-	// Important: Set ROBOREV_DATA_DIR so it writes runtime file to our tmpDir
+	// Important: Set ROBOREV_DATA_DIR so it writes runtime files under our tmpDir
 	cmd.Env = append(os.Environ(), "ROBOREV_DATA_DIR="+tmpDir)
 
 	// Capture output for debugging
@@ -220,8 +220,8 @@ func TestDaemonShutdownBySignal(t *testing.T) {
 	})
 
 	// 3. Wait for daemon to be ready
-	// The daemon writes daemon.<pid>.json
-	daemonJSON := filepath.Join(tmpDir, fmt.Sprintf("daemon.%d.json", cmd.Process.Pid))
+	// The daemon writes runtime/daemon.<pid>.json
+	daemonJSON := filepath.Join(tmpDir, "runtime", fmt.Sprintf("daemon.%d.json", cmd.Process.Pid))
 	if !waitFor(t, 5*time.Second, func() bool {
 		_, err := os.Stat(daemonJSON)
 		return err == nil

--- a/cmd/roborev/daemon_lifecycle.go
+++ b/cmd/roborev/daemon_lifecycle.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +17,8 @@ import (
 	"runtime"
 	"syscall"
 	"time"
+
+	kitdaemon "go.kenn.io/kit/daemon"
 
 	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/storage"
@@ -41,9 +44,11 @@ var (
 		if runtime.GOOS == "windows" {
 			newBinary += ".exe"
 		}
-		startCmd := exec.Command(newBinary, "daemon", "run")
-		startCmd.Env = filterGitEnv(os.Environ())
-		return startCmd.Start()
+		return kitdaemon.StartDetached(context.Background(), kitdaemon.StartDetachedOptions{
+			Executable: newBinary,
+			Args:       []string{"daemon", "run"},
+			Env:        filterGitEnv(os.Environ()),
+		})
 	}
 
 	// setupSignalHandler allows tests to mock signal handling
@@ -208,8 +213,8 @@ func ensureDaemon() error {
 		return nil
 	}
 
-	// Try the configured default address for manual/legacy daemon runs that do
-	// not have a runtime file yet.
+	// Try the configured default address for manual daemon runs that do not
+	// have a runtime file yet.
 	ep := getDaemonEndpoint()
 	if probe, err := daemon.ProbeDaemon(ep, 2*time.Second); err == nil {
 		if !skipVersionCheck {
@@ -238,36 +243,26 @@ func startDaemon() error {
 		fmt.Println("Starting daemon...")
 	}
 
-	// Use the current executable with "daemon run" subcommand
-	exe, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("failed to find executable: %w", err)
+	manager := kitdaemon.Manager{
+		Store:    daemon.RuntimeStore(),
+		Discover: daemon.DiscoverOptions(1 * time.Second),
+		Start: func(ctx context.Context) error {
+			exe, err := os.Executable()
+			if err != nil {
+				return fmt.Errorf("failed to find executable: %w", err)
+			}
+			return kitdaemon.StartDetached(ctx, kitdaemon.StartDetachedOptions{
+				Executable:      exe,
+				Args:            []string{"daemon", "run"},
+				Env:             filterGitEnv(os.Environ()),
+				RefuseEphemeral: os.Getenv("ROBOREV_TEST_ALLOW_AUTOSTART") != "1",
+			})
+		},
 	}
-	if shouldRefuseAutoStartDaemon(exe) {
-		return fmt.Errorf(
-			"refusing to auto-start daemon from ephemeral binary (%s); "+
-				"use the installed roborev binary instead",
-			filepath.Base(exe),
-		)
-	}
-
-	cmd := exec.Command(exe, "daemon", "run")
-	cmd.Env = filterGitEnv(os.Environ())
-	cmd.Stdout = nil
-	cmd.Stderr = nil
-	if err := cmd.Start(); err != nil {
+	if _, _, err := manager.Ensure(context.Background(), 3*time.Second); err != nil {
 		return fmt.Errorf("failed to start daemon: %w", err)
 	}
-
-	// Wait for daemon to publish a responsive runtime entry.
-	for range 30 {
-		time.Sleep(100 * time.Millisecond)
-		if _, err := daemon.GetAnyRunningDaemon(); err == nil {
-			return nil
-		}
-	}
-
-	return fmt.Errorf("daemon failed to start")
+	return nil
 }
 
 // stopDaemon stops any running daemons.

--- a/cmd/roborev/daemon_lifecycle_test.go
+++ b/cmd/roborev/daemon_lifecycle_test.go
@@ -15,58 +15,6 @@ import (
 	"go.kenn.io/roborev/internal/version"
 )
 
-func TestEnsureDaemonRestartsWhenLegacyProbeHasNoVersion(t *testing.T) {
-	t.Setenv("ROBOREV_SKIP_VERSION_CHECK", "")
-
-	tests := []struct {
-		name       string
-		statusCode int
-	}{
-		{name: "204 no content", statusCode: http.StatusNoContent},
-		{name: "500 server error", statusCode: http.StatusInternalServerError},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				switch r.URL.Path {
-				case "/api/ping":
-					w.WriteHeader(http.StatusNotFound)
-				case "/api/status":
-					w.WriteHeader(tt.statusCode)
-				default:
-					http.NotFound(w, r)
-				}
-			}))
-			defer server.Close()
-
-			origGetAnyRunningDaemon := getAnyRunningDaemon
-			origRestartDaemon := restartDaemonForEnsure
-			getAnyRunningDaemon = func() (*daemon.RuntimeInfo, error) {
-				return &daemon.RuntimeInfo{
-					PID:     1234,
-					Addr:    strings.TrimPrefix(server.URL, "http://"),
-					Version: "",
-				}, nil
-			}
-			restartCalls := 0
-			restartDaemonForEnsure = func() error {
-				restartCalls++
-				return nil
-			}
-			t.Cleanup(func() {
-				getAnyRunningDaemon = origGetAnyRunningDaemon
-				restartDaemonForEnsure = origRestartDaemon
-			})
-
-			if err := ensureDaemon(); err != nil {
-				require.NoError(t, err, "ensureDaemon returned error: %v")
-			}
-			assert.Equal(t, 1, restartCalls)
-		})
-	}
-}
-
 func TestGetDaemonEndpointAvoidsDefaultDaemonPortInTests(t *testing.T) {
 	exe, err := os.Executable()
 	require.NoError(t, err)
@@ -121,55 +69,6 @@ func TestGetDaemonEndpointIgnoresCachedDefaultFromEmptyServerFlagInTests(t *test
 	assert.Equal(t, "127.0.0.1:1", got.Address)
 }
 
-func TestEnsureDaemonRestartsWhenManualLegacyProbeHasNoVersion(t *testing.T) {
-	t.Setenv("ROBOREV_SKIP_VERSION_CHECK", "")
-
-	tests := []struct {
-		name       string
-		statusCode int
-	}{
-		{name: "204 no content", statusCode: http.StatusNoContent},
-		{name: "500 server error", statusCode: http.StatusInternalServerError},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				switch r.URL.Path {
-				case "/api/ping":
-					w.WriteHeader(http.StatusNotFound)
-				case "/api/status":
-					w.WriteHeader(tt.statusCode)
-				default:
-					http.NotFound(w, r)
-				}
-			}))
-			defer server.Close()
-
-			origGetAnyRunningDaemon := getAnyRunningDaemon
-			origRestartDaemon := restartDaemonForEnsure
-			getAnyRunningDaemon = func() (*daemon.RuntimeInfo, error) {
-				return nil, os.ErrNotExist
-			}
-			patchServerAddr(t, server.URL)
-			restartCalls := 0
-			restartDaemonForEnsure = func() error {
-				restartCalls++
-				return nil
-			}
-			t.Cleanup(func() {
-				getAnyRunningDaemon = origGetAnyRunningDaemon
-				restartDaemonForEnsure = origRestartDaemon
-			})
-
-			if err := ensureDaemon(); err != nil {
-				require.NoError(t, err, "ensureDaemon returned error: %v")
-			}
-			assert.Equal(t, 1, restartCalls)
-		})
-	}
-}
-
 func TestEnsureDaemonPrefersLiveDaemonVersionOverRuntimeMetadata(t *testing.T) {
 	t.Setenv("ROBOREV_SKIP_VERSION_CHECK", "")
 
@@ -177,6 +76,7 @@ func TestEnsureDaemonPrefersLiveDaemonVersionOverRuntimeMetadata(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/ping":
 			_ = json.NewEncoder(w).Encode(daemon.PingInfo{
+				OK:      true,
 				Service: "roborev",
 				Version: "v-other-daemon",
 			})
@@ -191,7 +91,7 @@ func TestEnsureDaemonPrefersLiveDaemonVersionOverRuntimeMetadata(t *testing.T) {
 	getAnyRunningDaemon = func() (*daemon.RuntimeInfo, error) {
 		return &daemon.RuntimeInfo{
 			PID:     1234,
-			Addr:    strings.TrimPrefix(server.URL, "http://"),
+			Address: strings.TrimPrefix(server.URL, "http://"),
 			Version: version.Version,
 		}, nil
 	}
@@ -219,7 +119,7 @@ func TestEnsureDaemonRestartsWhenLiveProbeFailsDespiteRuntimeVersion(t *testing.
 	getAnyRunningDaemon = func() (*daemon.RuntimeInfo, error) {
 		return &daemon.RuntimeInfo{
 			PID:     1234,
-			Addr:    "127.0.0.1:1",
+			Address: "127.0.0.1:1",
 			Version: version.Version,
 		}, nil
 	}

--- a/cmd/roborev/fix_test.go
+++ b/cmd/roborev/fix_test.go
@@ -1300,7 +1300,7 @@ func TestRunFixOpenRecoversFromDaemonRestartOnRequery(t *testing.T) {
 		case "/api/review/close":
 			w.WriteHeader(http.StatusOK)
 		case "/api/ping":
-			writeJSON(w, daemon.PingInfo{Service: "roborev", Version: version.Version})
+			writeJSON(w, daemon.PingInfo{OK: true, Service: "roborev", Version: version.Version})
 		default:
 			http.NotFound(w, r)
 		}

--- a/cmd/roborev/main_test.go
+++ b/cmd/roborev/main_test.go
@@ -778,104 +778,6 @@ func TestDaemonStopNotRunning(t *testing.T) {
 	assert.Equal(t, err, ErrDaemonNotRunning)
 }
 
-// TestDaemonStopInvalidPID verifies stopDaemon handles invalid PID in daemon.json
-func TestDaemonStopInvalidPID(t *testing.T) {
-	tmpDir := setupIsolatedDataDir(t)
-
-	// Create daemon.json with PID 0 and an address on a port that's definitely not in use
-	// Port 59999 is unlikely to be in use and will get connection refused quickly
-	daemonInfo := daemon.RuntimeInfo{PID: 0, Addr: "127.0.0.1:59999"}
-	data, _ := json.Marshal(daemonInfo)
-	if err := os.WriteFile(filepath.Join(tmpDir, "daemon.json"), data, 0o644); err != nil {
-		require.NoError(t, err, "write daemon.json: %v")
-	}
-
-	// ListAllRuntimes validates files and removes invalid ones (pid <= 0),
-	// so it returns an empty list, and stopDaemon returns ErrDaemonNotRunning.
-	// The key is that the invalid file gets cleaned up.
-	err := stopDaemon()
-	assert.Equal(t, err, ErrDaemonNotRunning)
-
-	// Verify daemon.json was cleaned up
-	_, statErr := os.Stat(filepath.Join(tmpDir, "daemon.json"))
-	assert.True(t, os.IsNotExist(statErr), "daemon.json should be cleaned up")
-}
-
-// TestDaemonStopCorruptedFile verifies stopDaemon cleans up malformed daemon.json
-func TestDaemonStopCorruptedFile(t *testing.T) {
-	tmpDir := setupIsolatedDataDir(t)
-
-	// Create corrupted daemon.json
-	if err := os.WriteFile(filepath.Join(tmpDir, "daemon.json"), []byte("not valid json"), 0o644); err != nil {
-		require.NoError(t, err, "write daemon.json: %v")
-	}
-
-	err := stopDaemon()
-	assert.Equal(t, err, ErrDaemonNotRunning)
-
-	// Verify daemon.json was cleaned up
-	_, statErr := os.Stat(filepath.Join(tmpDir, "daemon.json"))
-	assert.True(t, os.IsNotExist(statErr), "daemon.json should be cleaned up")
-}
-
-// TestDaemonStopTruncatedFile verifies stopDaemon cleans up truncated daemon.json
-// (yields io.ErrUnexpectedEOF during JSON decode)
-func TestDaemonStopTruncatedFile(t *testing.T) {
-	tmpDir := setupIsolatedDataDir(t)
-
-	// Create truncated daemon.json (partial JSON that triggers io.ErrUnexpectedEOF)
-	// A JSON object that ends abruptly mid-string causes io.ErrUnexpectedEOF
-	if err := os.WriteFile(filepath.Join(tmpDir, "daemon.json"), []byte(`{"pid": 123, "addr": "127.0.0.1:7373`), 0o644); err != nil {
-		require.NoError(t, err, "write daemon.json: %v")
-	}
-
-	err := stopDaemon()
-	assert.Equal(t, err, ErrDaemonNotRunning)
-
-	// Verify daemon.json was cleaned up
-	_, statErr := os.Stat(filepath.Join(tmpDir, "daemon.json"))
-	assert.True(t, os.IsNotExist(statErr), "daemon.json should be cleaned up")
-}
-
-// TestDaemonStopUnreadableFileSkipped verifies stopDaemon skips unreadable files
-// With the new per-PID runtime file pattern, ListAllRuntimes continues scanning
-// even when some files are unreadable. This allows daemon discovery to work even
-// if some runtime files are temporarily inaccessible.
-func TestDaemonStopUnreadableFileSkipped(t *testing.T) {
-	if os.Geteuid() == 0 {
-		t.Skip("skipping permission test when running as root")
-	}
-
-	tmpDir := setupIsolatedDataDir(t)
-
-	// Create daemon.json with valid content
-	daemonInfo := daemon.RuntimeInfo{PID: 12345, Addr: "127.0.0.1:7373"}
-	data, _ := json.Marshal(daemonInfo)
-	daemonPath := filepath.Join(tmpDir, "daemon.json")
-	if err := os.WriteFile(daemonPath, data, 0o644); err != nil {
-		require.NoError(t, err, "write daemon.json: %v")
-	}
-
-	// Remove read permission
-	if err := os.Chmod(daemonPath, 0o000); err != nil {
-		require.NoError(t, err, "chmod daemon.json: %v")
-	}
-	// Restore permission for cleanup
-	defer func() { _ = os.Chmod(daemonPath, 0o644) }()
-
-	// Probe whether chmod 0000 actually blocks reads on this filesystem
-	// (some filesystems like Windows or certain ACL-based systems may not enforce this)
-	if f, probeErr := os.Open(daemonPath); probeErr == nil {
-		f.Close()
-		t.Skip("filesystem does not enforce chmod 0000 read restrictions")
-	}
-
-	err := stopDaemon()
-	// With the new behavior, unreadable files are skipped during ListAllRuntimes.
-	// Since no readable daemon files exist, stopDaemon returns ErrDaemonNotRunning.
-	assert.Equal(t, err, ErrDaemonNotRunning)
-}
-
 func TestUpdateCmdHasNoRestartFlag(t *testing.T) {
 	cmd := updateCmd()
 
@@ -943,7 +845,7 @@ func TestRestartDaemonAfterUpdateNoRestart(t *testing.T) {
 	s := stubRestartVars(t)
 
 	getAnyRunningDaemon = func() (*daemon.RuntimeInfo, error) {
-		return &daemon.RuntimeInfo{PID: 100, Addr: "127.0.0.1:7373"}, nil
+		return &daemon.RuntimeInfo{PID: 100, Address: "127.0.0.1:7373"}, nil
 	}
 
 	output := captureStdout(t, func() {
@@ -962,10 +864,10 @@ func TestRestartDaemonAfterUpdateManagerRestarted(t *testing.T) {
 	getAnyRunningDaemon = func() (*daemon.RuntimeInfo, error) {
 		getCalls++
 		if getCalls == 1 {
-			return &daemon.RuntimeInfo{PID: 100, Addr: "127.0.0.1:7373"}, nil
+			return &daemon.RuntimeInfo{PID: 100, Address: "127.0.0.1:7373"}, nil
 		}
 		// After stop, an external manager restarted with a new PID.
-		return &daemon.RuntimeInfo{PID: 200, Addr: "127.0.0.1:7373"}, nil
+		return &daemon.RuntimeInfo{PID: 200, Address: "127.0.0.1:7373"}, nil
 	}
 
 	output := captureStdout(t, func() {
@@ -981,7 +883,7 @@ func TestRestartDaemonAfterUpdateStopFailureSamePID(t *testing.T) {
 	s := stubRestartVars(t)
 
 	getAnyRunningDaemon = func() (*daemon.RuntimeInfo, error) {
-		return &daemon.RuntimeInfo{PID: 100, Addr: "127.0.0.1:7373"}, nil
+		return &daemon.RuntimeInfo{PID: 100, Address: "127.0.0.1:7373"}, nil
 	}
 	stopDaemonForUpdate = func() error {
 		s.stopCalls++
@@ -1005,7 +907,7 @@ func TestWaitForDaemonExitProbeErrorWithRuntimePresentTimesOut(t *testing.T) {
 		return nil, os.ErrNotExist
 	}
 	listAllRuntimes = func() ([]*daemon.RuntimeInfo, error) {
-		return []*daemon.RuntimeInfo{{PID: 100, Addr: "127.0.0.1:7373"}}, nil
+		return []*daemon.RuntimeInfo{{PID: 100, Address: "127.0.0.1:7373"}}, nil
 	}
 	isPIDAliveForUpdate = func(pid int) bool {
 		return pid == 100
@@ -1023,7 +925,7 @@ func TestWaitForDaemonExitProbeErrorWithStaleRuntimeExits(t *testing.T) {
 		return nil, os.ErrNotExist
 	}
 	listAllRuntimes = func() ([]*daemon.RuntimeInfo, error) {
-		return []*daemon.RuntimeInfo{{PID: 100, Addr: "127.0.0.1:7373"}}, nil
+		return []*daemon.RuntimeInfo{{PID: 100, Address: "127.0.0.1:7373"}}, nil
 	}
 	// PID is dead; runtime entry is stale.
 	isPIDAliveForUpdate = func(int) bool {
@@ -1081,7 +983,7 @@ func TestWaitForDaemonExitDetectsUnresponsiveManagerHandoffFromRuntimePID(t *tes
 	}
 	listAllRuntimes = func() ([]*daemon.RuntimeInfo, error) {
 		return []*daemon.RuntimeInfo{
-			{PID: 200, Addr: "127.0.0.1:7373"},
+			{PID: 200, Address: "127.0.0.1:7373"},
 		}, nil
 	}
 	isPIDAliveForUpdate = func(pid int) bool {
@@ -1141,15 +1043,15 @@ func TestRestartDaemonAfterUpdateStopFailureManagerRestartNeedsCleanup(t *testin
 		getCalls++
 		// Initial probe sees old daemon.
 		if getCalls == 1 {
-			return &daemon.RuntimeInfo{PID: 100, Addr: "127.0.0.1:7373"}, nil
+			return &daemon.RuntimeInfo{PID: 100, Address: "127.0.0.1:7373"}, nil
 		}
 		// During first wait loop, manager PID appears but old runtime still exists.
 		if s.killCalls == 0 {
-			return &daemon.RuntimeInfo{PID: 200, Addr: "127.0.0.1:7373"}, nil
+			return &daemon.RuntimeInfo{PID: 200, Address: "127.0.0.1:7373"}, nil
 		}
 		// After forced kill and manual start, readiness probe succeeds.
 		if s.startCalls > 0 {
-			return &daemon.RuntimeInfo{PID: 300, Addr: "127.0.0.1:7373"}, nil
+			return &daemon.RuntimeInfo{PID: 300, Address: "127.0.0.1:7373"}, nil
 		}
 		// During second wait loop after kill, no daemon responds.
 		return nil, os.ErrNotExist
@@ -1158,8 +1060,8 @@ func TestRestartDaemonAfterUpdateStopFailureManagerRestartNeedsCleanup(t *testin
 		if s.killCalls == 0 {
 			// Before cleanup, one original PID still exists.
 			return []*daemon.RuntimeInfo{
-				{PID: 100, Addr: "127.0.0.1:7373"},
-				{PID: 101, Addr: "127.0.0.1:7373"},
+				{PID: 100, Address: "127.0.0.1:7373"},
+				{PID: 101, Address: "127.0.0.1:7373"},
 			}, nil
 		}
 		// Cleanup removed old daemons.
@@ -1186,19 +1088,19 @@ func TestRestartDaemonAfterUpdateManagerRestartedAfterKill(t *testing.T) {
 	getAnyRunningDaemon = func() (*daemon.RuntimeInfo, error) {
 		if s.killCalls == 0 {
 			// Before forced kill, old daemon stays on the same PID.
-			return &daemon.RuntimeInfo{PID: 100, Addr: "127.0.0.1:7373"}, nil
+			return &daemon.RuntimeInfo{PID: 100, Address: "127.0.0.1:7373"}, nil
 		}
 		// After forced kill, external manager restarts the daemon.
-		return &daemon.RuntimeInfo{PID: 500, Addr: "127.0.0.1:7373"}, nil
+		return &daemon.RuntimeInfo{PID: 500, Address: "127.0.0.1:7373"}, nil
 	}
 	listAllRuntimes = func() ([]*daemon.RuntimeInfo, error) {
 		if s.killCalls == 0 {
 			return []*daemon.RuntimeInfo{
-				{PID: 100, Addr: "127.0.0.1:7373"},
+				{PID: 100, Address: "127.0.0.1:7373"},
 			}, nil
 		}
 		return []*daemon.RuntimeInfo{
-			{PID: 500, Addr: "127.0.0.1:7373"},
+			{PID: 500, Address: "127.0.0.1:7373"},
 		}, nil
 	}
 
@@ -1218,7 +1120,7 @@ func TestRestartDaemonAfterUpdateManagerHandoffUnresponsiveUsesRuntimePID(t *tes
 	getAnyRunningDaemon = func() (*daemon.RuntimeInfo, error) {
 		getCalls++
 		if getCalls == 1 {
-			return &daemon.RuntimeInfo{PID: 100, Addr: "127.0.0.1:7373"}, nil
+			return &daemon.RuntimeInfo{PID: 100, Address: "127.0.0.1:7373"}, nil
 		}
 		// Replacement daemon is not yet responsive.
 		return nil, os.ErrNotExist
@@ -1230,12 +1132,12 @@ func TestRestartDaemonAfterUpdateManagerHandoffUnresponsiveUsesRuntimePID(t *tes
 		if listCalls == 1 {
 			// Initial snapshot for stop validation.
 			return []*daemon.RuntimeInfo{
-				{PID: 100, Addr: "127.0.0.1:7373"},
+				{PID: 100, Address: "127.0.0.1:7373"},
 			}, nil
 		}
 		// Runtime handoff to manager-restarted PID.
 		return []*daemon.RuntimeInfo{
-			{PID: 200, Addr: "127.0.0.1:7373"},
+			{PID: 200, Address: "127.0.0.1:7373"},
 		}, nil
 	}
 	isPIDAliveForUpdate = func(pid int) bool {
@@ -1260,12 +1162,12 @@ func TestRestartDaemonAfterUpdateManagerHandoffAfterKillNotReadyWarnsNoStart(t *
 		if s.killCalls == 0 {
 			// Initial probe + first wait loop see only the old daemon,
 			// forcing timeout and kill fallback.
-			return &daemon.RuntimeInfo{PID: 100, Addr: "127.0.0.1:7373"}, nil
+			return &daemon.RuntimeInfo{PID: 100, Address: "127.0.0.1:7373"}, nil
 		}
 		if !handoffSeen {
 			// After kill fallback, handoff PID appears once.
 			handoffSeen = true
-			return &daemon.RuntimeInfo{PID: 500, Addr: "127.0.0.1:7373"}, nil
+			return &daemon.RuntimeInfo{PID: 500, Address: "127.0.0.1:7373"}, nil
 		}
 		// Replacement remains unresponsive during readiness polling.
 		return nil, os.ErrNotExist
@@ -1274,11 +1176,11 @@ func TestRestartDaemonAfterUpdateManagerHandoffAfterKillNotReadyWarnsNoStart(t *
 	listAllRuntimes = func() ([]*daemon.RuntimeInfo, error) {
 		if s.killCalls == 0 {
 			return []*daemon.RuntimeInfo{
-				{PID: 100, Addr: "127.0.0.1:7373"},
+				{PID: 100, Address: "127.0.0.1:7373"},
 			}, nil
 		}
 		return []*daemon.RuntimeInfo{
-			{PID: 500, Addr: "127.0.0.1:7373"},
+			{PID: 500, Address: "127.0.0.1:7373"},
 		}, nil
 	}
 
@@ -1302,23 +1204,23 @@ func TestRestartDaemonAfterUpdateManagerRestartedAfterKillWithLingeringInitialPI
 	getAnyRunningDaemon = func() (*daemon.RuntimeInfo, error) {
 		if s.killCalls == 0 {
 			// Before forced kill, old daemon stays on the same PID.
-			return &daemon.RuntimeInfo{PID: 100, Addr: "127.0.0.1:7373"}, nil
+			return &daemon.RuntimeInfo{PID: 100, Address: "127.0.0.1:7373"}, nil
 		}
 		// After forced kill, external manager restarts one daemon PID.
-		return &daemon.RuntimeInfo{PID: 500, Addr: "127.0.0.1:7373"}, nil
+		return &daemon.RuntimeInfo{PID: 500, Address: "127.0.0.1:7373"}, nil
 	}
 	listAllRuntimes = func() ([]*daemon.RuntimeInfo, error) {
 		if s.killCalls == 0 {
 			// Initial runtime snapshot includes multiple daemon PIDs.
 			return []*daemon.RuntimeInfo{
-				{PID: 100, Addr: "127.0.0.1:7373"},
-				{PID: 101, Addr: "127.0.0.1:7373"},
+				{PID: 100, Address: "127.0.0.1:7373"},
+				{PID: 101, Address: "127.0.0.1:7373"},
 			}, nil
 		}
 		// After kill, previousPID is gone but another initial PID remains.
 		return []*daemon.RuntimeInfo{
-			{PID: 101, Addr: "127.0.0.1:7373"},
-			{PID: 500, Addr: "127.0.0.1:7373"},
+			{PID: 101, Address: "127.0.0.1:7373"},
+			{PID: 500, Address: "127.0.0.1:7373"},
 		}, nil
 	}
 	stopDaemonForUpdate = func() error {
@@ -1344,7 +1246,7 @@ func TestRestartDaemonAfterUpdateStopFailedPreviousPIDExitedButInitialPIDLingeri
 		getCalls++
 		if getCalls == 1 {
 			// Initial probe sees previous PID.
-			return &daemon.RuntimeInfo{PID: 100, Addr: "127.0.0.1:7373"}, nil
+			return &daemon.RuntimeInfo{PID: 100, Address: "127.0.0.1:7373"}, nil
 		}
 		// previousPID exited quickly; no replacement PID observed.
 		return nil, os.ErrNotExist
@@ -1354,19 +1256,19 @@ func TestRestartDaemonAfterUpdateStopFailedPreviousPIDExitedButInitialPIDLingeri
 		case 0:
 			// Initial snapshot includes multiple daemon PIDs.
 			return []*daemon.RuntimeInfo{
-				{PID: 100, Addr: "127.0.0.1:7373"},
-				{PID: 101, Addr: "127.0.0.1:7373"},
+				{PID: 100, Address: "127.0.0.1:7373"},
+				{PID: 101, Address: "127.0.0.1:7373"},
 			}, nil
 		case 1:
 			// waitForDaemonExit still sees previous PID.
 			return []*daemon.RuntimeInfo{
-				{PID: 100, Addr: "127.0.0.1:7373"},
-				{PID: 101, Addr: "127.0.0.1:7373"},
+				{PID: 100, Address: "127.0.0.1:7373"},
+				{PID: 101, Address: "127.0.0.1:7373"},
 			}, nil
 		default:
 			// previousPID gone, but another initial PID lingers.
 			return []*daemon.RuntimeInfo{
-				{PID: 101, Addr: "127.0.0.1:7373"},
+				{PID: 101, Address: "127.0.0.1:7373"},
 			}, nil
 		}
 	}
@@ -1393,7 +1295,7 @@ func TestRestartDaemonAfterUpdateStopFailedInitialSnapshotErrorWithLingeringRunt
 		getCalls++
 		if getCalls == 1 {
 			// Initial probe sees previous PID.
-			return &daemon.RuntimeInfo{PID: 100, Addr: "127.0.0.1:7373"}, nil
+			return &daemon.RuntimeInfo{PID: 100, Address: "127.0.0.1:7373"}, nil
 		}
 		// After stop attempt, daemon probe fails.
 		return nil, os.ErrNotExist
@@ -1409,7 +1311,7 @@ func TestRestartDaemonAfterUpdateStopFailedInitialSnapshotErrorWithLingeringRunt
 		case 2:
 			// waitForDaemonExit still sees previous PID.
 			return []*daemon.RuntimeInfo{
-				{PID: 100, Addr: "127.0.0.1:7373"},
+				{PID: 100, Address: "127.0.0.1:7373"},
 			}, nil
 		case 3:
 			// previousPID is now gone from runtime files.
@@ -1417,7 +1319,7 @@ func TestRestartDaemonAfterUpdateStopFailedInitialSnapshotErrorWithLingeringRunt
 		default:
 			// Verification after stop failure finds another lingering runtime.
 			return []*daemon.RuntimeInfo{
-				{PID: 101, Addr: "127.0.0.1:7373"},
+				{PID: 101, Address: "127.0.0.1:7373"},
 			}, nil
 		}
 	}
@@ -1444,12 +1346,12 @@ func TestRestartDaemonAfterUpdateStopFailedHandoffNotReadyWarnsNoStart(t *testin
 		if s.killCalls == 0 {
 			// Initial probe + first wait loop see only the old daemon,
 			// forcing timeout and kill fallback.
-			return &daemon.RuntimeInfo{PID: 100, Addr: "127.0.0.1:7373"}, nil
+			return &daemon.RuntimeInfo{PID: 100, Address: "127.0.0.1:7373"}, nil
 		}
 		if !handoffSeen {
 			// Second wait loop sees manager handoff PID once.
 			handoffSeen = true
-			return &daemon.RuntimeInfo{PID: 500, Addr: "127.0.0.1:7373"}, nil
+			return &daemon.RuntimeInfo{PID: 500, Address: "127.0.0.1:7373"}, nil
 		}
 		// Replacement remains unresponsive during readiness polling.
 		return nil, os.ErrNotExist
@@ -1458,12 +1360,12 @@ func TestRestartDaemonAfterUpdateStopFailedHandoffNotReadyWarnsNoStart(t *testin
 	listAllRuntimes = func() ([]*daemon.RuntimeInfo, error) {
 		if s.killCalls == 0 {
 			return []*daemon.RuntimeInfo{
-				{PID: 100, Addr: "127.0.0.1:7373"},
+				{PID: 100, Address: "127.0.0.1:7373"},
 			}, nil
 		}
 		// previousPID is gone; only replacement PID runtime remains.
 		return []*daemon.RuntimeInfo{
-			{PID: 500, Addr: "127.0.0.1:7373"},
+			{PID: 500, Address: "127.0.0.1:7373"},
 		}, nil
 	}
 
@@ -1494,10 +1396,10 @@ func TestRestartDaemonAfterUpdateStopFailedPreExistingPIDNotAcceptedAsHandoff(t 
 		getCalls++
 		if getCalls == 1 {
 			// Initial probe sees previous PID.
-			return &daemon.RuntimeInfo{PID: 100, Addr: "127.0.0.1:7373"}, nil
+			return &daemon.RuntimeInfo{PID: 100, Address: "127.0.0.1:7373"}, nil
 		}
 		// Existing daemon PID 200 remains responsive throughout.
-		return &daemon.RuntimeInfo{PID: 200, Addr: "127.0.0.1:7373"}, nil
+		return &daemon.RuntimeInfo{PID: 200, Address: "127.0.0.1:7373"}, nil
 	}
 
 	var listCalls int
@@ -1506,13 +1408,13 @@ func TestRestartDaemonAfterUpdateStopFailedPreExistingPIDNotAcceptedAsHandoff(t 
 		if listCalls == 1 {
 			// Initial snapshot already includes PID 200.
 			return []*daemon.RuntimeInfo{
-				{PID: 100, Addr: "127.0.0.1:7373"},
-				{PID: 200, Addr: "127.0.0.1:7373"},
+				{PID: 100, Address: "127.0.0.1:7373"},
+				{PID: 200, Address: "127.0.0.1:7373"},
 			}, nil
 		}
 		// previousPID disappeared, but pre-existing PID 200 remains.
 		return []*daemon.RuntimeInfo{
-			{PID: 200, Addr: "127.0.0.1:7373"},
+			{PID: 200, Address: "127.0.0.1:7373"},
 		}, nil
 	}
 	isPIDAliveForUpdate = func(pid int) bool {
@@ -1555,13 +1457,13 @@ func TestRestartDaemonAfterUpdateProbeFailFallback(t *testing.T) {
 			return nil, os.ErrNotExist
 		}
 		// After manual start, daemon responds with new PID.
-		return &daemon.RuntimeInfo{PID: 300, Addr: "127.0.0.1:7373"}, nil
+		return &daemon.RuntimeInfo{PID: 300, Address: "127.0.0.1:7373"}, nil
 	}
 	// Runtime files exist with a known PID.
 	listAllRuntimes = func() ([]*daemon.RuntimeInfo, error) {
 		if getCalls <= 3 {
 			return []*daemon.RuntimeInfo{
-				{PID: 100, Addr: "127.0.0.1:7373"},
+				{PID: 100, Address: "127.0.0.1:7373"},
 			}, nil
 		}
 		return nil, nil
@@ -1605,14 +1507,14 @@ func TestRestartDaemonAfterUpdateExitsQuickly(t *testing.T) {
 	getAnyRunningDaemon = func() (*daemon.RuntimeInfo, error) {
 		getCalls++
 		if getCalls == 1 {
-			return &daemon.RuntimeInfo{PID: 100, Addr: "127.0.0.1:7373"}, nil
+			return &daemon.RuntimeInfo{PID: 100, Address: "127.0.0.1:7373"}, nil
 		}
 		if getCalls == 2 {
 			// Daemon exited after stop.
 			return nil, os.ErrNotExist
 		}
 		// After manual start, daemon is ready.
-		return &daemon.RuntimeInfo{PID: 400, Addr: "127.0.0.1:7373"}, nil
+		return &daemon.RuntimeInfo{PID: 400, Address: "127.0.0.1:7373"}, nil
 	}
 
 	output := captureStdout(t, func() {

--- a/cmd/roborev/main_test_helpers_test.go
+++ b/cmd/roborev/main_test_helpers_test.go
@@ -172,10 +172,9 @@ func NewMockDaemon(t *testing.T, hooks MockRefineHooks) *MockDaemon {
 
 	require.NoError(t, os.MkdirAll(tmpDir, 0o755), "failed to create data dir")
 	mockAddr := ts.URL[7:] // strip "http://"
-	daemonInfo := daemon.RuntimeInfo{Addr: mockAddr, PID: os.Getpid(), Version: version.Version}
-	data, err := json.Marshal(daemonInfo)
-	require.NoError(t, err, "failed to marshal daemon.json")
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "daemon.json"), data, 0o644), "failed to write daemon.json")
+	require.NoError(t,
+		daemon.WriteRuntime(daemon.DaemonEndpoint{Network: "tcp", Address: mockAddr}, version.Version),
+		"failed to write daemon runtime")
 
 	origServerAddr := serverAddr
 	origGetAnyRunningDaemon := getAnyRunningDaemon
@@ -288,6 +287,7 @@ func (state *mockRefineState) handlePing(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	_ = json.NewEncoder(w).Encode(daemon.PingInfo{
+		OK:      true,
 		Service: "roborev",
 		Version: version.Version,
 		PID:     os.Getpid(),
@@ -500,23 +500,23 @@ func daemonFromHandler(t *testing.T, handler http.Handler) *MockDaemon {
 	})
 }
 
-// removeAllDaemonFiles removes all daemon runtime files from the data
+// removeAllDaemonFiles removes all daemon runtime files from the runtime
 // directory. Tests use this to simulate daemon death: once the runtime
 // files are gone, getDaemonEndpoint falls back to the serverAddr global,
 // which can be pointed at a dead address.
 func removeAllDaemonFiles(t *testing.T) {
 	t.Helper()
-	dataDir := os.Getenv("ROBOREV_DATA_DIR")
-	if dataDir == "" {
+	runtimeDir := daemon.RuntimeStore().Dir
+	if runtimeDir == "" {
 		return
 	}
-	entries, err := os.ReadDir(dataDir)
+	entries, err := os.ReadDir(runtimeDir)
 	if err != nil {
 		return
 	}
 	for _, e := range entries {
 		if strings.HasPrefix(e.Name(), "daemon.") && strings.HasSuffix(e.Name(), ".json") {
-			os.Remove(filepath.Join(dataDir, e.Name()))
+			os.Remove(filepath.Join(runtimeDir, e.Name()))
 		}
 	}
 }

--- a/cmd/roborev/run_test.go
+++ b/cmd/roborev/run_test.go
@@ -54,7 +54,7 @@ func newRunTestServer(t *testing.T, cfg mockServerConfig) *httptest.Server {
 
 		switch r.URL.Path {
 		case "/api/ping":
-			writeJSON(w, daemon.PingInfo{Service: "roborev", Version: version.Version})
+			writeJSON(w, daemon.PingInfo{OK: true, Service: "roborev", Version: version.Version})
 		case "/api/status":
 			// Required for ensureDaemon()
 			writeJSON(w, map[string]string{"version": version.Version})

--- a/cmd/roborev/tui/tui_test.go
+++ b/cmd/roborev/tui/tui_test.go
@@ -51,7 +51,7 @@ func testEndpointFromURL(rawURL string) daemon.DaemonEndpoint {
 
 // setupTuiTestEnv isolates the test from the production roborev environment
 // by setting ROBOREV_DATA_DIR to a temp directory. This prevents tests from
-// reading production daemon.json or affecting production state.
+// reading the production daemon runtime store or affecting production state.
 func setupTuiTestEnv(t *testing.T) string {
 	t.Helper()
 	tmpDir := t.TempDir()

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
 
             src = ./.;
 
-            vendorHash = "sha256-d+Byc8j5DafAm7xwF0F4/69mEByqSIiyjQJCchY5oa4=";
+            vendorHash = "sha256-6vcOo8qQIVNre8kSdQ7p6AfDamWdd+rUIECPPhtczkc=";
 
             subPackages = [ "cmd/roborev" ];
 

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx5
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+rMQ=
 github.com/fxamacker/cbor/v2 v2.9.1/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
+github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
+github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
@@ -91,8 +93,8 @@ github.com/jackc/pgx/v5 v5.10.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QII
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
-github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
-github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lucasb-eyer/go-colorful v1.4.0 h1:UtrWVfLdarDgc44HcS7pYloGHJUjHV/4FwW4TvVgFr4=

--- a/internal/daemon/activitylog_test.go
+++ b/internal/daemon/activitylog_test.go
@@ -133,7 +133,7 @@ func TestActivityLog_Details(t *testing.T) {
 
 	details := map[string]string{
 		"version": "1.0.0",
-		"addr":    "127.0.0.1:7373",
+		"address": "127.0.0.1:7373",
 		"pid":     "1234",
 	}
 	al.Log("daemon.started", "server", "started", details)

--- a/internal/daemon/endpoint.go
+++ b/internal/daemon/endpoint.go
@@ -1,25 +1,17 @@
 package daemon
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"net/http"
-	"os"
-	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
+
+	kitdaemon "go.kenn.io/kit/daemon"
 )
 
 // MaxUnixPathLen is the platform socket path length limit.
-// macOS/BSD: 104, Linux: 108.
-var MaxUnixPathLen = func() int {
-	if runtime.GOOS == "darwin" {
-		return 104
-	}
-	return 108
-}()
+var MaxUnixPathLen = kitdaemon.MaxUnixPathLen
 
 // DaemonEndpoint encapsulates the transport type and address for the daemon.
 type DaemonEndpoint struct {
@@ -27,107 +19,64 @@ type DaemonEndpoint struct {
 	Address string // "127.0.0.1:7373" or "/tmp/roborev-1000/daemon.sock"
 }
 
+func (e DaemonEndpoint) kitEndpoint() kitdaemon.Endpoint {
+	return kitdaemon.Endpoint{Network: e.Network, Address: e.Address}
+}
+
+func daemonEndpointFromKit(ep kitdaemon.Endpoint) DaemonEndpoint {
+	return DaemonEndpoint{Network: ep.Network, Address: ep.Address}
+}
+
 // ParseEndpoint parses a server_addr config value into a DaemonEndpoint.
 func ParseEndpoint(serverAddr string) (DaemonEndpoint, error) {
-	if serverAddr == "" {
-		return DaemonEndpoint{Network: "tcp", Address: "127.0.0.1:7373"}, nil
+	raw := serverAddr
+	if raw == "" {
+		raw = "127.0.0.1:7373"
 	}
 
-	if after, ok := strings.CutPrefix(serverAddr, "http://"); ok {
-		return parseTCPEndpoint(after)
+	ep, err := kitdaemon.ParseEndpoint(raw, kitdaemon.ParseEndpointOptions{
+		DefaultTCPAddress: "127.0.0.1:7373",
+		DefaultUnixPath:   DefaultSocketPath(),
+		TCPPolicy:         kitdaemon.RequireLoopback,
+	})
+	if err != nil {
+		if !strings.HasPrefix(raw, "unix://") {
+			return DaemonEndpoint{}, fmt.Errorf(
+				"daemon address %q must use a loopback host (127.0.0.1, localhost, or [::1]): %w",
+				raw, err)
+		}
+		return DaemonEndpoint{}, err
 	}
-
-	if strings.HasPrefix(serverAddr, "unix://") {
-		return parseUnixEndpoint(serverAddr)
-	}
-
-	return parseTCPEndpoint(serverAddr)
-}
-
-func parseTCPEndpoint(addr string) (DaemonEndpoint, error) {
-	if !isLoopbackAddr(addr) {
-		return DaemonEndpoint{}, fmt.Errorf(
-			"daemon address %q must use a loopback host (127.0.0.1, localhost, or [::1])", addr)
-	}
-	return DaemonEndpoint{Network: "tcp", Address: addr}, nil
-}
-
-func parseUnixEndpoint(raw string) (DaemonEndpoint, error) {
-	path := strings.TrimPrefix(raw, "unix://")
-
-	if path == "" {
-		path = DefaultSocketPath()
-		// Fall through to validate the auto-generated path too
-	}
-
-	if !filepath.IsAbs(path) {
-		return DaemonEndpoint{}, fmt.Errorf(
-			"unix socket path %q must be absolute", path)
-	}
-
-	if strings.ContainsRune(path, 0) {
-		return DaemonEndpoint{}, fmt.Errorf(
-			"unix socket path contains null byte")
-	}
-
-	if len(path) >= MaxUnixPathLen {
-		return DaemonEndpoint{}, fmt.Errorf(
-			"unix socket path %q (%d bytes) exceeds platform limit of %d bytes",
-			path, len(path), MaxUnixPathLen)
-	}
-
-	return DaemonEndpoint{Network: "unix", Address: path}, nil
+	return daemonEndpointFromKit(ep), nil
 }
 
 // DefaultSocketPath returns the auto-generated socket path under os.TempDir(),
-// or $XDG_RUNTIME_DIR when it is an absolute path to an existing directory
-// and the resulting socket path fits within MaxUnixPathLen.
+// or $XDG_RUNTIME_DIR when a safe path is available.
 func DefaultSocketPath() string {
-	xdg := os.Getenv("XDG_RUNTIME_DIR")
-	if xdg != "" && filepath.IsAbs(xdg) {
-		if info, err := os.Stat(xdg); err == nil && info.IsDir() {
-			p := filepath.Join(xdg, "roborev", "daemon.sock")
-			if len(p) < MaxUnixPathLen {
-				return p
-			}
-		}
-	}
-	return filepath.Join(os.TempDir(), fmt.Sprintf("roborev-%d", os.Getuid()), "daemon.sock")
+	return kitdaemon.DefaultSocketPath(daemonServiceName)
 }
 
 // IsUnix returns true if this endpoint uses a Unix domain socket.
 func (e DaemonEndpoint) IsUnix() bool {
-	return e.Network == "unix"
+	return e.kitEndpoint().IsUnix()
 }
 
 // BaseURL returns the HTTP base URL for constructing API requests.
 func (e DaemonEndpoint) BaseURL() string {
-	if e.IsUnix() {
-		return "http://localhost"
-	}
-	return "http://" + e.Address
+	return e.kitEndpoint().BaseURL()
 }
 
 // HTTPClient returns an http.Client configured for this endpoint's transport.
 func (e DaemonEndpoint) HTTPClient(timeout time.Duration) *http.Client {
-	if e.IsUnix() {
-		return &http.Client{
-			Timeout: timeout,
-			Transport: &http.Transport{
-				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-					return (&net.Dialer{}).DialContext(ctx, "unix", e.Address)
-				},
-				DisableKeepAlives: true,
-				Proxy:             nil, // Unix sockets are local; never proxy
-			},
-		}
-	}
-	return &http.Client{Timeout: timeout}
+	return e.kitEndpoint().HTTPClient(kitdaemon.HTTPClientOptions{
+		Timeout:           timeout,
+		DisableKeepAlives: e.IsUnix(),
+	})
 }
 
 // Listener creates a net.Listener bound to this endpoint.
 func (e DaemonEndpoint) Listener() (net.Listener, error) {
-	return net.Listen(e.Network, e.Address)
+	return e.kitEndpoint().Listen()
 }
 
 // String returns a human-readable representation for logging.
@@ -138,22 +87,10 @@ func (e DaemonEndpoint) String() string {
 // ConfigAddr returns a ParseEndpoint-compatible string suitable for
 // persisting in config or runtime metadata files.
 func (e DaemonEndpoint) ConfigAddr() string {
-	if e.IsUnix() {
-		return "unix://" + e.Address
-	}
-	return e.Address
+	return e.kitEndpoint().ConfigAddress()
 }
 
 // Port returns the TCP port, or 0 for Unix sockets.
 func (e DaemonEndpoint) Port() int {
-	if e.IsUnix() {
-		return 0
-	}
-	_, portStr, err := net.SplitHostPort(e.Address)
-	if err != nil {
-		return 0
-	}
-	port := 0
-	_, _ = fmt.Sscanf(portStr, "%d", &port)
-	return port
+	return e.kitEndpoint().Port()
 }

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -1,16 +1,16 @@
 package daemon
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
 	"net"
-	"net/http"
 	"os"
 	"path/filepath"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
+
+	kitdaemon "go.kenn.io/kit/daemon"
 
 	"go.kenn.io/roborev/internal/config"
 )
@@ -20,28 +20,74 @@ const daemonServiceName = "roborev"
 // RuntimeInfo stores daemon runtime state
 type RuntimeInfo struct {
 	PID        int    `json:"pid"`
-	Addr       string `json:"addr"`
-	Port       int    `json:"port"`
-	Network    string `json:"network"`
-	Version    string `json:"version"`
+	Network    string `json:"network,omitempty"`
+	Address    string `json:"address"`
+	Service    string `json:"service,omitempty"`
+	Version    string `json:"version,omitempty"`
 	SourcePath string `json:"-"` // Path to the runtime file (not serialized, set by ListAllRuntimes)
 }
 
-// Endpoint returns a DaemonEndpoint for this runtime. An empty Network defaults to "tcp"
-// for backwards compatibility with old runtime files that predate the Network field.
+// Endpoint returns a DaemonEndpoint for this runtime.
 func (r RuntimeInfo) Endpoint() DaemonEndpoint {
-	network := r.Network
-	if network == "" {
-		network = "tcp"
-	}
-	return DaemonEndpoint{Network: network, Address: r.Addr}
+	return daemonEndpointFromKit(kitdaemon.RuntimeRecord{
+		PID:     r.PID,
+		Network: r.Network,
+		Address: r.Address,
+		Service: r.Service,
+		Version: r.Version,
+	}.Endpoint())
 }
 
 // PingInfo is the minimal daemon identity payload used for liveness probes.
 type PingInfo struct {
+	OK      bool   `json:"ok"`
 	Service string `json:"service"`
 	Version string `json:"version"`
 	PID     int    `json:"pid,omitempty"`
+}
+
+func runtimeStore() kitdaemon.RuntimeStore {
+	return kitdaemon.RuntimeStore{
+		Dir:    filepath.Join(config.DataDir(), "runtime"),
+		Prefix: "daemon",
+	}
+}
+
+// RuntimeStore returns the shared kit runtime store used by roborev daemon
+// discovery and startup coordination.
+func RuntimeStore() kitdaemon.RuntimeStore {
+	return runtimeStore()
+}
+
+// DiscoverOptions returns the shared kit discovery options for roborev.
+func DiscoverOptions(timeout time.Duration) kitdaemon.DiscoverOptions {
+	return kitdaemon.DiscoverOptions{
+		Probe: kitdaemon.ProbeOptions{
+			ExpectedService: daemonServiceName,
+			Timeout:         timeout,
+		},
+	}
+}
+
+func runtimeInfoFromRecord(rec kitdaemon.RuntimeRecord) *RuntimeInfo {
+	ep := daemonEndpointFromKit(rec.Endpoint())
+	return &RuntimeInfo{
+		PID:        rec.PID,
+		Network:    ep.Network,
+		Address:    ep.Address,
+		Service:    rec.Service,
+		Version:    rec.Version,
+		SourcePath: rec.SourcePath,
+	}
+}
+
+func pingInfoFromKit(info kitdaemon.PingInfo) *PingInfo {
+	return &PingInfo{
+		OK:      info.OK,
+		Service: info.Service,
+		Version: info.Version,
+		PID:     info.PID,
+	}
 }
 
 // RuntimePath returns the path to the runtime info file for the current process
@@ -51,73 +97,19 @@ func RuntimePath() string {
 
 // RuntimePathForPID returns the path to the runtime info file for a specific PID
 func RuntimePathForPID(pid int) string {
-	return filepath.Join(config.DataDir(), fmt.Sprintf("daemon.%d.json", pid))
-}
-
-// LegacyRuntimePath returns the old daemon.json path for migration
-func LegacyRuntimePath() string {
-	return filepath.Join(config.DataDir(), "daemon.json")
+	path, err := runtimeStore().Path(pid)
+	if err != nil {
+		return filepath.Join(config.DataDir(), "runtime", fmt.Sprintf("daemon.%d.json", pid))
+	}
+	return path
 }
 
 // WriteRuntime saves the daemon runtime info atomically.
 // Uses write-to-temp-then-rename to prevent readers from seeing partial writes.
 func WriteRuntime(ep DaemonEndpoint, version string) error {
-	info := RuntimeInfo{
-		PID:     os.Getpid(),
-		Addr:    ep.Address,
-		Port:    ep.Port(),
-		Network: ep.Network,
-		Version: version,
-	}
-
-	path := RuntimePath()
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return err
-	}
-
-	data, err := json.MarshalIndent(info, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	// Write to temp file first for atomic creation
-	tmpFile, err := os.CreateTemp(dir, "daemon.*.json.tmp")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmpFile.Name()
-
-	// Clean up temp file on any error
-	success := false
-	defer func() {
-		if !success {
-			os.Remove(tmpPath)
-		}
-	}()
-
-	if _, err := tmpFile.Write(data); err != nil {
-		tmpFile.Close()
-		return err
-	}
-	if err := tmpFile.Close(); err != nil {
-		return err
-	}
-
-	// Atomic rename to final path
-	if err := os.Rename(tmpPath, path); err != nil {
-		return err
-	}
-
-	// Set permissions to 0644 explicitly. This intentionally ignores umask
-	// because the runtime file must be readable by other processes (CLI commands
-	// discovering the daemon). The file contains only PID/port/version, not secrets.
-	if err := os.Chmod(path, 0o644); err != nil {
-		return err
-	}
-
-	success = true
-	return nil
+	rec := kitdaemon.NewRuntimeRecord(daemonServiceName, version, ep.kitEndpoint())
+	_, err := runtimeStore().Write(rec)
+	return err
 }
 
 // ReadRuntime reads the daemon runtime info for the current process
@@ -127,17 +119,11 @@ func ReadRuntime() (*RuntimeInfo, error) {
 
 // ReadRuntimeForPID reads the daemon runtime info for a specific PID
 func ReadRuntimeForPID(pid int) (*RuntimeInfo, error) {
-	data, err := os.ReadFile(RuntimePathForPID(pid))
+	rec, err := runtimeStore().Read(RuntimePathForPID(pid))
 	if err != nil {
 		return nil, err
 	}
-
-	var info RuntimeInfo
-	if err := json.Unmarshal(data, &info); err != nil {
-		return nil, err
-	}
-
-	return &info, nil
+	return runtimeInfoFromRecord(rec), nil
 }
 
 // RemoveRuntime removes the runtime info file for the current process
@@ -154,59 +140,17 @@ func RemoveRuntimeForPID(pid int) {
 // Sets SourcePath on each RuntimeInfo for proper cleanup.
 // Continues scanning even if some files are unreadable (e.g., permission errors).
 func ListAllRuntimes() ([]*RuntimeInfo, error) {
-	dataDir := config.DataDir()
-
-	// Use os.ReadDir instead of filepath.Glob to handle paths with glob metacharacters
-	entries, err := os.ReadDir(dataDir)
+	records, err := runtimeStore().List()
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil // No data dir yet, no runtimes
+			return nil, nil
 		}
 		return nil, err
 	}
 
-	// Filter for daemon.*.json files
-	var matches []string
-	for _, entry := range entries {
-		name := entry.Name()
-		if strings.HasPrefix(name, "daemon.") && strings.HasSuffix(name, ".json") {
-			matches = append(matches, filepath.Join(dataDir, name))
-		}
-	}
-
-	// Also check for legacy daemon.json (already covered by the pattern above,
-	// but keep explicit check for clarity)
-	legacyPath := LegacyRuntimePath()
-	if _, err := os.Stat(legacyPath); err == nil {
-		// Check if already in matches (daemon.json matches daemon.*.json pattern)
-		found := slices.Contains(matches, legacyPath)
-		if !found {
-			matches = append(matches, legacyPath)
-		}
-	}
-
-	var runtimes []*RuntimeInfo
-	for _, path := range matches {
-		data, err := os.ReadFile(path)
-		if err != nil {
-			// Skip unreadable files (permission errors, file disappeared, etc.)
-			// Don't abort the whole scan - there may be other valid daemon files
-			continue
-		}
-		var info RuntimeInfo
-		if err := json.Unmarshal(data, &info); err != nil {
-			// Corrupted file - remove it
-			os.Remove(path)
-			continue
-		}
-		// Validate required fields - remove invalid entries
-		if info.PID <= 0 || info.Addr == "" {
-			os.Remove(path)
-			continue
-		}
-		// Track source path for proper cleanup
-		info.SourcePath = path
-		runtimes = append(runtimes, &info)
+	runtimes := make([]*RuntimeInfo, 0, len(records))
+	for _, rec := range records {
+		runtimes = append(runtimes, runtimeInfoFromRecord(rec))
 	}
 	return runtimes, nil
 }
@@ -214,24 +158,23 @@ func ListAllRuntimes() ([]*RuntimeInfo, error) {
 // GetAnyRunningDaemon returns info about a responsive daemon.
 // Returns os.ErrNotExist if no responsive daemon is found.
 func GetAnyRunningDaemon() (*RuntimeInfo, error) {
-	runtimes, err := ListAllRuntimes()
+	rec, _, ok, err := kitdaemon.Discover(context.Background(), runtimeStore(), kitdaemon.DiscoverOptions{
+		Probe: kitdaemon.ProbeOptions{
+			ExpectedService: daemonServiceName,
+			Timeout:         time.Second,
+		},
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	// Only return a daemon that's actually responding
-	for _, info := range runtimes {
-		if IsDaemonAlive(info.Endpoint()) {
-			return info, nil
-		}
+	if ok {
+		return runtimeInfoFromRecord(rec), nil
 	}
 
 	return nil, os.ErrNotExist
 }
 
 // ProbeDaemon validates that a daemon endpoint is serving the roborev daemon.
-// It prefers the lightweight /api/ping endpoint and falls back to /api/status
-// for older daemon versions that do not implement /api/ping yet.
 func ProbeDaemon(ep DaemonEndpoint, timeout time.Duration) (*PingInfo, error) {
 	if ep.Address == "" {
 		return nil, fmt.Errorf("empty daemon address")
@@ -239,12 +182,14 @@ func ProbeDaemon(ep DaemonEndpoint, timeout time.Duration) (*PingInfo, error) {
 	if !ep.IsUnix() && !isLoopbackAddr(ep.Address) {
 		return nil, fmt.Errorf("non-loopback daemon address: %s", ep.Address)
 	}
-	client := ep.HTTPClient(timeout)
-	baseURL := ep.BaseURL()
-	if info, shouldFallback, err := probeDaemonPing(client, baseURL); !shouldFallback {
-		return info, err
+	info, err := kitdaemon.Probe(context.Background(), ep.kitEndpoint(), kitdaemon.ProbeOptions{
+		ExpectedService: daemonServiceName,
+		Timeout:         timeout,
+	})
+	if err != nil {
+		return nil, err
 	}
-	return probeLegacyDaemonStatus(client, baseURL)
+	return pingInfoFromKit(info), nil
 }
 
 // IsDaemonAlive checks if a daemon at the given endpoint is actually responding.
@@ -266,63 +211,6 @@ func IsDaemonAlive(ep DaemonEndpoint) bool {
 		}
 	}
 	return false
-}
-
-func probeDaemonPing(client *http.Client, baseURL string) (*PingInfo, bool, error) {
-	resp, err := client.Get(baseURL + "/api/ping")
-	if err != nil {
-		return nil, false, err
-	}
-	defer resp.Body.Close()
-
-	switch resp.StatusCode {
-	case http.StatusOK:
-		var info PingInfo
-		if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
-			return nil, false, fmt.Errorf("decode daemon ping: %w", err)
-		}
-		if info.Service != daemonServiceName {
-			return nil, false, fmt.Errorf("unexpected daemon service %q", info.Service)
-		}
-		return &info, false, nil
-	case http.StatusNotFound, http.StatusMethodNotAllowed:
-		return nil, true, nil
-	default:
-		return nil, false, fmt.Errorf("daemon ping returned %d", resp.StatusCode)
-	}
-}
-
-func probeLegacyDaemonStatus(client *http.Client, baseURL string) (*PingInfo, error) {
-	resp, err := client.Get(baseURL + "/api/status")
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 500 && resp.StatusCode < 600 {
-		return &PingInfo{Service: daemonServiceName}, nil
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("daemon status returned %d", resp.StatusCode)
-	}
-	if resp.StatusCode == http.StatusNoContent {
-		return &PingInfo{Service: daemonServiceName}, nil
-	}
-
-	var status struct {
-		Version string `json:"version"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
-		return nil, fmt.Errorf("decode daemon status: %w", err)
-	}
-	if status.Version == "" {
-		return nil, fmt.Errorf("daemon status missing version")
-	}
-
-	return &PingInfo{
-		Service: daemonServiceName,
-		Version: status.Version,
-	}, nil
 }
 
 func parseDaemonBindAddr(addr string) (string, int, error) {
@@ -484,25 +372,6 @@ func CleanupZombieDaemons(target DaemonEndpoint) int {
 			cleaned++
 		} else if KillDaemon(info) {
 			cleaned++
-		}
-	}
-
-	// Clean up legacy daemon.json - it may contain stale info
-	// that ListAllRuntimes picked up
-	legacyPath := LegacyRuntimePath()
-	if _, err := os.Stat(legacyPath); err == nil {
-		// Read it to check if it's for a dead daemon
-		if data, err := os.ReadFile(legacyPath); err == nil {
-			var info RuntimeInfo
-			if json.Unmarshal(data, &info) == nil {
-				if !IsDaemonAlive(info.Endpoint()) {
-					// Legacy file points to dead daemon, remove it
-					os.Remove(legacyPath)
-				}
-			} else {
-				// Corrupted, remove it
-				os.Remove(legacyPath)
-			}
 		}
 	}
 

--- a/internal/daemon/runtime_integration_test.go
+++ b/internal/daemon/runtime_integration_test.go
@@ -29,8 +29,8 @@ func TestKillDaemonMakesHTTPForLoopback(t *testing.T) {
 	})
 
 	info := &RuntimeInfo{
-		PID:  math.MaxInt32,
-		Addr: addr, // Loopback address from test server
+		PID:     math.MaxInt32,
+		Address: addr, // Loopback address from test server
 	}
 
 	// This should make HTTP request since address is loopback

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -27,8 +27,7 @@ const (
 
 type runtimeData struct {
 	PID     int    `json:"pid"`
-	Addr    string `json:"addr"`
-	Port    int    `json:"port"`
+	Address string `json:"address"`
 	Version string `json:"version"`
 }
 
@@ -39,8 +38,7 @@ func createRuntimeFile(t *testing.T, dir string, pid int, data *runtimeData) str
 	if data == nil {
 		data = &runtimeData{
 			PID:     pid,
-			Addr:    defaultTestAddr,
-			Port:    defaultTestPort,
+			Address: defaultTestAddr,
 			Version: "test",
 		}
 	}
@@ -178,15 +176,10 @@ func TestRuntimeInfoReadWrite(t *testing.T) {
 			}, "ReadRuntime failed: %v", err)
 		}
 
-		if info.Addr != defaultTestAddr {
+		if info.Address != defaultTestAddr {
 			assert.Condition(t, func() bool {
 				return false
-			}, "Expected addr '%s', got '%s'", defaultTestAddr, info.Addr)
-		}
-		if info.Port != defaultTestPort {
-			assert.Condition(t, func() bool {
-				return false
-			}, "Expected port %d, got %d", defaultTestPort, info.Port)
+			}, "Expected addr '%s', got '%s'", defaultTestAddr, info.Address)
 		}
 		if info.PID == 0 {
 			assert.Condition(t, func() bool {
@@ -232,8 +225,8 @@ func TestKillDaemonSkipsHTTPForNonLoopback(t *testing.T) {
 	// through to killProcess (which returns true because of the mock).
 	// This must complete promptly without attempting network connections.
 	info := &RuntimeInfo{
-		PID:  os.Getpid(),          // Existing PID, but mocked as not-roborev
-		Addr: "192.168.1.100:7373", // Non-loopback address
+		PID:     os.Getpid(),          // Existing PID, but mocked as not-roborev
+		Address: "192.168.1.100:7373", // Non-loopback address
 	}
 
 	result := KillDaemon(info)
@@ -252,15 +245,17 @@ func TestListAllRuntimesSkipsUnreadableFiles(t *testing.T) {
 		t.Skip("chmod 0000 doesn't block reads on Windows")
 	}
 
-	dataDir := testenv.SetDataDir(t)
+	_ = testenv.SetDataDir(t)
+	runtimeDir := runtimeStore().Dir
+	require.NoError(t, os.MkdirAll(runtimeDir, 0o700))
 
 	// Create a valid runtime file
-	createRuntimeFile(t, dataDir, math.MaxInt32, nil)
+	createRuntimeFile(t, runtimeDir, math.MaxInt32, nil)
 
 	// Create an unreadable runtime file
-	unreadablePath := createRuntimeFile(t, dataDir, math.MaxInt32-1, &runtimeData{
-		PID:  math.MaxInt32 - 1,
-		Addr: "127.0.0.1:7374",
+	unreadablePath := createRuntimeFile(t, runtimeDir, math.MaxInt32-1, &runtimeData{
+		PID:     math.MaxInt32 - 1,
+		Address: "127.0.0.1:7374",
 	})
 	os.Chmod(unreadablePath, 0o000)
 	t.Cleanup(func() { os.Chmod(unreadablePath, 0o644) })
@@ -396,6 +391,7 @@ func TestProbeDaemonPrefersPing(t *testing.T) {
 	addr, mux := startMockDaemon(t)
 	mux.HandleFunc("/api/ping", func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(PingInfo{
+			OK:      true,
 			Service: daemonServiceName,
 			Version: "v-test",
 			PID:     123,
@@ -420,79 +416,6 @@ func TestProbeDaemonPrefersPing(t *testing.T) {
 	}
 }
 
-func TestProbeDaemonFallsBackToLegacyStatus(t *testing.T) {
-	addr, mux := startMockDaemon(t)
-	mux.HandleFunc("/api/ping", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-	})
-	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]string{"version": "v-legacy"})
-	})
-
-	info, err := ProbeDaemon(DaemonEndpoint{Network: "tcp", Address: addr}, time.Second)
-	if err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "ProbeDaemon legacy fallback failed: %v", err)
-	}
-	if info.Version != "v-legacy" {
-		require.Condition(t, func() bool {
-			return false
-		}, "ProbeDaemon version = %q, want %q", info.Version, "v-legacy")
-	}
-}
-
-func TestIsDaemonAliveLegacyStatusCodes(t *testing.T) {
-	tests := []struct {
-		name       string
-		statusCode int
-		wantAlive  bool
-	}{
-		// 2xx - success, daemon is alive
-		{"200 OK", http.StatusOK, true},
-		{"201 Created", http.StatusCreated, true},
-		{"204 No Content", http.StatusNoContent, true},
-
-		// 5xx - server error, daemon is alive but having issues
-		{"500 Internal Server Error", http.StatusInternalServerError, true},
-		{"502 Bad Gateway", http.StatusBadGateway, true},
-		{"503 Service Unavailable", http.StatusServiceUnavailable, true},
-
-		// 3xx - redirect, likely different service
-		{"301 Moved Permanently", http.StatusMovedPermanently, false},
-		{"302 Found", http.StatusFound, false},
-
-		// 4xx - client error, likely different service (auth proxy, unrelated API)
-		{"400 Bad Request", http.StatusBadRequest, false},
-		{"401 Unauthorized", http.StatusUnauthorized, false},
-		{"403 Forbidden", http.StatusForbidden, false},
-		{"404 Not Found", http.StatusNotFound, false},
-		{"405 Method Not Allowed", http.StatusMethodNotAllowed, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			addr, mux := startMockDaemon(t)
-			mux.HandleFunc("/api/ping", func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusNotFound)
-			})
-			mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(tt.statusCode)
-				if tt.statusCode >= 200 && tt.statusCode < 300 {
-					_ = json.NewEncoder(w).Encode(map[string]string{"version": "v-legacy"})
-				}
-			})
-			got := IsDaemonAlive(DaemonEndpoint{Network: "tcp", Address: addr})
-			if got != tt.wantAlive {
-				assert.Condition(t, func() bool {
-					return false
-				}, "IsDaemonAlive with %d = %v, want %v", tt.statusCode, got, tt.wantAlive)
-			}
-		})
-	}
-}
-
 func TestCleanupZombieDaemonsPreservesTargetSocket(t *testing.T) {
 	// Regression test: when a zombie's socket matches the target
 	// (e.g. a systemd-managed socket), cleanup must remove the
@@ -503,7 +426,7 @@ func TestCleanupZombieDaemonsPreservesTargetSocket(t *testing.T) {
 		t.Skip("Unix sockets not supported on Windows")
 	}
 
-	dataDir := testenv.SetDataDir(t)
+	_ = testenv.SetDataDir(t)
 	assert := assert.New(t)
 
 	// Create a real Unix socket as the "target" (stands in for the
@@ -526,14 +449,15 @@ func TestCleanupZombieDaemonsPreservesTargetSocket(t *testing.T) {
 	stalePID := os.Getpid()
 	runtimeJSON, err := json.Marshal(map[string]any{
 		"pid":     stalePID,
-		"addr":    socketPath,
-		"port":    0,
+		"address": socketPath,
 		"network": "unix",
 		"version": "stale",
 	})
 	require.NoError(t, err)
+	runtimeDir := runtimeStore().Dir
+	require.NoError(t, os.MkdirAll(runtimeDir, 0o700))
 	runtimePath := filepath.Join(
-		dataDir, fmt.Sprintf("daemon.%d.json", stalePID))
+		runtimeDir, fmt.Sprintf("daemon.%d.json", stalePID))
 	require.NoError(t, os.WriteFile(runtimePath, runtimeJSON, 0o644))
 
 	mockIdentifyProcess(t, func(pid int) processIdentity {
@@ -551,32 +475,21 @@ func TestRuntimeInfo_Endpoint(t *testing.T) {
 	assert := assert.New(t)
 
 	// TCP with explicit network
-	info := RuntimeInfo{PID: 1, Addr: "127.0.0.1:7373", Port: 7373, Network: "tcp"}
+	info := RuntimeInfo{PID: 1, Address: "127.0.0.1:7373", Network: "tcp"}
 	ep := info.Endpoint()
 	assert.Equal("tcp", ep.Network)
 	assert.Equal("127.0.0.1:7373", ep.Address)
 
 	// Unix
-	info = RuntimeInfo{PID: 1, Addr: "/tmp/test.sock", Port: 0, Network: "unix"}
+	info = RuntimeInfo{PID: 1, Address: "/tmp/test.sock", Network: "unix"}
 	ep = info.Endpoint()
 	assert.Equal("unix", ep.Network)
 	assert.Equal("/tmp/test.sock", ep.Address)
 
-	// Empty network defaults to TCP (backwards compat)
-	info = RuntimeInfo{PID: 1, Addr: "127.0.0.1:7373", Port: 7373, Network: ""}
+	// Empty network follows the kit runtime default.
+	info = RuntimeInfo{PID: 1, Address: "127.0.0.1:7373", Network: ""}
 	ep = info.Endpoint()
 	assert.Equal("tcp", ep.Network)
-}
-
-func TestRuntimeInfo_BackwardsCompat_NoNetworkField(t *testing.T) {
-	// Simulate old JSON without "network" field
-	data := []byte(`{"pid": 1234, "addr": "127.0.0.1:7373", "port": 7373, "version": "0.47.0"}`)
-	var info RuntimeInfo
-	require.NoError(t, json.Unmarshal(data, &info))
-	assert.Empty(t, info.Network)
-	ep := info.Endpoint()
-	assert.Equal(t, "tcp", ep.Network)
-	assert.Equal(t, "127.0.0.1:7373", ep.Address)
 }
 
 func TestListAllRuntimesWithGlobMetacharacters(t *testing.T) {
@@ -592,9 +505,11 @@ func TestListAllRuntimesWithGlobMetacharacters(t *testing.T) {
 
 	// Set ROBOREV_DATA_DIR to the directory with metacharacters
 	t.Setenv("ROBOREV_DATA_DIR", dataDir)
+	runtimeDir := runtimeStore().Dir
+	require.NoError(t, os.MkdirAll(runtimeDir, 0o700))
 
 	// Create a valid runtime file
-	createRuntimeFile(t, dataDir, math.MaxInt32, nil)
+	createRuntimeFile(t, runtimeDir, math.MaxInt32, nil)
 
 	// ListAllRuntimes should work despite glob metacharacters in path
 	runtimes, err := ListAllRuntimes()

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -163,7 +163,7 @@ func (s *Server) Start(ctx context.Context) error {
 		if listener != nil {
 			_ = listener.Close()
 		}
-		return fmt.Errorf("daemon already running (pid %d on %s)", info.PID, info.Addr)
+		return fmt.Errorf("daemon already running (pid %d on %s)", info.PID, info.Address)
 	}
 
 	// Reset stale jobs from previous runs
@@ -2356,6 +2356,7 @@ func (s *Server) humaPing(
 	ctx context.Context, input *struct{},
 ) (*PingOutput, error) {
 	return &PingOutput{Body: PingInfo{
+		OK:      true,
 		Service: daemonServiceName,
 		Version: version.Version,
 		PID:     os.Getpid(),

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -343,11 +343,11 @@ func TestServerStartSupportsIPv6LoopbackBindAddr(t *testing.T) {
 
 		info, err := ReadRuntime()
 		if err == nil {
-			host, _, splitErr := net.SplitHostPort(info.Addr)
+			host, _, splitErr := net.SplitHostPort(info.Address)
 			if splitErr != nil {
 				require.Condition(t, func() bool {
 					return false
-				}, "runtime addr %q is invalid: %v", info.Addr, splitErr)
+				}, "runtime addr %q is invalid: %v", info.Address, splitErr)
 			}
 			if host != "::1" {
 				require.Condition(t, func() bool {

--- a/internal/daemon_client/client.gen.go
+++ b/internal/daemon_client/client.gen.go
@@ -206,6 +206,7 @@ type DaemonStatus struct {
 	// Schema A URL to the JSON Schema for this object.
 	Schema              *string           `json:"$schema,omitempty"`
 	ActiveWorkers       int64             `json:"active_workers"`
+	Address             *string           `json:"address,omitempty"`
 	AppliedJobs         int64             `json:"applied_jobs"`
 	AutoDesign          *AutoDesignStatus `json:"auto_design,omitempty"`
 	CanceledJobs        int64             `json:"canceled_jobs"`
@@ -215,6 +216,8 @@ type DaemonStatus struct {
 	FailedJobs          int64             `json:"failed_jobs"`
 	MachineId           *string           `json:"machine_id,omitempty"`
 	MaxWorkers          int64             `json:"max_workers"`
+	Network             *string           `json:"network,omitempty"`
+	Port                *int64            `json:"port,omitempty"`
 	QueuedJobs          int64             `json:"queued_jobs"`
 	RebasedJobs         int64             `json:"rebased_jobs"`
 	RunningJobs         int64             `json:"running_jobs"`
@@ -425,6 +428,7 @@ type OverviewStats struct {
 type PingInfo struct {
 	// Schema A URL to the JSON Schema for this object.
 	Schema  *string `json:"$schema,omitempty"`
+	Ok      bool    `json:"ok"`
 	Pid     *int64  `json:"pid,omitempty"`
 	Service string  `json:"service"`
 	Version string  `json:"version"`

--- a/internal/daemon_client/openapi-3.0.json
+++ b/internal/daemon_client/openapi-3.0.json
@@ -342,6 +342,9 @@
             "format": "int64",
             "type": "integer"
           },
+          "address": {
+            "type": "string"
+          },
           "applied_jobs": {
             "format": "int64",
             "type": "integer"
@@ -373,6 +376,13 @@
             "type": "string"
           },
           "max_workers": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "network": {
+            "type": "string"
+          },
+          "port": {
             "format": "int64",
             "type": "integer"
           },
@@ -1022,6 +1032,9 @@
             "readOnly": true,
             "type": "string"
           },
+          "ok": {
+            "type": "boolean"
+          },
           "pid": {
             "format": "int64",
             "type": "integer"
@@ -1034,6 +1047,7 @@
           }
         },
         "required": [
+          "ok",
           "service",
           "version"
         ],

--- a/internal/testenv/barrier.go
+++ b/internal/testenv/barrier.go
@@ -83,7 +83,7 @@ func (b *ProdLogBarrier) checkRuntimeFile() []string {
 		if !b.runtime.exists {
 			return []string{
 				fmt.Sprintf(
-					"test wrote daemon.%d.json to prod data dir",
+					"test wrote daemon.%d.json to prod runtime dir",
 					b.pid,
 				),
 			}
@@ -91,7 +91,7 @@ func (b *ProdLogBarrier) checkRuntimeFile() []string {
 		if info.Size() != b.runtime.size || !info.ModTime().Equal(b.runtime.mtime) {
 			return []string{
 				fmt.Sprintf(
-					"test modified daemon.%d.json in prod data dir"+
+					"test modified daemon.%d.json in prod runtime dir"+
 						" (size %d→%d, mtime %s→%s)",
 					b.pid, b.runtime.size, info.Size(),
 					b.runtime.mtime.Format(time.RFC3339Nano),
@@ -104,7 +104,7 @@ func (b *ProdLogBarrier) checkRuntimeFile() []string {
 	if b.runtime.exists {
 		return []string{
 			fmt.Sprintf(
-				"test deleted daemon.%d.json from prod data dir",
+				"test deleted daemon.%d.json from prod runtime dir",
 				b.pid,
 			),
 		}
@@ -221,7 +221,9 @@ func newFileSnapshot(name, path string) fileSnapshot {
 
 func newRuntimeSnapshot(prodDataDir string, pid int) runtimeSnapshot {
 	snapshot := runtimeSnapshot{
-		path: filepath.Join(prodDataDir, fmt.Sprintf("daemon.%d.json", pid)),
+		path: filepath.Join(
+			prodDataDir, "runtime", fmt.Sprintf("daemon.%d.json", pid),
+		),
 	}
 	if info, err := os.Stat(snapshot.path); err == nil {
 		snapshot.exists = true

--- a/internal/testenv/barrier_test.go
+++ b/internal/testenv/barrier_test.go
@@ -63,13 +63,15 @@ func TestProdLogBarrierViolations(t *testing.T) {
 			name: "detects daemon runtime file creation",
 			mutate: func(t *testing.T, dir string) {
 				t.Helper()
-				runtimePath := filepath.Join(dir,
+				runtimeDir := filepath.Join(dir, "runtime")
+				require.NoError(t, os.MkdirAll(runtimeDir, 0o755))
+				runtimePath := filepath.Join(runtimeDir,
 					fmt.Sprintf("daemon.%d.json", os.Getpid()))
 				err := os.WriteFile(runtimePath, []byte("{}"), 0o644)
 				require.NoError(t, err, "failed to write runtime file")
 			},
 			wantViolations: []string{
-				fmt.Sprintf("test wrote daemon.%d.json to prod data dir", os.Getpid()),
+				fmt.Sprintf("test wrote daemon.%d.json to prod runtime dir", os.Getpid()),
 			},
 		},
 		{
@@ -87,7 +89,9 @@ func TestProdLogBarrierViolations(t *testing.T) {
 			name: "ignores pre-existing runtime file",
 			setup: func(t *testing.T, dir string) {
 				t.Helper()
-				runtimePath := filepath.Join(dir,
+				runtimeDir := filepath.Join(dir, "runtime")
+				require.NoError(t, os.MkdirAll(runtimeDir, 0o755))
+				runtimePath := filepath.Join(runtimeDir,
 					fmt.Sprintf("daemon.%d.json", os.Getpid()))
 				err := os.WriteFile(runtimePath, []byte("{}"), 0o644)
 				require.NoError(t, err, "failed to write initial runtime file")
@@ -97,14 +101,16 @@ func TestProdLogBarrierViolations(t *testing.T) {
 			name: "detects pre-existing runtime mutation",
 			setup: func(t *testing.T, dir string) {
 				t.Helper()
-				runtimePath := filepath.Join(dir,
+				runtimeDir := filepath.Join(dir, "runtime")
+				require.NoError(t, os.MkdirAll(runtimeDir, 0o755))
+				runtimePath := filepath.Join(runtimeDir,
 					fmt.Sprintf("daemon.%d.json", os.Getpid()))
 				err := os.WriteFile(runtimePath, []byte("{}"), 0o644)
 				require.NoError(t, err, "failed to write initial runtime file")
 			},
 			mutate: func(t *testing.T, dir string) {
 				t.Helper()
-				runtimePath := filepath.Join(dir,
+				runtimePath := filepath.Join(dir, "runtime",
 					fmt.Sprintf("daemon.%d.json", os.Getpid()))
 				err := os.WriteFile(runtimePath, []byte(`{"pid":999}`), 0o644)
 				require.NoError(t, err, "failed to modify runtime file")


### PR DESCRIPTION
## Summary
- replace roborev's custom daemon endpoint/runtime/start plumbing with go.kenn.io/kit daemon primitives
- drop legacy daemon runtime compatibility for addr/port/daemon.json and require kit-style ping responses
- keep roborev-specific server, worker, shutdown, and API behavior while delegating shared lifecycle concerns to the kit dependency

## Validation
- go fmt ./cmd/roborev ./internal/daemon
- go vet ./...
- go test ./...
- pre-commit golangci-lint hook