### PR TITLE
Make compact require actionable findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,6 +206,7 @@ Test conventions:
 - Commit after completing each piece of work; do not wait to be asked.
 - When committing, stage ALL modified files related to the work (including formatting-only and ancillary updates).
 - Before committing, run `git diff` and `git status` to verify nothing is unintentionally left unstaged.
+- When creating PRs, write a clean GitHub-facing summary with relevant context and links.
 - PR descriptions should not include standalone "Verification" or
   "Test Plan" sections unless the user explicitly asks for them. Keep PR
   bodies focused on summary, context, and behavior changes; rely on CI/status

--- a/cmd/roborev/compact.go
+++ b/cmd/roborev/compact.go
@@ -20,6 +20,7 @@ import (
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/daemon"
+	"go.kenn.io/roborev/internal/prompt"
 	"go.kenn.io/roborev/internal/review"
 	"go.kenn.io/roborev/internal/storage"
 )
@@ -216,9 +217,6 @@ func fetchJobBatch(ctx context.Context, ids []int64) (map[int64]storage.JobWithR
 // enqueueConsolidation creates and enqueues a consolidation job.
 // Returns the job ID for tracking.
 func enqueueConsolidation(ctx context.Context, cmd *cobra.Command, repoRoot string, jobReviews []jobReview, branchFilter string, opts compactOptions) (int64, error) {
-	// Build verification prompt
-	prompt := buildCompactPrompt(jobReviews, branchFilter, repoRoot)
-
 	// Resolve agent/model/reasoning using "fix" workflow so compact
 	// uses the same config as `roborev fix`.  Pass the resolved values
 	// to the daemon so it doesn't re-resolve under the "review" workflow.
@@ -236,6 +234,9 @@ func enqueueConsolidation(ctx context.Context, cmd *cobra.Command, repoRoot stri
 	agentName := config.ResolveAgentForWorkflow(
 		opts.agentName, repoRoot, cfg, "fix", reasoning,
 	)
+	// Build verification prompt after agent resolution so compact can reuse
+	// the selected agent's regular review output contract.
+	compactPrompt := buildCompactPrompt(jobReviews, branchFilter, repoRoot, agentName)
 	// Resolve model locally for display; the daemon re-resolves with
 	// its own canonical-agent comparison to skip generic default_model
 	// when the agent was overridden on CLI.
@@ -269,7 +270,7 @@ func enqueueConsolidation(ctx context.Context, cmd *cobra.Command, repoRoot stri
 	resolved.agentName = agentName
 	resolved.model = model
 	resolved.reasoning = reasoning
-	job, err := enqueueCompactJob(ctx, repoRoot, prompt, outputPrefix, label, branchFilter, resolved)
+	job, err := enqueueCompactJob(ctx, repoRoot, compactPrompt, outputPrefix, label, branchFilter, resolved)
 	if err != nil {
 		return 0, fmt.Errorf("enqueue verification job: %w", err)
 	}
@@ -461,8 +462,13 @@ func runCompact(cmd *cobra.Command, opts compactOptions) error {
 	return nil
 }
 
-func buildCompactPrompt(jobReviews []jobReview, branch, repoRoot string) string {
+func buildCompactPrompt(jobReviews []jobReview, branch, repoRoot, agentName string) string {
 	var sb strings.Builder
+
+	if reviewPrompt := strings.TrimSpace(prompt.GetSystemPrompt(agentName, "review")); reviewPrompt != "" {
+		sb.WriteString(reviewPrompt)
+		sb.WriteString("\n\n")
+	}
 
 	sb.WriteString("# Verification and Consolidation Request\n\n")
 	sb.WriteString("You are a code reviewer tasked with verifying and consolidating previous review findings.\n\n")
@@ -500,11 +506,10 @@ func buildCompactPrompt(jobReviews []jobReview, branch, repoRoot string) string 
 
 	sb.WriteString("## Expected Output\n\n")
 	sb.WriteString("Provide a consolidated review output containing only verified findings.\n")
-	sb.WriteString("Format it exactly like a code review, with:\n")
-	sb.WriteString("- Brief summary of findings\n")
-	sb.WriteString("- Each verified finding with severity, file/line, description\n")
-	sb.WriteString("- NO false positives or already-fixed issues\n\n")
-	sb.WriteString("If NO findings remain after verification, state \"All previous findings have been addressed.\"\n")
+	sb.WriteString("Use the same general structure as regular reviews so verdict parsing and downstream fix flows continue to work.\n")
+	sb.WriteString("Do not include false positives or already-fixed issues as findings.\n")
+	sb.WriteString("If any verified findings remain, repeat each remaining finding in the final review output; do not output only counts, totals, or a summary.\n")
+	sb.WriteString("If NO findings remain after verification, use the no-issues form from the regular review format.\n")
 
 	return sb.String()
 }

--- a/cmd/roborev/compact_test.go
+++ b/cmd/roborev/compact_test.go
@@ -34,6 +34,21 @@ func TestIsValidConsolidatedReview(t *testing.T) {
 			want:   true,
 		},
 		{
+			name: "invalid_remaining_count_without_findings",
+			output: `Verdict: Fail
+
+## Compact Analysis
+
+Verified and consolidated 6 open reviews from branch main
+
+Original jobs: 46, 45, 44, 41, 40, 38
+
+---
+
+Done. All 6 reviews have been verified against the current codebase: 4 previously-reported issues are fixed, 5 verified findings remain (1 high, 2 medium, 2 low).`,
+			want: false,
+		},
+		{
 			name:   "invalid_empty",
 			output: "",
 			want:   false,
@@ -253,6 +268,15 @@ func TestBuildCompactPrompt(t *testing.T) {
 				"Job 123",
 				"Finding 1: Issue in main.go",
 				"abc123d", // short SHA
+				"Do not include any front matter",
+				"Use the review output format above",
+				"Every verified finding that still applies must be repeated",
+				"Separate repeated findings with the same `---` delimiter",
+				"may mention how many prior findings were dropped",
+			},
+			wantNotContain: []string{
+				"If verified findings remain, format it exactly like this",
+				"     - **Severity**: High/Medium/Low",
 			},
 		},
 		{
@@ -287,7 +311,7 @@ func TestBuildCompactPrompt(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildCompactPrompt(tt.jobReviews, tt.branch, "")
+			got := buildCompactPrompt(tt.jobReviews, tt.branch, "", "codex")
 
 			for _, want := range tt.wantContains {
 				assert.Contains(t, got, want, "buildCompactPrompt() missing")

--- a/internal/daemon/compact.go
+++ b/internal/daemon/compact.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"slices"
 	"strings"
 
 	"go.kenn.io/roborev/internal/config"
@@ -74,5 +76,98 @@ func IsValidCompactOutput(output string) bool {
 		}
 	}
 
-	return true
+	return !reportsRemainingFindingsWithoutDetails(output)
+}
+
+var (
+	compactFileLinePattern        = regexp.MustCompile(`(?i)\b[\w./-]+\.(go|py|js|ts|tsx|jsx|java|rb|rs|c|cc|cpp|h|hpp|cs|php|swift|kt|m|mm|sql|yaml|yml|json|toml|md):\d+\b`)
+	compactPositiveRemainingCount = regexp.MustCompile(`\b[1-9]\d* (?:verified )?findings? remains?\b`)
+)
+
+func reportsRemainingFindingsWithoutDetails(output string) bool {
+	lower := strings.ToLower(output)
+	if reportsNoRemainingFindings(lower) {
+		return false
+	}
+	if !mentionsRemainingFindings(lower) {
+		return false
+	}
+	return !hasActionableCompactFinding(output, lower)
+}
+
+func reportsNoRemainingFindings(lower string) bool {
+	if compactPositiveRemainingCount.MatchString(lower) {
+		return false
+	}
+	return slices.ContainsFunc(compactNormalizedStatements(lower), isNoRemainingCompactStatement)
+}
+
+func compactNormalizedStatements(lower string) []string {
+	parts := strings.FieldsFunc(lower, func(r rune) bool {
+		switch r {
+		case '\n', '\r', '.', '!', '?', ',', ';', ':':
+			return true
+		default:
+			return false
+		}
+	})
+
+	statements := make([]string, 0, len(parts))
+	for _, part := range parts {
+		statement := strings.Trim(part, "-*_`> \t")
+		statement = strings.Join(strings.Fields(statement), " ")
+		if statement != "" {
+			statements = append(statements, statement)
+		}
+	}
+	return statements
+}
+
+func isNoRemainingCompactStatement(statement string) bool {
+	switch statement {
+	case "all previous findings have been addressed",
+		"all findings have been resolved",
+		"no issues found",
+		"no verified findings remain",
+		"no findings remain",
+		"no remaining findings",
+		"0 findings",
+		"0 findings remain",
+		"0 verified findings",
+		"0 verified findings remain",
+		"zero findings",
+		"zero findings remain",
+		"zero verified findings",
+		"zero verified findings remain":
+		return true
+	default:
+		return false
+	}
+}
+
+func mentionsRemainingFindings(lower string) bool {
+	remainingPhrases := []string{
+		"findings remain",
+		"finding remains",
+		"verified findings",
+		"verified finding",
+		"verdict: fail",
+	}
+	for _, phrase := range remainingPhrases {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasActionableCompactFinding(output, lower string) bool {
+	if compactFileLinePattern.MatchString(output) {
+		return true
+	}
+
+	return strings.Contains(lower, "**severity**:") &&
+		(strings.Contains(lower, "**location**:") ||
+			strings.Contains(lower, "**problem**:") ||
+			strings.Contains(lower, "**fix**:"))
 }

--- a/internal/daemon/compact.go
+++ b/internal/daemon/compact.go
@@ -82,6 +82,8 @@ func IsValidCompactOutput(output string) bool {
 var (
 	compactFileLinePattern        = regexp.MustCompile(`(?i)\b[\w./-]+\.(go|py|js|ts|tsx|jsx|java|rb|rs|c|cc|cpp|h|hpp|cs|php|swift|kt|m|mm|sql|yaml|yml|json|toml|md):\d+\b`)
 	compactPositiveRemainingCount = regexp.MustCompile(`\b[1-9]\d* (?:verified )?findings? remains?\b`)
+	compactFindingHeadingPattern  = regexp.MustCompile(`(?im)^#{1,6}\s*(review findings|verified findings|findings)\b`)
+	compactSeverityHeadingPattern = regexp.MustCompile(`(?im)^#{1,6}\s*(?:\*\*)?\s*(critical|high|medium|low)\b`)
 )
 
 func reportsRemainingFindingsWithoutDetails(output string) bool {
@@ -162,12 +164,21 @@ func mentionsRemainingFindings(lower string) bool {
 }
 
 func hasActionableCompactFinding(output, lower string) bool {
-	if compactFileLinePattern.MatchString(output) {
+	if hasStructuredCompactFinding(lower) {
 		return true
 	}
 
-	return strings.Contains(lower, "**severity**:") &&
-		(strings.Contains(lower, "**location**:") ||
-			strings.Contains(lower, "**problem**:") ||
-			strings.Contains(lower, "**fix**:"))
+	return compactFindingHeadingPattern.MatchString(output) &&
+		compactSeverityHeadingPattern.MatchString(output) &&
+		compactFileLinePattern.MatchString(output)
+}
+
+func hasStructuredCompactFinding(lower string) bool {
+	hasSeverity := strings.Contains(lower, "**severity**:")
+	hasLocation := strings.Contains(lower, "**location**:") ||
+		strings.Contains(lower, "**files**:")
+	hasDetails := strings.Contains(lower, "**problem**:") ||
+		strings.Contains(lower, "**issue**:") ||
+		strings.Contains(lower, "**fix**:")
+	return hasSeverity && hasLocation && hasDetails
 }

--- a/internal/daemon/compact_test.go
+++ b/internal/daemon/compact_test.go
@@ -120,6 +120,63 @@ func TestIsValidCompactOutput(t *testing.T) {
 		want  bool
 	}{
 		{"real_review", "No issues found.", true},
+		{"no_verified_findings_remain", "No verified findings remain.", true},
+		{"zero_findings", "0 findings.", true},
+		{"zero_findings_remain", "0 findings remain.", true},
+		{"zero_word_findings", "zero findings.", true},
+		{"zero_word_findings_remain", "zero findings remain.", true},
+		{"no_issues_with_dropped_verified_findings_summary", "No issues found.\nSummary: Dropped 4 previously reported verified findings because they no longer reproduce.", true},
+		{
+			"remaining_count_without_findings",
+			`Verdict: Fail
+
+## Compact Analysis
+
+Verified and consolidated 6 open reviews from branch main
+
+Original jobs: 46, 45, 44, 41, 40, 38
+
+---
+
+Done. All 6 reviews have been verified against the current codebase: 4 previously-reported issues are fixed, 5 verified findings remain (1 high, 2 medium, 2 low).`,
+			false,
+		},
+		{
+			"review_findings_with_actionable_entry",
+			`## Review Findings
+
+- **Severity**: High
+- **Location**: cmd/roborev/compact.go:42
+- **Problem**: Source jobs can be closed after a count-only compact result.
+- **Fix**: Reject compact output that says findings remain without listing them.`,
+			true,
+		},
+		{
+			"review_findings_header_with_remaining_count_only",
+			`Verdict: Fail
+
+## Review Findings
+
+5 verified findings remain.`,
+			false,
+		},
+		{
+			"ten_verified_findings_without_details",
+			`Verdict: Fail
+
+10 verified findings remain.`,
+			false,
+		},
+		{
+			"negated_resolved_phrase_with_remaining_count",
+			"Not all findings have been resolved: 5 verified findings remain.",
+			false,
+		},
+		{
+			"dropped_zero_summary_with_remaining_count",
+			"0 verified findings were dropped; 5 verified findings remain.",
+			false,
+		},
 		{"empty", "", false},
 		{"whitespace", "   \n  ", false},
 		{"error_prefix", "Error: something broke", false},

--- a/internal/daemon/compact_test.go
+++ b/internal/daemon/compact_test.go
@@ -177,6 +177,24 @@ Done. All 6 reviews have been verified against the current codebase: 4 previousl
 			"0 verified findings were dropped; 5 verified findings remain.",
 			false,
 		},
+		{
+			"remaining_count_with_file_line_without_findings",
+			"5 verified findings remain: cmd/foo.go:42",
+			false,
+		},
+		{
+			"review_findings_with_explicit_block",
+			`Verdict: Fail
+
+## Verified Findings
+
+### **Medium Severity**
+
+#### 1. State leak
+**Files:** cmd/roborev/compact.go:42
+**Issue:** The compact job closes source jobs before preserving actionable findings.`,
+			true,
+		},
 		{"empty", "", false},
 		{"whitespace", "   \n  ", false},
 		{"error_prefix", "Error: something broke", false},

--- a/internal/daemon/compact_test.go
+++ b/internal/daemon/compact_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/storage"
 )
 
 func setupTestEnv(t *testing.T) string {
@@ -205,6 +207,32 @@ Done. All 6 reviews have been verified against the current codebase: 4 previousl
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, IsValidCompactOutput(tt.input), "IsValidCompactOutput result mismatch")
+		})
+	}
+}
+
+func TestCleanCompactOutputsParseAsPassVerdicts(t *testing.T) {
+	outputs := []string{
+		"All previous findings have been addressed.",
+		"All findings have been resolved.",
+		"No issues found.",
+		"No verified findings remain.",
+		"No findings remain.",
+		"No remaining findings.",
+		"0 findings.",
+		"0 findings remain.",
+		"0 verified findings.",
+		"0 verified findings remain.",
+		"zero findings.",
+		"zero findings remain.",
+		"zero verified findings.",
+		"zero verified findings remain.",
+	}
+
+	for _, output := range outputs {
+		t.Run(output, func(t *testing.T) {
+			require.True(t, IsValidCompactOutput(output))
+			assert.Equal(t, "P", storage.ParseVerdict(output))
 		})
 	}
 }

--- a/internal/review/synthesis.go
+++ b/internal/review/synthesis.go
@@ -16,11 +16,11 @@ var severityAbove = map[string]string{
 	"medium":   "Only include Medium, High, and Critical findings.",
 }
 
-// VerifyDedupePreamble returns the static instruction block shared by the CLI
-// compact command and the panel synthesis worker: verify each finding against
-// the current codebase, consolidate duplicates, and emit only verified
-// findings. The text is byte-preserved so both call sites emit identical
-// instructions.
+// VerifyDedupePreamble returns the instruction block used by the compact
+// command's consolidation prompt: verify each finding against the current
+// codebase, consolidate duplicates, and re-emit every still-valid finding
+// using the regular review output format so downstream verdict parsing and
+// fix flows keep working.
 func VerifyDedupePreamble() string {
 	return "## Instructions\n\n" +
 		"1. **Verify each finding against the current codebase:**\n" +
@@ -32,10 +32,11 @@ func VerifyDedupePreamble() string {
 		"   - Merge duplicate findings from different reviews\n" +
 		"   - Provide a single comprehensive description for each group\n\n" +
 		"3. **Output format:**\n" +
-		"   - List only VERIFIED findings in your output\n" +
-		"   - Use the same severity levels (Critical, High, Medium, Low)\n" +
-		"   - Include file and line references where possible\n" +
-		"   - Explain what the issue is and why it matters\n\n"
+		"   - Use the review output format above, including verdict-compatible finding structure\n" +
+		"   - Every verified finding that still applies must be repeated in the compact output\n" +
+		"   - Separate repeated findings with the same `---` delimiter used by regular reviews\n" +
+		"   - Counts, totals, and summaries may accompany repeated findings, but must not replace them\n" +
+		"   - The summary may mention how many prior findings were dropped as fixed, duplicates, or false positives\n\n"
 }
 
 // BuildSynthesisPrompt creates the prompt for the synthesis agent.

--- a/internal/storage/db_job_test.go
+++ b/internal/storage/db_job_test.go
@@ -163,6 +163,31 @@ func TestReviewVerdictComputation(t *testing.T) {
 		assert.Equal(t, "P", *review.Job.Verdict)
 	})
 
+	t.Run("compact no remaining output stores pass verdict", func(t *testing.T) {
+		env := setupJobEnv(t, "/tmp/test-repo", "verdict-compact-clean")
+		_, err := env.db.ClaimJob("worker-1")
+		require.NoError(t, err)
+		require.NoError(t, env.db.CompleteJob(
+			env.job.ID, "codex", "the prompt",
+			"## Compact Analysis\n\n---\n\n0 findings remain.",
+		))
+
+		review, err := env.db.GetReviewByJobID(env.job.ID)
+		require.NoError(t, err, "GetReviewByJobID failed")
+
+		assert.NotNil(t, review.Job.Verdict)
+		assert.Equal(t, "P", *review.Job.Verdict)
+
+		var vb sql.NullInt64
+		err = env.db.QueryRow(
+			`SELECT verdict_bool FROM reviews WHERE job_id = ?`,
+			env.job.ID,
+		).Scan(&vb)
+		require.NoError(t, err)
+		assert.True(t, vb.Valid, "verdict_bool should be set")
+		assert.Equal(t, int64(1), vb.Int64)
+	})
+
 	t.Run("verdict nil when output is empty", func(t *testing.T) {
 		env := setupJobEnv(t, "/tmp/test-repo", "verdict-empty")
 		_, err := env.db.ClaimJob("worker-1")

--- a/internal/storage/db_job_test.go
+++ b/internal/storage/db_job_test.go
@@ -169,7 +169,7 @@ func TestReviewVerdictComputation(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, env.db.CompleteJob(
 			env.job.ID, "codex", "the prompt",
-			"## Compact Analysis\n\n---\n\n0 findings remain.",
+			"## Compact Analysis\n\n---\n\nNo remaining findings.",
 		))
 
 		review, err := env.db.GetReviewByJobID(env.job.ID)

--- a/internal/storage/verdict.go
+++ b/internal/storage/verdict.go
@@ -122,6 +122,8 @@ func isNoFindingVerdictLine(line string) bool {
 	case "all previous findings have been addressed",
 		"all findings have been resolved",
 		"no verified findings remain",
+		"no findings remain",
+		"no remaining findings",
 		"0 findings",
 		"0 findings remain",
 		"0 verified findings",

--- a/internal/storage/verdict.go
+++ b/internal/storage/verdict.go
@@ -78,6 +78,9 @@ func ParseVerdict(output string) string {
 		if isExplicitVerdictValue(normalized, "pass") {
 			return verdictPass
 		}
+		if isNoFindingVerdictLine(normalized) {
+			return verdictPass
+		}
 		if !hasPassPrefix(normalized) {
 			continue
 		}
@@ -110,6 +113,27 @@ func hasPassPrefix(line string) bool {
 		}
 	}
 	return false
+}
+
+func isNoFindingVerdictLine(line string) bool {
+	line = strings.TrimRight(line, ".!?")
+	line = strings.Join(strings.Fields(line), " ")
+	switch line {
+	case "all previous findings have been addressed",
+		"all findings have been resolved",
+		"no verified findings remain",
+		"0 findings",
+		"0 findings remain",
+		"0 verified findings",
+		"0 verified findings remain",
+		"zero findings",
+		"zero findings remain",
+		"zero verified findings",
+		"zero verified findings remain":
+		return true
+	default:
+		return false
+	}
 }
 
 func isExplicitVerdictValue(line, value string) bool {

--- a/internal/storage/verdict_test.go
+++ b/internal/storage/verdict_test.go
@@ -72,6 +72,41 @@ var verdictTests = []verdictTestCase{
 		want:   VerdictPass,
 	},
 	{
+		name:   "SimplePass/compact no verified findings remain",
+		output: "No verified findings remain.",
+		want:   VerdictPass,
+	},
+	{
+		name:   "SimplePass/compact zero findings",
+		output: "0 findings.",
+		want:   VerdictPass,
+	},
+	{
+		name:   "SimplePass/compact zero findings remain",
+		output: "0 findings remain.",
+		want:   VerdictPass,
+	},
+	{
+		name:   "SimplePass/compact zero word findings",
+		output: "zero findings.",
+		want:   VerdictPass,
+	},
+	{
+		name:   "SimplePass/compact zero word findings remain",
+		output: "zero findings remain.",
+		want:   VerdictPass,
+	},
+	{
+		name:   "SimplePass/compact all previous findings addressed",
+		output: "All previous findings have been addressed.",
+		want:   VerdictPass,
+	},
+	{
+		name:   "SimplePass/compact all findings resolved",
+		output: "All findings have been resolved.",
+		want:   VerdictPass,
+	},
+	{
 		name:   "SimplePass/bullet no issues found",
 		output: "- No issues found.",
 		want:   VerdictPass,

--- a/internal/storage/verdict_test.go
+++ b/internal/storage/verdict_test.go
@@ -77,6 +77,11 @@ var verdictTests = []verdictTestCase{
 		want:   VerdictPass,
 	},
 	{
+		name:   "SimplePass/compact no remaining findings",
+		output: "No remaining findings.",
+		want:   VerdictPass,
+	},
+	{
 		name:   "SimplePass/compact zero findings",
 		output: "0 findings.",
 		want:   VerdictPass,


### PR DESCRIPTION
## Summary
- Reuse the selected agent’s regular review output instructions for compact jobs so compacted reviews stay compatible with verdict parsing and downstream fix flows.
- Make compact-specific instructions explicit that every verified remaining finding must be repeated, with regular `---` separators between findings.
- Reject compact outputs that report remaining findings only as counts or summaries, while allowing summaries to mention dropped prior findings.

Fixes #763