### PR TITLE
Add build-time update disable flag

### DIFF
--- a/cmd/roborev/main_test.go
+++ b/cmd/roborev/main_test.go
@@ -27,6 +27,7 @@ import (
 	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/update"
 	"go.kenn.io/roborev/internal/version"
 )
 
@@ -679,6 +680,23 @@ func TestFilterGitEnv(t *testing.T) {
 	for i, got := range filtered {
 		assert.Equal(t, got, want[i])
 	}
+}
+
+func TestUpdateCmdDisabledBuildPrintsPackageManagerGuidance(t *testing.T) {
+	origDisabled := update.Disabled
+	update.Disabled = "true"
+	t.Cleanup(func() {
+		update.Disabled = origDisabled
+	})
+
+	cmd := updateCmd()
+	output := captureStdout(t, func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	assert.Contains(t, output, "disabled in this build")
+	assert.Contains(t, output, "package manager")
+	assert.NotContains(t, output, "Checking for updates")
 }
 
 func TestIsGoTestBinaryPath(t *testing.T) {

--- a/cmd/roborev/update.go
+++ b/cmd/roborev/update.go
@@ -363,6 +363,11 @@ official release over a dev build.
 Use --no-restart when daemon lifecycle is managed externally (for example,
 launchd or systemd).`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if update.IsDisabled() {
+				fmt.Println(update.DisabledMessage)
+				return nil
+			}
+
 			fmt.Println("Checking for updates...")
 
 			info, err := update.CheckForUpdate(true) // Force check, ignore cache

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -36,6 +37,22 @@ var (
 	checksumPattern    = regexp.MustCompile(`(?i)[a-f0-9]{64}`)
 	semverBasePattern  = regexp.MustCompile(`^\d+(?:\.\d+)+`)
 )
+
+// Disabled is a build-time string set with -ldflags -X to disable self-updates.
+var Disabled = "false"
+
+// DisabledMessage explains why the self-updater is unavailable in this build.
+const DisabledMessage = "roborev update is disabled in this build; use your package manager to update roborev"
+
+// IsDisabled reports whether self-update behavior is disabled for this build.
+func IsDisabled() bool {
+	switch strings.ToLower(strings.TrimSpace(Disabled)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
 
 // UpdateInfo contains information about an available update
 type UpdateInfo struct {
@@ -156,6 +173,10 @@ func defaultUpdater() *Updater {
 
 // CheckForUpdate checks if a newer version is available.
 func (u *Updater) CheckForUpdate(forceCheck bool) (*UpdateInfo, error) {
+	if IsDisabled() {
+		return nil, nil
+	}
+
 	build := u.currentBuild()
 
 	// Don't nag on dev builds. Explicit `roborev update` still works.
@@ -174,6 +195,10 @@ func (u *Updater) CheckForUpdate(forceCheck bool) (*UpdateInfo, error) {
 
 // PerformUpdate downloads and installs the update.
 func (u *Updater) PerformUpdate(info *UpdateInfo, reporter Reporter) error {
+	if IsDisabled() {
+		return errors.New(DisabledMessage)
+	}
+
 	reporter = normalizeReporter(reporter)
 
 	if info.Checksum == "" {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -48,6 +48,78 @@ func (r *testReporter) Progress(downloaded, total int64) {
 	r.progress = append(r.progress, downloaded, total)
 }
 
+func TestIsDisabled(t *testing.T) {
+	origDisabled := Disabled
+	t.Cleanup(func() {
+		Disabled = origDisabled
+	})
+
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{value: "", want: false},
+		{value: "false", want: false},
+		{value: "true", want: true},
+		{value: "TRUE", want: true},
+		{value: "1", want: true},
+		{value: "yes", want: true},
+		{value: "on", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			Disabled = tt.value
+			assert.Equal(t, tt.want, IsDisabled())
+		})
+	}
+}
+
+func TestCheckForUpdateDisabledSkipsReleaseFetch(t *testing.T) {
+	origDisabled := Disabled
+	Disabled = "true"
+	t.Cleanup(func() {
+		Disabled = origDisabled
+	})
+
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("release fetch should be skipped")
+	})}
+	updater := NewUpdater(Deps{
+		Client:   client,
+		Version:  "v1.2.3",
+		CacheDir: t.TempDir,
+	})
+
+	info, err := updater.CheckForUpdate(true)
+
+	require.NoError(t, err)
+	assert.Nil(t, info)
+}
+
+func TestPerformUpdateDisabledReturnsError(t *testing.T) {
+	origDisabled := Disabled
+	Disabled = "true"
+	t.Cleanup(func() {
+		Disabled = origDisabled
+	})
+
+	updater := NewUpdater(Deps{
+		MkdirTemp: func(string, string) (string, error) {
+			return "", fmt.Errorf("temp dir should not be created")
+		},
+	})
+
+	err := updater.PerformUpdate(&UpdateInfo{
+		AssetName: "roborev.tar.gz",
+		Checksum:  strings.Repeat("a", 64),
+	}, &testReporter{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disabled in this build")
+	assert.Contains(t, err.Error(), "package manager")
+}
+
 func TestSanitizeTarPath(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- add an ldflags-controlled update.Disabled switch for package-managed builds
- make update checks return no result when self-update is disabled, suppressing TUI update prompts
- make roborev update print package-manager guidance instead of checking or installing

## Verification
- go test ./...
- go vet ./...
- golangci-lint@v2.10.1 run ./...
- go build -ldflags "-X go.kenn.io/roborev/internal/update.Disabled=true" -o /tmp/roborev-disable-update ./cmd/roborev
- /tmp/roborev-disable-update update

Refs #610