### PR TITLE
Add daemon repo resolve endpoint

### DIFF
--- a/internal/daemon/routes.go
+++ b/internal/daemon/routes.go
@@ -60,6 +60,13 @@ func (s *Server) registerHumaAPI(mux *http.ServeMux) huma.API {
 			o.Tags = []string{"repos"}
 		})
 
+	huma.Get(api, "/api/repos/resolve", s.humaResolveRepo,
+		func(o *huma.Operation) {
+			o.OperationID = "resolve-repo"
+			o.Summary = "Resolve whether a path belongs to a tracked repo"
+			o.Tags = []string{"repos"}
+		})
+
 	huma.Get(api, "/api/branches", s.humaListBranches,
 		func(o *huma.Operation) {
 			o.OperationID = "list-branches"

--- a/internal/daemon/routes_test.go
+++ b/internal/daemon/routes_test.go
@@ -293,6 +293,7 @@ func TestHumaOpenAPISpec(t *testing.T) {
 		"/api/review":            "get",
 		"/api/comments":          "get",
 		"/api/repos":             "get",
+		"/api/repos/resolve":     "get",
 		"/api/branches":          "get",
 		"/api/status":            "get",
 		"/api/summary":           "get",

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -1128,6 +1128,39 @@ func (s *Server) humaListRepos(
 	return resp, nil
 }
 
+func (s *Server) humaResolveRepo(
+	ctx context.Context, input *ResolveRepoInput,
+) (*ResolveRepoOutput, error) {
+	path := strings.TrimSpace(input.Path)
+	if path == "" {
+		return nil, huma.Error400BadRequest("path is required")
+	}
+
+	lookupPath := path
+	if repoRoot, err := gitrepo.MainRoot(ctx, path); err == nil {
+		lookupPath = repoRoot
+	}
+
+	repo, err := s.db.GetRepoByPath(lookupPath)
+	if errors.Is(err, sql.ErrNoRows) {
+		return &ResolveRepoOutput{}, nil
+	}
+	if err != nil {
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("lookup repo: %v", err),
+		)
+	}
+
+	resp := &ResolveRepoOutput{}
+	resp.Body.Tracked = true
+	resp.Body.Repo = &ResolvedRepo{
+		RootPath: repo.RootPath,
+		Identity: repo.Identity,
+		Name:     repo.Name,
+	}
+	return resp, nil
+}
+
 func (s *Server) humaListBranches(
 	ctx context.Context, input *ListBranchesInput,
 ) (*ListBranchesOutput, error) {

--- a/internal/daemon/server_repos_test.go
+++ b/internal/daemon/server_repos_test.go
@@ -58,7 +58,7 @@ func TestHandleResolveRepo(t *testing.T) {
 	})
 
 	t.Run("path inside tracked repo resolves to root", func(t *testing.T) {
-		nestedPath := filepath.Join(repo.Root, "src", "pkg")
+		nestedPath := filepath.Join(stored.RootPath, "src", "pkg")
 		require.NoError(t, os.MkdirAll(nestedPath, 0o755))
 		req := httptest.NewRequest(
 			http.MethodGet,

--- a/internal/daemon/server_repos_test.go
+++ b/internal/daemon/server_repos_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -15,6 +16,103 @@ import (
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testutil"
 )
+
+func TestHandleResolveRepo(t *testing.T) {
+	server, db, _ := newTestServer(t)
+	repo := testutil.NewTestRepo(t)
+	identity := "https://github.com/test/resolve-repo.git"
+	stored, err := db.GetOrCreateRepo(repo.Root, identity)
+	require.NoError(t, err)
+
+	t.Run("tracked repo returns repo metadata", func(t *testing.T) {
+		req := httptest.NewRequest(
+			http.MethodGet,
+			"/api/repos/resolve?path="+url.QueryEscape(repo.Root),
+			nil,
+		)
+		w := httptest.NewRecorder()
+
+		server.httpServer.Handler.ServeHTTP(w, req)
+
+		testutil.AssertStatusCode(t, w, http.StatusOK)
+
+		var response struct {
+			Tracked bool `json:"tracked"`
+			Repo    *struct {
+				RootPath string `json:"root_path"`
+				Identity string `json:"identity"`
+				Name     string `json:"name"`
+			} `json:"repo,omitempty"`
+		}
+		testutil.DecodeJSON(t, w, &response)
+
+		require.True(t, response.Tracked)
+		require.NotNil(t, response.Repo)
+		assert.Equal(t, stored.RootPath, response.Repo.RootPath)
+		assert.Equal(t, identity, response.Repo.Identity)
+		assert.Equal(t, stored.Name, response.Repo.Name)
+	})
+
+	t.Run("path inside tracked repo resolves to root", func(t *testing.T) {
+		nestedPath := filepath.Join(repo.Root, "src", "pkg")
+		require.NoError(t, os.MkdirAll(nestedPath, 0o755))
+		req := httptest.NewRequest(
+			http.MethodGet,
+			"/api/repos/resolve?path="+url.QueryEscape(nestedPath),
+			nil,
+		)
+		w := httptest.NewRecorder()
+
+		server.httpServer.Handler.ServeHTTP(w, req)
+
+		testutil.AssertStatusCode(t, w, http.StatusOK)
+
+		var response struct {
+			Tracked bool `json:"tracked"`
+			Repo    *struct {
+				RootPath string `json:"root_path"`
+			} `json:"repo,omitempty"`
+		}
+		testutil.DecodeJSON(t, w, &response)
+
+		require.True(t, response.Tracked)
+		require.NotNil(t, response.Repo)
+		assert.Equal(t, stored.RootPath, response.Repo.RootPath)
+	})
+
+	t.Run("unknown repo returns untracked", func(t *testing.T) {
+		unknownPath := filepath.Join(t.TempDir(), "unknown-repo")
+		req := httptest.NewRequest(
+			http.MethodGet,
+			"/api/repos/resolve?path="+url.QueryEscape(unknownPath),
+			nil,
+		)
+		w := httptest.NewRecorder()
+
+		server.httpServer.Handler.ServeHTTP(w, req)
+
+		testutil.AssertStatusCode(t, w, http.StatusOK)
+
+		var response struct {
+			Tracked bool `json:"tracked"`
+			Repo    any  `json:"repo,omitempty"`
+		}
+		testutil.DecodeJSON(t, w, &response)
+
+		assert.False(t, response.Tracked)
+		assert.Nil(t, response.Repo)
+	})
+
+	t.Run("missing path returns client error", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/repos/resolve", nil)
+		w := httptest.NewRecorder()
+
+		server.httpServer.Handler.ServeHTTP(w, req)
+
+		testutil.AssertStatusCode(t, w, http.StatusBadRequest)
+		assert.Contains(t, w.Body.String(), "path is required")
+	})
+}
 
 func TestHandleListRepos(t *testing.T) {
 	server, db, tmpDir := newTestServer(t)

--- a/internal/daemon/server_repos_test.go
+++ b/internal/daemon/server_repos_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	gitrepo "go.kenn.io/kit/git/repo"
 
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testutil"
@@ -21,7 +23,9 @@ func TestHandleResolveRepo(t *testing.T) {
 	server, db, _ := newTestServer(t)
 	repo := testutil.NewTestRepo(t)
 	identity := "https://github.com/test/resolve-repo.git"
-	stored, err := db.GetOrCreateRepo(repo.Root, identity)
+	registeredRoot, err := gitrepo.MainRoot(context.Background(), repo.Root)
+	require.NoError(t, err)
+	stored, err := db.GetOrCreateRepo(registeredRoot, identity)
 	require.NoError(t, err)
 
 	t.Run("tracked repo returns repo metadata", func(t *testing.T) {

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -230,6 +230,28 @@ type ListReposOutput struct {
 	}
 }
 
+// -- GET /api/repos/resolve --
+
+// ResolveRepoInput holds query parameters for resolving a tracked repo.
+type ResolveRepoInput struct {
+	Path string `query:"path" doc:"Absolute path or path inside a repository"`
+}
+
+// ResolvedRepo is the tracked repo metadata returned by GET /api/repos/resolve.
+type ResolvedRepo struct {
+	RootPath string `json:"root_path"`
+	Identity string `json:"identity"`
+	Name     string `json:"name"`
+}
+
+// ResolveRepoOutput is the response for GET /api/repos/resolve.
+type ResolveRepoOutput struct {
+	Body struct {
+		Tracked bool          `json:"tracked"`
+		Repo    *ResolvedRepo `json:"repo,omitempty"`
+	}
+}
+
 // -- GET /api/branches --
 
 // ListBranchesInput holds query parameters for listing branches.

--- a/internal/storage/repos.go
+++ b/internal/storage/repos.go
@@ -141,11 +141,13 @@ func (db *DB) GetRepoByPath(rootPath string) (*Repo, error) {
 
 	var repo Repo
 	var createdAt string
-	err = db.QueryRow(`SELECT id, root_path, name, created_at FROM repos WHERE root_path = ?`, absPath).
-		Scan(&repo.ID, &repo.RootPath, &repo.Name, &createdAt)
+	var identityNullable sql.NullString
+	err = db.QueryRow(`SELECT id, root_path, name, identity, created_at FROM repos WHERE root_path = ?`, absPath).
+		Scan(&repo.ID, &repo.RootPath, &repo.Name, &identityNullable, &createdAt)
 	if err != nil {
 		return nil, err
 	}
+	repo.Identity = identityNullable.String
 	repo.CreatedAt = parseSQLiteTime(createdAt)
 	return &repo, nil
 }


### PR DESCRIPTION
Adds a read-only daemon endpoint for clients to resolve whether a path belongs to a tracked roborev repository.

Summary:
- register GET /api/repos/resolve in the daemon API
- return tracked repo metadata without enqueueing work or mutating repo state
- return HTTP 200 with tracked=false for unknown repos and 400 for malformed input
- include endpoint coverage for tracked, nested, unknown, and missing-path requests
- align the resolve endpoint fixture with the daemon's Git-root registration path so macOS/Windows CI does not depend on temp path spelling

Verification:
- env GOPATH=/tmp/roborev-go-path GOCACHE=/tmp/roborev-go-cache go test -race -count=1 ./internal/daemon -run 'TestHandleResolveRepo' -v
- env GOPATH=/tmp/roborev-go-path GOCACHE=/tmp/roborev-go-cache go test -count=1 ./internal/daemon ./internal/storage
- env GOPATH=/tmp/roborev-go-path GOCACHE=/tmp/roborev-go-cache go vet ./internal/daemon ./internal/storage