### PR TITLE
Route cost lookup through configurable usage endpoint

### DIFF
--- a/cmd/roborev/backfill_tokens.go
+++ b/cmd/roborev/backfill_tokens.go
@@ -69,17 +69,18 @@ will be skipped.`,
 					skipped++
 					continue
 				}
+				mergedUsage := mergeBackfillTokenUsage(job.TokenUsage, usage)
 
 				if dryRun {
 					fmt.Printf(
 						"job %d (%s): %s\n",
-						job.ID, job.Agent, usage.FormatSummary(),
+						job.ID, job.Agent, mergedUsage.FormatSummary(),
 					)
 					updated++
 					continue
 				}
 
-				j := tokens.ToJSON(usage)
+				j := tokens.ToJSON(mergedUsage)
 				if err := db.SaveJobTokenUsage(job.ID, j); err != nil {
 					log.Printf(
 						"job %d: save error: %v", job.ID, err,
@@ -90,7 +91,7 @@ will be skipped.`,
 				updated++
 				fmt.Printf(
 					"job %d (%s): %s\n",
-					job.ID, job.Agent, usage.FormatSummary(),
+					job.ID, job.Agent, mergedUsage.FormatSummary(),
 				)
 			}
 
@@ -157,6 +158,27 @@ func backfillCandidates(
 		out = append(out, job)
 	}
 	return out
+}
+
+func mergeBackfillTokenUsage(existingJSON string, fetched *tokens.Usage) *tokens.Usage {
+	if fetched == nil {
+		return tokens.ParseJSON(existingJSON)
+	}
+	merged := *fetched
+	existing := tokens.ParseJSON(existingJSON)
+	if existing == nil {
+		return &merged
+	}
+
+	if merged.OutputTokens == 0 && merged.PeakContextTokens == 0 {
+		merged.OutputTokens = existing.OutputTokens
+		merged.PeakContextTokens = existing.PeakContextTokens
+	}
+	if !merged.HasCost && existing.HasCost {
+		merged.CostUSD = existing.CostUSD
+		merged.HasCost = true
+	}
+	return &merged
 }
 
 func needsTokenCostBackfill(tokenUsage string) bool {

--- a/cmd/roborev/backfill_tokens.go
+++ b/cmd/roborev/backfill_tokens.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/tokens"
 )
@@ -24,6 +25,12 @@ and attempt to fetch token consumption from agentsview.
 This is best-effort: jobs whose session files have been deleted
 will be skipped.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.LoadGlobal()
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
+			fetchConfig := backfillCostFetchConfig(cfg)
+
 			db, err := storage.Open(storage.DefaultDBPath())
 			if err != nil {
 				return fmt.Errorf("open database: %w", err)
@@ -46,8 +53,8 @@ will be skipped.`,
 				ctx, cancel := context.WithTimeout(
 					context.Background(), 15*time.Second,
 				)
-				usage, fetchErr := tokens.FetchForSession(
-					ctx, job.SessionID,
+				usage, fetchErr := tokens.FetchForSessionWithConfig(
+					ctx, job.SessionID, fetchConfig,
 				)
 				cancel()
 
@@ -104,6 +111,16 @@ will be skipped.`,
 		"show what would be updated without writing",
 	)
 	return cmd
+}
+
+func backfillCostFetchConfig(cfg *config.Config) tokens.FetchConfig {
+	if cfg == nil {
+		cfg = config.DefaultConfig()
+	}
+	return tokens.FetchConfig{
+		Endpoint: cfg.Cost.Endpoint,
+		Timeout:  cfg.Cost.ResolvedTimeout(),
+	}
 }
 
 // backfillCandidates filters jobs to those eligible for token

--- a/cmd/roborev/backfill_tokens_test.go
+++ b/cmd/roborev/backfill_tokens_test.go
@@ -8,6 +8,7 @@ import (
 
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/tokens"
 )
 
 func TestBackfillCandidates(t *testing.T) {
@@ -193,4 +194,16 @@ func TestBackfillCostFetchConfig(t *testing.T) {
 
 	assert.Equal(t, "https://usage.example.test/api/v1/sessions/{session_id}/usage", got.Endpoint)
 	assert.Equal(t, 250*time.Millisecond, got.Timeout)
+}
+
+func TestMergeBackfillTokenUsagePreservesExistingCountsForCostOnlyFetch(t *testing.T) {
+	existing := `{"total_output_tokens":28800,"peak_context_tokens":118000}`
+	fetched := &tokens.Usage{CostUSD: 0.42, HasCost: true}
+
+	got := mergeBackfillTokenUsage(existing, fetched)
+
+	assert.Equal(t, int64(28800), got.OutputTokens)
+	assert.Equal(t, int64(118000), got.PeakContextTokens)
+	assert.True(t, got.HasCost)
+	assert.InDelta(t, 0.42, got.CostUSD, 1e-9)
 }

--- a/cmd/roborev/backfill_tokens_test.go
+++ b/cmd/roborev/backfill_tokens_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -181,4 +182,15 @@ func TestBackfillCandidates(t *testing.T) {
 			assert.Equal(t, tt.wantIDs, gotIDs)
 		})
 	}
+}
+
+func TestBackfillCostFetchConfig(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Cost.Endpoint = "https://usage.example.test/api/v1/sessions/{session_id}/usage"
+	cfg.Cost.Timeout = "250ms"
+
+	got := backfillCostFetchConfig(cfg)
+
+	assert.Equal(t, "https://usage.example.test/api/v1/sessions/{session_id}/usage", got.Endpoint)
+	assert.Equal(t, 250*time.Millisecond, got.Timeout)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	tomlv2 "github.com/pelletier/go-toml/v2"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,24 @@ type AgentConfig struct {
 	Pi    PiConfig    `toml:"pi"`
 }
 
+type CostConfig struct {
+	Endpoint string `toml:"endpoint" comment:"HTTP usage endpoint template for cost/token lookup. Use {session_id}; set empty to use agentsview CLI lookup only."`
+	Timeout  string `toml:"timeout" comment:"Timeout for HTTP usage endpoint lookups."`
+}
+
+// ResolvedTimeout returns the HTTP usage lookup timeout.
+func (c CostConfig) ResolvedTimeout() time.Duration {
+	const defaultTimeout = 10 * time.Second
+	if c.Timeout == "" {
+		return defaultTimeout
+	}
+	d, err := time.ParseDuration(c.Timeout)
+	if err != nil || d <= 0 {
+		return defaultTimeout
+	}
+	return d
+}
+
 // Config holds the daemon configuration
 type Config struct {
 	ServerAddr                 string `toml:"server_addr"`
@@ -193,6 +211,9 @@ type Config struct {
 
 	// CI poller configuration
 	CI CIConfig `toml:"ci"`
+
+	// Cost/token usage lookup configuration
+	Cost CostConfig `toml:"cost"`
 
 	// Agent-specific behavior
 	Agent AgentConfig `toml:"agent"`
@@ -378,7 +399,10 @@ type RepoConfig struct {
 	ACP *ACPAgentConfig `toml:"acp"`
 }
 
-const DefaultPiJSONSchemaExtension = "npm:@nqbao/pi-json-schema@0.1.1"
+const (
+	DefaultPiJSONSchemaExtension = "npm:@nqbao/pi-json-schema@0.1.1"
+	DefaultCostEndpoint          = "http://127.0.0.1:8080/api/v1/sessions/{session_id}/usage"
+)
 
 // DefaultConfig returns the default configuration
 func DefaultConfig() *Config {
@@ -394,6 +418,10 @@ func DefaultConfig() *Config {
 		PiCmd:              "pi",
 		OpenCodeCmd:        "opencode",
 		MouseEnabled:       true,
+		Cost: CostConfig{
+			Endpoint: DefaultCostEndpoint,
+			Timeout:  "10s",
+		},
 		Agent: AgentConfig{
 			Codex: CodexConfig{
 				DisableReviewSkills:    true,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -401,7 +401,6 @@ type RepoConfig struct {
 
 const (
 	DefaultPiJSONSchemaExtension = "npm:@nqbao/pi-json-schema@0.1.1"
-	DefaultCostEndpoint          = "http://127.0.0.1:8080/api/v1/sessions/{session_id}/usage"
 )
 
 // DefaultConfig returns the default configuration
@@ -419,8 +418,7 @@ func DefaultConfig() *Config {
 		OpenCodeCmd:        "opencode",
 		MouseEnabled:       true,
 		Cost: CostConfig{
-			Endpoint: DefaultCostEndpoint,
-			Timeout:  "10s",
+			Timeout: "10s",
 		},
 		Agent: AgentConfig{
 			Codex: CodexConfig{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -37,6 +37,9 @@ func TestDefaultConfig(t *testing.T) {
 	assert.True(t, cfg.Agent.Codex.DisableReviewSkills, "expected Codex review skills to be disabled by default")
 	assert.True(t, cfg.Agent.Codex.IgnoreReviewUserConfig, "expected Codex review user config to be ignored by default")
 	assert.Equal(t, "npm:@nqbao/pi-json-schema@0.1.1", cfg.Agent.Pi.JSONSchemaExtension)
+	assert.Equal(t, DefaultCostEndpoint, cfg.Cost.Endpoint)
+	assert.Equal(t, "10s", cfg.Cost.Timeout)
+	assert.Equal(t, 10*time.Second, cfg.Cost.ResolvedTimeout())
 }
 
 func TestDataDir(t *testing.T) {
@@ -145,6 +148,42 @@ jsonschemaextension = "/opt/roborev/pi-json-schema/index.ts"
 	cfg, err := LoadGlobalFrom(path)
 	require.NoError(t, err)
 	assert.Equal(t, "/opt/roborev/pi-json-schema/index.ts", cfg.Agent.Pi.JSONSchemaExtension)
+}
+
+func TestLoadGlobalCostConfigFromTOML(t *testing.T) {
+	testenv.SetDataDir(t)
+
+	path := filepath.Join(DataDir(), "config.toml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(`[cost]
+endpoint = "https://usage.example.test/api/v1/sessions/{session_id}/usage"
+timeout = "250ms"
+`), 0o600))
+
+	cfg, err := LoadGlobalFrom(path)
+	require.NoError(t, err)
+	assert.Equal(t, "https://usage.example.test/api/v1/sessions/{session_id}/usage", cfg.Cost.Endpoint)
+	assert.Equal(t, "250ms", cfg.Cost.Timeout)
+	assert.Equal(t, 250*time.Millisecond, cfg.Cost.ResolvedTimeout())
+}
+
+func TestCostConfigResolvedTimeoutFallsBackToDefault(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout string
+	}{
+		{name: "empty", timeout: ""},
+		{name: "invalid", timeout: "tomorrow"},
+		{name: "zero", timeout: "0"},
+		{name: "negative", timeout: "-1s"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := CostConfig{Timeout: tt.timeout}
+			assert.Equal(t, 10*time.Second, cfg.ResolvedTimeout())
+		})
+	}
 }
 
 func TestSaveAndLoadGlobalAutoFilterBranch(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -37,7 +37,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.True(t, cfg.Agent.Codex.DisableReviewSkills, "expected Codex review skills to be disabled by default")
 	assert.True(t, cfg.Agent.Codex.IgnoreReviewUserConfig, "expected Codex review user config to be ignored by default")
 	assert.Equal(t, "npm:@nqbao/pi-json-schema@0.1.1", cfg.Agent.Pi.JSONSchemaExtension)
-	assert.Equal(t, DefaultCostEndpoint, cfg.Cost.Endpoint)
+	assert.Empty(t, cfg.Cost.Endpoint)
 	assert.Equal(t, "10s", cfg.Cost.Timeout)
 	assert.Equal(t, 10*time.Second, cfg.Cost.ResolvedTimeout())
 }

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -54,8 +54,9 @@ type WorkerPool struct {
 	// field directly after construction (test-only access).
 	classify agent.LimitClassifier
 
-	// tokenUsageFetcher looks up captured session usage. Defaults to
-	// tokens.FetchForSession; tests substitute a deterministic fetcher.
+	// tokenUsageFetcher looks up captured session usage. Nil uses the
+	// configured tokens.FetchForSessionWithConfig path; tests substitute a
+	// deterministic fetcher.
 	tokenUsageFetcher func(context.Context, string) (*tokens.Usage, error)
 
 	// Output capture for tail command
@@ -90,7 +91,6 @@ func NewWorkerPool(db *storage.DB, cfgGetter ConfigGetter, numWorkers int, broad
 		agentCooldowns:    make(map[string]time.Time),
 		outputBuffers:     NewOutputBuffer(512*1024, 4*1024*1024), // 512KB/job, 4MB total
 		classify:          agent.ClassifyLimit,
-		tokenUsageFetcher: tokens.FetchForSession,
 		retryBackoff:      2 * time.Second,
 	}
 }
@@ -1137,7 +1137,16 @@ func (wp *WorkerPool) captureTokenUsageForSession(
 	}
 	fetcher := wp.tokenUsageFetcher
 	if fetcher == nil {
-		fetcher = tokens.FetchForSession
+		cfg := wp.cfgGetter.Config()
+		fetcher = func(ctx context.Context, sessionID string) (*tokens.Usage, error) {
+			return tokens.FetchForSessionWithConfig(
+				ctx, sessionID,
+				tokens.FetchConfig{
+					Endpoint: cfg.Cost.Endpoint,
+					Timeout:  cfg.Cost.ResolvedTimeout(),
+				},
+			)
+		}
 	}
 	usage, tokenErr := fetcher(ctx, capturedSession)
 	if tokenErr != nil {

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -78,20 +78,20 @@ type WorkerPool struct {
 // NewWorkerPool creates a new worker pool
 func NewWorkerPool(db *storage.DB, cfgGetter ConfigGetter, numWorkers int, broadcaster Broadcaster, errorLog *ErrorLog, activityLog *ActivityLog) *WorkerPool {
 	return &WorkerPool{
-		db:                db,
-		cfgGetter:         cfgGetter,
-		broadcaster:       broadcaster,
-		errorLog:          errorLog,
-		activityLog:       activityLog,
-		numWorkers:        numWorkers,
-		stopCh:            make(chan struct{}),
-		readyCh:           make(chan struct{}),
-		runningJobs:       make(map[int64]context.CancelFunc),
-		pendingCancels:    make(map[int64]bool),
-		agentCooldowns:    make(map[string]time.Time),
-		outputBuffers:     NewOutputBuffer(512*1024, 4*1024*1024), // 512KB/job, 4MB total
-		classify:          agent.ClassifyLimit,
-		retryBackoff:      2 * time.Second,
+		db:             db,
+		cfgGetter:      cfgGetter,
+		broadcaster:    broadcaster,
+		errorLog:       errorLog,
+		activityLog:    activityLog,
+		numWorkers:     numWorkers,
+		stopCh:         make(chan struct{}),
+		readyCh:        make(chan struct{}),
+		runningJobs:    make(map[int64]context.CancelFunc),
+		pendingCancels: make(map[int64]bool),
+		agentCooldowns: make(map[string]time.Time),
+		outputBuffers:  NewOutputBuffer(512*1024, 4*1024*1024), // 512KB/job, 4MB total
+		classify:       agent.ClassifyLimit,
+		retryBackoff:   2 * time.Second,
 	}
 }
 

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -51,7 +51,6 @@ func newWorkerTestContext(t *testing.T, workers int) *workerTestContext {
 	testutil.InitTestGitRepo(t, tmpDir)
 
 	cfg := config.DefaultConfig()
-	cfg.Cost.Endpoint = ""
 	if workers > 0 {
 		cfg.MaxWorkers = workers
 	}

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -27,6 +29,7 @@ import (
 	"go.kenn.io/roborev/internal/review"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testutil"
+	"go.kenn.io/roborev/internal/tokens"
 )
 
 const testWorkerID = "test-worker"
@@ -48,6 +51,7 @@ func newWorkerTestContext(t *testing.T, workers int) *workerTestContext {
 	testutil.InitTestGitRepo(t, tmpDir)
 
 	cfg := config.DefaultConfig()
+	cfg.Cost.Endpoint = ""
 	if workers > 0 {
 		cfg.MaxWorkers = workers
 	}
@@ -439,6 +443,80 @@ func TestProcessJob_CapturesSessionID(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProcessJob_FetchesConfiguredSessionUsageEndpoint(t *testing.T) {
+	tc := newWorkerTestContext(t, 1)
+	sha := testutil.GetHeadSHA(t, tc.TmpDir)
+	sessionID := "codex:thread/789"
+
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"session_id":"codex:thread/789","agent":"codex",`+
+			`"project":"roborev","total_output_tokens":28800,`+
+			`"peak_context_tokens":118000,"has_token_data":true,`+
+			`"cost_usd":0.42,"has_cost":true}`)
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := config.DefaultConfig()
+	cfg.Cost.Endpoint = server.URL + "/api/v1/sessions/{session_id}/usage"
+	cfg.Cost.Timeout = "1s"
+	tc.reconfigurePool(cfg)
+
+	agentName := "configured-session-usage-endpoint"
+	agent.Register(&sessionStreamingTestAgent{
+		name:       agentName,
+		streamLine: fmt.Sprintf(`{"type":"thread.started","thread_id":%q}`, sessionID),
+	})
+	t.Cleanup(func() { agent.Unregister(agentName) })
+
+	job := tc.createAndClaimJobWithAgent(t, sha, testWorkerID, agentName)
+	tc.Pool.processJob(testWorkerID, job)
+
+	updated := tc.assertJobStatus(t, job.ID, storage.JobStatusDone)
+	assert.Equal(t, sessionID, updated.SessionID)
+	assert.Equal(t, "/api/v1/sessions/codex:thread%2F789/usage", gotPath)
+
+	usage := tokens.ParseJSON(updated.TokenUsage)
+	require.NotNil(t, usage)
+	assert.Equal(t, int64(28800), usage.OutputTokens)
+	assert.Equal(t, int64(118000), usage.PeakContextTokens)
+	assert.True(t, usage.HasCost)
+	assert.InDelta(t, 0.42, usage.CostUSD, 1e-9)
+}
+
+func TestProcessJob_UsageEndpointFailureKeepsCompletedJob(t *testing.T) {
+	tc := newWorkerTestContext(t, 1)
+	sha := testutil.GetHeadSHA(t, tc.TmpDir)
+	sessionID := "codex:thread/fail"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":{"code":"usage_query_failed"}}`, http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := config.DefaultConfig()
+	cfg.Cost.Endpoint = server.URL + "/api/v1/sessions/{session_id}/usage"
+	cfg.Cost.Timeout = "1s"
+	tc.reconfigurePool(cfg)
+
+	agentName := "failing-session-usage-endpoint"
+	agent.Register(&sessionStreamingTestAgent{
+		name:       agentName,
+		streamLine: fmt.Sprintf(`{"type":"thread.started","thread_id":%q}`, sessionID),
+	})
+	t.Cleanup(func() { agent.Unregister(agentName) })
+
+	job := tc.createAndClaimJobWithAgent(t, sha, testWorkerID, agentName)
+	tc.Pool.processJob(testWorkerID, job)
+
+	updated := tc.assertJobStatus(t, job.ID, storage.JobStatusDone)
+	assert.Equal(t, sessionID, updated.SessionID)
+	assert.Empty(t, updated.TokenUsage)
 }
 
 func TestProcessJob_UsesStoredReviewPromptOverride(t *testing.T) {

--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -370,6 +370,7 @@ func fetchForSessionHTTP(
 	if err != nil {
 		return nil, fmt.Errorf("usage endpoint request: %w", err)
 	}
+	req.Header.Set("Accept", "application/json")
 	client := cfg.Client
 	if client == nil {
 		client = http.DefaultClient

--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -5,9 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os/exec"
 	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -22,6 +26,15 @@ type Usage struct {
 	HasCost           bool    `json:"has_cost,omitempty"`
 }
 
+// FetchConfig configures session usage lookup. When Endpoint is set,
+// roborev fetches usage over HTTP using a URL template containing
+// "{session_id}". An empty Endpoint preserves the agentsview CLI path.
+type FetchConfig struct {
+	Endpoint string
+	Timeout  time.Duration
+	Client   *http.Client
+}
+
 // agentsviewResponse is the JSON shape returned by both
 // `agentsview session usage <id> --format json` and the deprecated
 // `agentsview token-use <id>`. The session-usage shape is a strict
@@ -32,8 +45,20 @@ type agentsviewResponse struct {
 	Project           string  `json:"project"`
 	OutputTokens      int64   `json:"total_output_tokens"`
 	PeakContextTokens int64   `json:"peak_context_tokens"`
+	HasTokenData      bool    `json:"has_token_data"`
 	CostUSD           float64 `json:"cost_usd"`
 	HasCost           bool    `json:"has_cost"`
+}
+
+type httpUsageResponse struct {
+	SessionID         string   `json:"session_id"`
+	Agent             string   `json:"agent"`
+	Project           string   `json:"project"`
+	OutputTokens      *int64   `json:"total_output_tokens"`
+	PeakContextTokens *int64   `json:"peak_context_tokens"`
+	HasTokenData      *bool    `json:"has_token_data"`
+	CostUSD           *float64 `json:"cost_usd"`
+	HasCost           *bool    `json:"has_cost"`
 }
 
 // FormatSummary returns a compact human-readable summary like
@@ -242,6 +267,23 @@ func hasSessionUsageCommand(ctx context.Context, binPath string) bool {
 func FetchForSession(
 	ctx context.Context, sessionID string,
 ) (*Usage, error) {
+	return FetchForSessionWithConfig(ctx, sessionID, FetchConfig{})
+}
+
+// FetchForSessionWithConfig queries a configured HTTP endpoint when
+// provided; otherwise it uses the agentsview CLI path.
+func FetchForSessionWithConfig(
+	ctx context.Context, sessionID string, cfg FetchConfig,
+) (*Usage, error) {
+	if cfg.Endpoint != "" {
+		return fetchForSessionHTTP(ctx, sessionID, cfg)
+	}
+	return fetchForSessionCLI(ctx, sessionID)
+}
+
+func fetchForSessionCLI(
+	ctx context.Context, sessionID string,
+) (*Usage, error) {
 	if sessionID == "" {
 		return nil, nil
 	}
@@ -304,6 +346,100 @@ func FetchForSession(
 		CostUSD:           resp.CostUSD,
 		HasCost:           resp.HasCost,
 	}, nil
+}
+
+func fetchForSessionHTTP(
+	ctx context.Context, sessionID string, cfg FetchConfig,
+) (*Usage, error) {
+	if sessionID == "" {
+		return nil, nil
+	}
+	endpoint, err := expandEndpoint(cfg.Endpoint, sessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("usage endpoint request: %w", err)
+	}
+	client := cfg.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("usage endpoint request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		detail := strings.TrimSpace(string(body))
+		if detail == "" {
+			return nil, fmt.Errorf("usage endpoint HTTP %s", resp.Status)
+		}
+		return nil, fmt.Errorf("usage endpoint HTTP %s: %s", resp.Status, detail)
+	}
+
+	var respBody httpUsageResponse
+	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+		return nil, fmt.Errorf("parse usage endpoint output: %w", err)
+	}
+	return usageFromHTTPResponse(respBody)
+}
+
+func expandEndpoint(template, sessionID string) (string, error) {
+	const placeholder = "{session_id}"
+	if !strings.Contains(template, placeholder) {
+		return "", fmt.Errorf("usage endpoint missing %s placeholder", placeholder)
+	}
+	endpoint := strings.ReplaceAll(
+		template, placeholder, url.PathEscape(sessionID),
+	)
+	if _, err := url.ParseRequestURI(endpoint); err != nil {
+		return "", fmt.Errorf("usage endpoint URL: %w", err)
+	}
+	return endpoint, nil
+}
+
+func usageFromHTTPResponse(resp httpUsageResponse) (*Usage, error) {
+	if resp.HasTokenData == nil {
+		return nil, fmt.Errorf("usage endpoint schema: missing has_token_data")
+	}
+	if resp.HasCost == nil {
+		return nil, fmt.Errorf("usage endpoint schema: missing has_cost")
+	}
+
+	usage := &Usage{}
+	if *resp.HasTokenData {
+		if resp.OutputTokens == nil || resp.PeakContextTokens == nil {
+			return nil, fmt.Errorf("usage endpoint schema: missing token counts")
+		}
+		usage.OutputTokens = *resp.OutputTokens
+		usage.PeakContextTokens = *resp.PeakContextTokens
+	}
+	if *resp.HasCost {
+		if resp.CostUSD == nil {
+			return nil, fmt.Errorf("usage endpoint schema: missing cost_usd")
+		}
+		usage.CostUSD = *resp.CostUSD
+		usage.HasCost = true
+	}
+	if usage.OutputTokens == 0 && usage.PeakContextTokens == 0 && !usage.HasCost {
+		return nil, nil
+	}
+	return usage, nil
 }
 
 // ParseJSON deserializes a token_usage JSON blob from the database.

--- a/internal/tokens/tokens_test.go
+++ b/internal/tokens/tokens_test.go
@@ -273,6 +273,11 @@ func TestFetchForSessionWithConfigUsesHTTPEndpoint(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.EscapedPath()
 		assert.Equal(t, http.MethodGet, r.Method)
+		if r.Header.Get("Accept") != "application/json" {
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprint(w, "<!doctype html>")
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, `{"session_id":"codex:s/1","agent":"codex",`+
 			`"project":"roborev","total_output_tokens":28800,`+

--- a/internal/tokens/tokens_test.go
+++ b/internal/tokens/tokens_test.go
@@ -3,11 +3,14 @@ package tokens
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -263,6 +266,154 @@ exit 99
 	assert.Equal(t, int64(118000), usage.PeakContextTokens)
 	assert.True(t, usage.HasCost)
 	assert.InDelta(t, 0.42, usage.CostUSD, 1e-9)
+}
+
+func TestFetchForSessionWithConfigUsesHTTPEndpoint(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"session_id":"codex:s/1","agent":"codex",`+
+			`"project":"roborev","total_output_tokens":28800,`+
+			`"peak_context_tokens":118000,"has_token_data":true,`+
+			`"cost_usd":0.42,"has_cost":true}`)
+	}))
+	t.Cleanup(server.Close)
+
+	usage, err := FetchForSessionWithConfig(
+		context.Background(), "codex:s/1",
+		FetchConfig{
+			Endpoint: server.URL + "/api/v1/sessions/{session_id}/usage",
+			Timeout:  time.Second,
+		},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	assert.Equal(t, "/api/v1/sessions/codex:s%2F1/usage", gotPath)
+	assert.Equal(t, int64(28800), usage.OutputTokens)
+	assert.Equal(t, int64(118000), usage.PeakContextTokens)
+	assert.True(t, usage.HasCost)
+	assert.InDelta(t, 0.42, usage.CostUSD, 1e-9)
+}
+
+func TestFetchForSessionWithConfigHonorsUsageFlags(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"session_id":"s","agent":"codex",`+
+			`"total_output_tokens":999,"peak_context_tokens":888,`+
+			`"has_token_data":false,"cost_usd":0.0,"has_cost":true}`)
+	}))
+	t.Cleanup(server.Close)
+
+	usage, err := FetchForSessionWithConfig(
+		context.Background(), "s",
+		FetchConfig{
+			Endpoint: server.URL + "/usage/{session_id}",
+			Timeout:  time.Second,
+		},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	assert.Zero(t, usage.OutputTokens)
+	assert.Zero(t, usage.PeakContextTokens)
+	assert.True(t, usage.HasCost)
+	assert.InDelta(t, 0.0, usage.CostUSD, 1e-9)
+}
+
+func TestFetchForSessionWithConfigHTTPNotFoundMeansNoUsage(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(server.Close)
+
+	usage, err := FetchForSessionWithConfig(
+		context.Background(), "missing",
+		FetchConfig{
+			Endpoint: server.URL + "/usage/{session_id}",
+			Timeout:  time.Second,
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Nil(t, usage)
+}
+
+func TestFetchForSessionWithConfigHTTPStatusErrorReportsExactStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{
+			name:   "unauthorized",
+			status: http.StatusUnauthorized,
+			body:   `{"error":{"code":"unauthorized"}}`,
+		},
+		{
+			name:   "unprocessable entity",
+			status: http.StatusUnprocessableEntity,
+			body:   `{"error":{"code":"invalid_session_id"}}`,
+		},
+		{
+			name:   "internal server error",
+			status: http.StatusInternalServerError,
+			body:   `{"error":{"code":"usage_query_failed"}}`,
+		},
+		{
+			name:   "service unavailable without body",
+			status: http.StatusServiceUnavailable,
+			body:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if tt.body == "" {
+					w.WriteHeader(tt.status)
+					return
+				}
+				http.Error(w, tt.body, tt.status)
+			}))
+			t.Cleanup(server.Close)
+
+			usage, err := FetchForSessionWithConfig(
+				context.Background(), "s",
+				FetchConfig{
+					Endpoint: server.URL + "/usage/{session_id}",
+					Timeout:  time.Second,
+				},
+			)
+
+			require.Error(t, err)
+			assert.Nil(t, usage)
+			assert.Contains(t, err.Error(), fmt.Sprintf("HTTP %d %s", tt.status, http.StatusText(tt.status)))
+			if tt.body != "" {
+				assert.Contains(t, err.Error(), tt.body)
+			}
+		})
+	}
+}
+
+func TestFetchForSessionWithConfigRejectsBadSchema(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"session_id":"s","has_token_data":true,"has_cost":false}`)
+	}))
+	t.Cleanup(server.Close)
+
+	usage, err := FetchForSessionWithConfig(
+		context.Background(), "s",
+		FetchConfig{
+			Endpoint: server.URL + "/usage/{session_id}",
+			Timeout:  time.Second,
+		},
+	)
+
+	require.Error(t, err)
+	assert.Nil(t, usage)
+	assert.Contains(t, err.Error(), "missing token counts")
 }
 
 func TestFetchForSessionUsesSessionUsageWhenPrereleaseSupportsIt(t *testing.T) {

--- a/internal/tokens/tokens_test.go
+++ b/internal/tokens/tokens_test.go
@@ -273,11 +273,7 @@ func TestFetchForSessionWithConfigUsesHTTPEndpoint(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.EscapedPath()
 		assert.Equal(t, http.MethodGet, r.Method)
-		if r.Header.Get("Accept") != "application/json" {
-			w.Header().Set("Content-Type", "text/html")
-			fmt.Fprint(w, "<!doctype html>")
-			return
-		}
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, `{"session_id":"codex:s/1","agent":"codex",`+
 			`"project":"roborev","total_output_tokens":28800,`+


### PR DESCRIPTION
## Summary
- Add an opt-in `cost.endpoint` HTTP lookup path for session usage and cost data; when unset, roborev keeps using the existing `agentsview` binary lookup.
- Request JSON from configured usage endpoints with `Accept: application/json`, matching the deployed AgentsView route behavior.
- Decode the AgentsView session usage response shape, including `has_token_data`, `has_cost`, token counts, and `cost_usd`, with explicit schema mismatch errors.
- Wire the configured lookup into daemon job completion and `backfill-tokens`, preserving best-effort behavior for HTTP/status/schema failures.
- Merge fetched backfill usage with existing `token_usage` so cost-only responses do not erase stored token counts.

## Verification
- `GOCACHE=/tmp/roborev-go-build GOMODCACHE=/tmp/roborev-go-mod go fmt ./...`
- `GOCACHE=/tmp/roborev-go-build GOMODCACHE=/tmp/roborev-go-mod go vet ./...`
- `GOCACHE=/tmp/roborev-go-build GOMODCACHE=/tmp/roborev-go-mod go build ./...`
- `GOCACHE=/tmp/roborev-go-build GOMODCACHE=/tmp/roborev-go-mod go test ./...`
- Isolated ephemeral daemon using temp `ROBOREV_DATA_DIR` successfully ran `backfill-tokens` against `https://av.peregrine.edmontosaurus-alnitak.ts.net/api/v1/sessions/{session_id}/usage` and updated `1/1` jobs.