### PR TITLE
test(ci): keep poller tests off GitHub APIs

### DIFF
--- a/cmd/roborev/github_api_guard_test.go
+++ b/cmd/roborev/github_api_guard_test.go
@@ -1,0 +1,3 @@
+package main
+
+import _ "go.kenn.io/roborev/internal/testenv/githubguard"

--- a/cmd/roborev/tui/github_api_guard_test.go
+++ b/cmd/roborev/tui/github_api_guard_test.go
@@ -1,0 +1,3 @@
+package tui
+
+import _ "go.kenn.io/roborev/internal/testenv/githubguard"

--- a/github_api_guard_test.go
+++ b/github_api_guard_test.go
@@ -1,0 +1,3 @@
+package main
+
+import _ "go.kenn.io/roborev/internal/testenv/githubguard"

--- a/internal/agent/github_api_guard_test.go
+++ b/internal/agent/github_api_guard_test.go
@@ -1,0 +1,3 @@
+package agent
+
+import _ "go.kenn.io/roborev/internal/testenv/githubguard"

--- a/internal/config/github_api_guard_test.go
+++ b/internal/config/github_api_guard_test.go
@@ -1,0 +1,3 @@
+package config
+
+import _ "go.kenn.io/roborev/internal/testenv/githubguard"

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -69,6 +69,7 @@ func newCIPollerHarness(t *testing.T, identity string) *ciPollerHarness {
 	// agent binaries from the developer environment.
 	cfg.CI.SynthesisAgent = "test"
 	p := NewCIPoller(db, NewStaticConfig(cfg), nil)
+	stubCIPollerGitHubSideEffects(p)
 	// Default to assuming PR is open so tests don't shell out to `gh pr view`.
 	// Tests that need specific isPROpen behavior can override this.
 	p.isPROpenFn = func(string, int) bool { return true }
@@ -82,10 +83,56 @@ func newCIPollerHarness(t *testing.T, identity string) *ciPollerHarness {
 // call real git. mergeBaseFn returns "base-" + ref2.
 // Also stubs agent resolution so tests don't need real agents in PATH.
 func (h *ciPollerHarness) stubProcessPRGit() {
+	stubCIPollerGitHubSideEffects(h.Poller)
 	h.Poller.gitFetchFn = func(context.Context, string, []string) error { return nil }
 	h.Poller.gitFetchPRHeadFn = func(context.Context, string, int, []string) error { return nil }
 	h.Poller.mergeBaseFn = func(_, _, ref2 string) (string, error) { return "base-" + ref2, nil }
 	h.Poller.agentResolverFn = func(name string) (string, error) { return name, nil }
+}
+
+func stubCIPollerGitHubSideEffects(p *CIPoller) {
+	p.listTrustedActorsFn = func(context.Context, string) (map[string]struct{}, error) {
+		return nil, nil
+	}
+	p.listPRDiscussionFn = func(context.Context, string, int) ([]ghpkg.PRDiscussionComment, error) {
+		return nil, nil
+	}
+	p.setCommitStatusFn = func(string, string, string, string) error {
+		return nil
+	}
+}
+
+func TestCIPollerHarnessProcessPRGitStubsGitHubSideEffects(t *testing.T) {
+	h := newCIPollerHarness(t, "git@github.com:acme/api.git")
+	h.Cfg.CI.ReviewTypes = []string{"security"}
+	h.Cfg.CI.Agents = []string{"codex"}
+	h.Poller = NewCIPoller(h.DB, NewStaticConfig(h.Cfg), nil)
+
+	discussionCalls := 0
+	statusCalls := 0
+	h.Poller.listTrustedActorsFn = func(context.Context, string) (map[string]struct{}, error) {
+		discussionCalls++
+		return map[string]struct{}{"alice": {}}, nil
+	}
+	h.Poller.listPRDiscussionFn = func(context.Context, string, int) ([]ghpkg.PRDiscussionComment, error) {
+		discussionCalls++
+		return nil, nil
+	}
+	h.Poller.setCommitStatusFn = func(string, string, string, string) error {
+		statusCalls++
+		return nil
+	}
+
+	h.stubProcessPRGit()
+
+	err := h.Poller.processPR(context.Background(), "acme/api", ghPR{
+		Number:      42,
+		HeadRefOid:  "head-sha-123",
+		BaseRefName: "main",
+	}, h.Cfg)
+	require.NoError(t, err)
+	assert.Equal(t, 0, discussionCalls)
+	assert.Equal(t, 0, statusCalls)
 }
 
 // panelMembers returns the member jobs of the panel run for a PR at a HEAD SHA.
@@ -496,9 +543,7 @@ func TestCIPollerProcessPR_EnqueuesMatrix(t *testing.T) {
 	h.Cfg.CI.Agents = []string{"codex", "gemini"}
 	h.Cfg.CI.Model = "gpt-test"
 	h.Poller = NewCIPoller(h.DB, NewStaticConfig(h.Cfg), nil)
-	h.Poller.gitFetchFn = func(context.Context, string, []string) error { return nil }
-	h.Poller.gitFetchPRHeadFn = func(context.Context, string, int, []string) error { return nil }
-	h.Poller.agentResolverFn = func(name string) (string, error) { return name, nil }
+	h.stubProcessPRGit()
 	h.Poller.mergeBaseFn = func(_, ref1, ref2 string) (string, error) {
 		if ref1 != "origin/main" {
 			require.Condition(t, func() bool {
@@ -1945,6 +1990,7 @@ func TestCIPollerProcessPR_AutoClonesUnknownRepo(t *testing.T) {
 	cfg.CI.ReviewTypes = []string{"security"}
 	cfg.CI.Agents = []string{"codex"}
 	p := NewCIPoller(db, NewStaticConfig(cfg), nil)
+	stubCIPollerGitHubSideEffects(p)
 
 	// Stub git operations
 	p.gitFetchFn = func(context.Context, string, []string) error {
@@ -3085,6 +3131,7 @@ func newCIPanelGitHarness(t *testing.T) (*CIPoller, *storage.DB, *storage.Repo, 
 	p.gitFetchPRHeadFn = func(context.Context, string, int, []string) error { return nil }
 	p.agentResolverFn = func(name string) (string, error) { return name, nil }
 	p.isPROpenFn = func(string, int) bool { return true }
+	stubCIPollerGitHubSideEffects(p)
 	return p, db, row, repo, cfg
 }
 

--- a/internal/daemon/github_api_guard_test.go
+++ b/internal/daemon/github_api_guard_test.go
@@ -1,0 +1,3 @@
+package daemon
+
+import _ "go.kenn.io/roborev/internal/testenv/githubguard"

--- a/internal/daemon/stream_integration_test.go
+++ b/internal/daemon/stream_integration_test.go
@@ -80,7 +80,19 @@ func setupRepoAndJob(t *testing.T, db *storage.DB, tmpDir string) *storage.Revie
 			return false
 		}, "GetOrCreateRepo failed: %v", err)
 	}
-	return testutil.CreateTestJobWithSHA(t, db, repo, sha, "test")
+	commit, err := db.GetOrCreateCommit(repo.ID, sha, testutil.GitUserName, "test commit", time.Now())
+	require.NoError(t, err)
+	job, err := db.EnqueueJob(storage.EnqueueOpts{
+		RepoID:         repo.ID,
+		CommitID:       commit.ID,
+		GitRef:         sha,
+		Agent:          "test",
+		Prompt:         "prebuilt review prompt",
+		PromptPrebuilt: true,
+		JobType:        storage.JobTypeReview,
+	})
+	require.NoError(t, err)
+	return job
 }
 
 func TestBroadcasterIntegrationWithWorker(t *testing.T) {

--- a/internal/ghaction/github_api_guard_test.go
+++ b/internal/ghaction/github_api_guard_test.go
@@ -1,0 +1,3 @@
+package ghaction
+
+import _ "go.kenn.io/roborev/internal/testenv/githubguard"

--- a/internal/git/github_api_guard_test.go
+++ b/internal/git/github_api_guard_test.go
@@ -1,0 +1,3 @@
+package git
+
+import _ "go.kenn.io/roborev/internal/testenv/githubguard"

--- a/internal/githook/github_api_guard_test.go
+++ b/internal/githook/github_api_guard_test.go
@@ -1,0 +1,3 @@
+package githook
+
+import _ "go.kenn.io/roborev/internal/testenv/githubguard"

--- a/internal/github/github_api_guard_test.go
+++ b/internal/github/github_api_guard_test.go
@@ -1,0 +1,3 @@
+package github
+
+import _ "go.kenn.io/roborev/internal/testenv/githubguard"

--- a/internal/prompt/analyze/github_api_guard_test.go
+++ b/internal/prompt/analyze/github_api_guard_test.go
@@ -1,0 +1,3 @@
+package analyze
+
+import _ "go.kenn.io/roborev/internal/testenv/githubguard"

--- a/internal/prompt/github_api_guard_test.go
+++ b/internal/prompt/github_api_guard_test.go
@@ -1,0 +1,3 @@
+package prompt
+
+import _ "go.kenn.io/roborev/internal/testenv/githubguard"

--- a/internal/review/autotype/github_api_guard_test.go
+++ b/internal/review/autotype/github_api_guard_test.go
@@ -1,0 +1,3 @@
+package autotype
+
+import _ "go.kenn.io/roborev/internal/testenv/githubguard"

--- a/internal/review/github_api_guard_test.go
+++ b/internal/review/github_api_guard_test.go
@@ -1,0 +1,3 @@
+package review
+
+import _ "go.kenn.io/roborev/internal/testenv/githubguard"

--- a/internal/skills/github_api_guard_test.go
+++ b/internal/skills/github_api_guard_test.go
@@ -1,0 +1,3 @@
+package skills
+
+import _ "go.kenn.io/roborev/internal/testenv/githubguard"

--- a/internal/storage/github_api_guard_test.go
+++ b/internal/storage/github_api_guard_test.go
@@ -1,0 +1,3 @@
+package storage
+
+import _ "go.kenn.io/roborev/internal/testenv/githubguard"

--- a/internal/streamfmt/github_api_guard_test.go
+++ b/internal/streamfmt/github_api_guard_test.go
@@ -1,0 +1,3 @@
+package streamfmt
+
+import _ "go.kenn.io/roborev/internal/testenv/githubguard"

--- a/internal/testenv/github_api_guard.go
+++ b/internal/testenv/github_api_guard.go
@@ -15,8 +15,10 @@ type githubAPIGuardTransport struct {
 	base http.RoundTripper
 }
 
-var githubAPIGuardMu sync.Mutex
-var defaultGitHubAPIGuardBaseTransport = http.DefaultTransport
+var (
+	githubAPIGuardMu                   sync.Mutex
+	defaultGitHubAPIGuardBaseTransport = http.DefaultTransport
+)
 
 // InstallGitHubAPIGuard blocks Go HTTP requests to api.github.com for tests.
 func InstallGitHubAPIGuard() {

--- a/internal/testenv/github_api_guard.go
+++ b/internal/testenv/github_api_guard.go
@@ -1,0 +1,51 @@
+package testenv
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// ErrGitHubAPIBlocked marks a test-time request to the public GitHub API.
+var ErrGitHubAPIBlocked = errors.New("blocked GitHub API request during tests")
+
+type githubAPIGuardTransport struct {
+	base http.RoundTripper
+}
+
+var githubAPIGuardMu sync.Mutex
+var defaultGitHubAPIGuardBaseTransport = http.DefaultTransport
+
+// InstallGitHubAPIGuard blocks Go HTTP requests to api.github.com for tests.
+func InstallGitHubAPIGuard() {
+	githubAPIGuardMu.Lock()
+	defer githubAPIGuardMu.Unlock()
+
+	if GitHubAPIGuardInstalled() {
+		return
+	}
+	base := http.DefaultTransport
+	if base == nil {
+		base = defaultGitHubAPIGuardBaseTransport
+	}
+	http.DefaultTransport = githubAPIGuardTransport{base: base}
+}
+
+// GitHubAPIGuardInstalled reports whether the test HTTP guard is active.
+func GitHubAPIGuardInstalled() bool {
+	_, ok := http.DefaultTransport.(githubAPIGuardTransport)
+	return ok
+}
+
+func (transport githubAPIGuardTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req != nil && req.URL != nil && strings.EqualFold(req.URL.Hostname(), "api.github.com") {
+		return nil, fmt.Errorf("%w: %s %s", ErrGitHubAPIBlocked, req.Method, req.URL.Redacted())
+	}
+	base := transport.base
+	if base == nil {
+		base = defaultGitHubAPIGuardBaseTransport
+	}
+	return base.RoundTrip(req)
+}

--- a/internal/testenv/github_api_guard_test.go
+++ b/internal/testenv/github_api_guard_test.go
@@ -1,0 +1,77 @@
+package testenv
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestGitHubAPIGuardTransportBlocksAPIGitHub(t *testing.T) {
+	baseCalls := 0
+	transport := githubAPIGuardTransport{base: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		baseCalls++
+		return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+	})}
+	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/rate_limit", nil)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+
+	require.ErrorIs(t, err, ErrGitHubAPIBlocked)
+	assert.Nil(t, resp)
+	assert.Equal(t, 0, baseCalls)
+}
+
+func TestGitHubAPIGuardTransportAllowsOtherHosts(t *testing.T) {
+	baseCalls := 0
+	transport := githubAPIGuardTransport{base: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		baseCalls++
+		return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+	})}
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/status", nil)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, 1, baseCalls)
+}
+
+func TestInstalledGitHubAPIGuardBlocksDefaultClient(t *testing.T) {
+	assert.True(t, GitHubAPIGuardInstalled())
+
+	resp, err := http.Get("https://api.github.com/rate_limit")
+
+	require.ErrorIs(t, err, ErrGitHubAPIBlocked)
+	assert.Nil(t, resp)
+}
+
+func TestInstallGitHubAPIGuardWrapsDefaultTransportOnce(t *testing.T) {
+	original := http.DefaultTransport
+	defer func() {
+		http.DefaultTransport = original
+	}()
+	base := roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+	})
+	http.DefaultTransport = base
+
+	InstallGitHubAPIGuard()
+	InstallGitHubAPIGuard()
+
+	assert.True(t, GitHubAPIGuardInstalled())
+	guard, ok := http.DefaultTransport.(githubAPIGuardTransport)
+	require.True(t, ok)
+	_, nested := guard.base.(githubAPIGuardTransport)
+	assert.False(t, nested)
+}

--- a/internal/testenv/githubguard/githubguard.go
+++ b/internal/testenv/githubguard/githubguard.go
@@ -1,0 +1,8 @@
+// Package githubguard installs the test-only GitHub API HTTP guard.
+package githubguard
+
+import "go.kenn.io/roborev/internal/testenv"
+
+func init() {
+	testenv.InstallGitHubAPIGuard()
+}

--- a/internal/testenv/testmain_test.go
+++ b/internal/testenv/testmain_test.go
@@ -1,0 +1,11 @@
+package testenv
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	InstallGitHubAPIGuard()
+	os.Exit(m.Run())
+}

--- a/internal/testutil/github_api_guard_test.go
+++ b/internal/testutil/github_api_guard_test.go
@@ -1,0 +1,3 @@
+package testutil
+
+import _ "go.kenn.io/roborev/internal/testenv/githubguard"

--- a/internal/tokens/github_api_guard_test.go
+++ b/internal/tokens/github_api_guard_test.go
@@ -1,0 +1,3 @@
+package tokens
+
+import _ "go.kenn.io/roborev/internal/testenv/githubguard"

--- a/internal/update/github_api_guard_test.go
+++ b/internal/update/github_api_guard_test.go
@@ -1,0 +1,3 @@
+package update
+
+import _ "go.kenn.io/roborev/internal/testenv/githubguard"

--- a/internal/version/github_api_guard_test.go
+++ b/internal/version/github_api_guard_test.go
@@ -1,0 +1,3 @@
+package version
+
+import _ "go.kenn.io/roborev/internal/testenv/githubguard"

--- a/scripts/github_api_guard_test.go
+++ b/scripts/github_api_guard_test.go
@@ -1,0 +1,3 @@
+package scripts
+
+import _ "go.kenn.io/roborev/internal/testenv/githubguard"


### PR DESCRIPTION
## Summary

- Default CI poller test harness GitHub side-effect callbacks to in-process no-ops.
- Add a shared test HTTP guard that blocks Go requests to `api.github.com` through `http.DefaultTransport`.
- Install that guard in every current Go test package, while keeping `httptest` and custom-base GitHub client tests working.
- Add regression coverage for both the poller harness stubs and the default-client GitHub API blocker.
- Keep the stream worker integration test on the prebuilt-prompt path so it tests worker event broadcast without invoking unrelated prompt-builder git subprocesses.

## How this prevents CI API burn

The CI poller tests now avoid the known production GitHub callbacks by default: PR discussion lookup and commit-status posting are no-op callbacks unless a test explicitly captures or fakes them.

The broader guard catches future misses. If a Go test tries to dial `https://api.github.com/...` through the default HTTP transport, the request fails before it reaches the network with `ErrGitHubAPIBlocked`. That turns accidental GitHub API use into a test failure instead of a rate-limit drain.

## CI timeout follow-up

Run `26902373489` timed out on macOS in `TestBroadcasterIntegrationWithWorker`. The stack showed the test cleanup waiting on a worker that was still in prompt construction via `git log`; the log did not show a propagated `ErrGitHubAPIBlocked` or `api.github.com` request.

I replayed the daemon package locally with the CI shuffle seed. With the daemon guard import enabled, the package took `96.380s`; with that import temporarily disabled on the same machine, it took `95.917s`. That does not prove macOS cannot still be affected by the guard change, but it argues against the guard itself adding daemon-package runtime. The follow-up patch removes the unrelated prompt git work from the broadcaster test instead.

## Limitations

- This only changes tests. Production `NewCIPoller` and CLI CI paths still wire the real GitHub PR discussion, comment, and commit-status methods.
- This blocks Go `net/http` requests that use the default transport and target `api.github.com`. It does not block subprocesses such as `gh`, `curl`, or `git`.
- Custom test transports can still bypass the guard. Current custom transports are local fakes, but tests that install their own transport are responsible for not dialing GitHub.
- Go does not provide a repo-wide test init hook. The guard is imported by every current test package; new test packages should add the one-line `internal/testenv/githubguard` blank import or use the shared test main helper.
- The stream worker test now uses a prebuilt prompt. That keeps the worker, agent, database, and broadcaster path covered, but prompt construction remains covered by the prompt and worker prompt-specific tests rather than this broadcast test.

## Verification

- `go test ./internal/testenv ./internal/github -count=1`
- `golangci-lint v2.10.1 run ./...` (`0 issues.`)
- `go vet ./...`
- `go test -race -shuffle=on -tags integration ./internal/daemon -count=1 -v`
- `go test -race -shuffle=1780508639646939000 -tags integration ./internal/daemon -run TestBroadcasterIntegrationWithWorker -count=1 -v`
- `go test -race -shuffle=1780508639646939000 -tags integration ./internal/daemon -count=1`
- Grepped the captured daemon test log for `api.github.com`, `GET https://api.github.com`, and `POST https://api.github.com`; no matches.

I also ran `go test ./...` to catch compile issues across the new test imports. It still fails only in the existing `cmd/roborev` repo-root negative tests because this sandbox exposes `/tmp/.git`, which makes their temp directories look like they are inside a repo.
