### PR TITLE
Retain classifier job logs

### DIFF
--- a/cmd/roborev/config_cmd.go
+++ b/cmd/roborev/config_cmd.go
@@ -95,10 +95,12 @@ func findRepoRoot(resolver RepoResolver) (string, error) {
 	}
 
 	for {
-		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
-			return dir, nil
-		} else if !os.IsNotExist(err) {
+		ok, err := hasGitMetadata(dir)
+		if err != nil {
 			return "", err
+		}
+		if ok {
+			return dir, nil
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
@@ -106,6 +108,33 @@ func findRepoRoot(resolver RepoResolver) (string, error) {
 		}
 		dir = parent
 	}
+}
+
+func hasGitMetadata(dir string) (bool, error) {
+	gitPath := filepath.Join(dir, ".git")
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if !info.IsDir() {
+		data, err := os.ReadFile(gitPath)
+		if err != nil {
+			return false, err
+		}
+		return strings.HasPrefix(strings.TrimSpace(string(data)), "gitdir:"), nil
+	}
+
+	headInfo, err := os.Stat(filepath.Join(gitPath, "HEAD"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return !headInfo.IsDir(), nil
 }
 
 // getValueForScope retrieves a single config key value from the appropriate scope.

--- a/cmd/roborev/config_cmd_test.go
+++ b/cmd/roborev/config_cmd_test.go
@@ -113,8 +113,10 @@ func (s *stubRepoResolver) SetWorkingDirError(err error) {
 func createFakeGitRepo(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
-	err := os.Mkdir(filepath.Join(dir, ".git"), 0o755)
+	gitDir := filepath.Join(dir, ".git")
+	err := os.Mkdir(gitDir, 0o755)
 	require.NoError(t, err, "create .git dir: %v", err)
+	require.NoError(t, os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644))
 	return dir
 }
 
@@ -221,6 +223,21 @@ func TestRepoRoot(t *testing.T) {
 		resolver := &stubRepoResolver{}
 		resolver.SetGitError(errors.New(errGitStub))
 		resolver.SetWorkingDir(t.TempDir())
+
+		got, err := repoRoot(resolver)
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+
+	t.Run("ignores invalid git metadata in parent directory", func(t *testing.T) {
+		parent := t.TempDir()
+		require.NoError(t, os.Mkdir(filepath.Join(parent, ".git"), 0o755))
+		nested := filepath.Join(parent, "nested")
+		require.NoError(t, os.Mkdir(nested, 0o755))
+
+		resolver := &stubRepoResolver{}
+		resolver.SetGitError(errors.New(errGitStub))
+		resolver.SetWorkingDir(nested)
 
 		got, err := repoRoot(resolver)
 		require.NoError(t, err)

--- a/cmd/roborev/tui/render_log.go
+++ b/cmd/roborev/tui/render_log.go
@@ -71,12 +71,11 @@ func (m model) renderLogView() string {
 	}
 
 	// For auto-design-router rows (classify-typed, or terminal skipped
-	// design reviews) the streamed agent log is empty — the classifier
-	// runs as a one-shot SchemaAgent.Decide call, not a streaming chat.
-	// Surface the classifier's verdict and reasoning here so 'l' on a
-	// classify/skipped row actually shows something useful. Truncated
-	// to m.width so each returned string occupies exactly one terminal
-	// row, keeping the log content area aligned with logVisibleLines.
+	// design reviews), surface the classifier verdict and reasoning above
+	// any raw log lines. The header remains useful when the log file was
+	// cleaned up or the classifier failed before producing output.
+	// Truncated to m.width so each returned string occupies exactly one
+	// terminal row, keeping the log content area aligned with logVisibleLines.
 	for _, line := range classifyReasoningLines(job, m.width) {
 		b.WriteString(line)
 		b.WriteString("\x1b[K\n")

--- a/internal/daemon/classifier.go
+++ b/internal/daemon/classifier.go
@@ -33,13 +33,14 @@ var classifySchema = json.RawMessage(`{
 type classifierAdapter struct {
 	agent    agent.SchemaAgent
 	maxBytes int
+	output   io.Writer
 }
 
-func newClassifierAdapter(a agent.SchemaAgent, maxBytes int) *classifierAdapter {
+func newClassifierAdapter(a agent.SchemaAgent, maxBytes int, output io.Writer) *classifierAdapter {
 	if maxBytes <= 0 {
 		maxBytes = 20 * 1024
 	}
-	return &classifierAdapter{agent: a, maxBytes: maxBytes}
+	return &classifierAdapter{agent: a, maxBytes: maxBytes, output: output}
 }
 
 type classifyResult struct {
@@ -61,7 +62,11 @@ func (c *classifierAdapter) Decide(ctx context.Context, in autotype.Input) (bool
 		return false, "", fmt.Errorf("build prompt: %w", err)
 	}
 
-	raw, err := c.agent.ClassifyWithSchema(ctx, in.RepoPath, in.GitRef, p, classifySchema, io.Discard)
+	logOutput := c.output
+	if logOutput == nil {
+		logOutput = io.Discard
+	}
+	raw, err := c.agent.ClassifyWithSchema(ctx, in.RepoPath, in.GitRef, p, classifySchema, logOutput)
 	if err != nil {
 		return false, "", fmt.Errorf("classifier agent: %w", err)
 	}

--- a/internal/daemon/classifier_test.go
+++ b/internal/daemon/classifier_test.go
@@ -16,28 +16,51 @@ import (
 )
 
 type fakeSchemaAgent struct {
-	result json.RawMessage
-	err    error
+	name        string
+	commandLine string
+	result      json.RawMessage
+	err         error
+	logOutput   string
 }
 
-func (f *fakeSchemaAgent) Name() string { return "fake" }
+func (f *fakeSchemaAgent) Name() string {
+	if f.name != "" {
+		return f.name
+	}
+	return "fake"
+}
+
 func (f *fakeSchemaAgent) Review(context.Context, string, string, string, io.Writer) (string, error) {
 	return "", nil
 }
 func (f *fakeSchemaAgent) WithReasoning(agent.ReasoningLevel) agent.Agent { return f }
 func (f *fakeSchemaAgent) WithAgentic(bool) agent.Agent                   { return f }
 func (f *fakeSchemaAgent) WithModel(string) agent.Agent                   { return f }
-func (f *fakeSchemaAgent) CommandLine() string                            { return "fake" }
+func (f *fakeSchemaAgent) CommandLine() string {
+	if f.commandLine != "" {
+		return f.commandLine
+	}
+	return "fake"
+}
+
 func (f *fakeSchemaAgent) ClassifyWithSchema(
-	context.Context, string, string, string, json.RawMessage, io.Writer,
+	_ context.Context,
+	_, _, _ string,
+	_ json.RawMessage,
+	out io.Writer,
 ) (json.RawMessage, error) {
+	if f.logOutput != "" && out != nil {
+		if _, err := io.WriteString(out, f.logOutput); err != nil {
+			return nil, err
+		}
+	}
 	return f.result, f.err
 }
 
 func TestClassifierAdapter_Yes(t *testing.T) {
 	ad := newClassifierAdapter(&fakeSchemaAgent{
 		result: []byte(`{"design_review": true, "reason": "new package"}`),
-	}, 20*1024)
+	}, 20*1024, nil)
 	yes, reason, err := ad.Decide(context.Background(), autotype.Input{})
 	require.NoError(t, err)
 	assert.True(t, yes)
@@ -47,21 +70,36 @@ func TestClassifierAdapter_Yes(t *testing.T) {
 func TestClassifierAdapter_No(t *testing.T) {
 	ad := newClassifierAdapter(&fakeSchemaAgent{
 		result: []byte(`{"design_review": false, "reason": "local fix"}`),
-	}, 20*1024)
+	}, 20*1024, nil)
 	yes, reason, err := ad.Decide(context.Background(), autotype.Input{})
 	require.NoError(t, err)
 	assert.False(t, yes)
 	assert.Equal(t, "local fix", reason)
 }
 
+func TestClassifierAdapter_ForwardsProgressOutput(t *testing.T) {
+	var out strings.Builder
+	ad := newClassifierAdapter(&fakeSchemaAgent{
+		result:    []byte(`{"design_review": false, "reason": "local fix"}`),
+		logOutput: "classifier progress\n",
+	}, 20*1024, &out)
+
+	yes, reason, err := ad.Decide(context.Background(), autotype.Input{})
+
+	require.NoError(t, err)
+	assert.False(t, yes)
+	assert.Equal(t, "local fix", reason)
+	assert.Equal(t, "classifier progress\n", out.String())
+}
+
 func TestClassifierAdapter_AgentError(t *testing.T) {
-	ad := newClassifierAdapter(&fakeSchemaAgent{err: errors.New("boom")}, 20*1024)
+	ad := newClassifierAdapter(&fakeSchemaAgent{err: errors.New("boom")}, 20*1024, nil)
 	_, _, err := ad.Decide(context.Background(), autotype.Input{})
 	assert.ErrorContains(t, err, "boom")
 }
 
 func TestClassifierAdapter_InvalidJSON(t *testing.T) {
-	ad := newClassifierAdapter(&fakeSchemaAgent{result: []byte(`not json`)}, 20*1024)
+	ad := newClassifierAdapter(&fakeSchemaAgent{result: []byte(`not json`)}, 20*1024, nil)
 	_, _, err := ad.Decide(context.Background(), autotype.Input{})
 	assert.ErrorContains(t, err, "invalid")
 }
@@ -70,7 +108,7 @@ func TestClassifierAdapter_SanitizesReason_Length(t *testing.T) {
 	long := strings.Repeat("a", 1000)
 	ad := newClassifierAdapter(&fakeSchemaAgent{
 		result: []byte(`{"design_review":false,"reason":"` + long + `"}`),
-	}, 20*1024)
+	}, 20*1024, nil)
 	_, reason, err := ad.Decide(context.Background(), autotype.Input{})
 	require.NoError(t, err)
 	assert.LessOrEqual(t, len(reason), classifyReasonMaxLen)
@@ -79,7 +117,7 @@ func TestClassifierAdapter_SanitizesReason_Length(t *testing.T) {
 func TestClassifierAdapter_SanitizesReason_StripsControlChars(t *testing.T) {
 	ad := newClassifierAdapter(&fakeSchemaAgent{
 		result: []byte(`{"design_review":false,"reason":"hello\u0007world\nlocal"}`),
-	}, 20*1024)
+	}, 20*1024, nil)
 	_, reason, err := ad.Decide(context.Background(), autotype.Input{})
 	require.NoError(t, err)
 	// BEL control char dropped; \n folded to space.
@@ -96,7 +134,7 @@ func TestClassifierAdapter_RespectsMaxBytes(t *testing.T) {
 	// exercised.
 	ad := newClassifierAdapter(&fakeSchemaAgent{
 		result: []byte(`{"design_review": false, "reason": "ok"}`),
-	}, 4096)
+	}, 4096, nil)
 	_, _, err := ad.Decide(context.Background(), autotype.Input{
 		Diff:    strings.Repeat("+line\n", 1000),
 		Message: "feat: something",

--- a/internal/daemon/joblog.go
+++ b/internal/daemon/joblog.go
@@ -115,6 +115,13 @@ func ParseJobIDFromLogName(name string) (int64, bool) {
 	return id, true
 }
 
+type jobLogOpenMode int
+
+const (
+	jobLogTruncate jobLogOpenMode = iota
+	jobLogAppend
+)
+
 // jobLogWriter retries transient log-file open/write failures while buffering
 // a bounded amount of output in memory so jobs still get on-disk logs once the
 // filesystem recovers.
@@ -130,8 +137,16 @@ type jobLogWriter struct {
 }
 
 func newJobLogWriter(jobID int64) *jobLogWriter {
+	return newJobLogWriterWithMode(jobID, jobLogTruncate)
+}
+
+func newAppendingJobLogWriter(jobID int64) *jobLogWriter {
+	return newJobLogWriterWithMode(jobID, jobLogAppend)
+}
+
+func newJobLogWriterWithMode(jobID int64, mode jobLogOpenMode) *jobLogWriter {
 	w := &jobLogWriter{jobID: jobID}
-	w.tryOpenLocked(true)
+	w.tryOpenLocked(mode == jobLogTruncate)
 	return w
 }
 

--- a/internal/daemon/joblog_test.go
+++ b/internal/daemon/joblog_test.go
@@ -188,6 +188,36 @@ func TestJobLogWriter(t *testing.T) {
 		}
 	})
 
+	t.Run("append_mode_preserves_existing_log", func(t *testing.T) {
+		setupTestEnv(t)
+		require.NoError(t, os.MkdirAll(JobLogDir(), 0o700))
+		require.NoError(t, os.WriteFile(JobLogPath(205), []byte("classifier\n"), 0o600))
+
+		w := newAppendingJobLogWriter(205)
+		_, err := w.Write([]byte("review\n"))
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+
+		data, err := os.ReadFile(JobLogPath(205))
+		require.NoError(t, err)
+		assert.Equal(t, "classifier\nreview\n", string(data))
+	})
+
+	t.Run("default_mode_truncates_existing_log", func(t *testing.T) {
+		setupTestEnv(t)
+		require.NoError(t, os.MkdirAll(JobLogDir(), 0o700))
+		require.NoError(t, os.WriteFile(JobLogPath(206), []byte("old\n"), 0o600))
+
+		w := newJobLogWriter(206)
+		_, err := w.Write([]byte("new\n"))
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+
+		data, err := os.ReadFile(JobLogPath(206))
+		require.NoError(t, err)
+		assert.Equal(t, "new\n", string(data))
+	})
+
 	t.Run("retries_after_initial_open_failure", func(t *testing.T) {
 		setupTestEnv(t)
 		prevRetry := jobLogOpenRetryInterval

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -619,7 +619,7 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 	// transient filesystem failures so resource pressure does not permanently
 	// disable logging for the rest of the job.
 	var jobLog *jobLogWriter
-	if job.Source == "auto_design" && JobLogExists(job.ID) {
+	if shouldAppendReviewJobLog(job) {
 		jobLog = newAppendingJobLogWriter(job.ID)
 	} else {
 		jobLog = newJobLogWriter(job.ID)
@@ -807,6 +807,10 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 		Findings:     output,
 		WorktreePath: eventWorktreePath,
 	})
+}
+
+func shouldAppendReviewJobLog(job *storage.ReviewJob) bool {
+	return job.Source == "auto_design"
 }
 
 func (wp *WorkerPool) autoClosePassingReview(workerID string, job *storage.ReviewJob, output string) {

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -618,7 +618,12 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 	// Tee raw agent output to a per-job log file on disk. The writer retries
 	// transient filesystem failures so resource pressure does not permanently
 	// disable logging for the rest of the job.
-	jobLog := newJobLogWriter(job.ID)
+	var jobLog *jobLogWriter
+	if job.Source == "auto_design" && JobLogExists(job.ID) {
+		jobLog = newAppendingJobLogWriter(job.ID)
+	} else {
+		jobLog = newJobLogWriter(job.ID)
+	}
 	defer func() {
 		if err := jobLog.Close(); err != nil {
 			log.Printf("[%s] Warning: close job log for job %d: %v", workerID, job.ID, err)

--- a/internal/daemon/worker_classify.go
+++ b/internal/daemon/worker_classify.go
@@ -92,6 +92,12 @@ func (wp *WorkerPool) processClassifyJob(ctx context.Context, workerID string, j
 	classifyCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	maxBytes := config.ResolveClassifierMaxPromptSize(job.RepoPath, cfg)
+	jobLog := newJobLogWriter(job.ID)
+	defer func() {
+		if err := jobLog.Close(); err != nil {
+			log.Printf("[%s] Warning: close job log for classify job %d: %v", workerID, job.ID, err)
+		}
+	}()
 
 	if yes, reason, set := getTestClassifierVerdict(); set {
 		wp.applyClassifyVerdict(workerID, job, yes, reason)
@@ -153,7 +159,10 @@ func (wp *WorkerPool) processClassifyJob(ctx context.Context, workerID string, j
 		if !ok {
 			return false, "", selectedName, fmt.Errorf("classify_agent %q lost SchemaAgent capability after WithReasoning/WithModel", name)
 		}
-		yes, reason, err := newClassifierAdapter(sa, maxBytes).Decide(classifyCtx, in)
+		if err := wp.db.SaveJobCommandLine(job.ID, sa.CommandLine()); err != nil {
+			log.Printf("[%s] Error saving classifier command line for job %d: %v", workerID, job.ID, err)
+		}
+		yes, reason, err := newClassifierAdapter(sa, maxBytes, jobLog).Decide(classifyCtx, in)
 		return yes, reason, selectedName, err
 	}
 

--- a/internal/daemon/worker_classify.go
+++ b/internal/daemon/worker_classify.go
@@ -93,13 +93,19 @@ func (wp *WorkerPool) processClassifyJob(ctx context.Context, workerID string, j
 	defer cancel()
 	maxBytes := config.ResolveClassifierMaxPromptSize(job.RepoPath, cfg)
 	jobLog := newJobLogWriter(job.ID)
-	defer func() {
+	closeJobLog := func() {
+		if jobLog == nil {
+			return
+		}
 		if err := jobLog.Close(); err != nil {
 			log.Printf("[%s] Warning: close job log for classify job %d: %v", workerID, job.ID, err)
 		}
-	}()
+		jobLog = nil
+	}
+	defer closeJobLog()
 
 	if yes, reason, set := getTestClassifierVerdict(); set {
+		closeJobLog()
 		wp.applyClassifyVerdict(workerID, job, yes, reason)
 		return
 	}
@@ -115,6 +121,7 @@ func (wp *WorkerPool) processClassifyJob(ctx context.Context, workerID string, j
 	primary, err := config.ResolveClassifyAgent("", job.RepoPath, cfg)
 	if err != nil {
 		log.Printf("[%s] classifier config error for job %d: %v", workerID, job.ID, err)
+		closeJobLog()
 		wp.completeClassifyAsSkip(workerID, job, "classifier unavailable", err.Error())
 		return
 	}
@@ -179,11 +186,13 @@ func (wp *WorkerPool) processClassifyJob(ctx context.Context, workerID string, j
 	}
 	if err != nil {
 		log.Printf("[%s] classifier error for job %d: %v", workerID, job.ID, err)
+		closeJobLog()
 		wp.completeClassifyAsSkip(workerID, job,
 			publicClassifierSkipReason(err),
 			composeClassifyErrorDetail(err, backupErr))
 		return
 	}
+	closeJobLog()
 	wp.applyClassifyVerdict(workerID, job, yes, reason)
 }
 

--- a/internal/daemon/worker_classify_test.go
+++ b/internal/daemon/worker_classify_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testutil"
@@ -147,6 +148,49 @@ func TestResolveClassifyDiff_SkipsFetchForEmptyRef(t *testing.T) {
 		RepoPath: "/somewhere",
 	}
 	assert.Empty(t, resolveClassifyDiff("worker-4", job))
+}
+
+func TestProcessClassifyJob_WritesStandardLogAndCommandLine(t *testing.T) {
+	setupTestEnv(t)
+	tc := newWorkerTestContext(t, 1)
+
+	classifier := &fakeSchemaAgent{
+		name:        "fake-schema",
+		commandLine: "fake-schema classify --json",
+		result:      []byte(`{"design_review": false, "reason": "local change"}`),
+		logOutput:   "classifier progress\n",
+	}
+	agent.Register(classifier)
+	t.Cleanup(func() { agent.Unregister("fake-schema") })
+
+	cfg := config.DefaultConfig()
+	cfg.ClassifyAgent = "fake-schema"
+	tc.Pool.cfgGetter = NewStaticConfig(cfg)
+
+	_, err := tc.DB.GetOrCreateCommit(tc.Repo.ID, "classify-log", "Author", "s", time.Now())
+	require.NoError(t, err)
+	jobID, err := tc.DB.EnqueueAutoDesignJob(storage.EnqueueOpts{
+		RepoID:     tc.Repo.ID,
+		GitRef:     "classify-log",
+		JobType:    storage.JobTypeClassify,
+		ReviewType: "design",
+	})
+	require.NoError(t, err)
+	claimed, err := tc.DB.ClaimJob("worker-classify-log")
+	require.NoError(t, err)
+	require.Equal(t, jobID, claimed.ID)
+
+	tc.Pool.processClassifyJob(context.Background(), "worker-classify-log", claimed)
+
+	data, err := os.ReadFile(JobLogPath(jobID))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "classifier progress")
+
+	got, err := tc.DB.GetJobByID(jobID)
+	require.NoError(t, err)
+	assert.Equal(t, "fake-schema classify --json", got.CommandLine)
+	assert.Equal(t, storage.JobStatusSkipped, got.Status)
+	assert.Equal(t, "local change", got.SkipReason)
 }
 
 // waitForEvent reads one event from ch within timeout.

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -530,6 +530,15 @@ func TestProcessJob_PromotedAutoDesignAppendsExistingClassifierLog(t *testing.T)
 	assert.Contains(t, string(data), "design review progress")
 }
 
+func TestShouldAppendReviewJobLogForAutoDesignWithoutExistingLog(t *testing.T) {
+	setupTestEnv(t)
+	job := &storage.ReviewJob{ID: 909, Source: "auto_design"}
+
+	assert.False(t, JobLogExists(job.ID))
+	assert.True(t, shouldAppendReviewJobLog(job))
+	assert.False(t, shouldAppendReviewJobLog(&storage.ReviewJob{ID: 910}))
+}
+
 func TestApplyCodexReviewSettingsOnlyForReviewJobs(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Agent.Codex.DisableReviewSkills = true

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -481,6 +481,55 @@ func TestProcessJob_UsesStoredReviewPromptOverride(t *testing.T) {
 	assert.Equal(t, job.Prompt, updated.Prompt)
 }
 
+func TestProcessJob_PromotedAutoDesignAppendsExistingClassifierLog(t *testing.T) {
+	setupTestEnv(t)
+	tc := newWorkerTestContext(t, 1)
+
+	reviewer := &agent.FakeAgent{
+		NameStr: "fake-reviewer",
+		ReviewFn: func(ctx context.Context, repoPath, commitSHA, prompt string, output io.Writer) (string, error) {
+			if output != nil {
+				_, err := io.WriteString(output, "design review progress\n")
+				require.NoError(t, err)
+			}
+			return "review output", nil
+		},
+	}
+	agent.Register(reviewer)
+	t.Cleanup(func() { agent.Unregister("fake-reviewer") })
+
+	commit, err := tc.DB.GetOrCreateCommit(tc.Repo.ID, "promoted-log", "Author", "s", time.Now())
+	require.NoError(t, err)
+	jobID, err := tc.DB.EnqueueAutoDesignJob(storage.EnqueueOpts{
+		RepoID:     tc.Repo.ID,
+		CommitID:   commit.ID,
+		GitRef:     "promoted-log",
+		Agent:      "fake-reviewer",
+		JobType:    storage.JobTypeReview,
+		ReviewType: "design",
+	})
+	require.NoError(t, err)
+	require.NotZero(t, jobID)
+	_, err = tc.DB.Exec(
+		"UPDATE review_jobs SET prompt = ?, prompt_prebuilt = 1 WHERE id = ?",
+		"prebuilt design review prompt",
+		jobID,
+	)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(JobLogDir(), 0o700))
+	require.NoError(t, os.WriteFile(JobLogPath(jobID), []byte("classifier progress\n"), 0o600))
+
+	claimed, err := tc.DB.ClaimJob("worker-promoted-log")
+	require.NoError(t, err)
+	assert.Equal(t, "auto_design", claimed.Source)
+	tc.Pool.processJob("worker-promoted-log", claimed)
+
+	data, err := os.ReadFile(JobLogPath(jobID))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "classifier progress")
+	assert.Contains(t, string(data), "design review progress")
+}
+
 func TestApplyCodexReviewSettingsOnlyForReviewJobs(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Agent.Codex.DisableReviewSkills = true

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -360,7 +360,7 @@ func (db *DB) ClaimJob(workerID string) (*ReviewJob, error) {
 		SELECT j.id, j.repo_id, j.commit_id, j.git_ref, j.branch, j.session_id, j.agent, j.model, j.provider, j.requested_model, j.requested_provider, j.reasoning, j.status, j.enqueued_at,
 		       r.root_path, r.name, c.subject, j.diff_content, j.prompt, COALESCE(j.agentic, 0), COALESCE(j.prompt_prebuilt, 0), j.job_type, j.review_type,
 		       j.output_prefix, j.patch_id, j.parent_job_id, COALESCE(j.worktree_path, ''), j.command_line, COALESCE(j.min_severity, ''), COALESCE(j.backup_agent, ''), COALESCE(j.backup_model, ''),
-		       COALESCE(j.panel_run_uuid, ''), COALESCE(j.panel_role, ''), COALESCE(j.panel_name, ''), COALESCE(j.panel_member_name, ''), j.panel_member_index, COALESCE(j.panel_member_config_json, ''), COALESCE(j.claim_blocked, 0)
+		       COALESCE(j.panel_run_uuid, ''), COALESCE(j.panel_role, ''), COALESCE(j.panel_name, ''), COALESCE(j.panel_member_name, ''), j.panel_member_index, COALESCE(j.panel_member_config_json, ''), COALESCE(j.claim_blocked, 0), COALESCE(j.source, '')
 		FROM review_jobs j
 		JOIN repos r ON r.id = j.repo_id
 		LEFT JOIN commits c ON c.id = j.commit_id
@@ -370,7 +370,7 @@ func (db *DB) ClaimJob(workerID string) (*ReviewJob, error) {
 	`, workerID).Scan(&job.ID, &job.RepoID, &fields.CommitID, &job.GitRef, &fields.Branch, &fields.SessionID, &job.Agent, &fields.Model, &fields.Provider, &fields.RequestedModel, &fields.RequestedProvider, &job.Reasoning, &job.Status, &fields.EnqueuedAt,
 		&job.RepoPath, &job.RepoName, &fields.CommitSubject, &fields.DiffContent, &fields.Prompt, &fields.Agentic, &fields.PromptPrebuilt, &fields.JobType, &fields.ReviewType,
 		&fields.OutputPrefix, &fields.PatchID, &fields.ParentJobID, &fields.WorktreePath, &fields.CommandLine, &fields.MinSeverity, &fields.BackupAgent, &fields.BackupModel,
-		&fields.PanelRunUUID, &fields.PanelRole, &fields.PanelName, &fields.PanelMemberName, &fields.PanelMemberIndex, &fields.PanelMemberConfig, &fields.ClaimBlocked)
+		&fields.PanelRunUUID, &fields.PanelRole, &fields.PanelName, &fields.PanelMemberName, &fields.PanelMemberIndex, &fields.PanelMemberConfig, &fields.ClaimBlocked, &fields.Source)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/review_attempts_test.go
+++ b/internal/storage/review_attempts_test.go
@@ -269,15 +269,15 @@ func TestClaimDueReviewAttemptIsExclusive(t *testing.T) {
 	require.True(t, created)
 	require.NoError(t, db.DeferReviewAttempt("o/r", 9, "s", "transient", "x", "u",
 		now.Add(-time.Minute), false))
-	var wins int32
+	var wins atomic.Int32
 	var wg sync.WaitGroup
 	for range 8 {
 		wg.Go(func() {
 			if ok, _, _, _ := db.ClaimDueReviewAttempt("o/r", 9, "s", now); ok {
-				atomic.AddInt32(&wins, 1)
+				wins.Add(1)
 			}
 		})
 	}
 	wg.Wait()
-	assert.Equal(t, int32(1), atomic.LoadInt32(&wins))
+	assert.Equal(t, int32(1), wins.Load())
 }


### PR DESCRIPTION
## Summary
- route auto-design classifier agent output into the normal per-job log writer and save the resolved classifier command line
- close classifier logs before promote/skip transitions and make promoted auto-design review logs append even if the classifier log file is not present yet
- tighten fallback repo-root detection for invalid parent `.git` metadata and clear the current lint warning in review-attempt tests

## Verification
- `env GOPATH=/tmp/roborev-go-path GOCACHE=/tmp/roborev-go-cache go fmt ./...`
- `env GOPATH=/tmp/roborev-go-path GOCACHE=/tmp/roborev-go-cache go test ./...`
- `env GOPATH=/tmp/roborev-go-path GOCACHE=/tmp/roborev-go-cache go vet ./...`
- `env GOPATH=/tmp/roborev-go-path GOCACHE=/tmp/roborev-go-cache go build ./...`
- `env GOPATH=/tmp/roborev-go-path GOCACHE=/tmp/roborev-go-cache GOLANGCI_LINT_CACHE=/tmp/roborev-golangci-cache nix run 'nixpkgs#golangci-lint' -- run ./...` (`0 issues.`)