### PR TITLE
Fix review retry log handling

### DIFF
--- a/cmd/roborev/config_cmd.go
+++ b/cmd/roborev/config_cmd.go
@@ -124,9 +124,28 @@ func hasGitMetadata(dir string) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		return strings.HasPrefix(strings.TrimSpace(string(data)), "gitdir:"), nil
+		return hasGitFileMetadata(dir, data)
 	}
 
+	return hasGitDirMetadata(gitPath)
+}
+
+func hasGitFileMetadata(dir string, data []byte) (bool, error) {
+	gitDir, ok := strings.CutPrefix(strings.TrimSpace(string(data)), "gitdir:")
+	if !ok {
+		return false, nil
+	}
+	gitDir = strings.TrimSpace(gitDir)
+	if gitDir == "" {
+		return false, nil
+	}
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(dir, gitDir)
+	}
+	return hasGitDirMetadata(gitDir)
+}
+
+func hasGitDirMetadata(gitPath string) (bool, error) {
 	headInfo, err := os.Stat(filepath.Join(gitPath, "HEAD"))
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/cmd/roborev/config_cmd_test.go
+++ b/cmd/roborev/config_cmd_test.go
@@ -243,6 +243,36 @@ func TestRepoRoot(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, got)
 	})
+
+	t.Run("ignores malformed gitdir file", func(t *testing.T) {
+		parent := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(parent, ".git"), []byte("gitdir:\n"), 0o644))
+		nested := filepath.Join(parent, "nested")
+		require.NoError(t, os.Mkdir(nested, 0o755))
+
+		resolver := &stubRepoResolver{}
+		resolver.SetGitError(errors.New(errGitStub))
+		resolver.SetWorkingDir(nested)
+
+		got, err := repoRoot(resolver)
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+
+	t.Run("ignores gitdir file with missing target", func(t *testing.T) {
+		parent := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(parent, ".git"), []byte("gitdir: missing\n"), 0o644))
+		nested := filepath.Join(parent, "nested")
+		require.NoError(t, os.Mkdir(nested, 0o755))
+
+		resolver := &stubRepoResolver{}
+		resolver.SetGitError(errors.New(errGitStub))
+		resolver.SetWorkingDir(nested)
+
+		got, err := repoRoot(resolver)
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
 }
 
 func TestRequireRepoRoot(t *testing.T) {

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -810,7 +810,7 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 }
 
 func shouldAppendReviewJobLog(job *storage.ReviewJob) bool {
-	return job.Source == "auto_design"
+	return job.Source == "auto_design" && job.RetryCount == 0
 }
 
 func (wp *WorkerPool) autoClosePassingReview(workerID string, job *storage.ReviewJob, output string) {

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -607,6 +607,70 @@ func TestProcessJob_PromotedAutoDesignAppendsExistingClassifierLog(t *testing.T)
 	assert.Contains(t, string(data), "design review progress")
 }
 
+func TestProcessJob_RetriedAutoDesignTruncatesPreviousReviewLog(t *testing.T) {
+	setupTestEnv(t)
+	tc := newWorkerTestContext(t, 1)
+
+	reviewer := &agent.FakeAgent{
+		NameStr: "fake-reviewer",
+		ReviewFn: func(ctx context.Context, repoPath, commitSHA, prompt string, output io.Writer) (string, error) {
+			if output != nil {
+				_, err := io.WriteString(output, "retry review progress\n")
+				require.NoError(t, err)
+			}
+			return "retry review output", nil
+		},
+	}
+	agent.Register(reviewer)
+	t.Cleanup(func() { agent.Unregister("fake-reviewer") })
+
+	commit, err := tc.DB.GetOrCreateCommit(tc.Repo.ID, "promoted-retry-log", "Author", "s", time.Now())
+	require.NoError(t, err)
+	jobID, err := tc.DB.EnqueueAutoDesignJob(storage.EnqueueOpts{
+		RepoID:     tc.Repo.ID,
+		CommitID:   commit.ID,
+		GitRef:     "promoted-retry-log",
+		Agent:      "fake-reviewer",
+		JobType:    storage.JobTypeReview,
+		ReviewType: "design",
+	})
+	require.NoError(t, err)
+	_, err = tc.DB.Exec(
+		"UPDATE review_jobs SET prompt = ?, prompt_prebuilt = 1 WHERE id = ?",
+		"prebuilt design review prompt",
+		jobID,
+	)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(JobLogDir(), 0o700))
+	require.NoError(t, os.WriteFile(
+		JobLogPath(jobID),
+		[]byte("classifier progress\nstale failed review\n"),
+		0o600,
+	))
+
+	firstClaim, err := tc.DB.ClaimJob("worker-first-attempt")
+	require.NoError(t, err)
+	require.Equal(t, jobID, firstClaim.ID)
+	tc.Pool.failOrRetryInner("worker-first-attempt", firstClaim, "fake-reviewer", "connection reset", true)
+
+	retryCount, err := tc.DB.GetJobRetryCount(jobID)
+	require.NoError(t, err)
+	require.Equal(t, 1, retryCount)
+
+	retryClaim, err := tc.DB.ClaimJob("worker-retry-attempt")
+	require.NoError(t, err)
+	require.Equal(t, jobID, retryClaim.ID)
+
+	tc.Pool.processJob("worker-retry-attempt", retryClaim)
+
+	data, err := os.ReadFile(JobLogPath(jobID))
+	require.NoError(t, err)
+	logText := string(data)
+	assert.NotContains(t, logText, "classifier progress")
+	assert.NotContains(t, logText, "stale failed review")
+	assert.Contains(t, logText, "retry review progress")
+}
+
 func TestShouldAppendReviewJobLogForAutoDesignWithoutExistingLog(t *testing.T) {
 	setupTestEnv(t)
 	job := &storage.ReviewJob{ID: 909, Source: "auto_design"}

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -616,6 +616,16 @@ func TestShouldAppendReviewJobLogForAutoDesignWithoutExistingLog(t *testing.T) {
 	assert.False(t, shouldAppendReviewJobLog(&storage.ReviewJob{ID: 910}))
 }
 
+func TestShouldAppendReviewJobLogOnlyForFirstAutoDesignAttempt(t *testing.T) {
+	job := &storage.ReviewJob{
+		ID:         909,
+		Source:     "auto_design",
+		RetryCount: 1,
+	}
+
+	assert.False(t, shouldAppendReviewJobLog(job))
+}
+
 func TestApplyCodexReviewSettingsOnlyForReviewJobs(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Agent.Codex.DisableReviewSkills = true

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -360,7 +360,7 @@ func (db *DB) ClaimJob(workerID string) (*ReviewJob, error) {
 		SELECT j.id, j.repo_id, j.commit_id, j.git_ref, j.branch, j.session_id, j.agent, j.model, j.provider, j.requested_model, j.requested_provider, j.reasoning, j.status, j.enqueued_at,
 		       r.root_path, r.name, c.subject, j.diff_content, j.prompt, COALESCE(j.agentic, 0), COALESCE(j.prompt_prebuilt, 0), j.job_type, j.review_type,
 		       j.output_prefix, j.patch_id, j.parent_job_id, COALESCE(j.worktree_path, ''), j.command_line, COALESCE(j.min_severity, ''), COALESCE(j.backup_agent, ''), COALESCE(j.backup_model, ''),
-		       COALESCE(j.panel_run_uuid, ''), COALESCE(j.panel_role, ''), COALESCE(j.panel_name, ''), COALESCE(j.panel_member_name, ''), j.panel_member_index, COALESCE(j.panel_member_config_json, ''), COALESCE(j.claim_blocked, 0), COALESCE(j.source, '')
+		       COALESCE(j.panel_run_uuid, ''), COALESCE(j.panel_role, ''), COALESCE(j.panel_name, ''), COALESCE(j.panel_member_name, ''), j.panel_member_index, COALESCE(j.panel_member_config_json, ''), COALESCE(j.claim_blocked, 0), COALESCE(j.source, ''), j.retry_count
 		FROM review_jobs j
 		JOIN repos r ON r.id = j.repo_id
 		LEFT JOIN commits c ON c.id = j.commit_id
@@ -370,7 +370,7 @@ func (db *DB) ClaimJob(workerID string) (*ReviewJob, error) {
 	`, workerID).Scan(&job.ID, &job.RepoID, &fields.CommitID, &job.GitRef, &fields.Branch, &fields.SessionID, &job.Agent, &fields.Model, &fields.Provider, &fields.RequestedModel, &fields.RequestedProvider, &job.Reasoning, &job.Status, &fields.EnqueuedAt,
 		&job.RepoPath, &job.RepoName, &fields.CommitSubject, &fields.DiffContent, &fields.Prompt, &fields.Agentic, &fields.PromptPrebuilt, &fields.JobType, &fields.ReviewType,
 		&fields.OutputPrefix, &fields.PatchID, &fields.ParentJobID, &fields.WorktreePath, &fields.CommandLine, &fields.MinSeverity, &fields.BackupAgent, &fields.BackupModel,
-		&fields.PanelRunUUID, &fields.PanelRole, &fields.PanelName, &fields.PanelMemberName, &fields.PanelMemberIndex, &fields.PanelMemberConfig, &fields.ClaimBlocked, &fields.Source)
+		&fields.PanelRunUUID, &fields.PanelRole, &fields.PanelName, &fields.PanelMemberName, &fields.PanelMemberIndex, &fields.PanelMemberConfig, &fields.ClaimBlocked, &fields.Source, &job.RetryCount)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- keep auto-design classifier output only on the first promoted review attempt so retries truncate stale attempt logs
- validate .git gitdir fallbacks before treating a directory as a repo root