### PR TITLE
Fall back to main repo for gitignored .roborev.toml in worktrees

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -520,48 +520,52 @@ func (c *Config) migrateDeprecated(md toml.MetaData) {
 	}
 }
 
-// LoadRepoConfig loads per-repo config from .roborev.toml.
+// RepoConfigPath returns the .roborev.toml path that should be read for
+// repoPath, applying the linked-worktree fallback.
 //
-// When repoPath has no .roborev.toml, it falls back to the main repository
-// root. This matters for linked worktrees: a .roborev.toml that is gitignored
-// (or otherwise untracked) lives only in the main checkout's working tree, so
-// it is invisible from a worktree's directory. The fallback resolves the main
-// root via the git common dir and loads the config from there.
-func LoadRepoConfig(repoPath string) (*RepoConfig, error) {
-	cfg, found, err := loadRepoConfigAt(repoPath)
-	if err != nil {
-		return nil, err
-	}
-	if found {
-		return cfg, nil
+// A .roborev.toml that is gitignored (or otherwise untracked) lives only in
+// the main checkout's working tree, so it is invisible from a worktree's
+// directory. When repoPath has no .roborev.toml of its own, this resolves the
+// main repository root via the git common dir and returns its config path if
+// one exists there. Otherwise it returns repoPath's own (possibly nonexistent)
+// config path, so callers keep their existing "file missing" behavior.
+//
+// All per-repo config loaders (decoded and raw) route through this so they
+// agree on which file is authoritative.
+func RepoConfigPath(repoPath string) string {
+	local := filepath.Join(repoPath, ".roborev.toml")
+	if _, err := os.Stat(local); err == nil {
+		return local
 	}
 
-	// Not present at repoPath. If repoPath is a worktree, the config may live
-	// only in the main checkout (e.g. gitignored). Resolve the main root and
-	// retry there. Any resolution failure (not a git repo, etc.) leaves the
-	// original "no repo config" result intact.
+	// Not present (or unreadable) at repoPath. If repoPath is a worktree, the
+	// config may live only in the main checkout. Any resolution failure (not a
+	// git repo, etc.) falls through to the local path.
 	mainRoot, err := git.GetMainRepoRoot(repoPath)
 	if err != nil || mainRoot == "" || mainRoot == repoPath {
-		return nil, nil
+		return local
 	}
-	cfg, _, err = loadRepoConfigAt(mainRoot)
-	return cfg, err
+	mainPath := filepath.Join(mainRoot, ".roborev.toml")
+	if _, err := os.Stat(mainPath); err == nil {
+		return mainPath
+	}
+	return local
 }
 
-// loadRepoConfigAt loads .roborev.toml from a single directory. found reports
-// whether the file existed (regardless of parse outcome).
-func loadRepoConfigAt(dir string) (cfg *RepoConfig, found bool, err error) {
-	path := filepath.Join(dir, ".roborev.toml")
-	if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
-		return nil, false, nil
+// LoadRepoConfig loads per-repo config from .roborev.toml, applying the
+// linked-worktree fallback via RepoConfigPath.
+func LoadRepoConfig(repoPath string) (*RepoConfig, error) {
+	path := RepoConfigPath(repoPath)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil, nil // No repo config
 	}
 
-	var loaded RepoConfig
-	if _, err := toml.DecodeFile(path, &loaded); err != nil {
-		return nil, true, err
+	var cfg RepoConfig
+	if _, err := toml.DecodeFile(path, &cfg); err != nil {
+		return nil, err
 	}
 
-	return &loaded, true, nil
+	return &cfg, nil
 }
 
 // ValidateRepoConfig returns any repo-config load or parse error for repoPath.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -520,19 +520,48 @@ func (c *Config) migrateDeprecated(md toml.MetaData) {
 	}
 }
 
-// LoadRepoConfig loads per-repo config from .roborev.toml
+// LoadRepoConfig loads per-repo config from .roborev.toml.
+//
+// When repoPath has no .roborev.toml, it falls back to the main repository
+// root. This matters for linked worktrees: a .roborev.toml that is gitignored
+// (or otherwise untracked) lives only in the main checkout's working tree, so
+// it is invisible from a worktree's directory. The fallback resolves the main
+// root via the git common dir and loads the config from there.
 func LoadRepoConfig(repoPath string) (*RepoConfig, error) {
-	path := filepath.Join(repoPath, ".roborev.toml")
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return nil, nil // No repo config
-	}
-
-	var cfg RepoConfig
-	if _, err := toml.DecodeFile(path, &cfg); err != nil {
+	cfg, found, err := loadRepoConfigAt(repoPath)
+	if err != nil {
 		return nil, err
 	}
+	if found {
+		return cfg, nil
+	}
 
-	return &cfg, nil
+	// Not present at repoPath. If repoPath is a worktree, the config may live
+	// only in the main checkout (e.g. gitignored). Resolve the main root and
+	// retry there. Any resolution failure (not a git repo, etc.) leaves the
+	// original "no repo config" result intact.
+	mainRoot, err := git.GetMainRepoRoot(repoPath)
+	if err != nil || mainRoot == "" || mainRoot == repoPath {
+		return nil, nil
+	}
+	cfg, _, err = loadRepoConfigAt(mainRoot)
+	return cfg, err
+}
+
+// loadRepoConfigAt loads .roborev.toml from a single directory. found reports
+// whether the file existed (regardless of parse outcome).
+func loadRepoConfigAt(dir string) (cfg *RepoConfig, found bool, err error) {
+	path := filepath.Join(dir, ".roborev.toml")
+	if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+		return nil, false, nil
+	}
+
+	var loaded RepoConfig
+	if _, err := toml.DecodeFile(path, &loaded); err != nil {
+		return nil, true, err
+	}
+
+	return &loaded, true, nil
 }
 
 // ValidateRepoConfig returns any repo-config load or parse error for repoPath.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -526,9 +526,15 @@ func (c *Config) migrateDeprecated(md toml.MetaData) {
 // A .roborev.toml that is gitignored (or otherwise untracked) lives only in
 // the main checkout's working tree, so it is invisible from a worktree's
 // directory. When repoPath has no .roborev.toml of its own, this resolves the
-// main repository root via the git common dir and returns its config path if
-// one exists there. Otherwise it returns repoPath's own (possibly nonexistent)
-// config path, so callers keep their existing "file missing" behavior.
+// main repository root via the git common dir and returns its config path.
+//
+// The fallback applies only when the main config is untracked. A tracked
+// .roborev.toml is a versioned, branch-specific file: a worktree on a branch
+// that removed it (or predates it) must not silently inherit the main
+// checkout's branch copy, so in that case the worktree's own absence wins.
+//
+// Otherwise it returns repoPath's own (possibly nonexistent) config path, so
+// callers keep their existing "file missing" behavior.
 //
 // All per-repo config loaders (decoded and raw) route through this so they
 // agree on which file is authoritative.
@@ -546,10 +552,16 @@ func RepoConfigPath(repoPath string) string {
 		return local
 	}
 	mainPath := filepath.Join(mainRoot, ".roborev.toml")
-	if _, err := os.Stat(mainPath); err == nil {
-		return mainPath
+	if _, err := os.Stat(mainPath); err != nil {
+		return local
 	}
-	return local
+	// Only inherit an untracked (gitignored/machine-local) main config. A
+	// tracked file belongs to the main checkout's branch, not this worktree.
+	tracked, err := git.HasTrackedFilesUnder(mainRoot, mainPath)
+	if err != nil || tracked {
+		return local
+	}
+	return mainPath
 }
 
 // LoadRepoConfig loads per-repo config from .roborev.toml, applying the

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -355,6 +355,38 @@ func TestLoadRepoConfigWorktreeFallback(t *testing.T) {
 	assert.Equal(t, "claude-code", cfg.Agent)
 }
 
+// TestLoadRepoConfigWorktreeNoFallbackForTracked verifies that a tracked
+// .roborev.toml in the main checkout is NOT inherited by a worktree on a
+// branch that lacks it. A tracked file is branch-specific, so the worktree's
+// own absence must win.
+func TestLoadRepoConfigWorktreeNoFallbackForTracked(t *testing.T) {
+	main := t.TempDir()
+	execGit(t, main, "init")
+	execGit(t, main, "config", "user.email", "t@example.com")
+	execGit(t, main, "config", "user.name", "t")
+	writeTestFile(t, main, "base.txt", "base\n")
+	execGit(t, main, "add", ".")
+	execGit(t, main, "commit", "-m", "init")
+
+	// Create the worktree from a commit that has no .roborev.toml, then add a
+	// tracked .roborev.toml only on the main checkout's branch.
+	wt := filepath.Join(t.TempDir(), "wt")
+	execGit(t, main, "worktree", "add", "-b", "feature", wt, "HEAD")
+
+	writeRepoConfigStr(t, main, `agent = "claude-code"`)
+	execGit(t, main, "add", ".roborev.toml")
+	execGit(t, main, "commit", "-m", "add config on main")
+
+	// The worktree branch never received the tracked file, so it must not
+	// inherit the main checkout's branch copy.
+	_, statErr := os.Stat(filepath.Join(wt, ".roborev.toml"))
+	require.True(t, os.IsNotExist(statErr), "worktree should not contain .roborev.toml")
+
+	cfg, err := LoadRepoConfig(wt)
+	require.NoError(t, err)
+	assert.Nil(t, cfg, "tracked main config must not leak into a worktree on a branch that lacks it")
+}
+
 // TestLoadRepoConfigWorktreeLocalWins verifies that a worktree's own
 // .roborev.toml takes precedence over the main checkout's config.
 func TestLoadRepoConfigWorktreeLocalWins(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -324,6 +324,79 @@ func TestLoadRepoConfigMissing(t *testing.T) {
 	}, "Expected nil config when file doesn't exist")
 }
 
+// TestLoadRepoConfigWorktreeFallback verifies that a .roborev.toml living only
+// in the main checkout (e.g. gitignored, so absent from a linked worktree's
+// working tree) is still loaded when LoadRepoConfig is called against the
+// worktree directory.
+func TestLoadRepoConfigWorktreeFallback(t *testing.T) {
+	main := t.TempDir()
+	execGit(t, main, "init")
+	execGit(t, main, "config", "user.email", "t@example.com")
+	execGit(t, main, "config", "user.name", "t")
+	writeTestFile(t, main, "base.txt", "base\n")
+	execGit(t, main, "add", ".")
+	execGit(t, main, "commit", "-m", "init")
+
+	// Config exists only in the main checkout and is gitignored, so it is
+	// untracked and will not appear in a worktree's working tree.
+	writeTestFile(t, main, ".gitignore", ".roborev.toml\n")
+	writeRepoConfigStr(t, main, `agent = "claude-code"`)
+
+	wt := filepath.Join(t.TempDir(), "wt")
+	execGit(t, main, "worktree", "add", wt, "HEAD")
+
+	// Sanity: the worktree really lacks its own config.
+	_, statErr := os.Stat(filepath.Join(wt, ".roborev.toml"))
+	require.True(t, os.IsNotExist(statErr), "worktree should not contain .roborev.toml")
+
+	cfg, err := LoadRepoConfig(wt)
+	require.NoError(t, err)
+	require.NotNil(t, cfg, "expected fallback to main checkout config")
+	assert.Equal(t, "claude-code", cfg.Agent)
+}
+
+// TestLoadRepoConfigWorktreeLocalWins verifies that a worktree's own
+// .roborev.toml takes precedence over the main checkout's config.
+func TestLoadRepoConfigWorktreeLocalWins(t *testing.T) {
+	main := t.TempDir()
+	execGit(t, main, "init")
+	execGit(t, main, "config", "user.email", "t@example.com")
+	execGit(t, main, "config", "user.name", "t")
+	writeTestFile(t, main, "base.txt", "base\n")
+	execGit(t, main, "add", ".")
+	execGit(t, main, "commit", "-m", "init")
+
+	writeTestFile(t, main, ".gitignore", ".roborev.toml\n")
+	writeRepoConfigStr(t, main, `agent = "codex"`)
+
+	wt := filepath.Join(t.TempDir(), "wt")
+	execGit(t, main, "worktree", "add", wt, "HEAD")
+	writeRepoConfigStr(t, wt, `agent = "gemini"`)
+
+	cfg, err := LoadRepoConfig(wt)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "gemini", cfg.Agent, "worktree-local config should win over main")
+}
+
+// TestLoadRepoConfigSymlink verifies that a .roborev.toml that is a symlink to
+// a config file elsewhere is followed and loaded.
+func TestLoadRepoConfigSymlink(t *testing.T) {
+	target := t.TempDir()
+	writeTestFile(t, target, "shared.toml", `agent = "copilot"`)
+
+	repo := t.TempDir()
+	require.NoError(t, os.Symlink(
+		filepath.Join(target, "shared.toml"),
+		filepath.Join(repo, ".roborev.toml"),
+	))
+
+	cfg, err := LoadRepoConfig(repo)
+	require.NoError(t, err)
+	require.NotNil(t, cfg, "expected symlinked config to be loaded")
+	assert.Equal(t, "copilot", cfg.Agent)
+}
+
 func TestResolveJobTimeout(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -397,6 +397,31 @@ func TestLoadRepoConfigSymlink(t *testing.T) {
 	assert.Equal(t, "copilot", cfg.Agent)
 }
 
+// TestLoadRawRepoWorktreeFallback verifies that raw-config loading (used for
+// explicit-key detection) applies the same main-checkout fallback as
+// LoadRepoConfig when .roborev.toml exists only in the main checkout.
+func TestLoadRawRepoWorktreeFallback(t *testing.T) {
+	main := t.TempDir()
+	execGit(t, main, "init")
+	execGit(t, main, "config", "user.email", "t@example.com")
+	execGit(t, main, "config", "user.name", "t")
+	writeTestFile(t, main, "base.txt", "base\n")
+	execGit(t, main, "add", ".")
+	execGit(t, main, "commit", "-m", "init")
+
+	writeTestFile(t, main, ".gitignore", ".roborev.toml\n")
+	writeRepoConfigStr(t, main, "reuse_review_session_lookback = 5\n")
+
+	wt := filepath.Join(t.TempDir(), "wt")
+	execGit(t, main, "worktree", "add", wt, "HEAD")
+
+	raw, err := LoadRawRepo(wt)
+	require.NoError(t, err)
+	require.NotNil(t, raw, "expected raw config to fall back to main checkout")
+	assert.True(t, IsKeyInTOMLFile(raw, "reuse_review_session_lookback"),
+		"explicit key should be detected via the main-checkout fallback")
+}
+
 func TestResolveJobTimeout(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/internal/config/keyval.go
+++ b/internal/config/keyval.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"path/filepath"
 	"reflect"
 	"sort"
 	"strconv"
@@ -155,9 +154,12 @@ func LoadRawGlobal() (map[string]any, error) {
 	return LoadRawTOML(GlobalConfigPath())
 }
 
-// LoadRawRepo loads the repo config file as a raw TOML map.
+// LoadRawRepo loads the repo config file as a raw TOML map. It applies the
+// same linked-worktree fallback as LoadRepoConfig (via RepoConfigPath) so
+// explicit-key detection sees the authoritative config even when it lives only
+// in the main checkout.
 func LoadRawRepo(repoPath string) (map[string]any, error) {
-	return LoadRawTOML(filepath.Join(repoPath, ".roborev.toml"))
+	return LoadRawTOML(RepoConfigPath(repoPath))
 }
 
 // LoadRawTOML loads a TOML file as a raw map.


### PR DESCRIPTION
## Summary

- A `.roborev.toml` that is gitignored (or otherwise untracked) lives only in the main checkout's working tree, so it is invisible from a linked worktree's directory. Reviews and fix jobs that run against a worktree path silently lost the per-repo config.
- `LoadRepoConfig` now retries at the main repository root (resolved via the git common dir, using the existing `git.GetMainRepoRoot`) when no `.roborev.toml` exists at the given path. The extra git resolution only runs on the absent path, so the common case is unchanged.
- A worktree-local `.roborev.toml` still takes precedence when present.
- Symlinked `.roborev.toml` files already work (loading follows symlinks); added a test to pin this.
- Added tests for the worktree fallback, worktree-local precedence, and symlink cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)