### PR TITLE
Fix CI reviews reading stale checkouts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,11 +206,10 @@ Test conventions:
 - Commit after completing each piece of work; do not wait to be asked.
 - When committing, stage ALL modified files related to the work (including formatting-only and ancillary updates).
 - Before committing, run `git diff` and `git status` to verify nothing is unintentionally left unstaged.
-- PR descriptions should not use a standalone "Test Plan" section by
-  default. If verification commands were actually run, list them under
-  "Verification" as evidence. If verification is redundant or already
-  visible in CI, keep the PR body shorter instead of writing a ritual
-  checklist.
+- PR descriptions should not include standalone "Verification" or
+  "Test Plan" sections unless the user explicitly asks for them. Keep PR
+  bodies focused on summary, context, and behavior changes; rely on CI/status
+  checks for routine validation evidence.
 
 ## Review / Refine Guidance
 

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -1536,6 +1536,8 @@ func (p *CIPoller) listOpenPRs(ctx context.Context, ghRepo string) ([]ghPR, erro
 
 // gitFetchCtx runs git fetch in the repo with context for cancellation.
 func gitFetchCtx(ctx context.Context, repoPath string, env []string) error {
+	unlock := lockGitMetadata(repoPath)
+	defer unlock()
 	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "fetch", "--quiet")
 	if env != nil {
 		cmd.Env = env
@@ -1549,6 +1551,8 @@ func gitFetchCtx(ctx context.Context, repoPath string, env []string) error {
 // gitFetchPRHead fetches the head commit for a GitHub PR. This is needed
 // for fork-based PRs where the head commit isn't in the normal fetch refs.
 func gitFetchPRHead(ctx context.Context, repoPath string, prNumber int, env []string) error {
+	unlock := lockGitMetadata(repoPath)
+	defer unlock()
 	ref := fmt.Sprintf("pull/%d/head", prNumber)
 	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "fetch", "origin", ref, "--quiet")
 	if env != nil {

--- a/internal/daemon/ci_worktree.go
+++ b/internal/daemon/ci_worktree.go
@@ -1,0 +1,160 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	gitworktree "go.kenn.io/kit/git/worktree"
+
+	"go.kenn.io/roborev/internal/config"
+)
+
+const (
+	ciWorktreeDirName    = "ci-worktrees"
+	ciWorktreePrefix     = "roborev-ci-"
+	ciWorktreeRepoMarker = "roborev-ci-parent"
+)
+
+func ciWorktreeParentDir() string {
+	return filepath.Join(config.DataDir(), ciWorktreeDirName)
+}
+
+func writeCIWorktreeMarker(worktreeDir, repoPath string) error {
+	repoPath = strings.TrimSpace(repoPath)
+	if repoPath == "" {
+		return errors.New("repo path must not be empty")
+	}
+	markerPath, err := ciWorktreeMarkerPath(worktreeDir)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(
+		markerPath,
+		[]byte(canonicalPath(repoPath)+"\n"),
+		0o600,
+	)
+}
+
+func readCIWorktreeMarker(worktreeDir string) (string, error) {
+	markerPath, err := ciWorktreeMarkerPath(worktreeDir)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(markerPath)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func ciWorktreeMarkerPath(worktreeDir string) (string, error) {
+	gitDir, err := linkedWorktreeGitDir(worktreeDir)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(gitDir, ciWorktreeRepoMarker), nil
+}
+
+func linkedWorktreeGitDir(worktreeDir string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(worktreeDir, ".git"))
+	if err != nil {
+		return "", err
+	}
+	line := strings.TrimSpace(string(data))
+	const prefix = "gitdir:"
+	if !strings.HasPrefix(line, prefix) {
+		return "", fmt.Errorf("worktree %s has unsupported .git file", worktreeDir)
+	}
+	gitDir := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+	if gitDir == "" {
+		return "", fmt.Errorf("worktree %s has empty gitdir", worktreeDir)
+	}
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(worktreeDir, gitDir)
+	}
+	return filepath.Clean(gitDir), nil
+}
+
+func repoPathFromLinkedWorktree(worktreeDir string) (string, error) {
+	gitDir, err := linkedWorktreeGitDir(worktreeDir)
+	if err != nil {
+		return "", err
+	}
+	commonGitDir := filepath.Dir(filepath.Dir(gitDir))
+	if filepath.Base(commonGitDir) != ".git" {
+		return "", fmt.Errorf("worktree %s has unsupported common git dir %s", worktreeDir, commonGitDir)
+	}
+	return filepath.Dir(commonGitDir), nil
+}
+
+func cleanupStaleCIWorktrees(ctx context.Context) error {
+	parentDir := ciWorktreeParentDir()
+	entries, err := os.ReadDir(parentDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("read CI worktree parent: %w", err)
+	}
+
+	var errs []error
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), ciWorktreePrefix) {
+			continue
+		}
+		dir := filepath.Join(parentDir, entry.Name())
+		if err := removeStaleCIWorktree(ctx, dir); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func removeStaleCIWorktree(ctx context.Context, worktreeDir string) error {
+	repoPath, err := readCIWorktreeMarker(worktreeDir)
+	if err != nil || repoPath == "" {
+		repoPath, err = repoPathFromLinkedWorktree(worktreeDir)
+		if err != nil || repoPath == "" {
+			return removeCIWorktreeDir(worktreeDir)
+		}
+	}
+	if _, err := os.Stat(repoPath); err != nil {
+		return removeCIWorktreeDir(worktreeDir)
+	}
+
+	unlock := lockGitMetadata(repoPath)
+	defer unlock()
+
+	wt := &gitworktree.Worktree{Dir: worktreeDir, Repo: repoPath}
+	closeErr := wt.Close(ctx)
+	pruneErr := pruneGitWorktrees(ctx, repoPath)
+	if closeErr != nil {
+		if _, statErr := os.Stat(worktreeDir); statErr == nil {
+			return fmt.Errorf("remove stale CI worktree %s: %w", worktreeDir, closeErr)
+		}
+	}
+	if pruneErr != nil {
+		return fmt.Errorf("prune stale CI worktree metadata for %s: %w", repoPath, pruneErr)
+	}
+	return nil
+}
+
+func removeCIWorktreeDir(worktreeDir string) error {
+	if err := os.RemoveAll(worktreeDir); err != nil {
+		return fmt.Errorf("remove stale CI worktree directory %s: %w", worktreeDir, err)
+	}
+	return nil
+}
+
+func pruneGitWorktrees(ctx context.Context, repoPath string) error {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "worktree", "prune")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%w: %s", err, string(out))
+	}
+	return nil
+}

--- a/internal/daemon/git_lock.go
+++ b/internal/daemon/git_lock.go
@@ -1,0 +1,23 @@
+package daemon
+
+import (
+	"path/filepath"
+	"sync"
+)
+
+var gitMetadataLocks sync.Map
+
+func canonicalPath(path string) string {
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	return filepath.Clean(path)
+}
+
+func lockGitMetadata(repoPath string) func() {
+	key := canonicalPath(repoPath)
+	value, _ := gitMetadataLocks.LoadOrStore(key, &sync.Mutex{})
+	mu := value.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}

--- a/internal/daemon/rerun_panel.go
+++ b/internal/daemon/rerun_panel.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -41,6 +43,11 @@ func (s *Server) rerunPanelRun(job *storage.ReviewJob) (*RerunJobOutput, error) 
 	if len(members) == 0 {
 		return nil, huma.Error400BadRequest("panel run has no members to rerun")
 	}
+	source, err := s.panelRerunSource(job)
+	if err != nil {
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("resolve panel rerun source: %v", err))
+	}
 
 	runUUID := uuid.NewString()
 	memberOpts := make([]storage.EnqueueOpts, len(members))
@@ -50,7 +57,7 @@ func (s *Server) rerunPanelRun(job *storage.ReviewJob) (*RerunJobOutput, error) 
 			return nil, huma.Error500InternalServerError(
 				fmt.Sprintf("load member diff: %v", diffErr))
 		}
-		memberOpts[i] = panelRerunMemberOpts(members[i], runUUID, diff)
+		memberOpts[i] = panelRerunMemberOpts(members[i], runUUID, diff, source)
 	}
 
 	synthDiff, err := s.db.GetJobDiffContent(job.ID)
@@ -58,7 +65,7 @@ func (s *Server) rerunPanelRun(job *storage.ReviewJob) (*RerunJobOutput, error) 
 		return nil, huma.Error500InternalServerError(
 			fmt.Sprintf("load synthesis diff: %v", err))
 	}
-	synthOpts := panelRerunSynthesisOpts(job, runUUID, synthDiff)
+	synthOpts := panelRerunSynthesisOpts(job, runUUID, synthDiff, source)
 
 	if _, _, err := s.db.EnqueuePanelRun(memberOpts, synthOpts); err != nil {
 		return nil, huma.Error500InternalServerError(
@@ -70,6 +77,19 @@ func (s *Server) rerunPanelRun(job *storage.ReviewJob) (*RerunJobOutput, error) 
 	return resp, nil
 }
 
+func (s *Server) panelRerunSource(job *storage.ReviewJob) (string, error) {
+	if job.Source != "" {
+		return job.Source, nil
+	}
+	if _, err := s.db.GetCIPanelByRunUUID(job.PanelRunUUID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	return storage.JobSourceCI, nil
+}
+
 // panelRerunMemberOpts clones one member job into fresh EnqueueOpts for a new
 // run. It copies the full frozen target (commit/diff/patch/severity/worktree),
 // the resolved agent/model/provider/reasoning/review_type, the stored Prompt
@@ -77,7 +97,7 @@ func (s *Server) rerunPanelRun(job *storage.ReviewJob) (*RerunJobOutput, error) 
 // (name/index/config), reassigning only the run UUID. Review/range/dirty prompts
 // are rebuilt by the worker so reruns do not reuse stale prebuilt prompts. diff
 // is the member's stored dirty diff (empty for commit/range targets).
-func panelRerunMemberOpts(m storage.ReviewJob, runUUID, diff string) storage.EnqueueOpts {
+func panelRerunMemberOpts(m storage.ReviewJob, runUUID, diff, source string) storage.EnqueueOpts {
 	prompt := ""
 	if m.UsesStoredPrompt() {
 		prompt = m.Prompt
@@ -98,6 +118,7 @@ func panelRerunMemberOpts(m storage.ReviewJob, runUUID, diff string) storage.Enq
 		DiffContent:           diff,
 		Prompt:                prompt,
 		PromptPrebuilt:        false,
+		Source:                source,
 		OutputPrefix:          m.OutputPrefix,
 		Agentic:               m.Agentic,
 		JobType:               m.JobType,
@@ -117,7 +138,7 @@ func panelRerunMemberOpts(m storage.ReviewJob, runUUID, diff string) storage.Enq
 // panelRerunSynthesisOpts clones the synthesis parent into fresh EnqueueOpts for
 // a new run. EnqueuePanelRun re-enforces JobType=synthesis, role=synthesis, and
 // ClaimBlocked, but they are set here too so the opts are self-describing.
-func panelRerunSynthesisOpts(job *storage.ReviewJob, runUUID, diff string) storage.EnqueueOpts {
+func panelRerunSynthesisOpts(job *storage.ReviewJob, runUUID, diff, source string) storage.EnqueueOpts {
 	return storage.EnqueueOpts{
 		RepoID:            job.RepoID,
 		CommitID:          job.CommitIDValue(),
@@ -133,6 +154,7 @@ func panelRerunSynthesisOpts(job *storage.ReviewJob, runUUID, diff string) stora
 		PatchID:           job.PatchID,
 		DiffContent:       diff,
 		OutputPrefix:      job.OutputPrefix,
+		Source:            source,
 		Agentic:           job.Agentic,
 		JobType:           storage.JobTypeSynthesis,
 		WorktreePath:      job.WorktreePath,

--- a/internal/daemon/rerun_panel_test.go
+++ b/internal/daemon/rerun_panel_test.go
@@ -177,6 +177,52 @@ func TestRerunSynthesisCreatesNewRun(t *testing.T) {
 	assert.True(newSynth.ClaimBlocked, "new synthesis re-blocked until members finish")
 }
 
+func TestRerunCIPanelPreservesExactCheckoutSource(t *testing.T) {
+	assert := assert.New(t)
+	server, db, tmpDir := newTestServer(t)
+	repo, err := db.GetOrCreateRepo(tmpDir)
+	require.NoError(t, err)
+	commit, err := db.GetOrCreateCommit(repo.ID, "headsha", "A", "S", time.Now())
+	require.NoError(t, err)
+
+	gitRef := "base..headsha"
+	created, _, oldSynth, err := db.CreateCIPanelRun("acme/api", 77, "headsha",
+		[]storage.EnqueueOpts{{
+			RepoID:           repo.ID,
+			CommitID:         commit.ID,
+			GitRef:           gitRef,
+			Agent:            "ci-member",
+			JobType:          storage.JobTypeRange,
+			PanelName:        "ci",
+			PanelMemberName:  "m0",
+			PanelMemberIndex: 0,
+		}},
+		storage.EnqueueOpts{
+			RepoID: repo.ID, CommitID: commit.ID, GitRef: gitRef,
+			Agent: "ci-synth", PanelName: "ci",
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	oldPanel, err := db.GetCIPanelBySynthesisJobID(oldSynth.ID)
+	require.NoError(t, err)
+	_, err = db.Exec("UPDATE review_jobs SET source = NULL WHERE panel_run_uuid = ?", oldPanel.PanelRunUUID)
+	require.NoError(t, err)
+
+	newUUID, newMembers := rerunAndLoadNewRun(t, server, db, oldPanel.PanelRunUUID, oldSynth.ID)
+	require.Len(t, newMembers, 1)
+
+	assert.Equal(storage.JobSourceCI, newMembers[0].Source, "rerun CI members should retain exact-checkout metadata")
+	requiresExact, err := server.workerPool.jobRequiresCIExactCheckout(&newMembers[0])
+	require.NoError(t, err)
+	assert.True(requiresExact, "rerun CI members should still use exact checkouts")
+
+	newSynth, err := db.GetSynthesisJob(newUUID)
+	require.NoError(t, err)
+	assert.Equal(storage.JobSourceCI, newSynth.Source, "rerun CI synthesis should retain CI source metadata")
+}
+
 func TestRerunPanelPreservesStoredPrompt(t *testing.T) {
 	assert := assert.New(t)
 	server, db, _ := newTestServer(t)

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -237,6 +237,10 @@ func (s *Server) Start(ctx context.Context) error {
 		serveErrCh <- s.httpServer.Serve(listener)
 	}()
 
+	if err := cleanupStaleCIWorktrees(ctx); err != nil {
+		log.Printf("Warning: failed to clean up stale CI worktrees: %v", err)
+	}
+
 	// Start worker pool before advertising availability.
 	s.workerPool.Start()
 

--- a/internal/daemon/synthesis_worker.go
+++ b/internal/daemon/synthesis_worker.go
@@ -20,11 +20,10 @@ import (
 var errSynthesisCanceled = errors.New("synthesis canceled")
 
 // processSynthesisJob executes a panel synthesis job against the run's member
-// reviews. It runs read-only against job.RepoPath (no worktree) and picks one of
-// three branches: all members failed -> durable fail review (no agent); exactly
-// one member succeeded -> passthrough that member's output unless min-severity
-// filtering requires a synthesis pass; two or more succeeded -> a single
-// verify+dedupe agent call.
+// reviews. It picks one of three branches: all members failed -> durable fail
+// review (no agent); exactly one member succeeded -> passthrough that member's
+// output unless min-severity filtering requires a synthesis pass; two or more
+// succeeded -> a single verify+dedupe agent call.
 func (wp *WorkerPool) processSynthesisJob(
 	ctx context.Context, workerID string, job *storage.ReviewJob,
 ) {
@@ -234,13 +233,22 @@ func (wp *WorkerPool) runSynthesisAgent(
 	})
 	agentOutput = sessionWriter
 
-	// Verify findings against the reviewed checkout: a panel enqueued from a
-	// linked worktree must synthesize against that worktree, not the main repo.
-	repoPath := resolveEffectiveRepoPath(workerID, job)
 	var output string
 	if synthAgent, ok := a.(agent.SynthesisAgent); ok {
 		output, err = synthAgent.Synthesize(ctx, prompt, agentOutput)
 	} else {
+		// Verify findings against the reviewed checkout: a panel enqueued from a
+		// linked worktree must synthesize against that worktree, and CI panels
+		// get a detached checkout at the reviewed head instead of the stale
+		// shared clone.
+		repoPath, checkoutCleanup, checkoutErr := wp.prepareJobCheckout(ctx, workerID, job)
+		if checkoutCleanup != nil {
+			defer checkoutCleanup()
+		}
+		if checkoutErr != nil {
+			wp.failOrRetry(workerID, job, agentName, fmt.Sprintf("prepare checkout: %v", checkoutErr))
+			return "", agentName, checkoutErr
+		}
 		output, err = a.Review(ctx, repoPath, job.GitRef, prompt, agentOutput)
 	}
 	sessionWriter.Flush()

--- a/internal/daemon/synthesis_worker.go
+++ b/internal/daemon/synthesis_worker.go
@@ -241,15 +241,15 @@ func (wp *WorkerPool) runSynthesisAgent(
 		// linked worktree must synthesize against that worktree, and CI panels
 		// get a detached checkout at the reviewed head instead of the stale
 		// shared clone.
-		repoPath, checkoutCleanup, checkoutErr := wp.prepareJobCheckout(ctx, workerID, job)
-		if checkoutCleanup != nil {
-			defer checkoutCleanup()
+		checkout, checkoutErr := wp.prepareJobCheckout(ctx, workerID, job)
+		if checkout.cleanup != nil {
+			defer checkout.cleanup()
 		}
 		if checkoutErr != nil {
 			wp.failOrRetry(workerID, job, agentName, fmt.Sprintf("prepare checkout: %v", checkoutErr))
 			return "", agentName, checkoutErr
 		}
-		output, err = a.Review(ctx, repoPath, job.GitRef, prompt, agentOutput)
+		output, err = a.Review(ctx, checkout.agentRepoPath, job.GitRef, prompt, agentOutput)
 	}
 	sessionWriter.Flush()
 	if sessionID := sessionWriter.SessionID(); sessionID != "" {

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -295,10 +295,14 @@ func resolveEffectiveRepoPath(workerID string, job *storage.ReviewJob) string {
 
 type preparedJobCheckout struct {
 	// promptRepoPath is the trusted checkout used for prompt-side config,
-	// excludes, max-prompt sizing, and snapshot creation.
+	// excludes, max-prompt sizing, and snapshot_dir config.
 	promptRepoPath string
 	// agentRepoPath is the checkout used as the agent cwd.
 	agentRepoPath string
+	// snapshotTarget controls where oversized diff snapshot files are written.
+	// CI writes them into the exact agent checkout while resolving snapshot_dir
+	// from the trusted prompt checkout.
+	snapshotTarget prompt.SnapshotTarget
 	// eventWorktreePath is the caller-provided worktree path safe to expose
 	// to event consumers and hooks. Internal CI checkouts must stay private.
 	eventWorktreePath string
@@ -331,12 +335,22 @@ func (wp *WorkerPool) prepareJobCheckout(
 	return preparedJobCheckout{
 		promptRepoPath: job.RepoPath,
 		agentRepoPath:  agentRepoPath,
-		cleanup:        cleanup,
+		snapshotTarget: prompt.SnapshotTarget{
+			RepoPath:       agentRepoPath,
+			ConfigRepoPath: job.RepoPath,
+		},
+		cleanup: cleanup,
 	}, nil
 }
 
 func (wp *WorkerPool) jobRequiresCIExactCheckout(job *storage.ReviewJob) (bool, error) {
-	if wp.db == nil || job == nil || job.PanelRunUUID == "" || job.IsFixJob() {
+	if job == nil || job.PanelRunUUID == "" || job.IsFixJob() {
+		return false, nil
+	}
+	if job.Source == storage.JobSourceCI {
+		return true, nil
+	}
+	if wp.db == nil {
 		return false, nil
 	}
 	if _, err := wp.db.GetCIPanelByRunUUID(job.PanelRunUUID); err != nil {
@@ -514,8 +528,9 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 	}
 
 	// Resolve checkouts for this job. CI panel jobs run agents in a detached
-	// worktree at the reviewed head, but prompt-side config and snapshots stay
-	// tied to the trusted shared clone checkout.
+	// worktree at the reviewed head; prompt-side config stays tied to the
+	// trusted shared clone, while snapshots are written where the agent can read
+	// them.
 	checkout, err := wp.prepareJobCheckout(ctx, workerID, job)
 	if checkout.cleanup != nil {
 		defer checkout.cleanup()
@@ -547,7 +562,7 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 			ctx, checkout.promptRepoPath, cfg, job.ReviewType,
 		)
 		reviewPrompt, cleanup, err = preparePrebuiltPrompt(
-			checkout.promptRepoPath, job, reviewPrompt, excludes,
+			checkout.promptRepoPath, checkout.snapshotTarget, job, reviewPrompt, excludes,
 		)
 		if cleanup != nil {
 			defer cleanup()
@@ -586,7 +601,10 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 
 		if job.DiffContent != nil {
 			// Dirty job - use pre-captured diff
-			dirtyResult, dirtyErr := pb.BuildDirtyWithSnapshot(*job.DiffContent, cfg.ReviewContextCount, job.Agent, job.ReviewType, minSev)
+			dirtyResult, dirtyErr := pb.BuildDirtyWithSnapshotTarget(
+				*job.DiffContent, cfg.ReviewContextCount, job.Agent, job.ReviewType, minSev,
+				checkout.snapshotTarget,
+			)
 			if dirtyResult.Cleanup != nil {
 				defer dirtyResult.Cleanup()
 			}
@@ -598,9 +616,9 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 			excludes := config.ResolveExcludePatterns(
 				ctx, checkout.promptRepoPath, cfg, job.ReviewType,
 			)
-			snapResult, snapErr := pb.BuildWithSnapshot(
+			snapResult, snapErr := pb.BuildWithSnapshotTarget(
 				job.GitRef, cfg.ReviewContextCount, job.Agent,
-				job.ReviewType, minSev, excludes,
+				job.ReviewType, minSev, excludes, checkout.snapshotTarget,
 			)
 			if snapResult.Cleanup != nil {
 				defer snapResult.Cleanup()
@@ -1379,13 +1397,14 @@ func (wp *WorkerPool) failoverOrFail(
 }
 
 func preparePrebuiltPrompt(
-	repoPath string, job *storage.ReviewJob, reviewPrompt string, excludes []string,
+	repoPath string, snapshotTarget prompt.SnapshotTarget,
+	job *storage.ReviewJob, reviewPrompt string, excludes []string,
 ) (string, func(), error) {
 	if !strings.Contains(reviewPrompt, prompt.DiffFilePathPlaceholder) {
 		return reviewPrompt, nil, nil
 	}
 	builder := prompt.NewBuilder(nil).ForRepo(repoPath, job.RepoID)
-	diffFile, cleanup, err := builder.WriteDiffSnapshot(job.GitRef, excludes)
+	diffFile, cleanup, err := builder.WriteDiffSnapshotTarget(job.GitRef, excludes, snapshotTarget)
 	if err != nil {
 		return "", nil, fmt.Errorf("prepare diff snapshot for prebuilt prompt: %w", err)
 	}

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -277,10 +278,9 @@ func (wp *WorkerPool) unregisterRunningJob(jobID int64) {
 	wp.runningJobsMu.Unlock()
 }
 
-// resolveEffectiveRepoPath returns the checkout a job should run against: its
-// worktree when set and still a valid checkout of the same repo, otherwise the
-// main repo path. Both normal reviews and panel synthesis use this so they read
-// and verify against the reviewed checkout.
+// resolveEffectiveRepoPath returns the non-CI checkout a job should run
+// against: its worktree when set and still a valid checkout of the same repo,
+// otherwise the main repo path.
 func resolveEffectiveRepoPath(workerID string, job *storage.ReviewJob) string {
 	if job.WorktreePath == "" {
 		return job.RepoPath
@@ -291,6 +291,74 @@ func resolveEffectiveRepoPath(workerID string, job *storage.ReviewJob) string {
 		return job.RepoPath
 	}
 	return job.WorktreePath
+}
+
+func (wp *WorkerPool) prepareJobCheckout(
+	ctx context.Context, workerID string, job *storage.ReviewJob,
+) (string, func(), error) {
+	requiresCIWorktree, err := wp.jobRequiresCIExactCheckout(job)
+	if err != nil {
+		return "", nil, err
+	}
+	if !requiresCIWorktree {
+		return resolveEffectiveRepoPath(workerID, job), nil, nil
+	}
+	return wp.createCIExactCheckout(ctx, workerID, job)
+}
+
+func (wp *WorkerPool) jobRequiresCIExactCheckout(job *storage.ReviewJob) (bool, error) {
+	if wp.db == nil || job == nil || job.PanelRunUUID == "" || job.IsFixJob() {
+		return false, nil
+	}
+	if _, err := wp.db.GetCIPanelByRunUUID(job.PanelRunUUID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf("lookup CI panel run: %w", err)
+	}
+	return true, nil
+}
+
+func (wp *WorkerPool) createCIExactCheckout(
+	ctx context.Context, workerID string, job *storage.ReviewJob,
+) (string, func(), error) {
+	headRef := strings.TrimSpace(headOf(job.GitRef))
+	if headRef == "" {
+		return "", nil, fmt.Errorf("CI job %d has empty checkout ref", job.ID)
+	}
+	parentDir := ciWorktreeParentDir()
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		return "", nil, fmt.Errorf("create CI worktree parent: %w", err)
+	}
+	unlock := lockGitMetadata(job.RepoPath)
+	wt, createErr := gitworktree.Create(ctx, job.RepoPath, headRef, gitworktree.Options{
+		ParentDir:      parentDir,
+		Prefix:         fmt.Sprintf("%s%d-", ciWorktreePrefix, job.ID),
+		InitSubmodules: true,
+		PullLFS:        true,
+	})
+	if createErr == nil {
+		createErr = writeCIWorktreeMarker(wt.Dir, job.RepoPath)
+		if createErr != nil {
+			_ = wt.Close(context.Background())
+			createErr = fmt.Errorf("write CI worktree marker: %w", createErr)
+		}
+	}
+	unlock()
+	if createErr != nil {
+		return "", nil, createErr
+	}
+	log.Printf("[%s] CI job %d: running agent in exact checkout %s (%s)",
+		workerID, job.ID, wt.Dir, gitpkg.ShortRef(headRef))
+	cleanup := func() {
+		unlock := lockGitMetadata(job.RepoPath)
+		defer unlock()
+		if err := wt.Close(context.Background()); err != nil {
+			log.Printf("[%s] Warning: remove CI worktree for job %d: %v",
+				workerID, job.ID, err)
+		}
+	}
+	return wt.Dir, cleanup, nil
 }
 
 func (wp *WorkerPool) worker(id int) {
@@ -416,9 +484,18 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 		return
 	}
 
-	// Resolve effective repo path: use worktree if available, still exists,
-	// and is a valid git checkout for the same repository.
-	effectiveRepoPath := resolveEffectiveRepoPath(workerID, job)
+	// Resolve the checkout to review. CI panel jobs run in a detached
+	// worktree at the reviewed head so free-form agent reads cannot observe a
+	// stale shared clone checkout.
+	effectiveRepoPath, checkoutCleanup, err := wp.prepareJobCheckout(ctx, workerID, job)
+	if checkoutCleanup != nil {
+		defer checkoutCleanup()
+	}
+	if err != nil {
+		log.Printf("[%s] Error preparing checkout: %v", workerID, err)
+		wp.failOrRetry(workerID, job, job.Agent, fmt.Sprintf("prepare checkout: %v", err))
+		return
+	}
 
 	// Build the prompt (or use pre-stored prompt for task/compact jobs).
 	// Create a per-job builder with the snapshotted config so exclude
@@ -430,7 +507,6 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 	var reviewPrompt string
 	var promptToPersist string
 	storedPromptValue := job.Prompt
-	var err error
 	if job.PromptPrebuilt && storedPromptValue != "" {
 		// CI-enqueued review with prebuilt prompt (includes PR
 		// discussion context and system prompt). Use as-is so the

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -293,17 +293,38 @@ func resolveEffectiveRepoPath(workerID string, job *storage.ReviewJob) string {
 	return job.WorktreePath
 }
 
+type preparedJobCheckout struct {
+	// promptRepoPath is the trusted checkout used for prompt-side config,
+	// excludes, max-prompt sizing, and snapshot creation.
+	promptRepoPath string
+	// agentRepoPath is the checkout used as the agent cwd.
+	agentRepoPath string
+	cleanup       func()
+}
+
 func (wp *WorkerPool) prepareJobCheckout(
 	ctx context.Context, workerID string, job *storage.ReviewJob,
-) (string, func(), error) {
+) (preparedJobCheckout, error) {
 	requiresCIWorktree, err := wp.jobRequiresCIExactCheckout(job)
 	if err != nil {
-		return "", nil, err
+		return preparedJobCheckout{}, err
 	}
 	if !requiresCIWorktree {
-		return resolveEffectiveRepoPath(workerID, job), nil, nil
+		repoPath := resolveEffectiveRepoPath(workerID, job)
+		return preparedJobCheckout{
+			promptRepoPath: repoPath,
+			agentRepoPath:  repoPath,
+		}, nil
 	}
-	return wp.createCIExactCheckout(ctx, workerID, job)
+	agentRepoPath, cleanup, err := wp.createCIExactCheckout(ctx, workerID, job)
+	if err != nil {
+		return preparedJobCheckout{}, err
+	}
+	return preparedJobCheckout{
+		promptRepoPath: job.RepoPath,
+		agentRepoPath:  agentRepoPath,
+		cleanup:        cleanup,
+	}, nil
 }
 
 func (wp *WorkerPool) jobRequiresCIExactCheckout(job *storage.ReviewJob) (bool, error) {
@@ -484,12 +505,12 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 		return
 	}
 
-	// Resolve the checkout to review. CI panel jobs run in a detached
-	// worktree at the reviewed head so free-form agent reads cannot observe a
-	// stale shared clone checkout.
-	effectiveRepoPath, checkoutCleanup, err := wp.prepareJobCheckout(ctx, workerID, job)
-	if checkoutCleanup != nil {
-		defer checkoutCleanup()
+	// Resolve checkouts for this job. CI panel jobs run agents in a detached
+	// worktree at the reviewed head, but prompt-side config and snapshots stay
+	// tied to the trusted shared clone checkout.
+	checkout, err := wp.prepareJobCheckout(ctx, workerID, job)
+	if checkout.cleanup != nil {
+		defer checkout.cleanup()
 	}
 	if err != nil {
 		log.Printf("[%s] Error preparing checkout: %v", workerID, err)
@@ -500,7 +521,7 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 	// Build the prompt (or use pre-stored prompt for task/compact jobs).
 	// Create a per-job builder with the snapshotted config so exclude
 	// patterns are resolved consistently.
-	pb := prompt.NewBuilderWithConfig(wp.db, cfg).WithContext(ctx).ForRepo(effectiveRepoPath, job.RepoID)
+	pb := prompt.NewBuilderWithConfig(wp.db, cfg).WithContext(ctx).ForRepo(checkout.promptRepoPath, job.RepoID)
 	if err := pb.CleanupStaleSnapshots(prompt.DefaultStaleSnapshotAge); err != nil {
 		log.Printf("[%s] Warning: cleanup stale snapshots for job %d: %v", workerID, job.ID, err)
 	}
@@ -515,10 +536,10 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 		promptToPersist = storedPromptValue
 		var cleanup func()
 		excludes := config.ResolveExcludePatterns(
-			ctx, effectiveRepoPath, cfg, job.ReviewType,
+			ctx, checkout.promptRepoPath, cfg, job.ReviewType,
 		)
 		reviewPrompt, cleanup, err = preparePrebuiltPrompt(
-			effectiveRepoPath, job, reviewPrompt, excludes,
+			checkout.promptRepoPath, job, reviewPrompt, excludes,
 		)
 		if cleanup != nil {
 			defer cleanup()
@@ -546,7 +567,7 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 		// Resolve effective min-severity: job-level override wins, then cascade.
 		minSev := job.MinSeverity
 		if minSev == "" {
-			resolved, resErr := config.ResolveReviewMinSeverity("", effectiveRepoPath, cfg)
+			resolved, resErr := config.ResolveReviewMinSeverity("", checkout.promptRepoPath, cfg)
 			if resErr != nil {
 				log.Printf("[%s] Error resolving min-severity: %v", workerID, resErr)
 				wp.failOrRetry(workerID, job, job.Agent, fmt.Sprintf("resolve min-severity: %v", resErr))
@@ -567,7 +588,7 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 			// Normal job - build prompt from git ref, writing a diff
 			// snapshot file when the diff is too large to inline.
 			excludes := config.ResolveExcludePatterns(
-				ctx, effectiveRepoPath, cfg, job.ReviewType,
+				ctx, checkout.promptRepoPath, cfg, job.ReviewType,
 			)
 			snapResult, snapErr := pb.BuildWithSnapshot(
 				job.GitRef, cfg.ReviewContextCount, job.Agent,
@@ -656,7 +677,7 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 	// Enforce the final submission size after all prompt transformations.
 	// Oversized prompts are deterministic and should never be sent to any
 	// agent just to discover a context-window failure.
-	maxPromptSize := config.ResolveMaxPromptSize(effectiveRepoPath, cfg)
+	maxPromptSize := config.ResolveMaxPromptSize(checkout.promptRepoPath, cfg)
 	if maxPromptSize > 0 && len(reviewPrompt) > maxPromptSize {
 		wp.failoverOrFailNonRetryableAgent(
 			workerID, job, agentName,
@@ -667,8 +688,8 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 
 	// Use the effective worktree path for events (empty when worktree is gone or not a worktree job).
 	eventWorktreePath := ""
-	if effectiveRepoPath != job.RepoPath {
-		eventWorktreePath = effectiveRepoPath
+	if checkout.agentRepoPath != job.RepoPath {
+		eventWorktreePath = checkout.agentRepoPath
 	}
 
 	// Broadcast started event
@@ -715,7 +736,7 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 
 	// For fix jobs, create an isolated worktree to run the agent in.
 	// The agent modifies files in the worktree; afterwards we capture the diff as a patch.
-	reviewRepoPath := effectiveRepoPath
+	reviewRepoPath := checkout.agentRepoPath
 	var fixWorktree *gitworktree.Worktree
 	if job.IsFixJob() {
 		wt, wtErr := gitworktree.Create(ctx, job.RepoPath, job.GitRef, gitworktree.Options{

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -299,7 +299,10 @@ type preparedJobCheckout struct {
 	promptRepoPath string
 	// agentRepoPath is the checkout used as the agent cwd.
 	agentRepoPath string
-	cleanup       func()
+	// eventWorktreePath is the caller-provided worktree path safe to expose
+	// to event consumers and hooks. Internal CI checkouts must stay private.
+	eventWorktreePath string
+	cleanup           func()
 }
 
 func (wp *WorkerPool) prepareJobCheckout(
@@ -311,9 +314,14 @@ func (wp *WorkerPool) prepareJobCheckout(
 	}
 	if !requiresCIWorktree {
 		repoPath := resolveEffectiveRepoPath(workerID, job)
+		eventWorktreePath := ""
+		if job.WorktreePath != "" && repoPath == job.WorktreePath {
+			eventWorktreePath = job.WorktreePath
+		}
 		return preparedJobCheckout{
-			promptRepoPath: repoPath,
-			agentRepoPath:  repoPath,
+			promptRepoPath:    repoPath,
+			agentRepoPath:     repoPath,
+			eventWorktreePath: eventWorktreePath,
 		}, nil
 	}
 	agentRepoPath, cleanup, err := wp.createCIExactCheckout(ctx, workerID, job)
@@ -686,11 +694,7 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 		return
 	}
 
-	// Use the effective worktree path for events (empty when worktree is gone or not a worktree job).
-	eventWorktreePath := ""
-	if checkout.agentRepoPath != job.RepoPath {
-		eventWorktreePath = checkout.agentRepoPath
-	}
+	eventWorktreePath := checkout.eventWorktreePath
 
 	// Broadcast started event
 	wp.broadcaster.Broadcast(Event{

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -416,13 +416,24 @@ func TestWorkerCIPanelMemberRunsAgainstReviewedHeadWorktree(t *testing.T) {
 	require.True(t, created)
 	require.Len(t, members, 1)
 
-	pool := NewWorkerPool(db, NewStaticConfig(config.DefaultConfig()), 1, NewBroadcaster(), nil, nil)
+	broadcaster := NewBroadcaster()
+	_, eventCh := broadcaster.Subscribe("")
+	pool := NewWorkerPool(db, NewStaticConfig(config.DefaultConfig()), 1, broadcaster, nil, nil)
 	claimed, err := db.ClaimJob(testWorkerID)
 	require.NoError(t, err)
 	require.NotNil(t, claimed)
 	require.Equal(t, members[0].ID, claimed.ID)
 
 	pool.processJob(testWorkerID, claimed)
+
+	startedEvent, ok := waitForEvent(t, eventCh, time.Second)
+	require.True(t, ok, "expected review.started event")
+	require.Equal(t, "review.started", startedEvent.Type)
+	assert.Empty(t, startedEvent.WorktreePath, "CI exact worktree should not be exposed to hooks or event consumers")
+	completedEvent, ok := waitForEvent(t, eventCh, time.Second)
+	require.True(t, ok, "expected review.completed event")
+	require.Equal(t, "review.completed", completedEvent.Type)
+	assert.Empty(t, completedEvent.WorktreePath, "CI exact worktree should not be exposed to hooks or event consumers")
 
 	stored := repo.RevParse("HEAD")
 	assert.Equal(t, staleHead, stored, "shared CI clone checkout should not move")

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -437,6 +437,95 @@ func TestWorkerCIPanelMemberRunsAgainstReviewedHeadWorktree(t *testing.T) {
 	assert.Equal(t, storage.JobStatusDone, tcJob.Status)
 }
 
+func TestWorkerCIPanelPromptSnapshotIgnoresPRHeadExcludeConfig(t *testing.T) {
+	t.Setenv("ROBOREV_DATA_DIR", t.TempDir())
+
+	db := testutil.OpenTestDB(t)
+	repo := testutil.NewGitRepo(t)
+	baseSHA := repo.CommitFile("README.md", "base\n", "base")
+	repo.Checkout("-b", "pr-head")
+	repo.WriteFile(".roborev.toml", "exclude_patterns = [\"secret.txt\"]\n")
+	repo.WriteFile("secret.txt", "SECRET_SENTINEL_FROM_PR\n")
+	var big strings.Builder
+	for range 400 {
+		big.WriteString(strings.Repeat("large diff content ", 8))
+		big.WriteString("\n")
+	}
+	repo.WriteFile("big.txt", big.String())
+	repo.RunGit("add", ".roborev.toml", "secret.txt", "big.txt")
+	repo.RunGit("commit", "-m", "pr adds untrusted config and files")
+	headSHA := repo.HeadSHA()
+	repo.Checkout("main")
+
+	storedRepo, err := db.GetOrCreateRepo(repo.Path(), "https://github.com/acme/api.git")
+	require.NoError(t, err)
+
+	const agentName = "ci-snapshot-reader"
+	var (
+		agentRepoPath   string
+		snapshotPath    string
+		snapshotContent string
+	)
+	snapshotRE := regexp.MustCompile("`([^`]+roborev-snapshot-[^`]+\\.diff)`")
+	agent.Register(&agent.FakeAgent{
+		NameStr: agentName,
+		ReviewFn: func(ctx context.Context, repoPath, commitSHA, reviewPrompt string, output io.Writer) (string, error) {
+			agentRepoPath = repoPath
+			match := snapshotRE.FindStringSubmatch(reviewPrompt)
+			if match == nil {
+				return "", fmt.Errorf("review prompt did not reference a snapshot file")
+			}
+			snapshotPath = match[1]
+			data, err := os.ReadFile(snapshotPath)
+			if err != nil {
+				return "", err
+			}
+			snapshotContent = string(data)
+			return "No issues found.", nil
+		},
+	})
+	t.Cleanup(func() { agent.Unregister(agentName) })
+
+	cfg := config.DefaultConfig()
+	cfg.DefaultMaxPromptSize = 6000
+	gitRef := baseSHA + ".." + headSHA
+	created, members, _, err := db.CreateCIPanelRun("acme/api", 104, headSHA,
+		[]storage.EnqueueOpts{{
+			RepoID:           storedRepo.ID,
+			GitRef:           gitRef,
+			Agent:            agentName,
+			JobType:          storage.JobTypeRange,
+			PanelName:        "ci",
+			PanelMemberName:  "snapshot-reader",
+			PanelMemberIndex: 0,
+		}},
+		storage.EnqueueOpts{RepoID: storedRepo.ID, GitRef: gitRef, Agent: "test", PanelName: "ci"},
+	)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.Len(t, members, 1)
+
+	pool := NewWorkerPool(db, NewStaticConfig(cfg), 1, NewBroadcaster(), nil, nil)
+	claimed, err := db.ClaimJob(testWorkerID)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	require.Equal(t, members[0].ID, claimed.ID)
+
+	pool.processJob(testWorkerID, claimed)
+
+	job, err := db.GetJobByID(claimed.ID)
+	require.NoError(t, err)
+	require.Equal(t, storage.JobStatusDone, job.Status)
+	require.NotEqual(t, repo.Path(), agentRepoPath, "agent should still run in the exact PR-head worktree")
+	require.NotEmpty(t, snapshotPath)
+	snapshotRoot := filepath.Clean(filepath.Dir(filepath.Dir(snapshotPath)))
+	assert.Equal(t, filepath.Join(repo.Path(), ".roborev"), snapshotRoot,
+		"CI snapshots should be created under the trusted shared checkout")
+	assert.NotContains(t, snapshotPath, agentRepoPath)
+	assert.Contains(t, snapshotContent, "SECRET_SENTINEL_FROM_PR",
+		"PR-head exclude_patterns must not suppress files from CI diff snapshots")
+}
+
 func TestCleanupStaleCIWorktreesRemovesOrphanedDetachedWorktree(t *testing.T) {
 	t.Setenv("ROBOREV_DATA_DIR", t.TempDir())
 

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -552,15 +552,28 @@ func TestCleanupStaleCIWorktreesRemovesOrphanedDetachedWorktree(t *testing.T) {
 	_, rootMarkerErr := os.Stat(filepath.Join(worktreeDir, ciWorktreeRepoMarker))
 	require.ErrorIs(t, rootMarkerErr, os.ErrNotExist, "CI marker should not be agent-visible in the worktree")
 
+	normalizedWorktreeDir := normalizeGitListPath(t, worktreeDir)
 	listBefore := repo.Run("worktree", "list", "--porcelain")
-	require.Contains(t, listBefore, worktreeDir)
+	require.Contains(t, normalizeGitListOutput(listBefore), normalizedWorktreeDir)
 
 	require.NoError(t, cleanupStaleCIWorktrees(context.Background()))
 
 	_, statErr := os.Stat(worktreeDir)
 	require.ErrorIs(t, statErr, os.ErrNotExist, "stale CI worktree directory should be removed")
 	listAfter := repo.Run("worktree", "list", "--porcelain")
-	assert.NotContains(t, listAfter, worktreeDir)
+	assert.NotContains(t, normalizeGitListOutput(listAfter), normalizedWorktreeDir)
+}
+
+func normalizeGitListPath(t *testing.T, path string) string {
+	t.Helper()
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	return filepath.ToSlash(filepath.Clean(path))
+}
+
+func normalizeGitListOutput(output string) string {
+	return filepath.ToSlash(strings.ReplaceAll(output, "\\", "/"))
 }
 
 func TestWorkerCIPanelMembersAtDifferentHeadsRunConcurrentlyInSeparateWorktrees(t *testing.T) {
@@ -653,14 +666,26 @@ func TestWorkerCIPanelMembersAtDifferentHeadsRunConcurrentlyInSeparateWorktrees(
 		defer wg.Done()
 		pool.processJob("worker-ci-b", claimedB)
 	}()
+	workersDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(workersDone)
+	}()
 
 	var releaseOnce sync.Once
 	releaseAgents := func() {
 		releaseOnce.Do(func() { close(release) })
 	}
-	defer releaseAgents()
+	defer func() {
+		releaseAgents()
+		select {
+		case <-workersDone:
+		case <-time.After(30 * time.Second):
+			t.Log("timed out waiting for concurrent CI workers to finish")
+		}
+	}()
 
-	deadline := time.After(5 * time.Second)
+	deadline := time.After(30 * time.Second)
 	for received := range 2 {
 		select {
 		case <-started:
@@ -669,7 +694,7 @@ func TestWorkerCIPanelMembersAtDifferentHeadsRunConcurrentlyInSeparateWorktrees(
 		}
 	}
 	releaseAgents()
-	wg.Wait()
+	<-workersDone
 
 	mu.Lock()
 	assert.Equal(t, "A", seenMarkers[headA])

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -356,6 +357,242 @@ func TestWorkerPoolCancelJobConcurrentRegister(t *testing.T) {
 	}
 
 	tc.Pool.unregisterRunningJob(job.ID)
+}
+
+func TestWorkerCIPanelMemberRunsAgainstReviewedHeadWorktree(t *testing.T) {
+	t.Setenv("ROBOREV_DATA_DIR", t.TempDir())
+
+	db := testutil.OpenTestDB(t)
+	repo := testutil.NewGitRepo(t)
+	repo.CommitFile("go.mod", "module github.com/wesm/middleman\n", "old module")
+	staleHead := repo.HeadSHA()
+	baseSHA := repo.CommitFile("README.md", "base\n", "base")
+	repo.CommitFile("go.mod", "module go.kenn.io/middleman\n", "module migration")
+	headSHA := repo.CommitFile("internal/testenv/githubguard/githubguard.go", "package githubguard\n", "guard")
+	repo.Checkout("--detach", staleHead)
+
+	storedRepo, err := db.GetOrCreateRepo(repo.Path(), "https://github.com/kenn-io/middleman.git")
+	require.NoError(t, err)
+
+	const agentName = "ci-module-reader"
+	var (
+		agentRepoPath string
+		agentHead     string
+		moduleLine    string
+	)
+	agent.Register(&agent.FakeAgent{
+		NameStr: agentName,
+		ReviewFn: func(ctx context.Context, repoPath, commitSHA, reviewPrompt string, output io.Writer) (string, error) {
+			agentRepoPath = repoPath
+			headOut, err := exec.CommandContext(ctx, "git", "-C", repoPath, "rev-parse", "HEAD").Output()
+			if err != nil {
+				return "", err
+			}
+			agentHead = strings.TrimSpace(string(headOut))
+			data, err := os.ReadFile(filepath.Join(repoPath, "go.mod"))
+			if err != nil {
+				return "", err
+			}
+			moduleLine = strings.TrimSpace(string(data))
+			return "No issues found.", nil
+		},
+	})
+	t.Cleanup(func() { agent.Unregister(agentName) })
+
+	gitRef := baseSHA + ".." + headSHA
+	created, members, _, err := db.CreateCIPanelRun("kenn-io/middleman", 20446, headSHA,
+		[]storage.EnqueueOpts{{
+			RepoID:           storedRepo.ID,
+			GitRef:           gitRef,
+			Agent:            agentName,
+			JobType:          storage.JobTypeRange,
+			PanelName:        "ci",
+			PanelMemberName:  "module-reader",
+			PanelMemberIndex: 0,
+		}},
+		storage.EnqueueOpts{RepoID: storedRepo.ID, GitRef: gitRef, Agent: "test", PanelName: "ci"},
+	)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.Len(t, members, 1)
+
+	pool := NewWorkerPool(db, NewStaticConfig(config.DefaultConfig()), 1, NewBroadcaster(), nil, nil)
+	claimed, err := db.ClaimJob(testWorkerID)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	require.Equal(t, members[0].ID, claimed.ID)
+
+	pool.processJob(testWorkerID, claimed)
+
+	stored := repo.RevParse("HEAD")
+	assert.Equal(t, staleHead, stored, "shared CI clone checkout should not move")
+	assert.Equal(t, headSHA, agentHead, "agent should run in a checkout of the reviewed PR head")
+	assert.Equal(t, "module go.kenn.io/middleman", moduleLine)
+	assert.NotEqual(t, repo.Path(), agentRepoPath, "agent should not run in the stale shared clone")
+	require.NotEmpty(t, agentRepoPath)
+	_, statErr := os.Stat(agentRepoPath)
+	require.ErrorIs(t, statErr, os.ErrNotExist, "temporary CI worktree should be removed after the job")
+	tcJob, err := db.GetJobByID(claimed.ID)
+	require.NoError(t, err)
+	assert.Equal(t, storage.JobStatusDone, tcJob.Status)
+}
+
+func TestCleanupStaleCIWorktreesRemovesOrphanedDetachedWorktree(t *testing.T) {
+	t.Setenv("ROBOREV_DATA_DIR", t.TempDir())
+
+	repo := testutil.NewGitRepo(t)
+	headSHA := repo.CommitFile("marker.txt", "head\n", "head")
+
+	pool := NewWorkerPool(nil, NewStaticConfig(config.DefaultConfig()), 1, NewBroadcaster(), nil, nil)
+	worktreeDir, normalCleanup, err := pool.createCIExactCheckout(context.Background(), testWorkerID, &storage.ReviewJob{
+		ID:       42,
+		RepoPath: repo.Path(),
+		GitRef:   headSHA,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, worktreeDir)
+	require.NotNil(t, normalCleanup)
+	t.Cleanup(func() {
+		if _, err := os.Stat(worktreeDir); err == nil {
+			normalCleanup()
+		}
+	})
+	markerPath, err := ciWorktreeMarkerPath(worktreeDir)
+	require.NoError(t, err)
+	assert.FileExists(t, markerPath)
+	_, rootMarkerErr := os.Stat(filepath.Join(worktreeDir, ciWorktreeRepoMarker))
+	require.ErrorIs(t, rootMarkerErr, os.ErrNotExist, "CI marker should not be agent-visible in the worktree")
+
+	listBefore := repo.Run("worktree", "list", "--porcelain")
+	require.Contains(t, listBefore, worktreeDir)
+
+	require.NoError(t, cleanupStaleCIWorktrees(context.Background()))
+
+	_, statErr := os.Stat(worktreeDir)
+	require.ErrorIs(t, statErr, os.ErrNotExist, "stale CI worktree directory should be removed")
+	listAfter := repo.Run("worktree", "list", "--porcelain")
+	assert.NotContains(t, listAfter, worktreeDir)
+}
+
+func TestWorkerCIPanelMembersAtDifferentHeadsRunConcurrentlyInSeparateWorktrees(t *testing.T) {
+	t.Setenv("ROBOREV_DATA_DIR", t.TempDir())
+
+	db := testutil.OpenTestDB(t)
+	repo := testutil.NewGitRepo(t)
+	repo.CommitFile("go.mod", "module example.com/ci\n", "module")
+	staleHead := repo.HeadSHA()
+	baseSHA := repo.CommitFile("README.md", "base\n", "base")
+	headA := repo.CommitFile("marker.txt", "A\n", "marker A")
+	headB := repo.CommitFile("marker.txt", "B\n", "marker B")
+	repo.Checkout("--detach", staleHead)
+
+	storedRepo, err := db.GetOrCreateRepo(repo.Path(), "https://github.com/acme/api.git")
+	require.NoError(t, err)
+
+	const agentName = "ci-concurrent-reader"
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	var mu sync.Mutex
+	seenMarkers := map[string]string{}
+	seenPaths := map[string]string{}
+	agent.Register(&agent.FakeAgent{
+		NameStr: agentName,
+		ReviewFn: func(ctx context.Context, repoPath, commitSHA, reviewPrompt string, output io.Writer) (string, error) {
+			headOut, err := exec.CommandContext(ctx, "git", "-C", repoPath, "rev-parse", "HEAD").Output()
+			if err != nil {
+				return "", err
+			}
+			head := strings.TrimSpace(string(headOut))
+			data, err := os.ReadFile(filepath.Join(repoPath, "marker.txt"))
+			if err != nil {
+				return "", err
+			}
+			mu.Lock()
+			seenMarkers[head] = strings.TrimSpace(string(data))
+			seenPaths[head] = repoPath
+			mu.Unlock()
+			started <- struct{}{}
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-release:
+			}
+			return "No issues found.", nil
+		},
+	})
+	t.Cleanup(func() { agent.Unregister(agentName) })
+
+	createRun := func(pr int, head, gitRef string) *storage.ReviewJob {
+		t.Helper()
+		created, members, _, err := db.CreateCIPanelRun("acme/api", pr, head,
+			[]storage.EnqueueOpts{{
+				RepoID:           storedRepo.ID,
+				GitRef:           gitRef,
+				Agent:            agentName,
+				JobType:          storage.JobTypeRange,
+				PanelName:        "ci",
+				PanelMemberName:  fmt.Sprintf("reader-%d", pr),
+				PanelMemberIndex: 0,
+			}},
+			storage.EnqueueOpts{RepoID: storedRepo.ID, GitRef: gitRef, Agent: "test", PanelName: "ci"},
+		)
+		require.NoError(t, err)
+		require.True(t, created)
+		require.Len(t, members, 1)
+		return members[0]
+	}
+	memberA := createRun(1, headA, baseSHA+".."+headA)
+	memberB := createRun(2, headB, headA+".."+headB)
+
+	claimedA, err := db.ClaimJob("worker-ci-a")
+	require.NoError(t, err)
+	require.NotNil(t, claimedA)
+	require.Equal(t, memberA.ID, claimedA.ID)
+	claimedB, err := db.ClaimJob("worker-ci-b")
+	require.NoError(t, err)
+	require.NotNil(t, claimedB)
+	require.Equal(t, memberB.ID, claimedB.ID)
+
+	pool := NewWorkerPool(db, NewStaticConfig(config.DefaultConfig()), 2, NewBroadcaster(), nil, nil)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		pool.processJob("worker-ci-a", claimedA)
+	}()
+	go func() {
+		defer wg.Done()
+		pool.processJob("worker-ci-b", claimedB)
+	}()
+
+	var releaseOnce sync.Once
+	releaseAgents := func() {
+		releaseOnce.Do(func() { close(release) })
+	}
+	defer releaseAgents()
+
+	deadline := time.After(5 * time.Second)
+	for received := range 2 {
+		select {
+		case <-started:
+		case <-deadline:
+			require.Equal(t, 2, received, "timed out waiting for concurrent CI agents to start")
+		}
+	}
+	releaseAgents()
+	wg.Wait()
+
+	mu.Lock()
+	assert.Equal(t, "A", seenMarkers[headA])
+	assert.Equal(t, "B", seenMarkers[headB])
+	assert.NotEqual(t, seenPaths[headA], seenPaths[headB])
+	mu.Unlock()
+	assert.Equal(t, staleHead, repo.RevParse("HEAD"), "shared CI clone checkout should not move")
+	for _, id := range []int64{claimedA.ID, claimedB.ID} {
+		job, err := db.GetJobByID(id)
+		require.NoError(t, err)
+		assert.Equal(t, storage.JobStatusDone, job.Status)
+	}
 }
 
 type sessionStreamingTestAgent struct {

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -448,14 +448,14 @@ func TestWorkerCIPanelMemberRunsAgainstReviewedHeadWorktree(t *testing.T) {
 	assert.Equal(t, storage.JobStatusDone, tcJob.Status)
 }
 
-func TestWorkerCIPanelPromptSnapshotIgnoresPRHeadExcludeConfig(t *testing.T) {
+func TestWorkerCIPanelPromptSnapshotUsesTrustedConfigAndAgentCheckout(t *testing.T) {
 	t.Setenv("ROBOREV_DATA_DIR", t.TempDir())
 
 	db := testutil.OpenTestDB(t)
 	repo := testutil.NewGitRepo(t)
 	baseSHA := repo.CommitFile("README.md", "base\n", "base")
 	repo.Checkout("-b", "pr-head")
-	repo.WriteFile(".roborev.toml", "exclude_patterns = [\"secret.txt\"]\n")
+	repo.WriteFile(".roborev.toml", "exclude_patterns = [\"secret.txt\"]\nsnapshot_dir = \"pr-controlled-snapshots\"\n")
 	repo.WriteFile("secret.txt", "SECRET_SENTINEL_FROM_PR\n")
 	var big strings.Builder
 	for range 400 {
@@ -530,9 +530,10 @@ func TestWorkerCIPanelPromptSnapshotIgnoresPRHeadExcludeConfig(t *testing.T) {
 	require.NotEqual(t, repo.Path(), agentRepoPath, "agent should still run in the exact PR-head worktree")
 	require.NotEmpty(t, snapshotPath)
 	snapshotRoot := filepath.Clean(filepath.Dir(filepath.Dir(snapshotPath)))
-	assert.Equal(t, filepath.Join(repo.Path(), ".roborev"), snapshotRoot,
-		"CI snapshots should be created under the trusted shared checkout")
-	assert.NotContains(t, snapshotPath, agentRepoPath)
+	assert.Equal(t, filepath.Join(agentRepoPath, ".roborev"), snapshotRoot,
+		"CI snapshots should be created where the exact-checkout agent can read them")
+	assert.NotContains(t, snapshotPath, "pr-controlled-snapshots",
+		"PR-head snapshot_dir must not control CI snapshot placement")
 	assert.Contains(t, snapshotContent, "SECRET_SENTINEL_FROM_PR",
 		"PR-head exclude_patterns must not suppress files from CI diff snapshots")
 }
@@ -1204,6 +1205,7 @@ func TestPreparePrebuiltPrompt_ReplacesDiffFilePlaceholder(t *testing.T) {
 
 	reviewPrompt, cleanup, err := preparePrebuiltPrompt(
 		tc.TmpDir,
+		prompt.SnapshotTarget{},
 		job,
 		"## Pull Request Discussion\n\n### Diff\n\nRead the diff from: `"+prompt.DiffFilePathPlaceholder+"`\n",
 		nil,
@@ -1228,6 +1230,7 @@ func TestPreparePrebuiltPrompt_RequotesDiffPathWithSingleQuote(t *testing.T) {
 
 	reviewPrompt, cleanup, err := preparePrebuiltPrompt(
 		repoPath,
+		prompt.SnapshotTarget{},
 		job,
 		"### Diff\n\nRead the diff from: `"+prompt.DiffFilePathPlaceholder+"`\n",
 		nil,
@@ -1253,6 +1256,7 @@ func TestPreparePrebuiltPrompt_AllowsUnsafeModeByStillWritingDiffFile(t *testing
 
 	reviewPrompt, cleanup, err := preparePrebuiltPrompt(
 		tc.TmpDir,
+		prompt.SnapshotTarget{},
 		job,
 		"### Diff\n\nRead the diff from: `"+prompt.DiffFilePathPlaceholder+"`\n",
 		nil,

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -207,14 +207,32 @@ type SnapshotResult struct {
 	Cleanup func()
 }
 
+// SnapshotTarget controls where oversized diff snapshot files are written.
+// The zero value writes snapshots under the builder repo using that repo's
+// snapshot_dir config. Set RepoPath to write under a different checkout, and
+// ConfigRepoPath to resolve snapshot_dir from a trusted checkout.
+type SnapshotTarget struct {
+	RepoPath       string
+	ConfigRepoPath string
+}
+
 // BuildWithSnapshot builds a review prompt, automatically writing a diff snapshot file
 // when the diff is too large to inline.
 func (b *Builder) BuildWithSnapshot(gitRef string, contextCount int, agentName, reviewType, minSeverity string, excludes []string) (SnapshotResult, error) {
+	return b.BuildWithSnapshotTarget(gitRef, contextCount, agentName, reviewType, minSeverity, excludes, SnapshotTarget{})
+}
+
+// BuildWithSnapshotTarget is like BuildWithSnapshot, but lets callers place the
+// snapshot under a different checkout while preserving trusted config resolution.
+func (b *Builder) BuildWithSnapshotTarget(
+	gitRef string, contextCount int, agentName, reviewType, minSeverity string,
+	excludes []string, target SnapshotTarget,
+) (SnapshotResult, error) {
 	p, err := b.BuildWithDiffFile(gitRef, contextCount, agentName, reviewType, minSeverity, "")
 	if !errors.Is(err, ErrDiffTruncatedNoFile) {
 		return SnapshotResult{Prompt: p}, err
 	}
-	diffFile, cleanup, writeErr := b.WriteDiffSnapshot(gitRef, excludes)
+	diffFile, cleanup, writeErr := b.WriteDiffSnapshotTarget(gitRef, excludes, target)
 	if writeErr != nil {
 		return SnapshotResult{}, fmt.Errorf("write diff snapshot: %w", writeErr)
 	}
@@ -230,6 +248,12 @@ func (b *Builder) BuildWithSnapshot(gitRef string, contextCount int, agentName, 
 // file. The file intentionally lives outside .git so sandboxed agents can read
 // it without inlining oversized diffs into the submitted prompt.
 func (b *Builder) WriteDiffSnapshot(gitRef string, excludes []string) (string, func(), error) {
+	return b.WriteDiffSnapshotTarget(gitRef, excludes, SnapshotTarget{})
+}
+
+// WriteDiffSnapshotTarget is like WriteDiffSnapshot, but writes the snapshot
+// under target.RepoPath while resolving snapshot_dir from target.ConfigRepoPath.
+func (b *Builder) WriteDiffSnapshotTarget(gitRef string, excludes []string, target SnapshotTarget) (string, func(), error) {
 	var (
 		fullDiff string
 		err      error
@@ -245,24 +269,52 @@ func (b *Builder) WriteDiffSnapshot(gitRef string, excludes []string) (string, f
 	if fullDiff == "" {
 		return "", nil, fmt.Errorf("diff is empty")
 	}
-	return b.writeExternalDiffSnapshot(fullDiff)
+	return b.writeExternalDiffSnapshotTarget(fullDiff, target)
 }
 
-func (b *Builder) writeExternalDiffSnapshot(diff string) (string, func(), error) {
-	snapshotRoot, err := config.ResolveSnapshotDir(b.repoPath)
+func (b *Builder) writeExternalDiffSnapshotTarget(diff string, target SnapshotTarget) (string, func(), error) {
+	repoPath, snapshotRoot, err := b.resolveSnapshotTarget(target)
 	if err != nil {
-		return "", nil, fmt.Errorf("resolve snapshot dir: %w", err)
-	}
-	if err := validateSnapshotRoot(b.repoPath, snapshotRoot); err != nil {
 		return "", nil, err
 	}
-	if err := ensureSnapshotRootIgnored(b.repoPath, snapshotRoot); err != nil {
+	return writeExternalDiffSnapshot(repoPath, snapshotRoot, diff)
+}
+
+func (b *Builder) resolveSnapshotTarget(target SnapshotTarget) (string, string, error) {
+	repoPath := target.RepoPath
+	if repoPath == "" {
+		repoPath = b.repoPath
+	}
+	configRepoPath := target.ConfigRepoPath
+	if configRepoPath == "" {
+		configRepoPath = repoPath
+	}
+	configuredRoot, err := config.ResolveSnapshotDir(configRepoPath)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve snapshot dir: %w", err)
+	}
+	rel, err := filepath.Rel(configRepoPath, configuredRoot)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve snapshot dir relative path: %w", err)
+	}
+	rel = filepath.Clean(rel)
+	if rel == "." || !filepath.IsLocal(rel) {
+		return "", "", fmt.Errorf("snapshot_dir must be under the config repo root: %s", configuredRoot)
+	}
+	return repoPath, filepath.Join(repoPath, rel), nil
+}
+
+func writeExternalDiffSnapshot(repoPath, snapshotRoot, diff string) (string, func(), error) {
+	if err := validateSnapshotRoot(repoPath, snapshotRoot); err != nil {
+		return "", nil, err
+	}
+	if err := ensureSnapshotRootIgnored(repoPath, snapshotRoot); err != nil {
 		return "", nil, fmt.Errorf("ensure snapshot dir ignored: %w", err)
 	}
 	if err := os.MkdirAll(snapshotRoot, 0o755); err != nil {
 		return "", nil, fmt.Errorf("create snapshot root: %w", err)
 	}
-	if err := validateSnapshotRoot(b.repoPath, snapshotRoot); err != nil {
+	if err := validateSnapshotRoot(repoPath, snapshotRoot); err != nil {
 		return "", nil, err
 	}
 	snapshotLifecycleMu.Lock()
@@ -423,12 +475,21 @@ func (b *Builder) CleanupStaleSnapshots(olderThan time.Duration) error {
 // BuildDirtyWithSnapshot builds a dirty review prompt, writing the diff to a snapshot file
 // when it's too large to inline.
 func (b *Builder) BuildDirtyWithSnapshot(diff string, contextCount int, agentName, reviewType, minSeverity string) (SnapshotResult, error) {
+	return b.BuildDirtyWithSnapshotTarget(diff, contextCount, agentName, reviewType, minSeverity, SnapshotTarget{})
+}
+
+// BuildDirtyWithSnapshotTarget is like BuildDirtyWithSnapshot, but lets callers
+// place the snapshot under a different checkout while preserving trusted config
+// resolution.
+func (b *Builder) BuildDirtyWithSnapshotTarget(
+	diff string, contextCount int, agentName, reviewType, minSeverity string, target SnapshotTarget,
+) (SnapshotResult, error) {
 	p, err := b.BuildDirty(diff, contextCount, agentName, reviewType, minSeverity)
 	if err != nil {
 		return SnapshotResult{}, err
 	}
 	if strings.Contains(p, dirtyTruncatedDiffMarker) && len(diff) > 0 {
-		diffFile, cleanup, snapErr := b.writeExternalDiffSnapshot(diff)
+		diffFile, cleanup, snapErr := b.writeExternalDiffSnapshotTarget(diff, target)
 		if snapErr != nil {
 			return SnapshotResult{}, fmt.Errorf("dirty diff snapshot: %w", snapErr)
 		}

--- a/internal/storage/ci_panels.go
+++ b/internal/storage/ci_panels.go
@@ -101,6 +101,15 @@ func (db *DB) GetCIPanelBySynthesisJobID(jobID int64) (*CIPanel, error) {
 	return scanCIPanel(row)
 }
 
+// GetCIPanelByRunUUID returns the CI panel mapping for a panel run UUID.
+// Returns sql.ErrNoRows when the panel run is not CI-owned.
+func (db *DB) GetCIPanelByRunUUID(panelRunUUID string) (*CIPanel, error) {
+	row := db.QueryRow(`SELECT `+ciPanelColumns+`
+		FROM ci_pr_panels
+		WHERE panel_run_uuid = ?`, panelRunUUID)
+	return scanCIPanel(row)
+}
+
 // CreateCIPanelRun atomically reserves the ci_pr_panels row, inserts the run's
 // member + synthesis jobs (sharing one generated panel_run_uuid), and backfills
 // synthesis_job_id — all in one BEGIN IMMEDIATE transaction. Returns

--- a/internal/storage/ci_panels.go
+++ b/internal/storage/ci_panels.go
@@ -198,8 +198,10 @@ func (db *DB) createCIPanelRunTx(ctx context.Context, exec execer, githubRepo st
 	// enforces role/gate but NOT the run uuid.
 	for i := range members {
 		members[i].PanelRunUUID = runUUID
+		members[i].Source = JobSourceCI
 	}
 	synthesis.PanelRunUUID = runUUID
+	synthesis.Source = JobSourceCI
 
 	mems, syn, err := db.enqueuePanelRunTx(ctx, exec, members, synthesis, machineID, now)
 	if err != nil {

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -79,6 +79,7 @@ type EnqueueOpts struct {
 	PromptPrebuilt    bool   // Prompt is prebuilt and should be used as-is by the worker
 	Label             string // Display label in TUI for task jobs (default: "prompt")
 	JobType           string // Explicit job type (review/range/dirty/task/compact/fix); inferred if empty
+	Source            string // Automation source (empty = explicit/user row)
 	ParentJobID       int64  // Parent job being fixed (for fix jobs)
 	WorktreePath      string // Worktree checkout path (empty = use main repo root)
 	MinSeverity       string // Minimum severity filter (canonical: critical/high/medium/low or empty)
@@ -180,8 +181,8 @@ func (db *DB) insertJobTx(ctx context.Context, exec execer, opts EnqueueOpts, ui
 		INSERT INTO review_jobs (repo_id, commit_id, git_ref, branch, session_id, agent, model, provider, requested_model, requested_provider, reasoning,
 			status, job_type, review_type, patch_id, diff_content, prompt, agentic, prompt_prebuilt, output_prefix,
 			parent_job_id, uuid, source_machine_id, updated_at, worktree_path, min_severity, backup_agent, backup_model,
-			panel_run_uuid, panel_role, panel_name, panel_member_name, panel_member_index, panel_member_config_json, claim_blocked)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			panel_run_uuid, panel_role, panel_name, panel_member_name, panel_member_index, panel_member_config_json, claim_blocked, source)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		opts.RepoID, commitIDParam, gitRef, nullString(opts.Branch), nullString(opts.SessionID),
 		opts.Agent, nullString(opts.Model), nullString(opts.Provider), nullString(opts.RequestedModel), nullString(opts.RequestedProvider), reasoning,
 		jobType, opts.ReviewType, nullString(opts.PatchID),
@@ -189,7 +190,7 @@ func (db *DB) insertJobTx(ctx context.Context, exec execer, opts EnqueueOpts, ui
 		nullString(opts.OutputPrefix), parentJobIDParam,
 		uid, machineID, nowStr, opts.WorktreePath, normalizeMinSeverityForWrite(opts.MinSeverity), opts.BackupAgent, opts.BackupModel,
 		nullString(opts.PanelRunUUID), nullString(opts.PanelRole), nullString(opts.PanelName),
-		nullString(opts.PanelMemberName), opts.PanelMemberIndex, nullString(opts.PanelMemberConfigJSON), claimBlockedInt)
+		nullString(opts.PanelMemberName), opts.PanelMemberIndex, nullString(opts.PanelMemberConfigJSON), claimBlockedInt, nullString(opts.Source))
 	if err != nil {
 		return nil, err
 	}
@@ -230,6 +231,7 @@ func (db *DB) insertJobTx(ctx context.Context, exec execer, opts EnqueueOpts, ui
 		PanelMemberIndex:      opts.PanelMemberIndex,
 		PanelMemberConfigJSON: opts.PanelMemberConfigJSON,
 		ClaimBlocked:          opts.ClaimBlocked,
+		Source:                opts.Source,
 	}
 	if opts.ParentJobID > 0 {
 		job.ParentJobID = &opts.ParentJobID

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -58,6 +58,12 @@ const (
 	PanelRoleSynthesis = "synthesis"
 )
 
+// Job source values identify daemon-created automation rows.
+const (
+	JobSourceAutoDesign = "auto_design"
+	JobSourceCI         = "ci"
+)
+
 type ReviewJob struct {
 	ID                int64      `json:"id"`
 	RepoID            int64      `json:"repo_id"`
@@ -87,7 +93,7 @@ type ReviewJob struct {
 	PatchID           string     `json:"patch_id,omitempty"`      // Stable patch-id for rebase tracking
 	OutputPrefix      string     `json:"output_prefix,omitempty"` // Prefix to prepend to review output
 	SkipReason        string     `json:"skip_reason,omitempty"`   // Reason a design review was skipped (status=skipped only)
-	Source            string     `json:"source,omitempty"`        // "auto_design" for auto-dispatched rows; empty for explicit/user rows
+	Source            string     `json:"source,omitempty"`        // Automation source; empty for explicit/user rows
 	ParentJobID       *int64     `json:"parent_job_id,omitempty"` // Job being fixed (for fix jobs)
 	Patch             *string    `json:"patch,omitempty"`         // Generated diff patch (for completed fix jobs)
 	WorktreePath      string     `json:"worktree_path,omitempty"` // Worktree checkout path (empty = use RepoPath)

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -687,10 +687,10 @@ func (p *PgPool) UpsertJob(ctx context.Context, j SyncableJob, pgRepoID int64, p
 		INSERT INTO review_jobs (
 			uuid, repo_id, commit_id, git_ref, session_id, agent, model, provider, requested_model, requested_provider, reasoning, job_type, review_type, patch_id, status, agentic,
 			enqueued_at, started_at, finished_at, prompt, diff_content, error, token_usage,
-			worktree_path, min_severity,
+			worktree_path, source, min_severity,
 			panel_run_uuid, panel_role, panel_name, panel_member_name, panel_member_index, panel_member_config_json,
 			source_machine_id, backup_agent, backup_model, updated_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, clock_timestamp())
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, clock_timestamp())
 		ON CONFLICT (uuid) DO UPDATE SET
 			status = EXCLUDED.status,
 			finished_at = EXCLUDED.finished_at,
@@ -705,6 +705,7 @@ func (p *PgPool) UpsertJob(ctx context.Context, j SyncableJob, pgRepoID int64, p
 			patch_id = EXCLUDED.patch_id,
 			token_usage = COALESCE(EXCLUDED.token_usage, review_jobs.token_usage),
 			worktree_path = COALESCE(EXCLUDED.worktree_path, review_jobs.worktree_path),
+			source = COALESCE(EXCLUDED.source, review_jobs.source),
 			min_severity = EXCLUDED.min_severity,
 			backup_agent = EXCLUDED.backup_agent,
 			backup_model = EXCLUDED.backup_model,
@@ -717,7 +718,7 @@ func (p *PgPool) UpsertJob(ctx context.Context, j SyncableJob, pgRepoID int64, p
 			updated_at = clock_timestamp()
 	`, j.UUID, pgRepoID, pgCommitID, j.GitRef, nullString(j.SessionID), j.Agent, nullString(j.Model), nullString(j.Provider), nullString(j.RequestedModel), nullString(j.RequestedProvider), nullString(j.Reasoning),
 		defaultStr(j.JobType, "review"), j.ReviewType, nullString(j.PatchID), j.Status, j.Agentic, j.EnqueuedAt, j.StartedAt, j.FinishedAt,
-		nullString(j.Prompt), j.DiffContent, nullString(j.Error), nullString(j.TokenUsage), nullString(j.WorktreePath), normalizeMinSeverityForWrite(j.MinSeverity),
+		nullString(j.Prompt), j.DiffContent, nullString(j.Error), nullString(j.TokenUsage), nullString(j.WorktreePath), nullString(j.Source), normalizeMinSeverityForWrite(j.MinSeverity),
 		nullString(j.PanelRunUUID), nullString(j.PanelRole), nullString(j.PanelName), nullString(j.PanelMemberName), j.PanelMemberIndex, nullString(j.PanelMemberConfigJSON),
 		j.SourceMachineID, j.BackupAgent, j.BackupModel)
 	return err
@@ -779,6 +780,7 @@ type PulledJob struct {
 	Error                 string
 	TokenUsage            string
 	WorktreePath          string
+	Source                string
 	MinSeverity           string
 	BackupAgent           string
 	BackupModel           string
@@ -813,7 +815,7 @@ func (p *PgPool) PullJobs(ctx context.Context, excludeMachineID string, cursor s
 			j.git_ref, COALESCE(j.session_id, ''), j.agent, COALESCE(j.model, ''), COALESCE(j.provider, ''), COALESCE(j.requested_model, ''), COALESCE(j.requested_provider, ''), COALESCE(j.reasoning, ''), COALESCE(j.job_type, 'review'), COALESCE(j.review_type, ''), COALESCE(j.patch_id, ''), j.status, j.agentic,
 			j.enqueued_at, j.started_at, j.finished_at,
 			COALESCE(j.prompt, ''), j.diff_content, COALESCE(j.error, ''), COALESCE(j.token_usage, ''),
-			COALESCE(j.worktree_path, ''), COALESCE(j.min_severity, ''), COALESCE(j.backup_agent, ''), COALESCE(j.backup_model, ''),
+			COALESCE(j.worktree_path, ''), COALESCE(j.source, ''), COALESCE(j.min_severity, ''), COALESCE(j.backup_agent, ''), COALESCE(j.backup_model, ''),
 			COALESCE(j.panel_run_uuid, ''), COALESCE(j.panel_role, ''), COALESCE(j.panel_name, ''), COALESCE(j.panel_member_name, ''), COALESCE(j.panel_member_index, 0), COALESCE(j.panel_member_config_json, ''),
 			j.source_machine_id, j.updated_at, j.id
 		FROM review_jobs j
@@ -842,7 +844,7 @@ func (p *PgPool) PullJobs(ctx context.Context, excludeMachineID string, cursor s
 			&j.GitRef, &j.SessionID, &j.Agent, &j.Model, &j.Provider, &j.RequestedModel, &j.RequestedProvider, &j.Reasoning, &j.JobType, &j.ReviewType, &j.PatchID, &j.Status, &j.Agentic,
 			&j.EnqueuedAt, &j.StartedAt, &j.FinishedAt,
 			&j.Prompt, &diffContent, &j.Error, &j.TokenUsage,
-			&j.WorktreePath, &j.MinSeverity, &j.BackupAgent, &j.BackupModel,
+			&j.WorktreePath, &j.Source, &j.MinSeverity, &j.BackupAgent, &j.BackupModel,
 			&j.PanelRunUUID, &j.PanelRole, &j.PanelName, &j.PanelMemberName, &j.PanelMemberIndex, &j.PanelMemberConfigJSON,
 			&j.SourceMachineID, &j.UpdatedAt, &lastID,
 		)
@@ -1131,10 +1133,10 @@ func (p *PgPool) BatchUpsertJobs(ctx context.Context, jobs []JobWithPgIDs) ([]bo
 			INSERT INTO review_jobs (
 				uuid, repo_id, commit_id, git_ref, session_id, agent, model, provider, requested_model, requested_provider, reasoning, job_type, review_type, patch_id, status, agentic,
 				enqueued_at, started_at, finished_at, prompt, diff_content, error, token_usage,
-				worktree_path, min_severity,
+				worktree_path, source, min_severity,
 				panel_run_uuid, panel_role, panel_name, panel_member_name, panel_member_index, panel_member_config_json,
 				source_machine_id, backup_agent, backup_model, updated_at
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, clock_timestamp())
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, clock_timestamp())
 			ON CONFLICT (uuid) DO UPDATE SET
 				status = EXCLUDED.status,
 				finished_at = EXCLUDED.finished_at,
@@ -1149,6 +1151,7 @@ func (p *PgPool) BatchUpsertJobs(ctx context.Context, jobs []JobWithPgIDs) ([]bo
 				patch_id = EXCLUDED.patch_id,
 				token_usage = COALESCE(EXCLUDED.token_usage, review_jobs.token_usage),
 				worktree_path = COALESCE(EXCLUDED.worktree_path, review_jobs.worktree_path),
+				source = COALESCE(EXCLUDED.source, review_jobs.source),
 				min_severity = EXCLUDED.min_severity,
 				backup_agent = EXCLUDED.backup_agent,
 				backup_model = EXCLUDED.backup_model,
@@ -1161,7 +1164,7 @@ func (p *PgPool) BatchUpsertJobs(ctx context.Context, jobs []JobWithPgIDs) ([]bo
 				updated_at = clock_timestamp()
 		`, j.UUID, jw.PgRepoID, jw.PgCommitID, j.GitRef, nullString(j.SessionID), j.Agent, nullString(j.Model), nullString(j.Provider), nullString(j.RequestedModel), nullString(j.RequestedProvider), nullString(j.Reasoning),
 			defaultStr(j.JobType, "review"), j.ReviewType, nullString(j.PatchID), j.Status, j.Agentic, j.EnqueuedAt, j.StartedAt, j.FinishedAt,
-			nullString(j.Prompt), j.DiffContent, nullString(j.Error), nullString(j.TokenUsage), nullString(j.WorktreePath), normalizeMinSeverityForWrite(j.MinSeverity),
+			nullString(j.Prompt), j.DiffContent, nullString(j.Error), nullString(j.TokenUsage), nullString(j.WorktreePath), nullString(j.Source), normalizeMinSeverityForWrite(j.MinSeverity),
 			nullString(j.PanelRunUUID), nullString(j.PanelRole), nullString(j.PanelName), nullString(j.PanelMemberName), j.PanelMemberIndex, nullString(j.PanelMemberConfigJSON),
 			j.SourceMachineID, j.BackupAgent, j.BackupModel)
 	}

--- a/internal/storage/postgres_test.go
+++ b/internal/storage/postgres_test.go
@@ -832,6 +832,62 @@ func TestIntegration_BatchUpsertJobs(t *testing.T) {
 		assert.Equal(t, "/worktrees/feature-x", found.WorktreePath)
 	})
 
+	t.Run("source round-trips through batch upsert and pull", func(t *testing.T) {
+		jobUUID := uuid.NewString()
+		machineID := uuid.NewString()
+		commitSHA := "batch-source-sha-" + jobUUID
+		commitID := createTestCommit(t, pool.Pool(), TestCommitOpts{
+			RepoID: repoID, SHA: commitSHA,
+		})
+		jobs := []JobWithPgIDs{{
+			Job: SyncableJob{
+				UUID:            jobUUID,
+				RepoIdentity:    "https://github.com/test/batch-jobs-test.git",
+				CommitSHA:       commitSHA,
+				GitRef:          commitSHA,
+				Agent:           "test",
+				Status:          "done",
+				Source:          JobSourceCI,
+				SourceMachineID: machineID,
+				EnqueuedAt:      time.Now(),
+			},
+			PgRepoID:   repoID,
+			PgCommitID: &commitID,
+		}}
+
+		success, err := pool.BatchUpsertJobs(ctx, jobs)
+		require.NoError(t, err)
+		assert.Equal(t, 1, countSuccesses(success))
+
+		var storedSource *string
+		err = pool.pool.QueryRow(ctx,
+			`SELECT source FROM review_jobs WHERE uuid = $1`, jobUUID,
+		).Scan(&storedSource)
+		require.NoError(t, err)
+		require.NotNil(t, storedSource)
+		assert.Equal(t, JobSourceCI, *storedSource)
+
+		var updatedAt time.Time
+		var rowID int64
+		err = pool.pool.QueryRow(ctx,
+			`SELECT updated_at, id FROM review_jobs WHERE uuid = $1`, jobUUID,
+		).Scan(&updatedAt, &rowID)
+		require.NoError(t, err)
+		cursor := fmt.Sprintf("%s %d", updatedAt.Format(time.RFC3339Nano), rowID-1)
+
+		pulled, _, err := pool.PullJobs(ctx, uuid.NewString(), cursor, 100)
+		require.NoError(t, err)
+		var found *PulledJob
+		for i := range pulled {
+			if pulled[i].UUID == jobUUID {
+				found = &pulled[i]
+				break
+			}
+		}
+		require.NotNil(t, found, "expected job %s in pull results", jobUUID)
+		assert.Equal(t, JobSourceCI, found.Source)
+	})
+
 	t.Run("model provider fields round-trip through batch upsert and pull", func(t *testing.T) {
 		jobUUID := uuid.NewString()
 		machineID := uuid.NewString()
@@ -1227,4 +1283,50 @@ func TestIntegration_UpsertJob_BackfillsModel(t *testing.T) {
 	assert.Nil(t, providerCleared, "Expected empty provider upsert to clear existing provider")
 	assert.Nil(t, requestedModelCleared, "Expected empty requested_model upsert to clear existing requested model")
 	assert.Nil(t, requestedProviderCleared, "Expected empty requested_provider upsert to clear existing requested provider")
+}
+
+func TestIntegration_UpsertJob_PreservesSource(t *testing.T) {
+	pool := openTestPgPool(t)
+	ctx := t.Context()
+
+	machineID := uuid.NewString()
+	jobUUID := uuid.NewString()
+	repoIdentity := "test-repo-source-" + time.Now().Format("20060102150405")
+
+	defer func() {
+		pool.pool.Exec(ctx, `DELETE FROM review_jobs WHERE uuid = $1`, jobUUID)
+		pool.pool.Exec(ctx, `DELETE FROM repos WHERE identity = $1`, repoIdentity)
+		pool.pool.Exec(ctx, `DELETE FROM machines WHERE machine_id = $1`, machineID)
+	}()
+
+	require.NoError(t, pool.RegisterMachine(ctx, machineID, "test"))
+	repoID, err := pool.GetOrCreateRepo(ctx, repoIdentity)
+	require.NoError(t, err)
+
+	job := SyncableJob{
+		UUID:            jobUUID,
+		RepoIdentity:    repoIdentity,
+		GitRef:          "HEAD",
+		Agent:           "test-agent",
+		Status:          "done",
+		Source:          JobSourceCI,
+		SourceMachineID: machineID,
+		EnqueuedAt:      time.Now(),
+	}
+	require.NoError(t, pool.UpsertJob(ctx, job, repoID, nil))
+
+	var source *string
+	require.NoError(t, pool.pool.QueryRow(ctx,
+		`SELECT source FROM review_jobs WHERE uuid = $1`, jobUUID,
+	).Scan(&source))
+	require.NotNil(t, source)
+	assert.Equal(t, JobSourceCI, *source)
+
+	job.Source = ""
+	require.NoError(t, pool.UpsertJob(ctx, job, repoID, nil))
+	require.NoError(t, pool.pool.QueryRow(ctx,
+		`SELECT source FROM review_jobs WHERE uuid = $1`, jobUUID,
+	).Scan(&source))
+	require.NotNil(t, source)
+	assert.Equal(t, JobSourceCI, *source)
 }

--- a/internal/storage/sync.go
+++ b/internal/storage/sync.go
@@ -331,6 +331,7 @@ type SyncableJob struct {
 	Error                 string
 	TokenUsage            string
 	WorktreePath          string
+	Source                string
 	MinSeverity           string
 	BackupAgent           string
 	BackupModel           string
@@ -354,7 +355,7 @@ func (db *DB) GetJobsToSync(machineID string, limit int) ([]SyncableJob, error) 
 			j.git_ref, COALESCE(j.session_id, ''), j.agent, COALESCE(j.model, ''), COALESCE(j.provider, ''), COALESCE(j.requested_model, ''), COALESCE(j.requested_provider, ''), COALESCE(j.reasoning, ''), COALESCE(j.job_type, 'review'), COALESCE(j.review_type, ''), COALESCE(j.patch_id, ''), j.status, j.agentic,
 			j.enqueued_at, COALESCE(j.started_at, ''), COALESCE(j.finished_at, ''),
 			COALESCE(j.prompt, ''), j.diff_content, COALESCE(j.error, ''), COALESCE(j.token_usage, ''),
-			COALESCE(j.worktree_path, ''), COALESCE(j.min_severity, ''), COALESCE(j.backup_agent, ''), COALESCE(j.backup_model, ''),
+			COALESCE(j.worktree_path, ''), COALESCE(j.source, ''), COALESCE(j.min_severity, ''), COALESCE(j.backup_agent, ''), COALESCE(j.backup_model, ''),
 			COALESCE(j.panel_run_uuid, ''), COALESCE(j.panel_role, ''), COALESCE(j.panel_name, ''), COALESCE(j.panel_member_name, ''), COALESCE(j.panel_member_index, 0), COALESCE(j.panel_member_config_json, ''),
 			j.source_machine_id, j.updated_at
 		FROM review_jobs j
@@ -391,7 +392,7 @@ func (db *DB) GetJobsToSync(machineID string, limit int) ([]SyncableJob, error) 
 			&j.GitRef, &j.SessionID, &j.Agent, &j.Model, &j.Provider, &j.RequestedModel, &j.RequestedProvider, &j.Reasoning, &j.JobType, &j.ReviewType, &j.PatchID, &j.Status, &j.Agentic,
 			&enqueuedAt, &startedAt, &finishedAt,
 			&j.Prompt, &diffContent, &j.Error, &j.TokenUsage,
-			&j.WorktreePath, &j.MinSeverity, &j.BackupAgent, &j.BackupModel,
+			&j.WorktreePath, &j.Source, &j.MinSeverity, &j.BackupAgent, &j.BackupModel,
 			&j.PanelRunUUID, &j.PanelRole, &j.PanelName, &j.PanelMemberName, &j.PanelMemberIndex, &j.PanelMemberConfigJSON,
 			&j.SourceMachineID, &updatedAt,
 		)
@@ -636,10 +637,10 @@ func (db *DB) UpsertPulledJob(j PulledJob, repoID int64, commitID *int64) error 
 		INSERT INTO review_jobs (
 			uuid, repo_id, commit_id, git_ref, session_id, agent, model, provider, requested_model, requested_provider, reasoning, job_type, review_type, patch_id, status, agentic,
 			enqueued_at, started_at, finished_at, prompt, diff_content, error, token_usage,
-			worktree_path, min_severity, backup_agent, backup_model,
+			worktree_path, source, min_severity, backup_agent, backup_model,
 			panel_run_uuid, panel_role, panel_name, panel_member_name, panel_member_index, panel_member_config_json,
 			source_machine_id, updated_at, synced_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(uuid) DO UPDATE SET
 			status = excluded.status,
 			finished_at = excluded.finished_at,
@@ -654,6 +655,7 @@ func (db *DB) UpsertPulledJob(j PulledJob, repoID int64, commitID *int64) error 
 			patch_id = excluded.patch_id,
 			token_usage = COALESCE(excluded.token_usage, review_jobs.token_usage),
 			worktree_path = COALESCE(excluded.worktree_path, review_jobs.worktree_path),
+			source = COALESCE(excluded.source, review_jobs.source),
 			min_severity = excluded.min_severity,
 			backup_agent = excluded.backup_agent,
 			backup_model = excluded.backup_model,
@@ -677,7 +679,7 @@ func (db *DB) UpsertPulledJob(j PulledJob, repoID int64, commitID *int64) error 
 		j.ReviewType, nullStr(j.PatchID), j.Status, j.Agentic, j.EnqueuedAt.Format(time.RFC3339),
 		nullTimeStr(j.StartedAt), nullTimeStr(j.FinishedAt),
 		nullStr(j.Prompt), j.DiffContent, nullStr(j.Error), nullStr(j.TokenUsage),
-		nullStr(j.WorktreePath), normalizeMinSeverityForWrite(j.MinSeverity), j.BackupAgent, j.BackupModel,
+		nullStr(j.WorktreePath), nullStr(j.Source), normalizeMinSeverityForWrite(j.MinSeverity), j.BackupAgent, j.BackupModel,
 		nullStr(j.PanelRunUUID), nullStr(j.PanelRole), nullStr(j.PanelName), nullStr(j.PanelMemberName), j.PanelMemberIndex, nullStr(j.PanelMemberConfigJSON),
 		j.SourceMachineID, j.UpdatedAt.Format(time.RFC3339), now, now)
 	return err

--- a/internal/storage/sync_backfill_test.go
+++ b/internal/storage/sync_backfill_test.go
@@ -259,6 +259,40 @@ func TestGetJobsToSync_IncludesWorktreePath(t *testing.T) {
 	assert.Equal(t, "/worktrees/feature-branch", found.WorktreePath)
 }
 
+func TestGetJobsToSync_IncludesSource(t *testing.T) {
+	h := newSyncTestHelper(t)
+
+	commit, err := h.db.GetOrCreateCommit(h.repo.ID, "source-sync-abc", "Author", "Subject", time.Now())
+	require.NoError(t, err)
+
+	job, err := h.db.EnqueueJob(EnqueueOpts{
+		RepoID:   h.repo.ID,
+		CommitID: commit.ID,
+		GitRef:   "source-sync-abc",
+		Agent:    "test",
+		Source:   JobSourceCI,
+	})
+	require.NoError(t, err)
+
+	claimed, err := h.db.ClaimJob("w-sync-source")
+	require.NoError(t, err)
+	require.Equal(t, job.ID, claimed.ID)
+	require.NoError(t, h.db.CompleteJob(job.ID, "test", "prompt", "PASS"))
+
+	jobs, err := h.db.GetJobsToSync(h.machineID, 10)
+	require.NoError(t, err)
+
+	var found *SyncableJob
+	for i := range jobs {
+		if jobs[i].UUID == job.UUID {
+			found = &jobs[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "expected job %s in sync results", job.UUID)
+	assert.Equal(t, JobSourceCI, found.Source)
+}
+
 func TestUpsertPulledJob_PreservesWorktreePath(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()
@@ -300,6 +334,41 @@ func TestUpsertPulledJob_PreservesWorktreePath(t *testing.T) {
 	).Scan(&wt)
 	require.NoError(t, err)
 	assert.Equal(t, "/worktrees/my-branch", wt)
+}
+
+func TestUpsertPulledJob_PreservesSource(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo, err := db.GetOrCreateRepo("/test/repo-source-sync")
+	require.NoError(t, err)
+
+	jobUUID := "test-uuid-source-" + time.Now().Format("20060102150405")
+	pulledJob := PulledJob{
+		UUID:            jobUUID,
+		RepoIdentity:    "/test/repo-source-sync",
+		GitRef:          "HEAD",
+		Agent:           "test-agent",
+		Status:          "done",
+		Source:          JobSourceCI,
+		SourceMachineID: "test-machine",
+		EnqueuedAt:      time.Now(),
+		UpdatedAt:       time.Now(),
+	}
+	require.NoError(t, db.UpsertPulledJob(pulledJob, repo.ID, nil))
+
+	var source string
+	require.NoError(t, db.QueryRow(
+		`SELECT COALESCE(source, '') FROM review_jobs WHERE uuid = ?`, jobUUID,
+	).Scan(&source))
+	assert.Equal(t, JobSourceCI, source)
+
+	pulledJob.Source = ""
+	require.NoError(t, db.UpsertPulledJob(pulledJob, repo.ID, nil))
+	require.NoError(t, db.QueryRow(
+		`SELECT COALESCE(source, '') FROM review_jobs WHERE uuid = ?`, jobUUID,
+	).Scan(&source))
+	assert.Equal(t, JobSourceCI, source)
 }
 
 func TestUpsertPulledJob_ClearsModelAndProviderFields(t *testing.T) {


### PR DESCRIPTION
## Summary

This fixes a CI poller correctness bug where CI reviews fetched the right commits and built the right diff range, but still ran the review agent in the shared clone's existing working tree. If that checkout was stale, any file the agent read outside the diff, such as `go.mod`, could come from an old commit and contradict the reviewed code.

## Issue

The poller reuses long-lived local clones for CI. Fetching kept object data current, so merge bases and diffs were correct, but the working tree `HEAD` was never moved after clone. CI panel members then ran with `cwd` set to that shared clone. In practice, a review of `ede4c2a..ccf2159` could build a correct diff while the agent read a weeks-old `go.mod` from the shared checkout and reported a false positive against the wrong module path.

There is also a concurrency constraint: multiple CI reviews for the same repository can run at different heads at the same time. Resetting or checking out the shared clone would race and would serialize review work behind slow agent runs.

## Changes

- Run CI panel member agents in per-job detached git worktrees at the reviewed head SHA.
- Keep the shared clone as the object store and trusted prompt/config checkout; it is no longer used as the agent cwd for CI reviews.
- Serialize git metadata operations per repo for fetch/worktree add/remove.
- Clean up per-job CI worktrees on job completion and prune stale CI worktrees on daemon startup.
- Keep prompt-side config, exclude patterns, max prompt size, and snapshot creation tied to the trusted shared/default-branch checkout so PR-head `.roborev.toml` cannot hide files from CI snapshots.
- Cover CI synthesis fallback so non-synthesis agents also run against the correct reviewed checkout.
- Update `AGENTS.md` so PR descriptions avoid standalone `Verification` and `Test Plan` sections by default.
