### PR TITLE
Put "No issues found." on its own line in default review prompts

### DIFF
--- a/internal/prompt/templates/default_design_review.md.gotmpl
+++ b/internal/prompt/templates/default_design_review.md.gotmpl
@@ -23,6 +23,6 @@ After reviewing, provide:
 4. Any missing considerations not covered by the design
 5. A verdict: Pass or Fail with brief justification
 
-If you find no issues, state "No issues found." after the summary.{{.System.NoSkillsInstruction}}{{.System.ToolchainVerificationInstruction}}
+If you find no issues, state "No issues found." on its own line after the summary.{{.System.NoSkillsInstruction}}{{.System.ToolchainVerificationInstruction}}
 
 Current date: {{.System.CurrentDate}} (UTC)

--- a/internal/prompt/templates/default_dirty.md.gotmpl
+++ b/internal/prompt/templates/default_dirty.md.gotmpl
@@ -27,6 +27,6 @@ After reviewing, provide:
 
 Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file or diff-level when the issue is an omission or spans a range), the severity must match the impact you described, and no two findings should contradict each other. Drop any finding that fails these checks.
 
-If you find no issues, state "No issues found." after the summary.{{.System.NoSkillsInstruction}}{{.System.ToolchainVerificationInstruction}}
+If you find no issues, state "No issues found." on its own line after the summary.{{.System.NoSkillsInstruction}}{{.System.ToolchainVerificationInstruction}}
 
 Current date: {{.System.CurrentDate}} (UTC)

--- a/internal/prompt/templates/default_range.md.gotmpl
+++ b/internal/prompt/templates/default_range.md.gotmpl
@@ -32,6 +32,6 @@ After reviewing, provide:
 
 Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file or diff-level when the issue is an omission or spans a range), the severity must match the impact you described, and no two findings should contradict each other. Drop any finding that fails these checks.
 
-If you find no issues, state "No issues found." after the summary.{{.System.NoSkillsInstruction}}{{.System.ToolchainVerificationInstruction}}
+If you find no issues, state "No issues found." on its own line after the summary.{{.System.NoSkillsInstruction}}{{.System.ToolchainVerificationInstruction}}
 
 Current date: {{.System.CurrentDate}} (UTC)

--- a/internal/prompt/templates/default_review.md.gotmpl
+++ b/internal/prompt/templates/default_review.md.gotmpl
@@ -32,6 +32,6 @@ After reviewing, provide:
 
 Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file or diff-level when the issue is an omission or spans a range), the severity must match the impact you described, and no two findings should contradict each other. Drop any finding that fails these checks.
 
-If you find no issues, state "No issues found." after the summary.{{.System.NoSkillsInstruction}}{{.System.ToolchainVerificationInstruction}}
+If you find no issues, state "No issues found." on its own line after the summary.{{.System.NoSkillsInstruction}}{{.System.ToolchainVerificationInstruction}}
 
 Current date: {{.System.CurrentDate}} (UTC)

--- a/internal/prompt/templates/default_security.md.gotmpl
+++ b/internal/prompt/templates/default_security.md.gotmpl
@@ -28,7 +28,7 @@ For each finding, provide:
 
 Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file-level when the issue spans a range) and describe a plausible exploit path. The severity must match the exploitability you described. Drop any finding that fails these checks.
 
-If you find no security issues, state "No issues found." after the summary.
+If you find no security issues, state "No issues found." on its own line after the summary.
 Do not report code quality or style issues unless they have security implications.{{.System.NoSkillsInstruction}}{{.System.ToolchainVerificationInstruction}}
 
 Current date: {{.System.CurrentDate}} (UTC)

--- a/internal/prompt/testdata/golden/design_review.golden
+++ b/internal/prompt/testdata/golden/design_review.golden
@@ -23,7 +23,7 @@ After reviewing, provide:
 4. Any missing considerations not covered by the design
 5. A verdict: Pass or Fail with brief justification
 
-If you find no issues, state "No issues found." after the summary.
+If you find no issues, state "No issues found." on its own line after the summary.
 
 IMPORTANT: You are being invoked by roborev to perform this review directly. Do NOT use any external skills, slash commands, or CLI tools (such as "roborev review") to delegate this task. Perform the review yourself by analyzing the diff provided below.
 

--- a/internal/prompt/testdata/golden/dirty_review.golden
+++ b/internal/prompt/testdata/golden/dirty_review.golden
@@ -27,7 +27,7 @@ After reviewing, provide:
 
 Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file or diff-level when the issue is an omission or spans a range), the severity must match the impact you described, and no two findings should contradict each other. Drop any finding that fails these checks.
 
-If you find no issues, state "No issues found." after the summary.
+If you find no issues, state "No issues found." on its own line after the summary.
 
 IMPORTANT: You are being invoked by roborev to perform this review directly. Do NOT use any external skills, slash commands, or CLI tools (such as "roborev review") to delegate this task. Perform the review yourself by analyzing the diff provided below.
 

--- a/internal/prompt/testdata/golden/dirty_truncated.golden
+++ b/internal/prompt/testdata/golden/dirty_truncated.golden
@@ -27,7 +27,7 @@ After reviewing, provide:
 
 Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file or diff-level when the issue is an omission or spans a range), the severity must match the impact you described, and no two findings should contradict each other. Drop any finding that fails these checks.
 
-If you find no issues, state "No issues found." after the summary.
+If you find no issues, state "No issues found." on its own line after the summary.
 
 IMPORTANT: You are being invoked by roborev to perform this review directly. Do NOT use any external skills, slash commands, or CLI tools (such as "roborev review") to delegate this task. Perform the review yourself by analyzing the diff provided below.
 

--- a/internal/prompt/testdata/golden/previous_reviews_with_comments.golden
+++ b/internal/prompt/testdata/golden/previous_reviews_with_comments.golden
@@ -32,7 +32,7 @@ After reviewing, provide:
 
 Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file or diff-level when the issue is an omission or spans a range), the severity must match the impact you described, and no two findings should contradict each other. Drop any finding that fails these checks.
 
-If you find no issues, state "No issues found." after the summary.
+If you find no issues, state "No issues found." on its own line after the summary.
 
 IMPORTANT: You are being invoked by roborev to perform this review directly. Do NOT use any external skills, slash commands, or CLI tools (such as "roborev review") to delegate this task. Perform the review yourself by analyzing the diff provided below.
 

--- a/internal/prompt/testdata/golden/range_truncated.golden
+++ b/internal/prompt/testdata/golden/range_truncated.golden
@@ -32,7 +32,7 @@ After reviewing, provide:
 
 Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file or diff-level when the issue is an omission or spans a range), the severity must match the impact you described, and no two findings should contradict each other. Drop any finding that fails these checks.
 
-If you find no issues, state "No issues found." after the summary.
+If you find no issues, state "No issues found." on its own line after the summary.
 
 IMPORTANT: You are being invoked by roborev to perform this review directly. Do NOT use any external skills, slash commands, or CLI tools (such as "roborev review") to delegate this task. Perform the review yourself by analyzing the diff provided below.
 

--- a/internal/prompt/testdata/golden/range_with_in_range_reviews.golden
+++ b/internal/prompt/testdata/golden/range_with_in_range_reviews.golden
@@ -32,7 +32,7 @@ After reviewing, provide:
 
 Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file or diff-level when the issue is an omission or spans a range), the severity must match the impact you described, and no two findings should contradict each other. Drop any finding that fails these checks.
 
-If you find no issues, state "No issues found." after the summary.
+If you find no issues, state "No issues found." on its own line after the summary.
 
 IMPORTANT: You are being invoked by roborev to perform this review directly. Do NOT use any external skills, slash commands, or CLI tools (such as "roborev review") to delegate this task. Perform the review yourself by analyzing the diff provided below.
 

--- a/internal/prompt/testdata/golden/security_review.golden
+++ b/internal/prompt/testdata/golden/security_review.golden
@@ -28,7 +28,7 @@ For each finding, provide:
 
 Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file-level when the issue spans a range) and describe a plausible exploit path. The severity must match the exploitability you described. Drop any finding that fails these checks.
 
-If you find no security issues, state "No issues found." after the summary.
+If you find no security issues, state "No issues found." on its own line after the summary.
 Do not report code quality or style issues unless they have security implications.
 
 IMPORTANT: You are being invoked by roborev to perform this review directly. Do NOT use any external skills, slash commands, or CLI tools (such as "roborev review") to delegate this task. Perform the review yourself by analyzing the diff provided below.

--- a/internal/prompt/testdata/golden/single_review_default.golden
+++ b/internal/prompt/testdata/golden/single_review_default.golden
@@ -32,7 +32,7 @@ After reviewing, provide:
 
 Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file or diff-level when the issue is an omission or spans a range), the severity must match the impact you described, and no two findings should contradict each other. Drop any finding that fails these checks.
 
-If you find no issues, state "No issues found." after the summary.
+If you find no issues, state "No issues found." on its own line after the summary.
 
 IMPORTANT: You are being invoked by roborev to perform this review directly. Do NOT use any external skills, slash commands, or CLI tools (such as "roborev review") to delegate this task. Perform the review yourself by analyzing the diff provided below.
 

--- a/internal/prompt/testdata/golden/single_truncated_diff.golden
+++ b/internal/prompt/testdata/golden/single_truncated_diff.golden
@@ -32,7 +32,7 @@ After reviewing, provide:
 
 Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file or diff-level when the issue is an omission or spans a range), the severity must match the impact you described, and no two findings should contradict each other. Drop any finding that fails these checks.
 
-If you find no issues, state "No issues found." after the summary.
+If you find no issues, state "No issues found." on its own line after the summary.
 
 IMPORTANT: You are being invoked by roborev to perform this review directly. Do NOT use any external skills, slash commands, or CLI tools (such as "roborev review") to delegate this task. Perform the review yourself by analyzing the diff provided below.
 

--- a/internal/prompt/testdata/golden/single_with_additional_context.golden
+++ b/internal/prompt/testdata/golden/single_with_additional_context.golden
@@ -32,7 +32,7 @@ After reviewing, provide:
 
 Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file or diff-level when the issue is an omission or spans a range), the severity must match the impact you described, and no two findings should contradict each other. Drop any finding that fails these checks.
 
-If you find no issues, state "No issues found." after the summary.
+If you find no issues, state "No issues found." on its own line after the summary.
 
 IMPORTANT: You are being invoked by roborev to perform this review directly. Do NOT use any external skills, slash commands, or CLI tools (such as "roborev review") to delegate this task. Perform the review yourself by analyzing the diff provided below.
 

--- a/internal/prompt/testdata/golden/single_with_guidelines.golden
+++ b/internal/prompt/testdata/golden/single_with_guidelines.golden
@@ -32,7 +32,7 @@ After reviewing, provide:
 
 Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file or diff-level when the issue is an omission or spans a range), the severity must match the impact you described, and no two findings should contradict each other. Drop any finding that fails these checks.
 
-If you find no issues, state "No issues found." after the summary.
+If you find no issues, state "No issues found." on its own line after the summary.
 
 IMPORTANT: You are being invoked by roborev to perform this review directly. Do NOT use any external skills, slash commands, or CLI tools (such as "roborev review") to delegate this task. Perform the review yourself by analyzing the diff provided below.
 

--- a/internal/prompt/testdata/golden/single_with_previous_reviews.golden
+++ b/internal/prompt/testdata/golden/single_with_previous_reviews.golden
@@ -32,7 +32,7 @@ After reviewing, provide:
 
 Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file or diff-level when the issue is an omission or spans a range), the severity must match the impact you described, and no two findings should contradict each other. Drop any finding that fails these checks.
 
-If you find no issues, state "No issues found." after the summary.
+If you find no issues, state "No issues found." on its own line after the summary.
 
 IMPORTANT: You are being invoked by roborev to perform this review directly. Do NOT use any external skills, slash commands, or CLI tools (such as "roborev review") to delegate this task. Perform the review yourself by analyzing the diff provided below.
 

--- a/internal/prompt/testdata/golden/single_with_severity_filter.golden
+++ b/internal/prompt/testdata/golden/single_with_severity_filter.golden
@@ -32,7 +32,7 @@ After reviewing, provide:
 
 Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file or diff-level when the issue is an omission or spans a range), the severity must match the impact you described, and no two findings should contradict each other. Drop any finding that fails these checks.
 
-If you find no issues, state "No issues found." after the summary.
+If you find no issues, state "No issues found." on its own line after the summary.
 
 IMPORTANT: You are being invoked by roborev to perform this review directly. Do NOT use any external skills, slash commands, or CLI tools (such as "roborev review") to delegate this task. Perform the review yourself by analyzing the diff provided below.
 


### PR DESCRIPTION
Summary

- The verdict parser treats a review as a pass only when `No issues found.` begins a line (`hasPassPrefix` in `internal/storage/verdict.go`). The `default_*` review templates told agents to state the phrase "after the summary", which leads agents to append it to the end of the summary sentence. Mid-line, the parser does not detect it, so a review that found nothing is recorded as Fail (surfaced by #789).
- Update the five `default_*` templates (review, range, dirty, security, design) to instruct agents to put `No issues found.` on its own line, where the parser looks. The claude-code and codex templates already say "start immediately with", so they were left unchanged.
- Regenerate the affected prompt golden fixtures.
- Scope note: this aligns conforming agents with the parser; it does not add parser heuristics. The output in #789 also emitted a contradictory `Verdict: Fail` header that contradicts its own "no issues" conclusion, which remains a model-conformance limitation no parser change can resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)