### PR TITLE
Publish packages to Artifact Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,14 +53,102 @@ jobs:
           name: roborev-release-tarballs
           path: dist/*.tar.gz
 
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: roborev-linux-packages
+          path: |
+            dist/*.deb
+            dist/*.rpm
+          if-no-files-found: error
+
+  publish-package-artifacts:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: roborev-linux-packages
+          path: packages
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: roborev-release-tarballs
+          path: tarballs
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3
+        with:
+          project_id: ${{ vars.KENN_PACKAGES_PROJECT }}
+          workload_identity_provider: ${{ vars.KENN_PACKAGES_WIF_PROVIDER }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db  # v3.0.1
+
+      - name: Upload packages to Artifact Registry
+        shell: bash
+        env:
+          KENN_PACKAGES_PROJECT: ${{ vars.KENN_PACKAGES_PROJECT }}
+          KENN_PACKAGES_LOCATION: ${{ vars.KENN_PACKAGES_LOCATION }}
+          KENN_PACKAGES_APT_REPOSITORY: ${{ vars.KENN_PACKAGES_APT_REPOSITORY }}
+          KENN_PACKAGES_BIN_REPOSITORY: ${{ vars.KENN_PACKAGES_BIN_REPOSITORY }}
+          KENN_PACKAGES_YUM_REPOSITORY: ${{ vars.KENN_PACKAGES_YUM_REPOSITORY }}
+        run: |
+          set -euo pipefail
+
+          VERSION=${GITHUB_REF#refs/tags/v}
+          shopt -s nullglob
+          tarballs=(tarballs/*.tar.gz)
+          debs=(packages/*.deb)
+          rpms=(packages/*.rpm)
+
+          if [ "${#tarballs[@]}" -eq 0 ]; then
+            printf 'ERROR: no release tarballs found in tarballs\n' >&2
+            exit 1
+          fi
+          if [ "${#debs[@]}" -eq 0 ]; then
+            printf 'ERROR: no Debian packages found in packages\n' >&2
+            exit 1
+          fi
+          if [ "${#rpms[@]}" -eq 0 ]; then
+            printf 'ERROR: no RPM packages found in packages\n' >&2
+            exit 1
+          fi
+
+          gcloud artifacts generic upload \
+            --project="$KENN_PACKAGES_PROJECT" \
+            --location="$KENN_PACKAGES_LOCATION" \
+            --repository="$KENN_PACKAGES_BIN_REPOSITORY" \
+            --package=roborev \
+            --version="$VERSION" \
+            --source-directory=tarballs \
+            --skip-existing
+
+          for deb in "${debs[@]}"; do
+            gcloud artifacts apt upload "$KENN_PACKAGES_APT_REPOSITORY" \
+              --project="$KENN_PACKAGES_PROJECT" \
+              --location="$KENN_PACKAGES_LOCATION" \
+              --source="$deb"
+          done
+
+          for rpm in "${rpms[@]}"; do
+            gcloud artifacts yum upload "$KENN_PACKAGES_YUM_REPOSITORY" \
+              --project="$KENN_PACKAGES_PROJECT" \
+              --location="$KENN_PACKAGES_LOCATION" \
+              --source="$rpm"
+          done
+
   update-homebrew:
     needs: release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
+          name: roborev-release-tarballs
           path: artifacts
-          merge-multiple: true
 
       - name: Compute SHA256 for all binaries
         id: sha256


### PR DESCRIPTION
This moves roborev’s Linux package publication into Google Artifact Registry after GoReleaser creates the release artifacts.

The release workflow now keeps GoReleaser responsible for building and publishing the GitHub release, then runs a separate Artifact Registry job that authenticates with GitHub OIDC through Workload Identity Federation. That job uploads:

- release tarballs to the configured generic/bin repository
- `.deb` packages to the configured Apt repository
- `.rpm` packages to the configured Yum repository

The generic repository uses tarballs rather than raw binaries. Tarballs match the existing release artifact shape, keep OS/architecture naming consistent, leave room for bundled files if needed later, and avoid adding a second direct-download format without a concrete install path that needs bare executables.

The Homebrew update job now downloads only `roborev-release-tarballs`. Once the release job started producing a second artifact bundle for Linux packages, the previous “download every artifact and merge them” behavior would have put `.deb` and `.rpm` files into the Homebrew checksum workspace. The formula updater only needs tarballs, so narrowing that download keeps the job input precise.

The Artifact Registry settings are repository variables, not secrets:
`KENN_PACKAGES_PROJECT`, `KENN_PACKAGES_LOCATION`, `KENN_PACKAGES_WIF_PROVIDER`, `KENN_PACKAGES_APT_REPOSITORY`, `KENN_PACKAGES_BIN_REPOSITORY`, and `KENN_PACKAGES_YUM_REPOSITORY` are resource identifiers used to address GCP and Artifact Registry resources. They do not include credentials, access tokens, private keys, or service account keys. Access still depends on GitHub’s OIDC token and the IAM bindings created in the packages project.

Verification
I verified the “not secrets” assertion this way:

- Google documents project IDs as identifiers and explicitly says project/resource names are exposed in references, so they should not contain sensitive information. That supports treating `KENN_PACKAGES_PROJECT` as an identifier, not a credential. Source: Google Cloud project docs (https://docs.cloud.google.com/resource-manager/docs/creating-managing-projects)

- Artifact Registry repository paths are addressed by project, location, and repository name. Those values are routing/resource identifiers, not authentication material. Source: Artifact Registry names/docs (https://cloud.google.com/artifact-registry/docs/docker/names)

- Google’s auth action takes `workload_identity_provider` as a provider resource name. It is an input identifying the WIF provider; access still depends on OIDC token exchange and IAM. Source: google-github-actions/auth (https://github.com/google-github-actions/auth)

- Generic Artifact Registry upload is designed for versioned immutable artifacts that do not fit a package-specific format, which matches tarballs. Source: Artifact Registry generic docs (https://docs.cloud.google.com/artifact-registry/docs/generic)
