### PR TITLE
Reduce dependency metadata false positives

### DIFF
--- a/cmd/roborev/review.go
+++ b/cmd/roborev/review.go
@@ -301,7 +301,7 @@ Examples:
 						len(diffContent), MaxDirtyDiffSize)
 				}
 
-				if diffContent == "" && len(dirtyFiles) == 0 {
+				if diffContent == "" && !prompt.HasDependencyMetadataFiles(dirtyFiles) {
 					return fmt.Errorf("no changes to review (diff is empty)")
 				}
 

--- a/cmd/roborev/review.go
+++ b/cmd/roborev/review.go
@@ -170,6 +170,7 @@ Examples:
 
 			var gitRef string
 			var diffContent string
+			var dirtyFiles []string
 
 			if branch != "" {
 				// Branch review - review all commits since diverging from base
@@ -277,6 +278,10 @@ Examples:
 				if !hasChanges {
 					return fmt.Errorf("no uncommitted changes to review")
 				}
+				dirtyFiles, err = git.GetDirtyFilesChanged(root)
+				if err != nil {
+					return fmt.Errorf("get dirty files: %w", err)
+				}
 
 				// Generate dirty diff (includes untracked files).
 				// Use working-tree repo config (not default branch) for
@@ -296,7 +301,7 @@ Examples:
 						len(diffContent), MaxDirtyDiffSize)
 				}
 
-				if diffContent == "" {
+				if diffContent == "" && len(dirtyFiles) == 0 {
 					return fmt.Errorf("no changes to review (diff is empty)")
 				}
 
@@ -325,7 +330,7 @@ Examples:
 				if panel != "" && panel != "none" && !quiet {
 					cmd.PrintErrf("Note: --panel %q is ignored with --local (panels require the daemon); running a single-agent review.\n", panel)
 				}
-				return runLocalReview(cmd, root, gitRef, diffContent, agent, model, provider, reasoning, reviewType, quiet, minSeverity)
+				return runLocalReview(cmd, root, gitRef, diffContent, dirtyFiles, agent, model, provider, reasoning, reviewType, quiet, minSeverity)
 			}
 
 			// Build request body
@@ -339,6 +344,7 @@ Examples:
 				Reasoning:   reasoning,
 				ReviewType:  reviewType,
 				DiffContent: diffContent,
+				DirtyFiles:  dirtyFiles,
 				MinSeverity: minSeverity,
 				Panel:       panel,
 			}
@@ -425,7 +431,7 @@ Examples:
 }
 
 // runLocalReview runs a review directly without the daemon
-func runLocalReview(cmd *cobra.Command, repoPath, gitRef, diffContent, agentName, model, provider, reasoning, reviewType string, quiet bool, minSeverity string) error {
+func runLocalReview(cmd *cobra.Command, repoPath, gitRef, diffContent string, dirtyFiles []string, agentName, model, provider, reasoning, reviewType string, quiet bool, minSeverity string) error {
 	ctx := cmd.Context()
 
 	// Load config
@@ -509,9 +515,9 @@ func runLocalReview(cmd *cobra.Command, repoPath, gitRef, diffContent, agentName
 	pb := prompt.NewBuilderWithConfig(nil, cfg).WithContext(ctx).ForRepo(repoPath, 0)
 	var reviewPrompt string
 	var snapshotCleanup func()
-	if diffContent != "" {
+	if diffContent != "" || len(dirtyFiles) > 0 {
 		// Dirty review
-		dirtyResult, dirtyErr := pb.BuildDirtyWithSnapshot(diffContent, cfg.ReviewContextCount, a.Name(), reviewType, resolvedMinSev)
+		dirtyResult, dirtyErr := pb.BuildDirtyWithSnapshotAndFiles(diffContent, dirtyFiles, cfg.ReviewContextCount, a.Name(), reviewType, resolvedMinSev)
 		reviewPrompt = dirtyResult.Prompt
 		snapshotCleanup = dirtyResult.Cleanup
 		err = dirtyErr

--- a/internal/daemon/enqueue_descriptor_test.go
+++ b/internal/daemon/enqueue_descriptor_test.go
@@ -94,6 +94,47 @@ func TestEnqueueDirtyUnchanged(t *testing.T) {
 	assert.Equal(diff, *claimed.DiffContent)
 }
 
+func TestEnqueueDirtyRejectsEmptyNonMetadataDiff(t *testing.T) {
+	server, _, _ := newTestServer(t)
+
+	repo := testutil.NewGitRepo(t)
+	repo.CommitFile("a.txt", "a", "add a")
+
+	req := testutil.MakeJSONRequest(t, http.MethodPost, "/api/enqueue", EnqueueRequest{
+		RepoPath:   repo.Path(),
+		GitRef:     "dirty",
+		Agent:      "test",
+		DirtyFiles: []string{".cache/generated.bin"},
+	})
+	w := httptest.NewRecorder()
+	server.httpServer.Handler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "diff_content required")
+}
+
+func TestEnqueueDirtyMetadataOnlyPersistsDirtyFiles(t *testing.T) {
+	server, db, _ := newTestServer(t)
+
+	repo := testutil.NewGitRepo(t)
+	repo.CommitFile("a.txt", "a", "add a")
+
+	job := enqueueViaHTTP(t, server, EnqueueRequest{
+		RepoPath:   repo.Path(),
+		GitRef:     "dirty",
+		Agent:      "test",
+		DirtyFiles: []string{"go.sum"},
+	})
+
+	claimed, err := db.ClaimJob("worker")
+	require.NoError(t, err)
+	require.Equal(t, job.ID, claimed.ID)
+	assert.Equal(t, storage.JobTypeDirty, claimed.JobType)
+	assert.Nil(t, claimed.DiffContent)
+	assert.Equal(t, []string{"go.sum"}, claimed.DirtyFiles)
+	assert.False(t, claimed.PromptPrebuilt, "dirty metadata should be rebuilt by the worker")
+}
+
 // TestEnqueueRangeUnchanged pins the range enqueue path: the symbolic
 // "<a>..<b>" request is frozen to "<sha>..<sha>" and classified as a range.
 func TestEnqueueRangeUnchanged(t *testing.T) {

--- a/internal/daemon/panel_enqueue.go
+++ b/internal/daemon/panel_enqueue.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/git"
+	"go.kenn.io/roborev/internal/prompt"
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -31,6 +33,7 @@ type targetDescriptor struct {
 	sessionSHA        string // SHA to key session reuse on ("" for prompt jobs)
 	patchID           string
 	diffContent       string
+	dirtyFiles        []string
 	minSeverity       string
 	worktreePath      string
 	jobType           string // req.JobType for prompt; "" lets EnqueueJob infer dirty/range/review
@@ -198,7 +201,7 @@ func (s *Server) descriptorForPrompt(in freezeInputs) targetDescriptor {
 func (s *Server) descriptorForDirty(
 	ctx context.Context, in freezeInputs,
 ) (targetDescriptor, *RawJSONOutput) {
-	if in.req.DiffContent == "" {
+	if in.req.DiffContent == "" && len(in.req.DirtyFiles) == 0 {
 		out, _ := rawJSONOutput(http.StatusBadRequest,
 			ErrorResponse{Error: "diff_content required for dirty review"})
 		return targetDescriptor{}, out
@@ -231,6 +234,8 @@ func (s *Server) descriptorForDirty(
 		branch:            in.req.Branch,
 		sessionSHA:        targetSHA,
 		diffContent:       in.req.DiffContent,
+		dirtyFiles:        slices.Clone(in.req.DirtyFiles),
+		jobType:           storage.JobTypeDirty,
 		minSeverity:       in.normalizedMinSev,
 		worktreePath:      in.worktreePath,
 		requestedModel:    in.requestedModel,
@@ -407,7 +412,11 @@ func (s *Server) enqueuePanelRun(ctx context.Context, in panelRunInputs) (*RawJS
 	}
 
 	runUUID := uuid.NewString()
-	memberOpts := panelMemberOpts(in.descriptor, in.panelName, runUUID, members, in.resolutionPath, in.cfg)
+	memberOpts, err := panelMemberOpts(in.descriptor, in.panelName, runUUID, members, in.resolutionPath, in.cfg)
+	if err != nil {
+		return rawJSONOutput(http.StatusInternalServerError,
+			ErrorResponse{Error: fmt.Sprintf("build panel member opts: %v", err)})
+	}
 	synthOpts := panelSynthesisOpts(in.descriptor, in.panelName, runUUID, synth)
 
 	memberJobs, synthJob, err := s.db.EnqueuePanelRun(memberOpts, synthOpts)
@@ -470,7 +479,7 @@ func panelHasDesignMember(members []config.ResolvedMember) bool {
 func panelMemberOpts(
 	descriptor targetDescriptor, panelName, runUUID string, members []config.ResolvedMember,
 	repoPath string, cfg *config.Config,
-) []storage.EnqueueOpts {
+) ([]storage.EnqueueOpts, error) {
 	out := make([]storage.EnqueueOpts, len(members))
 	for i, m := range members {
 		o := descriptor.baseOpts()
@@ -478,12 +487,41 @@ func panelMemberOpts(
 		o.Agent, o.Model = resolvePanelMemberExecution(m, descriptor, repoPath, cfg)
 		o.Provider = m.Provider
 		o.Reasoning, o.ReviewType = m.Reasoning, m.ReviewType
+		prompt, err := buildDirtyPrebuiltPrompt(repoPath, descriptor.repoID, descriptor, cfg, o.Agent, o.ReviewType)
+		if err != nil {
+			return nil, err
+		}
+		if prompt != "" {
+			o.Prompt = prompt
+			o.PromptPrebuilt = true
+		}
 		o.PanelRunUUID, o.PanelRole = runUUID, storage.PanelRoleMember
 		o.PanelName, o.PanelMemberName, o.PanelMemberIndex = panelName, m.Name, m.Index
 		o.PanelMemberConfigJSON = string(cfgJSON)
 		out[i] = o
 	}
-	return out
+	return out, nil
+}
+
+func buildDirtyPrebuiltPrompt(
+	repoPath string,
+	repoID int64,
+	descriptor targetDescriptor,
+	cfg *config.Config,
+	agentName, reviewType string,
+) (string, error) {
+	if descriptor.gitRef != "dirty" || len(descriptor.dirtyFiles) == 0 {
+		return "", nil
+	}
+	builder := prompt.NewBuilderWithConfig(nil, cfg).ForRepo(repoPath, repoID)
+	return builder.BuildDirtyWithFiles(
+		descriptor.diffContent,
+		descriptor.dirtyFiles,
+		cfg.ReviewContextCount,
+		agentName,
+		reviewType,
+		descriptor.minSeverity,
+	)
 }
 
 func resolvePanelMemberExecution(

--- a/internal/daemon/panel_enqueue.go
+++ b/internal/daemon/panel_enqueue.go
@@ -53,7 +53,7 @@ type targetDescriptor struct {
 func (d targetDescriptor) baseOpts() storage.EnqueueOpts {
 	return storage.EnqueueOpts{
 		RepoID: d.repoID, CommitID: d.commitID, GitRef: d.gitRef, Branch: d.branch,
-		PatchID: d.patchID, DiffContent: d.diffContent, MinSeverity: d.minSeverity,
+		PatchID: d.patchID, DiffContent: d.diffContent, DirtyFiles: d.dirtyFiles, MinSeverity: d.minSeverity,
 		WorktreePath: d.worktreePath, JobType: d.jobType, Prompt: d.prompt,
 		PromptPrebuilt: d.promptPrebuilt, OutputPrefix: d.outputPrefix, Label: d.label,
 		Agentic: d.agentic, RequestedModel: d.requestedModel, RequestedProvider: d.requestedProvider,
@@ -201,7 +201,7 @@ func (s *Server) descriptorForPrompt(in freezeInputs) targetDescriptor {
 func (s *Server) descriptorForDirty(
 	ctx context.Context, in freezeInputs,
 ) (targetDescriptor, *RawJSONOutput) {
-	if in.req.DiffContent == "" && len(in.req.DirtyFiles) == 0 {
+	if in.req.DiffContent == "" && !prompt.HasDependencyMetadataFiles(in.req.DirtyFiles) {
 		out, _ := rawJSONOutput(http.StatusBadRequest,
 			ErrorResponse{Error: "diff_content required for dirty review"})
 		return targetDescriptor{}, out
@@ -412,11 +412,7 @@ func (s *Server) enqueuePanelRun(ctx context.Context, in panelRunInputs) (*RawJS
 	}
 
 	runUUID := uuid.NewString()
-	memberOpts, err := panelMemberOpts(in.descriptor, in.panelName, runUUID, members, in.resolutionPath, in.cfg)
-	if err != nil {
-		return rawJSONOutput(http.StatusInternalServerError,
-			ErrorResponse{Error: fmt.Sprintf("build panel member opts: %v", err)})
-	}
+	memberOpts := panelMemberOpts(in.descriptor, in.panelName, runUUID, members, in.resolutionPath, in.cfg)
 	synthOpts := panelSynthesisOpts(in.descriptor, in.panelName, runUUID, synth)
 
 	memberJobs, synthJob, err := s.db.EnqueuePanelRun(memberOpts, synthOpts)
@@ -479,7 +475,7 @@ func panelHasDesignMember(members []config.ResolvedMember) bool {
 func panelMemberOpts(
 	descriptor targetDescriptor, panelName, runUUID string, members []config.ResolvedMember,
 	repoPath string, cfg *config.Config,
-) ([]storage.EnqueueOpts, error) {
+) []storage.EnqueueOpts {
 	out := make([]storage.EnqueueOpts, len(members))
 	for i, m := range members {
 		o := descriptor.baseOpts()
@@ -487,41 +483,12 @@ func panelMemberOpts(
 		o.Agent, o.Model = resolvePanelMemberExecution(m, descriptor, repoPath, cfg)
 		o.Provider = m.Provider
 		o.Reasoning, o.ReviewType = m.Reasoning, m.ReviewType
-		prompt, err := buildDirtyPrebuiltPrompt(repoPath, descriptor.repoID, descriptor, cfg, o.Agent, o.ReviewType)
-		if err != nil {
-			return nil, err
-		}
-		if prompt != "" {
-			o.Prompt = prompt
-			o.PromptPrebuilt = true
-		}
 		o.PanelRunUUID, o.PanelRole = runUUID, storage.PanelRoleMember
 		o.PanelName, o.PanelMemberName, o.PanelMemberIndex = panelName, m.Name, m.Index
 		o.PanelMemberConfigJSON = string(cfgJSON)
 		out[i] = o
 	}
-	return out, nil
-}
-
-func buildDirtyPrebuiltPrompt(
-	repoPath string,
-	repoID int64,
-	descriptor targetDescriptor,
-	cfg *config.Config,
-	agentName, reviewType string,
-) (string, error) {
-	if descriptor.gitRef != "dirty" || len(descriptor.dirtyFiles) == 0 {
-		return "", nil
-	}
-	builder := prompt.NewBuilderWithConfig(nil, cfg).ForRepo(repoPath, repoID)
-	return builder.BuildDirtyWithFiles(
-		descriptor.diffContent,
-		descriptor.dirtyFiles,
-		cfg.ReviewContextCount,
-		agentName,
-		reviewType,
-		descriptor.minSeverity,
-	)
+	return out
 }
 
 func resolvePanelMemberExecution(

--- a/internal/daemon/rerun_panel.go
+++ b/internal/daemon/rerun_panel.go
@@ -57,7 +57,12 @@ func (s *Server) rerunPanelRun(job *storage.ReviewJob) (*RerunJobOutput, error) 
 			return nil, huma.Error500InternalServerError(
 				fmt.Sprintf("load member diff: %v", diffErr))
 		}
-		memberOpts[i] = panelRerunMemberOpts(members[i], runUUID, diff, source)
+		dirtyFiles, filesErr := s.db.GetJobDirtyFiles(members[i].ID)
+		if filesErr != nil {
+			return nil, huma.Error500InternalServerError(
+				fmt.Sprintf("load member dirty files: %v", filesErr))
+		}
+		memberOpts[i] = panelRerunMemberOpts(members[i], runUUID, diff, dirtyFiles, source)
 	}
 
 	synthDiff, err := s.db.GetJobDiffContent(job.ID)
@@ -65,7 +70,12 @@ func (s *Server) rerunPanelRun(job *storage.ReviewJob) (*RerunJobOutput, error) 
 		return nil, huma.Error500InternalServerError(
 			fmt.Sprintf("load synthesis diff: %v", err))
 	}
-	synthOpts := panelRerunSynthesisOpts(job, runUUID, synthDiff, source)
+	synthDirtyFiles, err := s.db.GetJobDirtyFiles(job.ID)
+	if err != nil {
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("load synthesis dirty files: %v", err))
+	}
+	synthOpts := panelRerunSynthesisOpts(job, runUUID, synthDiff, synthDirtyFiles, source)
 
 	if _, _, err := s.db.EnqueuePanelRun(memberOpts, synthOpts); err != nil {
 		return nil, huma.Error500InternalServerError(
@@ -97,7 +107,7 @@ func (s *Server) panelRerunSource(job *storage.ReviewJob) (string, error) {
 // (name/index/config), reassigning only the run UUID. Review/range/dirty prompts
 // are rebuilt by the worker so reruns do not reuse stale prebuilt prompts. diff
 // is the member's stored dirty diff (empty for commit/range targets).
-func panelRerunMemberOpts(m storage.ReviewJob, runUUID, diff, source string) storage.EnqueueOpts {
+func panelRerunMemberOpts(m storage.ReviewJob, runUUID, diff string, dirtyFiles []string, source string) storage.EnqueueOpts {
 	prompt := ""
 	if m.UsesStoredPrompt() {
 		prompt = m.Prompt
@@ -116,6 +126,7 @@ func panelRerunMemberOpts(m storage.ReviewJob, runUUID, diff, source string) sto
 		ReviewType:            m.ReviewType,
 		PatchID:               m.PatchID,
 		DiffContent:           diff,
+		DirtyFiles:            dirtyFiles,
 		Prompt:                prompt,
 		PromptPrebuilt:        false,
 		Source:                source,
@@ -138,7 +149,7 @@ func panelRerunMemberOpts(m storage.ReviewJob, runUUID, diff, source string) sto
 // panelRerunSynthesisOpts clones the synthesis parent into fresh EnqueueOpts for
 // a new run. EnqueuePanelRun re-enforces JobType=synthesis, role=synthesis, and
 // ClaimBlocked, but they are set here too so the opts are self-describing.
-func panelRerunSynthesisOpts(job *storage.ReviewJob, runUUID, diff, source string) storage.EnqueueOpts {
+func panelRerunSynthesisOpts(job *storage.ReviewJob, runUUID, diff string, dirtyFiles []string, source string) storage.EnqueueOpts {
 	return storage.EnqueueOpts{
 		RepoID:            job.RepoID,
 		CommitID:          job.CommitIDValue(),
@@ -153,6 +164,7 @@ func panelRerunSynthesisOpts(job *storage.ReviewJob, runUUID, diff, source strin
 		ReviewType:        job.ReviewType,
 		PatchID:           job.PatchID,
 		DiffContent:       diff,
+		DirtyFiles:        dirtyFiles,
 		OutputPrefix:      job.OutputPrefix,
 		Source:            source,
 		Agentic:           job.Agentic,

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -1833,6 +1833,15 @@ func (s *Server) enqueueSingleAgent(
 	o.Provider = in.descriptor.requestedProvider
 	o.Reasoning = in.reasoning
 	o.ReviewType = in.req.ReviewType
+	if prompt, err := buildDirtyPrebuiltPrompt(in.resolutionPath, in.repo.ID, in.descriptor, in.cfg, agentName, in.req.ReviewType); err != nil {
+		return rawJSONOutput(
+			http.StatusInternalServerError,
+			ErrorResponse{Error: fmt.Sprintf("build dirty prompt: %v", err)},
+		)
+	} else if prompt != "" {
+		o.Prompt = prompt
+		o.PromptPrebuilt = true
+	}
 	if in.descriptor.sessionSHA != "" {
 		o.SessionID = s.findReusableSessionID(ctx,
 			in.checkoutRoot, in.repo.ID, in.req.Branch, agentName,

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -1833,15 +1833,6 @@ func (s *Server) enqueueSingleAgent(
 	o.Provider = in.descriptor.requestedProvider
 	o.Reasoning = in.reasoning
 	o.ReviewType = in.req.ReviewType
-	if prompt, err := buildDirtyPrebuiltPrompt(in.resolutionPath, in.repo.ID, in.descriptor, in.cfg, agentName, in.req.ReviewType); err != nil {
-		return rawJSONOutput(
-			http.StatusInternalServerError,
-			ErrorResponse{Error: fmt.Sprintf("build dirty prompt: %v", err)},
-		)
-	} else if prompt != "" {
-		o.Prompt = prompt
-		o.PromptPrebuilt = true
-	}
 	if in.descriptor.sessionSHA != "" {
 		o.SessionID = s.findReusableSessionID(ctx,
 			in.checkoutRoot, in.repo.ID, in.req.Branch, agentName,

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -3,24 +3,25 @@ package daemon
 import "go.kenn.io/roborev/internal/storage"
 
 type EnqueueRequest struct {
-	RepoPath     string `json:"repo_path"`
-	CommitSHA    string `json:"commit_sha,omitempty"` // Single commit (for backwards compat)
-	GitRef       string `json:"git_ref,omitempty"`    // Single commit, range like "abc..def", or "dirty"
-	Branch       string `json:"branch,omitempty"`     // Branch name at time of job creation
-	Since        string `json:"since,omitempty"`      // RFC3339 lower bound for insights datasets
-	Agent        string `json:"agent,omitempty"`
-	Model        string `json:"model,omitempty"`         // Model to use (for opencode: provider/model format)
-	DiffContent  string `json:"diff_content,omitempty"`  // Pre-captured diff for dirty reviews
-	Reasoning    string `json:"reasoning,omitempty"`     // Reasoning level: thorough, standard, fast
-	ReviewType   string `json:"review_type,omitempty"`   // Review type (e.g., "security") — changes system prompt
-	CustomPrompt string `json:"custom_prompt,omitempty"` // Custom prompt for ad-hoc agent work
-	Agentic      bool   `json:"agentic,omitempty"`       // Enable agentic mode (allow file edits)
-	OutputPrefix string `json:"output_prefix,omitempty"` // Prefix to prepend to review output
-	JobType      string `json:"job_type,omitempty"`      // Explicit job type (review/range/dirty/task/insights/compact/fix)
-	Provider     string `json:"provider,omitempty"`      // Provider for pi agent (e.g., "anthropic")
-	MinSeverity  string `json:"min_severity,omitempty"`  // Minimum severity filter: critical, high, medium, low
-	Panel        string `json:"panel,omitempty"`         // Panel name; "none" forces single-agent
-	Source       string `json:"source,omitempty"`        // Provenance, e.g. "post_commit" (empty = foreground)
+	RepoPath     string   `json:"repo_path"`
+	CommitSHA    string   `json:"commit_sha,omitempty"` // Single commit (for backwards compat)
+	GitRef       string   `json:"git_ref,omitempty"`    // Single commit, range like "abc..def", or "dirty"
+	Branch       string   `json:"branch,omitempty"`     // Branch name at time of job creation
+	Since        string   `json:"since,omitempty"`      // RFC3339 lower bound for insights datasets
+	Agent        string   `json:"agent,omitempty"`
+	Model        string   `json:"model,omitempty"`         // Model to use (for opencode: provider/model format)
+	DiffContent  string   `json:"diff_content,omitempty"`  // Pre-captured diff for dirty reviews
+	DirtyFiles   []string `json:"dirty_files,omitempty"`   // Unfiltered dirty file names for prompt metadata
+	Reasoning    string   `json:"reasoning,omitempty"`     // Reasoning level: thorough, standard, fast
+	ReviewType   string   `json:"review_type,omitempty"`   // Review type (e.g., "security") — changes system prompt
+	CustomPrompt string   `json:"custom_prompt,omitempty"` // Custom prompt for ad-hoc agent work
+	Agentic      bool     `json:"agentic,omitempty"`       // Enable agentic mode (allow file edits)
+	OutputPrefix string   `json:"output_prefix,omitempty"` // Prefix to prepend to review output
+	JobType      string   `json:"job_type,omitempty"`      // Explicit job type (review/range/dirty/task/insights/compact/fix)
+	Provider     string   `json:"provider,omitempty"`      // Provider for pi agent (e.g., "anthropic")
+	MinSeverity  string   `json:"min_severity,omitempty"`  // Minimum severity filter: critical, high, medium, low
+	Panel        string   `json:"panel,omitempty"`         // Panel name; "none" forces single-agent
+	Source       string   `json:"source,omitempty"`        // Provenance, e.g. "post_commit" (empty = foreground)
 }
 
 // PanelEnqueueResponse is returned when an enqueue fans out into a panel run.

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -599,10 +599,14 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 			minSev = resolved
 		}
 
-		if job.DiffContent != nil {
+		if job.IsDirtyJob() {
 			// Dirty job - use pre-captured diff
-			dirtyResult, dirtyErr := pb.BuildDirtyWithSnapshotTarget(
-				*job.DiffContent, cfg.ReviewContextCount, job.Agent, job.ReviewType, minSev,
+			diffContent := ""
+			if job.DiffContent != nil {
+				diffContent = *job.DiffContent
+			}
+			dirtyResult, dirtyErr := pb.BuildDirtyWithSnapshotTargetAndFiles(
+				diffContent, job.DirtyFiles, cfg.ReviewContextCount, job.Agent, job.ReviewType, minSev,
 				checkout.snapshotTarget,
 			)
 			if dirtyResult.Cleanup != nil {

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -921,6 +921,40 @@ func TestProcessJob_UsesStoredReviewPromptOverride(t *testing.T) {
 	assert.Equal(t, job.Prompt, updated.Prompt)
 }
 
+func TestProcessJob_BuildsDirtyPromptFromPersistedDirtyFiles(t *testing.T) {
+	tc := newWorkerTestContext(t, 1)
+
+	var capturedPrompt string
+	agentName := "dirty-files-prompt-capture"
+	agent.Register(&agent.FakeAgent{
+		NameStr: agentName,
+		ReviewFn: func(ctx context.Context, repoPath, commitSHA, reviewPrompt string, output io.Writer) (string, error) {
+			capturedPrompt = reviewPrompt
+			return "No issues found.", nil
+		},
+	})
+	t.Cleanup(func() { agent.Unregister(agentName) })
+
+	job, err := tc.DB.EnqueueJob(storage.EnqueueOpts{
+		RepoID:     tc.Repo.ID,
+		GitRef:     "dirty",
+		Agent:      agentName,
+		JobType:    storage.JobTypeDirty,
+		DirtyFiles: []string{"go.sum"},
+	})
+	require.NoError(t, err)
+
+	claimed, err := tc.DB.ClaimJob(testWorkerID)
+	require.NoError(t, err)
+	require.Equal(t, job.ID, claimed.ID)
+
+	tc.Pool.processJob(testWorkerID, claimed)
+
+	tc.assertJobStatus(t, job.ID, storage.JobStatusDone)
+	assert.Contains(t, capturedPrompt, "## Dependency Metadata")
+	assert.Contains(t, capturedPrompt, "go.sum changed")
+}
+
 func TestProcessJob_PromotedAutoDesignAppendsExistingClassifierLog(t *testing.T) {
 	setupTestEnv(t)
 	tc := newWorkerTestContext(t, 1)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -772,6 +772,48 @@ func HasUncommittedChanges(repoPath string) (bool, error) {
 	return len(strings.TrimSpace(string(out))) > 0, nil
 }
 
+// GetDirtyFilesChanged returns changed file names for staged, unstaged, and
+// untracked working-tree changes before review diff exclusions are applied.
+func GetDirtyFilesChanged(repoPath string) ([]string, error) {
+	cmd := exec.Command("git", "status", "--porcelain")
+	cmd.Dir = repoPath
+
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git status: %w", err)
+	}
+
+	seen := make(map[string]struct{})
+	for raw := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		path := strings.TrimSpace(line[2:])
+		if before, after, ok := strings.Cut(path, " -> "); ok {
+			seen[normalizeStatusPath(before)] = struct{}{}
+			seen[normalizeStatusPath(after)] = struct{}{}
+			continue
+		}
+		seen[normalizeStatusPath(path)] = struct{}{}
+	}
+
+	files := make([]string, 0, len(seen))
+	for file := range seen {
+		if file != "" {
+			files = append(files, file)
+		}
+	}
+	slices.Sort(files)
+	return files, nil
+}
+
+func normalizeStatusPath(path string) string {
+	path = strings.TrimSpace(path)
+	path = strings.Trim(path, `"`)
+	return path
+}
+
 // EmptyTreeSHA is the SHA of an empty tree in git, used for diffing against
 // the root commit or repos with no commits.
 const EmptyTreeSHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -775,7 +775,7 @@ func HasUncommittedChanges(repoPath string) (bool, error) {
 // GetDirtyFilesChanged returns changed file names for staged, unstaged, and
 // untracked working-tree changes before review diff exclusions are applied.
 func GetDirtyFilesChanged(repoPath string) ([]string, error) {
-	cmd := exec.Command("git", "status", "--porcelain")
+	cmd := exec.Command("git", "status", "--porcelain=v1", "-uall")
 	cmd.Dir = repoPath
 
 	out, err := cmd.Output()

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -901,44 +901,12 @@ func GetDirtyDiff(
 	return result.String(), nil
 }
 
-// excludedPathPatterns contains pathspec patterns for files that should be excluded from diffs.
-// These are typically generated files that add noise to code reviews.
+// excludedPathPatterns contains pathspec patterns for generated directories that
+// add noise to code reviews. Dependency lockfiles and checksum manifests stay in
+// review diffs because reviewers need them to validate manifest changes.
 // Uses :(exclude,glob)**/ form so patterns match at any directory depth.
 // Directory patterns use :(exclude) without glob since git recognizes them as trees.
 var excludedPathPatterns = []string{
-	// JavaScript / Node
-	":(exclude,glob)**/package-lock.json",
-	":(exclude,glob)**/yarn.lock",
-	":(exclude,glob)**/pnpm-lock.yaml",
-	":(exclude,glob)**/bun.lockb",
-	":(exclude,glob)**/bun.lock",
-	// Python
-	":(exclude,glob)**/uv.lock",
-	":(exclude,glob)**/poetry.lock",
-	":(exclude,glob)**/Pipfile.lock",
-	":(exclude,glob)**/pdm.lock",
-	// Go
-	":(exclude,glob)**/go.sum",
-	// Rust
-	":(exclude,glob)**/Cargo.lock",
-	":(exclude,glob)**/cargo.lock", // lowercase for case-insensitive filesystems
-	// Ruby
-	":(exclude,glob)**/Gemfile.lock",
-	// PHP
-	":(exclude,glob)**/composer.lock",
-	// .NET
-	":(exclude,glob)**/packages.lock.json",
-	// Dart / Flutter
-	":(exclude,glob)**/pubspec.lock",
-	// Elixir
-	":(exclude,glob)**/mix.lock",
-	// Swift
-	":(exclude,glob)**/Package.resolved",
-	// iOS / macOS
-	":(exclude,glob)**/Podfile.lock",
-	// Nix
-	":(exclude,glob)**/flake.lock",
-	// Directories — trailing /** matches all files inside at any depth
 	":(exclude,glob)**/.beads/**",
 	":(exclude,glob)**/.gocache/**",
 	":(exclude,glob)**/.cache/**",

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -901,12 +901,45 @@ func GetDirtyDiff(
 	return result.String(), nil
 }
 
-// excludedPathPatterns contains pathspec patterns for generated directories that
-// add noise to code reviews. Dependency lockfiles and checksum manifests stay in
-// review diffs because reviewers need them to validate manifest changes.
+// excludedPathPatterns contains pathspec patterns for generated or mechanical
+// files that add noise to code reviews. Prompt construction summarizes omitted
+// dependency metadata separately so reviewers can still verify manifest/lockfile
+// consistency without inlining large lockfile bodies.
 // Uses :(exclude,glob)**/ form so patterns match at any directory depth.
 // Directory patterns use :(exclude) without glob since git recognizes them as trees.
 var excludedPathPatterns = []string{
+	// JavaScript / Node
+	":(exclude,glob)**/package-lock.json",
+	":(exclude,glob)**/yarn.lock",
+	":(exclude,glob)**/pnpm-lock.yaml",
+	":(exclude,glob)**/bun.lockb",
+	":(exclude,glob)**/bun.lock",
+	// Python
+	":(exclude,glob)**/uv.lock",
+	":(exclude,glob)**/poetry.lock",
+	":(exclude,glob)**/Pipfile.lock",
+	":(exclude,glob)**/pdm.lock",
+	// Go
+	":(exclude,glob)**/go.sum",
+	// Rust
+	":(exclude,glob)**/Cargo.lock",
+	":(exclude,glob)**/cargo.lock", // lowercase for case-insensitive filesystems
+	// Ruby
+	":(exclude,glob)**/Gemfile.lock",
+	// PHP
+	":(exclude,glob)**/composer.lock",
+	// .NET
+	":(exclude,glob)**/packages.lock.json",
+	// Dart / Flutter
+	":(exclude,glob)**/pubspec.lock",
+	// Elixir
+	":(exclude,glob)**/mix.lock",
+	// Swift
+	":(exclude,glob)**/Package.resolved",
+	// iOS / macOS
+	":(exclude,glob)**/Podfile.lock",
+	// Nix
+	":(exclude,glob)**/flake.lock",
 	":(exclude,glob)**/.beads/**",
 	":(exclude,glob)**/.gocache/**",
 	":(exclude,glob)**/.cache/**",

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1050,7 +1050,7 @@ func TestGetDiffExtraExcludes(t *testing.T) {
 	assert.NotContains(t, diff, "custom.lock")
 }
 
-func TestGetRangeDiffIncludesDependencyMetadata(t *testing.T) {
+func TestGetRangeDiffExcludesDependencyMetadataBodies(t *testing.T) {
 	repo := NewTestRepoWithCommit(t)
 	repo.WriteFile("frontend/package.json", `{"dependencies":{"react":"18.2.0"}}`+"\n")
 	repo.WriteFile("frontend/package-lock.json", `{"packages":{"":{"dependencies":{"react":"18.2.0"}}}}`+"\n")
@@ -1067,9 +1067,9 @@ func TestGetRangeDiffIncludesDependencyMetadata(t *testing.T) {
 	diff, err := GetRangeDiff(repo.Dir, "HEAD~1..HEAD")
 	require.NoError(t, err)
 	assert.Contains(t, diff, "frontend/package.json")
-	assert.Contains(t, diff, "frontend/package-lock.json")
 	assert.Contains(t, diff, "go.mod")
-	assert.Contains(t, diff, "go.sum")
+	assert.NotContains(t, diff, "frontend/package-lock.json")
+	assert.NotContains(t, diff, "go.sum")
 }
 
 func TestGetDiffExcludesNestedFiles(t *testing.T) {
@@ -1265,7 +1265,7 @@ func TestGetDirtyDiffExcludesUntrackedFiles(t *testing.T) {
 		assert.NotContains(t, diff, "vendor/sub/util.go")
 	})
 
-	t.Run("dependency metadata stays visible", func(t *testing.T) {
+	t.Run("dependency metadata bodies are excluded", func(t *testing.T) {
 		repo := NewTestRepoWithCommit(t)
 		repo.WriteFile("keep.go", "package main\n")
 		repo.WriteFile("sub/uv.lock", "lock\n")
@@ -1277,11 +1277,11 @@ func TestGetDirtyDiffExcludesUntrackedFiles(t *testing.T) {
 		diff, err := GetDirtyDiff(repo.Dir)
 		require.NoError(t, err)
 		assert.Contains(t, diff, "keep.go")
-		assert.Contains(t, diff, "uv.lock")
-		assert.Contains(t, diff, "package-lock.json")
-		assert.Contains(t, diff, "Cargo.lock")
-		assert.Contains(t, diff, "cargo.lock")
-		assert.Contains(t, diff, "go.sum")
+		assert.NotContains(t, diff, "uv.lock")
+		assert.NotContains(t, diff, "package-lock.json")
+		assert.NotContains(t, diff, "Cargo.lock")
+		assert.NotContains(t, diff, "cargo.lock")
+		assert.NotContains(t, diff, "go.sum")
 	})
 
 	t.Run("basename glob pattern", func(t *testing.T) {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1004,6 +1004,18 @@ func TestGetDirtyFilesChangedIncludesExcludedDependencyMetadata(t *testing.T) {
 	assert.Contains(t, files, "package-lock.json")
 }
 
+func TestGetDirtyFilesChangedExpandsUntrackedDirectories(t *testing.T) {
+	repo := NewTestRepoWithCommit(t)
+	repo.WriteFile("frontend/package-lock.json", "lock\n")
+	repo.WriteFile("frontend/src/index.js", "console.log('x')\n")
+
+	files, err := GetDirtyFilesChanged(repo.Dir)
+	require.NoError(t, err)
+	assert.Contains(t, files, "frontend/package-lock.json")
+	assert.Contains(t, files, "frontend/src/index.js")
+	assert.NotContains(t, files, "frontend/")
+}
+
 func TestFormatExcludeArgs(t *testing.T) {
 	assert.Nil(t, FormatExcludeArgs(nil))
 	assert.Nil(t, FormatExcludeArgs([]string{}))

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -993,6 +993,17 @@ func TestGetDirtyDiffStagedThenDeleted(t *testing.T) {
 	assert.Contains(t, diff, "staged content", "expected staged diff to include content")
 }
 
+func TestGetDirtyFilesChangedIncludesExcludedDependencyMetadata(t *testing.T) {
+	repo := NewTestRepoWithCommit(t)
+	repo.WriteFile("package-lock.json", "lock\n")
+	repo.WriteFile("go.sum", "sum\n")
+
+	files, err := GetDirtyFilesChanged(repo.Dir)
+	require.NoError(t, err)
+	assert.Contains(t, files, "go.sum")
+	assert.Contains(t, files, "package-lock.json")
+}
+
 func TestFormatExcludeArgs(t *testing.T) {
 	assert.Nil(t, FormatExcludeArgs(nil))
 	assert.Nil(t, FormatExcludeArgs([]string{}))

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1050,11 +1050,33 @@ func TestGetDiffExtraExcludes(t *testing.T) {
 	assert.NotContains(t, diff, "custom.lock")
 }
 
+func TestGetRangeDiffIncludesDependencyMetadata(t *testing.T) {
+	repo := NewTestRepoWithCommit(t)
+	repo.WriteFile("frontend/package.json", `{"dependencies":{"react":"18.2.0"}}`+"\n")
+	repo.WriteFile("frontend/package-lock.json", `{"packages":{"":{"dependencies":{"react":"18.2.0"}}}}`+"\n")
+	repo.WriteFile("go.mod", "module example.com/app\n\nrequire github.com/jackc/pgx/v5 v5.9.0\n")
+	repo.WriteFile("go.sum", "github.com/jackc/pgx/v5 v5.9.0 h1:old\n")
+	repo.CommitAll("add dependency metadata")
+
+	repo.WriteFile("frontend/package.json", `{"dependencies":{"react":"18.3.1"}}`+"\n")
+	repo.WriteFile("frontend/package-lock.json", `{"packages":{"":{"dependencies":{"react":"18.3.1"}}}}`+"\n")
+	repo.WriteFile("go.mod", "module example.com/app\n\nrequire github.com/jackc/pgx/v5 v5.10.0\n")
+	repo.WriteFile("go.sum", "github.com/jackc/pgx/v5 v5.10.0 h1:new\n")
+	repo.CommitAll("bump dependency metadata")
+
+	diff, err := GetRangeDiff(repo.Dir, "HEAD~1..HEAD")
+	require.NoError(t, err)
+	assert.Contains(t, diff, "frontend/package.json")
+	assert.Contains(t, diff, "frontend/package-lock.json")
+	assert.Contains(t, diff, "go.mod")
+	assert.Contains(t, diff, "go.sum")
+}
+
 func TestGetDiffExcludesNestedFiles(t *testing.T) {
 	// Verify that built-in and extra excludes work at any depth
 	repo := NewTestRepoWithCommit(t)
 	repo.WriteFile("keep.txt", "keep\n")
-	repo.WriteFile("sub/uv.lock", "nested builtin\n")
+	repo.WriteFile("sub/.cache/generated.txt", "nested builtin\n")
 	repo.WriteFile("sub/deep/custom.lock", "nested custom\n")
 	repo.CommitAll("add nested files")
 
@@ -1063,8 +1085,8 @@ func TestGetDiffExcludesNestedFiles(t *testing.T) {
 	diff, err := GetDiff(repo.Dir, sha, "custom.lock")
 	require.NoError(t, err)
 	assert.Contains(t, diff, "keep.txt")
-	assert.NotContains(t, diff, "uv.lock",
-		"built-in exclude should match nested uv.lock")
+	assert.NotContains(t, diff, ".cache/generated.txt",
+		"built-in exclude should match nested cache files")
 	assert.NotContains(t, diff, "custom.lock",
 		"extra exclude should match nested custom.lock")
 }
@@ -1074,8 +1096,8 @@ func setupDiffExcludesGeneratedFilesTest(t *testing.T) (*TestRepo, string) {
 	repo := NewTestRepoWithCommit(t)
 
 	repo.WriteFile(".beads/notes.md", "beads\n")
-	repo.WriteFile("uv.lock", "lock\n")
-	repo.WriteFile("go.sum", "sum\n")
+	repo.WriteFile(".gocache/object", "cache\n")
+	repo.WriteFile(".cache/object", "cache\n")
 	repo.WriteFile("keep.txt", "keep\n")
 
 	repo.CommitAll("add files")
@@ -1088,9 +1110,9 @@ func TestGetDiffExcludesGeneratedFiles(t *testing.T) {
 	assertExcluded := func(t *testing.T, diff string) {
 		t.Helper()
 		require.Contains(t, diff, "keep.txt", "expected generated files filter to retain keep.txt")
-		require.NotContains(t, diff, "uv.lock", "expected generated files filter to exclude uv.lock")
-		require.NotContains(t, diff, "go.sum", "expected generated files filter to exclude go.sum")
 		require.NotContains(t, diff, ".beads/", "expected generated files filter to exclude .beads files")
+		require.NotContains(t, diff, ".gocache/", "expected generated files filter to exclude .gocache files")
+		require.NotContains(t, diff, ".cache/", "expected generated files filter to exclude .cache files")
 	}
 
 	t.Run("GetDiff", func(t *testing.T) {
@@ -1243,7 +1265,7 @@ func TestGetDirtyDiffExcludesUntrackedFiles(t *testing.T) {
 		assert.NotContains(t, diff, "vendor/sub/util.go")
 	})
 
-	t.Run("builtin lockfiles", func(t *testing.T) {
+	t.Run("dependency metadata stays visible", func(t *testing.T) {
 		repo := NewTestRepoWithCommit(t)
 		repo.WriteFile("keep.go", "package main\n")
 		repo.WriteFile("sub/uv.lock", "lock\n")
@@ -1255,11 +1277,11 @@ func TestGetDirtyDiffExcludesUntrackedFiles(t *testing.T) {
 		diff, err := GetDirtyDiff(repo.Dir)
 		require.NoError(t, err)
 		assert.Contains(t, diff, "keep.go")
-		assert.NotContains(t, diff, "uv.lock")
-		assert.NotContains(t, diff, "package-lock.json")
-		assert.NotContains(t, diff, "Cargo.lock")
-		assert.NotContains(t, diff, "cargo.lock")
-		assert.NotContains(t, diff, "go.sum")
+		assert.Contains(t, diff, "uv.lock")
+		assert.Contains(t, diff, "package-lock.json")
+		assert.Contains(t, diff, "Cargo.lock")
+		assert.Contains(t, diff, "cargo.lock")
+		assert.Contains(t, diff, "go.sum")
 	})
 
 	t.Run("basename glob pattern", func(t *testing.T) {

--- a/internal/prompt/dependency_metadata.go
+++ b/internal/prompt/dependency_metadata.go
@@ -1,0 +1,118 @@
+package prompt
+
+import (
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+var dependencyMetadataNames = map[string]struct{}{
+	"package.json":       {},
+	"package-lock.json":  {},
+	"yarn.lock":          {},
+	"pnpm-lock.yaml":     {},
+	"bun.lockb":          {},
+	"bun.lock":           {},
+	"go.mod":             {},
+	"go.sum":             {},
+	"pyproject.toml":     {},
+	"requirements.txt":   {},
+	"uv.lock":            {},
+	"poetry.lock":        {},
+	"Pipfile.lock":       {},
+	"pdm.lock":           {},
+	"Cargo.toml":         {},
+	"Cargo.lock":         {},
+	"cargo.lock":         {},
+	"Gemfile":            {},
+	"Gemfile.lock":       {},
+	"composer.json":      {},
+	"composer.lock":      {},
+	"packages.lock.json": {},
+	"pubspec.yaml":       {},
+	"pubspec.lock":       {},
+	"mix.exs":            {},
+	"mix.lock":           {},
+	"Package.swift":      {},
+	"Package.resolved":   {},
+	"Podfile":            {},
+	"Podfile.lock":       {},
+	"flake.nix":          {},
+	"flake.lock":         {},
+	"pom.xml":            {},
+	"build.gradle":       {},
+	"build.gradle.kts":   {},
+	"gradle.lockfile":    {},
+	"requirements.in":    {},
+	"setup.py":           {},
+	"setup.cfg":          {},
+	"environment.yml":    {},
+	"environment.yaml":   {},
+	"conda-lock.yml":     {},
+	"conda-lock.yaml":    {},
+}
+
+func buildDependencyMetadataSection(files []string) string {
+	metadata := changedDependencyMetadataFiles(files)
+	if len(metadata) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("## Dependency Metadata\n\n")
+	b.WriteString("Lockfile and checksum bodies may be omitted from the main diff to keep reviews focused. Use this file list as dependency-consistency evidence; do not infer that a companion file is missing just because its body is omitted.\n\n")
+	b.WriteString("Changed dependency metadata:\n")
+	for _, file := range metadata {
+		b.WriteString("- ")
+		b.WriteString(dependencyMetadataLine(file, metadata))
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+func changedDependencyMetadataFiles(files []string) []string {
+	seen := make(map[string]struct{}, len(files))
+	for _, file := range files {
+		file = strings.TrimSpace(filepath.ToSlash(file))
+		if file == "" {
+			continue
+		}
+		if _, ok := dependencyMetadataNames[filepath.Base(file)]; ok {
+			seen[file] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for file := range seen {
+		out = append(out, file)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func dependencyMetadataLine(file string, metadata []string) string {
+	switch filepath.Base(file) {
+	case "package.json":
+		if !anyCompanionChanged(file, metadata, "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lockb", "bun.lock") {
+			return file + " changed; no JavaScript lockfile change detected"
+		}
+	case "go.mod":
+		if !anyCompanionChanged(file, metadata, "go.sum") {
+			return file + " changed; no go.sum change detected"
+		}
+	}
+	return file + " changed"
+}
+
+func anyCompanionChanged(file string, metadata []string, names ...string) bool {
+	dir := filepath.Dir(file)
+	for _, candidate := range metadata {
+		if filepath.Dir(candidate) != dir {
+			continue
+		}
+		if slices.Contains(names, filepath.Base(candidate)) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/prompt/dependency_metadata.go
+++ b/internal/prompt/dependency_metadata.go
@@ -93,7 +93,7 @@ func changedDependencyMetadataFiles(files []string) []string {
 func dependencyMetadataLine(file string, metadata []string) string {
 	switch filepath.Base(file) {
 	case "package.json":
-		if !anyCompanionChanged(file, metadata, "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lockb", "bun.lock") {
+		if !anyFileChanged(metadata, "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lockb", "bun.lock") {
 			return file + " changed; no JavaScript lockfile change detected"
 		}
 	case "go.mod":
@@ -102,6 +102,15 @@ func dependencyMetadataLine(file string, metadata []string) string {
 		}
 	}
 	return file + " changed"
+}
+
+func anyFileChanged(metadata []string, names ...string) bool {
+	for _, candidate := range metadata {
+		if slices.Contains(names, filepath.Base(candidate)) {
+			return true
+		}
+	}
+	return false
 }
 
 func anyCompanionChanged(file string, metadata []string, names ...string) bool {

--- a/internal/prompt/dependency_metadata.go
+++ b/internal/prompt/dependency_metadata.go
@@ -71,6 +71,12 @@ func buildDependencyMetadataSection(files []string) string {
 	return b.String()
 }
 
+// HasDependencyMetadataFiles reports whether files contains dependency metadata
+// that buildDependencyMetadataSection will summarize.
+func HasDependencyMetadataFiles(files []string) bool {
+	return len(changedDependencyMetadataFiles(files)) > 0
+}
+
 func changedDependencyMetadataFiles(files []string) []string {
 	seen := make(map[string]struct{}, len(files))
 	for _, file := range files {

--- a/internal/prompt/dependency_metadata_test.go
+++ b/internal/prompt/dependency_metadata_test.go
@@ -1,0 +1,17 @@
+package prompt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildDependencyMetadataSectionReportsMissingCompanions(t *testing.T) {
+	section := buildDependencyMetadataSection([]string{
+		"frontend/package.json",
+		"go.mod",
+	})
+
+	assert.Contains(t, section, "frontend/package.json changed; no JavaScript lockfile change detected")
+	assert.Contains(t, section, "go.mod changed; no go.sum change detected")
+}

--- a/internal/prompt/dependency_metadata_test.go
+++ b/internal/prompt/dependency_metadata_test.go
@@ -15,3 +15,14 @@ func TestBuildDependencyMetadataSectionReportsMissingCompanions(t *testing.T) {
 	assert.Contains(t, section, "frontend/package.json changed; no JavaScript lockfile change detected")
 	assert.Contains(t, section, "go.mod changed; no go.sum change detected")
 }
+
+func TestBuildDependencyMetadataSectionTreatsWorkspaceLockfileAsCompanion(t *testing.T) {
+	section := buildDependencyMetadataSection([]string{
+		"packages/api/package.json",
+		"pnpm-lock.yaml",
+	})
+
+	assert.Contains(t, section, "packages/api/package.json changed")
+	assert.NotContains(t, section, "no JavaScript lockfile change detected")
+	assert.Contains(t, section, "pnpm-lock.yaml changed")
+}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -478,13 +478,30 @@ func (b *Builder) BuildDirtyWithSnapshot(diff string, contextCount int, agentNam
 	return b.BuildDirtyWithSnapshotTarget(diff, contextCount, agentName, reviewType, minSeverity, SnapshotTarget{})
 }
 
+// BuildDirtyWithSnapshotAndFiles is like BuildDirtyWithSnapshot, but includes
+// unfiltered dirty file names so metadata for excluded lockfiles/checksums can
+// still be summarized.
+func (b *Builder) BuildDirtyWithSnapshotAndFiles(
+	diff string, changedFiles []string, contextCount int, agentName, reviewType, minSeverity string,
+) (SnapshotResult, error) {
+	return b.BuildDirtyWithSnapshotTargetAndFiles(diff, changedFiles, contextCount, agentName, reviewType, minSeverity, SnapshotTarget{})
+}
+
 // BuildDirtyWithSnapshotTarget is like BuildDirtyWithSnapshot, but lets callers
 // place the snapshot under a different checkout while preserving trusted config
 // resolution.
 func (b *Builder) BuildDirtyWithSnapshotTarget(
 	diff string, contextCount int, agentName, reviewType, minSeverity string, target SnapshotTarget,
 ) (SnapshotResult, error) {
-	p, err := b.BuildDirty(diff, contextCount, agentName, reviewType, minSeverity)
+	return b.BuildDirtyWithSnapshotTargetAndFiles(diff, nil, contextCount, agentName, reviewType, minSeverity, target)
+}
+
+// BuildDirtyWithSnapshotTargetAndFiles is like BuildDirtyWithSnapshotTarget,
+// but includes unfiltered dirty file names for dependency metadata summaries.
+func (b *Builder) BuildDirtyWithSnapshotTargetAndFiles(
+	diff string, changedFiles []string, contextCount int, agentName, reviewType, minSeverity string, target SnapshotTarget,
+) (SnapshotResult, error) {
+	p, err := b.BuildDirtyWithFiles(diff, changedFiles, contextCount, agentName, reviewType, minSeverity)
 	if err != nil {
 		return SnapshotResult{}, err
 	}
@@ -507,7 +524,15 @@ func (b *Builder) BuildDirtyWithSnapshotTarget(
 // The diff is provided directly since it was captured at enqueue time.
 // reviewType selects the system prompt variant (e.g., "security"); any default alias (see config.IsDefaultReviewType) uses the standard prompt.
 func (b *Builder) BuildDirty(diff string, contextCount int, agentName, reviewType, minSeverity string) (string, error) {
+	return b.BuildDirtyWithFiles(diff, nil, contextCount, agentName, reviewType, minSeverity)
+}
+
+// BuildDirtyWithFiles constructs a dirty review prompt and includes unfiltered
+// dirty file names for dependency metadata summaries. The diff itself may have
+// review exclusions applied.
+func (b *Builder) BuildDirtyWithFiles(diff string, changedFiles []string, contextCount int, agentName, reviewType, minSeverity string) (string, error) {
 	ctx := b.newPromptBuildContext(agentName, reviewType, minSeverity, "dirty", optionalSectionsView{})
+	ctx.optional.DependencyMetadata = buildDependencyMetadataSection(changedFiles)
 
 	// Add project-specific guidelines if configured
 	if repoCfg, err := config.LoadRepoConfig(b.repoPath); err == nil && repoCfg != nil {

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -1058,6 +1058,9 @@ func (b *Builder) buildSinglePrompt(sha string, contextCount int, agentName, rev
 
 	// Include previous review attempts for this same commit (for re-reviews)
 	ctx.optional.PreviousAttempts = previousAttemptViewsFromContexts(b.previousAttemptContexts(sha))
+	if files, err := git.GetFilesChanged(b.repoPath, sha); err == nil {
+		ctx.optional.DependencyMetadata = buildDependencyMetadataSection(files)
+	}
 
 	// Current commit section
 	shortSHA := gitrepo.ShortSHA(sha)
@@ -1181,6 +1184,9 @@ func (b *Builder) buildRangePrompt(rangeRef string, contextCount int, agentName,
 	commits, err := git.GetRangeCommits(b.repoPath, rangeRef)
 	if err != nil {
 		return "", fmt.Errorf("get range commits: %w", err)
+	}
+	if files, err := git.GetRangeFilesChanged(b.repoPath, rangeRef); err == nil {
+		ctx.optional.DependencyMetadata = buildDependencyMetadataSection(files)
 	}
 
 	// Include per-commit reviews for commits inside the range so the agent

--- a/internal/prompt/prompt_body_templates.go
+++ b/internal/prompt/prompt_body_templates.go
@@ -129,11 +129,12 @@ func reviewAttemptsFromView(views []reviewAttemptView) []ReviewAttemptTemplateCo
 
 func reviewOptionalContextFromView(view optionalSectionsView) ReviewOptionalContext {
 	return ReviewOptionalContext{
-		ProjectGuidelines: markdownSectionFromView(view.ProjectGuidelines),
-		AdditionalContext: view.AdditionalContext,
-		PreviousReviews:   previousReviewsFromView(view.PreviousReviews),
-		InRangeReviews:    inRangeReviewsFromView(view.InRangeReviews),
-		PreviousAttempts:  reviewAttemptsFromView(view.PreviousAttempts),
+		ProjectGuidelines:  markdownSectionFromView(view.ProjectGuidelines),
+		AdditionalContext:  view.AdditionalContext,
+		DependencyMetadata: view.DependencyMetadata,
+		PreviousReviews:    previousReviewsFromView(view.PreviousReviews),
+		InRangeReviews:     inRangeReviewsFromView(view.InRangeReviews),
+		PreviousAttempts:   reviewAttemptsFromView(view.PreviousAttempts),
 	}
 }
 

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -486,6 +486,25 @@ func TestBuildDirtyWithReviewAlias(t *testing.T) {
 	assertContains(t, prompt, "uncommitted changes", "Expected dirty system prompt for reviewType=review alias, got wrong prompt type")
 }
 
+func TestBuildDirtyWithFilesSummarizesExcludedDependencyMetadata(t *testing.T) {
+	b := NewBuilder(nil)
+	repoPath := t.TempDir()
+
+	prompt, err := b.ForRepo(repoPath, 0).BuildDirtyWithFiles(
+		"",
+		[]string{"package-lock.json", "go.sum"},
+		0,
+		"test",
+		"",
+		"",
+	)
+	require.NoError(t, err)
+
+	assertContains(t, prompt, "## Dependency Metadata", "expected dependency metadata summary")
+	assertContains(t, prompt, "package-lock.json changed", "expected dirty lockfile summary")
+	assertContains(t, prompt, "go.sum changed", "expected dirty checksum summary")
+}
+
 func TestBuildRangeWithReviewAlias(t *testing.T) {
 	repoPath, commits := setupTestRepo(t)
 	// Use a two-commit range

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -99,6 +99,37 @@ func TestBuildPromptWithAdditionalContextAndPreviousAttemptsPreservesSectionOrde
 	assert.Less(t, previousAttemptsPos, currentCommitPos)
 }
 
+func TestBuildRangePromptSummarizesExcludedDependencyMetadata(t *testing.T) {
+	repo := newTestRepo(t)
+	require.NoError(t, os.MkdirAll(filepath.Join(repo.dir, "frontend"), 0o755))
+	repo.writeFile("frontend/package.json", `{"dependencies":{"react":"18.2.0"}}`+"\n")
+	repo.writeFile("frontend/package-lock.json", `{"packages":{"":{"dependencies":{"react":"18.2.0"}}}}`+"\n")
+	repo.writeFile("go.mod", "module example.com/app\n\nrequire github.com/jackc/pgx/v5 v5.9.0\n")
+	repo.writeFile("go.sum", "github.com/jackc/pgx/v5 v5.9.0 h1:old\n")
+	repo.git("add", "-A")
+	repo.git("commit", "-m", "add dependency metadata")
+	baseSHA := repo.git("rev-parse", "HEAD")
+
+	repo.writeFile("frontend/package.json", `{"dependencies":{"react":"18.3.1"}}`+"\n")
+	repo.writeFile("frontend/package-lock.json", `{"packages":{"":{"dependencies":{"react":"18.3.1"}}}}`+"\n")
+	repo.writeFile("go.mod", "module example.com/app\n\nrequire github.com/jackc/pgx/v5 v5.10.0\n")
+	repo.writeFile("go.sum", "github.com/jackc/pgx/v5 v5.10.0 h1:new\n")
+	repo.git("add", "-A")
+	repo.git("commit", "-m", "bump dependency metadata")
+
+	rangeRef := baseSHA + ".." + repo.git("rev-parse", "HEAD")
+	prompt, err := NewBuilder(nil).ForRepo(repo.dir, 0).Build(rangeRef, 0, "test", "", "")
+	require.NoError(t, err)
+
+	assertContains(t, prompt, "## Dependency Metadata", "expected dependency metadata summary")
+	assertContains(t, prompt, "frontend/package-lock.json changed", "expected lockfile change summary")
+	assertContains(t, prompt, "go.sum changed", "expected checksum change summary")
+	assertContains(t, prompt, "frontend/package.json", "manifest body should remain in main diff")
+	assertContains(t, prompt, "go.mod", "manifest body should remain in main diff")
+	assertNotContains(t, prompt, `-"github.com/jackc/pgx/v5 v5.9.0 h1:old"`, "go.sum body should stay out of main diff")
+	assertNotContains(t, prompt, `-"packages"`, "package-lock body should stay out of main diff")
+}
+
 func TestOrderedPreviousReviewViewsRendersOldestFirst(t *testing.T) {
 	views := orderedPreviousReviewViews([]HistoricalReviewContext{
 		{SHA: "ccccccc", Review: &storage.Review{Output: "newest"}},

--- a/internal/prompt/template_context.go
+++ b/internal/prompt/template_context.go
@@ -58,11 +58,12 @@ const (
 )
 
 type ReviewOptionalContext struct {
-	ProjectGuidelines *MarkdownSection
-	AdditionalContext string
-	PreviousReviews   []PreviousReviewTemplateContext
-	InRangeReviews    []InRangeReviewTemplateContext
-	PreviousAttempts  []ReviewAttemptTemplateContext
+	ProjectGuidelines  *MarkdownSection
+	AdditionalContext  string
+	DependencyMetadata string
+	PreviousReviews    []PreviousReviewTemplateContext
+	InRangeReviews     []InRangeReviewTemplateContext
+	PreviousAttempts   []ReviewAttemptTemplateContext
 }
 
 func (o ReviewOptionalContext) Clone() ReviewOptionalContext {
@@ -89,6 +90,7 @@ func (o ReviewOptionalContext) Clone() ReviewOptionalContext {
 func (o ReviewOptionalContext) IsEmpty() bool {
 	return o.ProjectGuidelines == nil &&
 		o.AdditionalContext == "" &&
+		o.DependencyMetadata == "" &&
 		len(o.PreviousReviews) == 0 &&
 		len(o.InRangeReviews) == 0 &&
 		len(o.PreviousAttempts) == 0
@@ -112,6 +114,8 @@ func (o *ReviewOptionalContext) TrimNext() bool {
 		o.InRangeReviews = nil
 	case len(o.PreviousReviews) > 0:
 		o.PreviousReviews = nil
+	case o.DependencyMetadata != "":
+		o.DependencyMetadata = ""
 	case o.AdditionalContext != "":
 		o.AdditionalContext = ""
 	case o.ProjectGuidelines != nil:

--- a/internal/prompt/templates/prompt_sections.md.gotmpl
+++ b/internal/prompt/templates/prompt_sections.md.gotmpl
@@ -6,6 +6,7 @@ These guidelines supplement the default review criteria and may add repo-specifi
 
 {{end}}{{end}}
 {{define "additional_context"}}{{- .AdditionalContext -}}{{end}}
+{{define "dependency_metadata"}}{{- .DependencyMetadata -}}{{end}}
 {{define "review_comments"}}{{if .}}Comments on this review:
 {{range .}}- {{.Responder}}: {{printf "%q" .Response}}
 {{end}}
@@ -50,7 +51,7 @@ responses from developers. Use this context to:
 
 {{template "review_comments" .Comments}}
 {{- end}}{{end}}{{end}}
-{{define "optional_sections"}}{{template "project_guidelines" .}}{{template "additional_context" .}}{{template "previous_reviews" .}}{{template "in_range_reviews" .}}{{template "previous_review_attempts" .}}{{end}}
+{{define "optional_sections"}}{{template "project_guidelines" .}}{{template "additional_context" .}}{{template "dependency_metadata" .}}{{template "previous_reviews" .}}{{template "in_range_reviews" .}}{{template "previous_review_attempts" .}}{{end}}
 {{define "current_commit_required"}}## Current Commit
 
 **Commit:** {{.Commit}}

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -55,6 +55,7 @@ CREATE TABLE IF NOT EXISTS review_jobs (
   prompt TEXT,
   retry_count INTEGER NOT NULL DEFAULT 0,
   diff_content TEXT,
+  dirty_files TEXT,
   output_prefix TEXT,
   job_type TEXT NOT NULL DEFAULT 'review',
   review_type TEXT NOT NULL DEFAULT '',
@@ -252,6 +253,18 @@ func (db *DB) migrate() error {
 		}
 	}
 
+	// Migration: add dirty_files column to review_jobs if missing (for dirty review metadata)
+	err = db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('review_jobs') WHERE name = 'dirty_files'`).Scan(&count)
+	if err != nil {
+		return fmt.Errorf("check dirty_files column: %w", err)
+	}
+	if count == 0 {
+		_, err = db.Exec(`ALTER TABLE review_jobs ADD COLUMN dirty_files TEXT`)
+		if err != nil {
+			return fmt.Errorf("add dirty_files column: %w", err)
+		}
+	}
+
 	// Migration: add reasoning column to review_jobs if missing
 	err = db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('review_jobs') WHERE name = 'reasoning'`).Scan(&count)
 	if err != nil {
@@ -384,6 +397,7 @@ func (db *DB) migrate() error {
 				prompt TEXT,
 				retry_count INTEGER NOT NULL DEFAULT 0,
 				diff_content TEXT,
+				dirty_files TEXT,
 				agentic INTEGER NOT NULL DEFAULT 0,
 				output_prefix TEXT
 			)
@@ -393,8 +407,8 @@ func (db *DB) migrate() error {
 		}
 
 		// Check which optional columns exist in source table
-		var hasDiffContent, hasReasoning, hasAgentic, hasModel, hasProvider, hasRequestedModel, hasRequestedProvider, hasBranch, hasSessionID, hasOutputPrefix bool
-		checkRows, checkErr := tx.Query(`SELECT name FROM pragma_table_info('review_jobs') WHERE name IN ('diff_content', 'reasoning', 'agentic', 'model', 'provider', 'requested_model', 'requested_provider', 'branch', 'session_id', 'output_prefix')`)
+		var hasDiffContent, hasDirtyFiles, hasReasoning, hasAgentic, hasModel, hasProvider, hasRequestedModel, hasRequestedProvider, hasBranch, hasSessionID, hasOutputPrefix bool
+		checkRows, checkErr := tx.Query(`SELECT name FROM pragma_table_info('review_jobs') WHERE name IN ('diff_content', 'dirty_files', 'reasoning', 'agentic', 'model', 'provider', 'requested_model', 'requested_provider', 'branch', 'session_id', 'output_prefix')`)
 		if checkErr == nil {
 			for checkRows.Next() {
 				var colName string
@@ -402,6 +416,8 @@ func (db *DB) migrate() error {
 				switch colName {
 				case "diff_content":
 					hasDiffContent = true
+				case "dirty_files":
+					hasDirtyFiles = true
 				case "reasoning":
 					hasReasoning = true
 				case "agentic":
@@ -455,6 +471,9 @@ func (db *DB) migrate() error {
 		baseCols = append(baseCols, "status", "enqueued_at", "started_at", "finished_at", "worker_id", "error", "prompt", "retry_count")
 		if hasDiffContent {
 			baseCols = append(baseCols, "diff_content")
+		}
+		if hasDirtyFiles {
+			baseCols = append(baseCols, "dirty_files")
 		}
 		if hasAgentic {
 			baseCols = append(baseCols, "agentic")

--- a/internal/storage/db_job_test.go
+++ b/internal/storage/db_job_test.go
@@ -1120,6 +1120,36 @@ func TestReenqueueJob_ClearsPrebuiltPrompt(t *testing.T) {
 	assert.Empty(t, updated.Prompt, "rerun should clear stored prompt")
 }
 
+func TestReenqueueJob_PreservesDirtyFiles(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo := createRepo(t, db, "/tmp/rerun-dirty-files")
+	job, err := db.EnqueueJob(EnqueueOpts{
+		RepoID:     repo.ID,
+		GitRef:     "dirty",
+		Agent:      "test",
+		JobType:    JobTypeDirty,
+		DirtyFiles: []string{"frontend/package-lock.json"},
+	})
+	require.NoError(t, err)
+
+	claimed, err := db.ClaimJob("worker-1")
+	require.NoError(t, err)
+	require.Equal(t, job.ID, claimed.ID)
+	require.NoError(t, db.CompleteJob(job.ID, "test", "prompt", "review output"))
+
+	err = db.ReenqueueJob(job.ID, ReenqueueOpts{})
+	require.NoError(t, err)
+
+	reclaimed, err := db.ClaimJob("worker-2")
+	require.NoError(t, err)
+	require.Equal(t, job.ID, reclaimed.ID)
+	assert.Equal(t, []string{"frontend/package-lock.json"}, reclaimed.DirtyFiles)
+	assert.Nil(t, reclaimed.DiffContent)
+	assert.False(t, reclaimed.PromptPrebuilt)
+}
+
 func TestReenqueueJob_PreservesTaskPrompt(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()

--- a/internal/storage/hydration.go
+++ b/internal/storage/hydration.go
@@ -29,6 +29,7 @@ type reviewJobScanFields struct {
 	ParentJobID       sql.NullInt64
 	Patch             sql.NullString
 	DiffContent       sql.NullString
+	DirtyFiles        sql.NullString
 	OutputPrefix      sql.NullString
 	CommandLine       sql.NullString
 	TokenUsage        sql.NullString
@@ -92,6 +93,9 @@ func applyReviewJobScan(job *ReviewJob, fields reviewJobScanFields) {
 	}
 	if fields.DiffContent.Valid {
 		job.DiffContent = &fields.DiffContent.String
+	}
+	if fields.DirtyFiles.Valid {
+		job.DirtyFiles = decodeDirtyFiles(fields.DirtyFiles.String)
 	}
 	if fields.OutputPrefix.Valid {
 		job.OutputPrefix = fields.OutputPrefix.String

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -55,7 +56,7 @@ func parseSQLiteTime(s string) time.Time {
 // EnqueueOpts contains options for creating any type of review job.
 // The job type is inferred from which fields are set (in priority order):
 //   - Prompt != "" → "task" (custom prompt job)
-//   - DiffContent != "" → "dirty" (uncommitted changes)
+//   - DiffContent != "" or DirtyFiles != empty → "dirty" (uncommitted changes)
 //   - CommitID > 0 → "review" (single commit)
 //   - otherwise → "range" (commit range)
 type EnqueueOpts struct {
@@ -73,6 +74,7 @@ type EnqueueOpts struct {
 	ReviewType        string // e.g. "security" — changes which system prompt is used
 	PatchID           string // Stable patch-id for rebase tracking
 	DiffContent       string // For dirty reviews (captured at enqueue time)
+	DirtyFiles        []string
 	Prompt            string // For task jobs (pre-stored prompt)
 	OutputPrefix      string // Prefix to prepend to review output
 	Agentic           bool   // Allow file edits and command execution
@@ -129,7 +131,7 @@ func (db *DB) insertJobTx(ctx context.Context, exec execer, opts EnqueueOpts, ui
 		switch {
 		case opts.Prompt != "":
 			jobType = JobTypeTask
-		case opts.DiffContent != "":
+		case opts.DiffContent != "" || len(opts.DirtyFiles) > 0:
 			jobType = JobTypeDirty
 		case opts.CommitID > 0:
 			jobType = JobTypeReview
@@ -171,6 +173,10 @@ func (db *DB) insertJobTx(ctx context.Context, exec execer, opts EnqueueOpts, ui
 	if opts.PromptPrebuilt {
 		promptPrebuiltInt = 1
 	}
+	dirtyFilesJSON, err := encodeDirtyFiles(opts.DirtyFiles)
+	if err != nil {
+		return nil, err
+	}
 
 	claimBlockedInt := 0
 	if opts.ClaimBlocked {
@@ -179,14 +185,14 @@ func (db *DB) insertJobTx(ctx context.Context, exec execer, opts EnqueueOpts, ui
 
 	result, err := exec.ExecContext(ctx, `
 		INSERT INTO review_jobs (repo_id, commit_id, git_ref, branch, session_id, agent, model, provider, requested_model, requested_provider, reasoning,
-			status, job_type, review_type, patch_id, diff_content, prompt, agentic, prompt_prebuilt, output_prefix,
+			status, job_type, review_type, patch_id, diff_content, dirty_files, prompt, agentic, prompt_prebuilt, output_prefix,
 			parent_job_id, uuid, source_machine_id, updated_at, worktree_path, min_severity, backup_agent, backup_model,
 			panel_run_uuid, panel_role, panel_name, panel_member_name, panel_member_index, panel_member_config_json, claim_blocked, source)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		opts.RepoID, commitIDParam, gitRef, nullString(opts.Branch), nullString(opts.SessionID),
 		opts.Agent, nullString(opts.Model), nullString(opts.Provider), nullString(opts.RequestedModel), nullString(opts.RequestedProvider), reasoning,
 		jobType, opts.ReviewType, nullString(opts.PatchID),
-		nullString(opts.DiffContent), nullString(opts.Prompt), agenticInt, promptPrebuiltInt,
+		nullString(opts.DiffContent), nullString(dirtyFilesJSON), nullString(opts.Prompt), agenticInt, promptPrebuiltInt,
 		nullString(opts.OutputPrefix), parentJobIDParam,
 		uid, machineID, nowStr, opts.WorktreePath, normalizeMinSeverityForWrite(opts.MinSeverity), opts.BackupAgent, opts.BackupModel,
 		nullString(opts.PanelRunUUID), nullString(opts.PanelRole), nullString(opts.PanelName),
@@ -211,6 +217,7 @@ func (db *DB) insertJobTx(ctx context.Context, exec execer, opts EnqueueOpts, ui
 		JobType:               jobType,
 		ReviewType:            opts.ReviewType,
 		PatchID:               opts.PatchID,
+		DirtyFiles:            append([]string(nil), opts.DirtyFiles...),
 		Status:                JobStatusQueued,
 		EnqueuedAt:            now,
 		Prompt:                opts.Prompt,
@@ -360,7 +367,7 @@ func (db *DB) ClaimJob(workerID string) (*ReviewJob, error) {
 	var fields reviewJobScanFields
 	err = db.QueryRow(`
 		SELECT j.id, j.repo_id, j.commit_id, j.git_ref, j.branch, j.session_id, j.agent, j.model, j.provider, j.requested_model, j.requested_provider, j.reasoning, j.status, j.enqueued_at,
-		       r.root_path, r.name, c.subject, j.diff_content, j.prompt, COALESCE(j.agentic, 0), COALESCE(j.prompt_prebuilt, 0), j.job_type, j.review_type,
+		       r.root_path, r.name, c.subject, j.diff_content, j.dirty_files, j.prompt, COALESCE(j.agentic, 0), COALESCE(j.prompt_prebuilt, 0), j.job_type, j.review_type,
 		       j.output_prefix, j.patch_id, j.parent_job_id, COALESCE(j.worktree_path, ''), j.command_line, COALESCE(j.min_severity, ''), COALESCE(j.backup_agent, ''), COALESCE(j.backup_model, ''),
 		       COALESCE(j.panel_run_uuid, ''), COALESCE(j.panel_role, ''), COALESCE(j.panel_name, ''), COALESCE(j.panel_member_name, ''), j.panel_member_index, COALESCE(j.panel_member_config_json, ''), COALESCE(j.claim_blocked, 0), COALESCE(j.source, ''), j.retry_count
 		FROM review_jobs j
@@ -370,7 +377,7 @@ func (db *DB) ClaimJob(workerID string) (*ReviewJob, error) {
 		ORDER BY j.started_at DESC
 		LIMIT 1
 	`, workerID).Scan(&job.ID, &job.RepoID, &fields.CommitID, &job.GitRef, &fields.Branch, &fields.SessionID, &job.Agent, &fields.Model, &fields.Provider, &fields.RequestedModel, &fields.RequestedProvider, &job.Reasoning, &job.Status, &fields.EnqueuedAt,
-		&job.RepoPath, &job.RepoName, &fields.CommitSubject, &fields.DiffContent, &fields.Prompt, &fields.Agentic, &fields.PromptPrebuilt, &fields.JobType, &fields.ReviewType,
+		&job.RepoPath, &job.RepoName, &fields.CommitSubject, &fields.DiffContent, &fields.DirtyFiles, &fields.Prompt, &fields.Agentic, &fields.PromptPrebuilt, &fields.JobType, &fields.ReviewType,
 		&fields.OutputPrefix, &fields.PatchID, &fields.ParentJobID, &fields.WorktreePath, &fields.CommandLine, &fields.MinSeverity, &fields.BackupAgent, &fields.BackupModel,
 		&fields.PanelRunUUID, &fields.PanelRole, &fields.PanelName, &fields.PanelMemberName, &fields.PanelMemberIndex, &fields.PanelMemberConfig, &fields.ClaimBlocked, &fields.Source, &job.RetryCount)
 	if err != nil {
@@ -1022,7 +1029,7 @@ func (db *DB) ListJobs(statusFilter string, repoFilter string, limit, offset int
 		       COALESCE(j.agentic, 0), COALESCE(j.prompt_prebuilt, 0), r.root_path, r.name, c.subject, rv.closed, rv.output,
 		       rv.verdict_bool, j.source_machine_id, j.uuid, j.model, j.job_type, j.review_type, j.patch_id,
 		       j.parent_job_id, j.provider, j.requested_model, j.requested_provider, j.token_usage, COALESCE(j.worktree_path, ''),
-		       j.command_line, COALESCE(j.min_severity, ''), COALESCE(j.backup_agent, ''), COALESCE(j.backup_model, ''),
+		       j.command_line, j.dirty_files, COALESCE(j.min_severity, ''), COALESCE(j.backup_agent, ''), COALESCE(j.backup_model, ''),
 		       COALESCE(j.skip_reason, ''), COALESCE(j.source, ''),
 		       COALESCE(j.panel_run_uuid, ''), COALESCE(j.panel_role, ''), COALESCE(j.panel_name, ''), COALESCE(j.panel_member_name, ''), j.panel_member_index, COALESCE(j.panel_member_config_json, ''), COALESCE(j.claim_blocked, 0)
 		FROM review_jobs j
@@ -1063,7 +1070,7 @@ func (db *DB) ListJobs(statusFilter string, repoFilter string, limit, offset int
 			&fields.Agentic, &fields.PromptPrebuilt, &j.RepoPath, &j.RepoName, &fields.CommitSubject, &fields.Closed, &output,
 			&verdictBool, &fields.SourceMachineID, &fields.UUID, &fields.Model, &fields.JobType, &fields.ReviewType, &fields.PatchID,
 			&fields.ParentJobID, &fields.Provider, &fields.RequestedModel, &fields.RequestedProvider, &fields.TokenUsage, &fields.WorktreePath,
-			&fields.CommandLine, &fields.MinSeverity, &fields.BackupAgent, &fields.BackupModel,
+			&fields.CommandLine, &fields.DirtyFiles, &fields.MinSeverity, &fields.BackupAgent, &fields.BackupModel,
 			&fields.SkipReason, &fields.Source,
 			&fields.PanelRunUUID, &fields.PanelRole, &fields.PanelName, &fields.PanelMemberName, &fields.PanelMemberIndex, &fields.PanelMemberConfig, &fields.ClaimBlocked)
 		if err != nil {
@@ -1115,7 +1122,7 @@ func (db *DB) GetJobByID(id int64) (*ReviewJob, error) {
 		SELECT j.id, j.repo_id, j.commit_id, j.git_ref, j.branch, j.session_id, j.agent, j.reasoning, j.status, j.enqueued_at,
 		       j.started_at, j.finished_at, j.worker_id, j.error, j.prompt, COALESCE(j.agentic, 0),
 		       r.root_path, r.name, c.subject, j.model, j.provider, j.requested_model, j.requested_provider, j.job_type, j.review_type, j.patch_id, COALESCE(j.output_prefix, ''),
-		       j.parent_job_id, j.patch, j.token_usage, COALESCE(j.worktree_path, ''), j.command_line, COALESCE(j.min_severity, ''), COALESCE(j.backup_agent, ''), COALESCE(j.backup_model, ''),
+		       j.parent_job_id, j.patch, j.token_usage, j.dirty_files, COALESCE(j.worktree_path, ''), j.command_line, COALESCE(j.min_severity, ''), COALESCE(j.backup_agent, ''), COALESCE(j.backup_model, ''),
 		       COALESCE(j.skip_reason, ''), COALESCE(j.source, ''),
 		       COALESCE(j.panel_run_uuid, ''), COALESCE(j.panel_role, ''), COALESCE(j.panel_name, ''), COALESCE(j.panel_member_name, ''), j.panel_member_index, COALESCE(j.panel_member_config_json, ''), COALESCE(j.claim_blocked, 0)
 		FROM review_jobs j
@@ -1125,7 +1132,7 @@ func (db *DB) GetJobByID(id int64) (*ReviewJob, error) {
 	`, id).Scan(&j.ID, &j.RepoID, &fields.CommitID, &j.GitRef, &fields.Branch, &fields.SessionID, &j.Agent, &j.Reasoning, &j.Status, &fields.EnqueuedAt,
 		&fields.StartedAt, &fields.FinishedAt, &fields.WorkerID, &fields.Error, &fields.Prompt, &fields.Agentic,
 		&j.RepoPath, &j.RepoName, &fields.CommitSubject, &fields.Model, &fields.Provider, &fields.RequestedModel, &fields.RequestedProvider, &fields.JobType, &fields.ReviewType, &fields.PatchID, &fields.OutputPrefix,
-		&fields.ParentJobID, &fields.Patch, &fields.TokenUsage, &fields.WorktreePath, &fields.CommandLine, &fields.MinSeverity, &fields.BackupAgent, &fields.BackupModel,
+		&fields.ParentJobID, &fields.Patch, &fields.TokenUsage, &fields.DirtyFiles, &fields.WorktreePath, &fields.CommandLine, &fields.MinSeverity, &fields.BackupAgent, &fields.BackupModel,
 		&fields.SkipReason, &fields.Source,
 		&fields.PanelRunUUID, &fields.PanelRole, &fields.PanelName, &fields.PanelMemberName, &fields.PanelMemberIndex, &fields.PanelMemberConfig, &fields.ClaimBlocked)
 	if err != nil {
@@ -1150,6 +1157,22 @@ func (db *DB) GetJobDiffContent(jobID int64) (string, error) {
 		return "", fmt.Errorf("get job diff content: %w", err)
 	}
 	return diff, nil
+}
+
+// GetJobDirtyFiles returns the stored unfiltered dirty file names for a job.
+func (db *DB) GetJobDirtyFiles(jobID int64) ([]string, error) {
+	var files sql.NullString
+	err := db.QueryRow(
+		"SELECT dirty_files FROM review_jobs WHERE id = ?",
+		jobID,
+	).Scan(&files)
+	if err != nil {
+		return nil, fmt.Errorf("get job dirty files: %w", err)
+	}
+	if !files.Valid {
+		return nil, nil
+	}
+	return decodeDirtyFiles(files.String), nil
 }
 
 // GetJobCounts returns counts of jobs by status
@@ -1839,4 +1862,26 @@ func (db *DB) HasAutoDesignSlotForCommit(repoID int64, sha string) (bool, error)
 		return false, fmt.Errorf("query auto-design slot: %w", err)
 	}
 	return n > 0, nil
+}
+
+func encodeDirtyFiles(files []string) (string, error) {
+	if len(files) == 0 {
+		return "", nil
+	}
+	data, err := json.Marshal(files)
+	if err != nil {
+		return "", fmt.Errorf("encode dirty files: %w", err)
+	}
+	return string(data), nil
+}
+
+func decodeDirtyFiles(data string) []string {
+	if data == "" {
+		return nil
+	}
+	var files []string
+	if err := json.Unmarshal([]byte(data), &files); err != nil {
+		return nil
+	}
+	return files
 }

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -87,6 +87,7 @@ type ReviewJob struct {
 	Prompt            string     `json:"prompt,omitempty"`
 	RetryCount        int        `json:"retry_count"`
 	DiffContent       *string    `json:"diff_content,omitempty"`  // For dirty reviews (uncommitted changes)
+	DirtyFiles        []string   `json:"dirty_files,omitempty"`   // Unfiltered dirty file names for prompt metadata
 	Agentic           bool       `json:"agentic"`                 // Enable agentic mode (allow file edits)
 	PromptPrebuilt    bool       `json:"prompt_prebuilt"`         // Prompt was set at enqueue time and should be used as-is
 	ReviewType        string     `json:"review_type,omitempty"`   // Review type (e.g., "security") - changes system prompt

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -15,12 +15,12 @@ import (
 )
 
 // PostgreSQL schema version - increment when schema changes
-const pgSchemaVersion = 15
+const pgSchemaVersion = 16
 
 // pgSchemaName is the PostgreSQL schema used to isolate roborev tables
 const pgSchemaName = "roborev"
 
-//go:embed schemas/postgres_v15.sql
+//go:embed schemas/postgres_v16.sql
 var pgSchemaSQL string
 
 // pgSchemaStatements returns the individual DDL statements for schema creation.
@@ -383,6 +383,11 @@ func (p *PgPool) EnsureSchema(ctx context.Context) error {
 				}
 			}
 		}
+		if currentVersion < 16 {
+			if _, err = p.pool.Exec(ctx, `ALTER TABLE review_jobs ADD COLUMN IF NOT EXISTS dirty_files TEXT`); err != nil {
+				return fmt.Errorf("v16 migration (add dirty_files): %w", err)
+			}
+		}
 		// Update version
 		_, err = p.pool.Exec(ctx, `INSERT INTO schema_version (version) VALUES ($1) ON CONFLICT (version) DO NOTHING`, pgSchemaVersion)
 		if err != nil {
@@ -683,14 +688,18 @@ func (p *PgPool) Tx(ctx context.Context, fn func(tx pgx.Tx) error) error {
 
 // UpsertJob inserts or updates a job in PostgreSQL
 func (p *PgPool) UpsertJob(ctx context.Context, j SyncableJob, pgRepoID int64, pgCommitID *int64) error {
-	_, err := p.pool.Exec(ctx, `
+	dirtyFilesJSON, err := encodeDirtyFiles(j.DirtyFiles)
+	if err != nil {
+		return err
+	}
+	_, err = p.pool.Exec(ctx, `
 		INSERT INTO review_jobs (
 			uuid, repo_id, commit_id, git_ref, session_id, agent, model, provider, requested_model, requested_provider, reasoning, job_type, review_type, patch_id, status, agentic,
-			enqueued_at, started_at, finished_at, prompt, diff_content, error, token_usage,
+			enqueued_at, started_at, finished_at, prompt, diff_content, dirty_files, error, token_usage,
 			worktree_path, source, min_severity,
 			panel_run_uuid, panel_role, panel_name, panel_member_name, panel_member_index, panel_member_config_json,
 			source_machine_id, backup_agent, backup_model, updated_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, clock_timestamp())
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, clock_timestamp())
 		ON CONFLICT (uuid) DO UPDATE SET
 			status = EXCLUDED.status,
 			finished_at = EXCLUDED.finished_at,
@@ -703,6 +712,7 @@ func (p *PgPool) UpsertJob(ctx context.Context, j SyncableJob, pgRepoID int64, p
 			session_id = COALESCE(EXCLUDED.session_id, review_jobs.session_id),
 			commit_id = EXCLUDED.commit_id,
 			patch_id = EXCLUDED.patch_id,
+			dirty_files = COALESCE(EXCLUDED.dirty_files, review_jobs.dirty_files),
 			token_usage = COALESCE(EXCLUDED.token_usage, review_jobs.token_usage),
 			worktree_path = COALESCE(EXCLUDED.worktree_path, review_jobs.worktree_path),
 			source = COALESCE(EXCLUDED.source, review_jobs.source),
@@ -718,7 +728,7 @@ func (p *PgPool) UpsertJob(ctx context.Context, j SyncableJob, pgRepoID int64, p
 			updated_at = clock_timestamp()
 	`, j.UUID, pgRepoID, pgCommitID, j.GitRef, nullString(j.SessionID), j.Agent, nullString(j.Model), nullString(j.Provider), nullString(j.RequestedModel), nullString(j.RequestedProvider), nullString(j.Reasoning),
 		defaultStr(j.JobType, "review"), j.ReviewType, nullString(j.PatchID), j.Status, j.Agentic, j.EnqueuedAt, j.StartedAt, j.FinishedAt,
-		nullString(j.Prompt), j.DiffContent, nullString(j.Error), nullString(j.TokenUsage), nullString(j.WorktreePath), nullString(j.Source), normalizeMinSeverityForWrite(j.MinSeverity),
+		nullString(j.Prompt), j.DiffContent, nullString(dirtyFilesJSON), nullString(j.Error), nullString(j.TokenUsage), nullString(j.WorktreePath), nullString(j.Source), normalizeMinSeverityForWrite(j.MinSeverity),
 		nullString(j.PanelRunUUID), nullString(j.PanelRole), nullString(j.PanelName), nullString(j.PanelMemberName), j.PanelMemberIndex, nullString(j.PanelMemberConfigJSON),
 		j.SourceMachineID, j.BackupAgent, j.BackupModel)
 	return err
@@ -777,6 +787,7 @@ type PulledJob struct {
 	FinishedAt            *time.Time
 	Prompt                string
 	DiffContent           *string
+	DirtyFiles            []string
 	Error                 string
 	TokenUsage            string
 	WorktreePath          string
@@ -814,7 +825,7 @@ func (p *PgPool) PullJobs(ctx context.Context, excludeMachineID string, cursor s
 			j.uuid, r.identity, COALESCE(c.sha, ''), COALESCE(c.author, ''), COALESCE(c.subject, ''), COALESCE(c.timestamp, '1970-01-01'::timestamptz),
 			j.git_ref, COALESCE(j.session_id, ''), j.agent, COALESCE(j.model, ''), COALESCE(j.provider, ''), COALESCE(j.requested_model, ''), COALESCE(j.requested_provider, ''), COALESCE(j.reasoning, ''), COALESCE(j.job_type, 'review'), COALESCE(j.review_type, ''), COALESCE(j.patch_id, ''), j.status, j.agentic,
 			j.enqueued_at, j.started_at, j.finished_at,
-			COALESCE(j.prompt, ''), j.diff_content, COALESCE(j.error, ''), COALESCE(j.token_usage, ''),
+			COALESCE(j.prompt, ''), j.diff_content, j.dirty_files, COALESCE(j.error, ''), COALESCE(j.token_usage, ''),
 			COALESCE(j.worktree_path, ''), COALESCE(j.source, ''), COALESCE(j.min_severity, ''), COALESCE(j.backup_agent, ''), COALESCE(j.backup_model, ''),
 			COALESCE(j.panel_run_uuid, ''), COALESCE(j.panel_role, ''), COALESCE(j.panel_name, ''), COALESCE(j.panel_member_name, ''), COALESCE(j.panel_member_index, 0), COALESCE(j.panel_member_config_json, ''),
 			j.source_machine_id, j.updated_at, j.id
@@ -838,12 +849,13 @@ func (p *PgPool) PullJobs(ctx context.Context, excludeMachineID string, cursor s
 	for rows.Next() {
 		var j PulledJob
 		var diffContent *string
+		var dirtyFiles *string
 
 		err := rows.Scan(
 			&j.UUID, &j.RepoIdentity, &j.CommitSHA, &j.CommitAuthor, &j.CommitSubject, &j.CommitTimestamp,
 			&j.GitRef, &j.SessionID, &j.Agent, &j.Model, &j.Provider, &j.RequestedModel, &j.RequestedProvider, &j.Reasoning, &j.JobType, &j.ReviewType, &j.PatchID, &j.Status, &j.Agentic,
 			&j.EnqueuedAt, &j.StartedAt, &j.FinishedAt,
-			&j.Prompt, &diffContent, &j.Error, &j.TokenUsage,
+			&j.Prompt, &diffContent, &dirtyFiles, &j.Error, &j.TokenUsage,
 			&j.WorktreePath, &j.Source, &j.MinSeverity, &j.BackupAgent, &j.BackupModel,
 			&j.PanelRunUUID, &j.PanelRole, &j.PanelName, &j.PanelMemberName, &j.PanelMemberIndex, &j.PanelMemberConfigJSON,
 			&j.SourceMachineID, &j.UpdatedAt, &lastID,
@@ -853,6 +865,9 @@ func (p *PgPool) PullJobs(ctx context.Context, excludeMachineID string, cursor s
 		}
 
 		j.DiffContent = diffContent
+		if dirtyFiles != nil {
+			j.DirtyFiles = decodeDirtyFiles(*dirtyFiles)
+		}
 		lastUpdatedAt = j.UpdatedAt
 		jobs = append(jobs, j)
 	}
@@ -1129,14 +1144,18 @@ func (p *PgPool) BatchUpsertJobs(ctx context.Context, jobs []JobWithPgIDs) ([]bo
 	batch := &pgx.Batch{}
 	for _, jw := range jobs {
 		j := jw.Job
+		dirtyFilesJSON, err := encodeDirtyFiles(j.DirtyFiles)
+		if err != nil {
+			return nil, err
+		}
 		batch.Queue(`
 			INSERT INTO review_jobs (
 				uuid, repo_id, commit_id, git_ref, session_id, agent, model, provider, requested_model, requested_provider, reasoning, job_type, review_type, patch_id, status, agentic,
-				enqueued_at, started_at, finished_at, prompt, diff_content, error, token_usage,
+				enqueued_at, started_at, finished_at, prompt, diff_content, dirty_files, error, token_usage,
 				worktree_path, source, min_severity,
 				panel_run_uuid, panel_role, panel_name, panel_member_name, panel_member_index, panel_member_config_json,
 				source_machine_id, backup_agent, backup_model, updated_at
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, clock_timestamp())
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, clock_timestamp())
 			ON CONFLICT (uuid) DO UPDATE SET
 				status = EXCLUDED.status,
 				finished_at = EXCLUDED.finished_at,
@@ -1149,6 +1168,7 @@ func (p *PgPool) BatchUpsertJobs(ctx context.Context, jobs []JobWithPgIDs) ([]bo
 				session_id = COALESCE(EXCLUDED.session_id, review_jobs.session_id),
 				commit_id = EXCLUDED.commit_id,
 				patch_id = EXCLUDED.patch_id,
+				dirty_files = COALESCE(EXCLUDED.dirty_files, review_jobs.dirty_files),
 				token_usage = COALESCE(EXCLUDED.token_usage, review_jobs.token_usage),
 				worktree_path = COALESCE(EXCLUDED.worktree_path, review_jobs.worktree_path),
 				source = COALESCE(EXCLUDED.source, review_jobs.source),
@@ -1164,7 +1184,7 @@ func (p *PgPool) BatchUpsertJobs(ctx context.Context, jobs []JobWithPgIDs) ([]bo
 				updated_at = clock_timestamp()
 		`, j.UUID, jw.PgRepoID, jw.PgCommitID, j.GitRef, nullString(j.SessionID), j.Agent, nullString(j.Model), nullString(j.Provider), nullString(j.RequestedModel), nullString(j.RequestedProvider), nullString(j.Reasoning),
 			defaultStr(j.JobType, "review"), j.ReviewType, nullString(j.PatchID), j.Status, j.Agentic, j.EnqueuedAt, j.StartedAt, j.FinishedAt,
-			nullString(j.Prompt), j.DiffContent, nullString(j.Error), nullString(j.TokenUsage), nullString(j.WorktreePath), nullString(j.Source), normalizeMinSeverityForWrite(j.MinSeverity),
+			nullString(j.Prompt), j.DiffContent, nullString(dirtyFilesJSON), nullString(j.Error), nullString(j.TokenUsage), nullString(j.WorktreePath), nullString(j.Source), normalizeMinSeverityForWrite(j.MinSeverity),
 			nullString(j.PanelRunUUID), nullString(j.PanelRole), nullString(j.PanelName), nullString(j.PanelMemberName), j.PanelMemberIndex, nullString(j.PanelMemberConfigJSON),
 			j.SourceMachineID, j.BackupAgent, j.BackupModel)
 	}

--- a/internal/storage/schemas/postgres_v16.sql
+++ b/internal/storage/schemas/postgres_v16.sql
@@ -1,0 +1,161 @@
+-- PostgreSQL schema version 16
+-- On top of v15 (panel + backup columns), adds dirty_files to review_jobs.
+-- v15 added subagent review panel columns
+-- (panel_run_uuid, panel_role, panel_name, panel_member_name,
+-- panel_member_index, panel_member_config_json) and job-level failover
+-- override columns (backup_agent, backup_model) to review_jobs. claim_blocked
+-- is local-only (SQLite scheduling gate) and intentionally NOT present here.
+-- Also defines ci_pr_review_attempts (local CI-poller retry state) appended to
+-- v15 for schema parity (not sync-replicated).
+-- Note: Version is managed by EnsureSchema(), not this file.
+
+CREATE SCHEMA IF NOT EXISTS roborev;
+
+CREATE TABLE IF NOT EXISTS roborev.schema_version (
+  version INTEGER PRIMARY KEY,
+  applied_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.machines (
+  id SERIAL PRIMARY KEY,
+  machine_id UUID UNIQUE NOT NULL,
+  name TEXT,
+  last_seen_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.repos (
+  id SERIAL PRIMARY KEY,
+  identity TEXT UNIQUE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.commits (
+  id SERIAL PRIMARY KEY,
+  repo_id INTEGER REFERENCES roborev.repos(id),
+  sha TEXT NOT NULL,
+  author TEXT NOT NULL,
+  subject TEXT NOT NULL,
+  timestamp TIMESTAMP WITH TIME ZONE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  UNIQUE(repo_id, sha)
+);
+
+CREATE TABLE IF NOT EXISTS roborev.review_jobs (
+  id SERIAL PRIMARY KEY,
+  uuid UUID UNIQUE NOT NULL,
+  repo_id INTEGER NOT NULL REFERENCES roborev.repos(id),
+  commit_id INTEGER REFERENCES roborev.commits(id),
+  git_ref TEXT NOT NULL,
+  branch TEXT,
+  session_id TEXT,
+  agent TEXT NOT NULL,
+  model TEXT,
+  provider TEXT,
+  requested_model TEXT,
+  requested_provider TEXT,
+  reasoning TEXT,
+  job_type TEXT NOT NULL DEFAULT 'review',
+  review_type TEXT NOT NULL DEFAULT '',
+  patch_id TEXT,
+  status TEXT NOT NULL CHECK(status IN ('queued', 'running', 'done', 'failed', 'canceled', 'applied', 'rebased', 'skipped')),
+  agentic BOOLEAN DEFAULT FALSE,
+  enqueued_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  started_at TIMESTAMP WITH TIME ZONE,
+  finished_at TIMESTAMP WITH TIME ZONE,
+  retry_not_before TIMESTAMP WITH TIME ZONE,
+  prompt TEXT,
+  diff_content TEXT,
+  dirty_files TEXT,
+  error TEXT,
+  token_usage TEXT,
+  worktree_path TEXT,
+  min_severity TEXT NOT NULL DEFAULT '',
+  backup_agent TEXT NOT NULL DEFAULT '',
+  backup_model TEXT NOT NULL DEFAULT '',
+  skip_reason TEXT,
+  source TEXT,
+  panel_run_uuid TEXT,
+  panel_role TEXT,
+  panel_name TEXT,
+  panel_member_name TEXT,
+  panel_member_index INTEGER,
+  panel_member_config_json TEXT,
+  source_machine_id UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.reviews (
+  id SERIAL PRIMARY KEY,
+  uuid UUID UNIQUE NOT NULL,
+  job_uuid UUID NOT NULL REFERENCES roborev.review_jobs(uuid),
+  agent TEXT NOT NULL,
+  prompt TEXT NOT NULL,
+  output TEXT NOT NULL,
+  closed BOOLEAN NOT NULL DEFAULT FALSE,
+  updated_by_machine_id UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.responses (
+  id SERIAL PRIMARY KEY,
+  uuid UUID UNIQUE NOT NULL,
+  job_uuid UUID NOT NULL REFERENCES roborev.review_jobs(uuid),
+  responder TEXT NOT NULL,
+  response TEXT NOT NULL,
+  source_machine_id UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  inserted_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp()
+);
+
+-- ci_pr_review_attempts holds local CI-poller retry state keyed by
+-- (github_repo, pr_number, head_sha). It is the durable source of truth for
+-- whether a HEAD is being reviewed and, when an AI-provider outage defers it,
+-- when to retry. One row per reviewed HEAD. next_attempt_at is NULL while a
+-- run is in-flight or pending and set once deferred. state is one of
+-- 'pending', 'deferred', or 'done'. This table is created in both the SQLite
+-- and Postgres backends for schema parity per the design, but it is NOT
+-- registered in any sync cursor (not sync-replicated). Avoid inline
+-- semicolons in this comment -- pgSchemaStatements splits the embedded
+-- Postgres schema on semicolons, so a literal one here would fragment the
+-- comment into a bad statement.
+CREATE TABLE IF NOT EXISTS roborev.ci_pr_review_attempts (
+  id BIGSERIAL PRIMARY KEY,
+  github_repo TEXT NOT NULL,
+  pr_number INTEGER NOT NULL,
+  head_sha TEXT NOT NULL,
+  attempt INTEGER NOT NULL DEFAULT 1,
+  first_attempt_at TIMESTAMPTZ NOT NULL,
+  next_attempt_at TIMESTAMPTZ,
+  last_error_class TEXT NOT NULL DEFAULT '',
+  consecutive_genuine_attempts INTEGER NOT NULL DEFAULT 0,
+  last_error_excerpt TEXT NOT NULL DEFAULT '',
+  last_panel_run_uuid TEXT NOT NULL DEFAULT '',
+  state TEXT NOT NULL DEFAULT 'pending',
+  updated_at TIMESTAMPTZ NOT NULL,
+  UNIQUE(github_repo, pr_number, head_sha)
+);
+
+CREATE INDEX IF NOT EXISTS idx_review_jobs_source ON roborev.review_jobs(source_machine_id);
+CREATE INDEX IF NOT EXISTS idx_review_jobs_updated ON roborev.review_jobs(updated_at);
+-- Note: idx_review_jobs_branch, idx_review_jobs_job_type,
+-- idx_review_jobs_patch_id, and idx_review_jobs_panel are created by
+-- migration code, not here (to support upgrades from older versions
+-- where those columns don't exist yet — the embedded schema is replayed
+-- on every startup, including against older databases).
+CREATE INDEX IF NOT EXISTS idx_reviews_job_uuid ON roborev.reviews(job_uuid);
+CREATE INDEX IF NOT EXISTS idx_reviews_updated ON roborev.reviews(updated_at);
+CREATE INDEX IF NOT EXISTS idx_responses_job_uuid ON roborev.responses(job_uuid);
+CREATE INDEX IF NOT EXISTS idx_responses_id ON roborev.responses(id);
+-- idx_responses_inserted is created by EnsureSchema after migrations so
+-- upgrades from older schemas do not try to index a column before it exists.
+-- Partial unique indexes for auto-design dedup are created by EnsureSchema
+-- (fresh-init block + v12 migration step) — placing them here would break
+-- v1->v12 migrations where the source column doesn't yet exist when this
+-- schema is replayed.
+
+CREATE TABLE IF NOT EXISTS roborev.sync_metadata (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);

--- a/internal/storage/sync.go
+++ b/internal/storage/sync.go
@@ -380,6 +380,7 @@ type SyncableJob struct {
 	FinishedAt            *time.Time
 	Prompt                string
 	DiffContent           *string
+	DirtyFiles            []string
 	Error                 string
 	TokenUsage            string
 	WorktreePath          string
@@ -406,7 +407,7 @@ func (db *DB) GetJobsToSync(machineID string, limit int) ([]SyncableJob, error) 
 			j.commit_id, COALESCE(c.sha, ''), COALESCE(c.author, ''), COALESCE(c.subject, ''), COALESCE(c.timestamp, ''),
 			j.git_ref, COALESCE(j.session_id, ''), j.agent, COALESCE(j.model, ''), COALESCE(j.provider, ''), COALESCE(j.requested_model, ''), COALESCE(j.requested_provider, ''), COALESCE(j.reasoning, ''), COALESCE(j.job_type, 'review'), COALESCE(j.review_type, ''), COALESCE(j.patch_id, ''), j.status, j.agentic,
 			j.enqueued_at, COALESCE(j.started_at, ''), COALESCE(j.finished_at, ''),
-			COALESCE(j.prompt, ''), j.diff_content, COALESCE(j.error, ''), COALESCE(j.token_usage, ''),
+			COALESCE(j.prompt, ''), j.diff_content, j.dirty_files, COALESCE(j.error, ''), COALESCE(j.token_usage, ''),
 			COALESCE(j.worktree_path, ''), COALESCE(j.source, ''), COALESCE(j.min_severity, ''), COALESCE(j.backup_agent, ''), COALESCE(j.backup_model, ''),
 			COALESCE(j.panel_run_uuid, ''), COALESCE(j.panel_role, ''), COALESCE(j.panel_name, ''), COALESCE(j.panel_member_name, ''), COALESCE(j.panel_member_index, 0), COALESCE(j.panel_member_config_json, ''),
 			j.source_machine_id, j.updated_at
@@ -437,13 +438,14 @@ func (db *DB) GetJobsToSync(machineID string, limit int) ([]SyncableJob, error) 
 		var enqueuedAt, startedAt, finishedAt, commitTimestamp, updatedAt string
 		var commitID sql.NullInt64
 		var diffContent sql.NullString
+		var dirtyFiles sql.NullString
 
 		err := rows.Scan(
 			&j.ID, &j.UUID, &j.RepoID, &j.RepoIdentity,
 			&commitID, &j.CommitSHA, &j.CommitAuthor, &j.CommitSubject, &commitTimestamp,
 			&j.GitRef, &j.SessionID, &j.Agent, &j.Model, &j.Provider, &j.RequestedModel, &j.RequestedProvider, &j.Reasoning, &j.JobType, &j.ReviewType, &j.PatchID, &j.Status, &j.Agentic,
 			&enqueuedAt, &startedAt, &finishedAt,
-			&j.Prompt, &diffContent, &j.Error, &j.TokenUsage,
+			&j.Prompt, &diffContent, &dirtyFiles, &j.Error, &j.TokenUsage,
 			&j.WorktreePath, &j.Source, &j.MinSeverity, &j.BackupAgent, &j.BackupModel,
 			&j.PanelRunUUID, &j.PanelRole, &j.PanelName, &j.PanelMemberName, &j.PanelMemberIndex, &j.PanelMemberConfigJSON,
 			&j.SourceMachineID, &updatedAt,
@@ -457,6 +459,9 @@ func (db *DB) GetJobsToSync(machineID string, limit int) ([]SyncableJob, error) 
 		}
 		if diffContent.Valid {
 			j.DiffContent = &diffContent.String
+		}
+		if dirtyFiles.Valid {
+			j.DirtyFiles = decodeDirtyFiles(dirtyFiles.String)
 		}
 		j.EnqueuedAt = parseSQLiteTime(enqueuedAt)
 		if startedAt != "" {
@@ -685,14 +690,18 @@ func (db *DB) MarkCommentsSynced(responseIDs []int64) error {
 // Sets synced_at to prevent re-pushing. Requires repo to exist.
 func (db *DB) UpsertPulledJob(j PulledJob, repoID int64, commitID *int64) error {
 	now := time.Now().UTC().Format(time.RFC3339)
-	_, err := db.Exec(`
+	dirtyFilesJSON, err := encodeDirtyFiles(j.DirtyFiles)
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec(`
 		INSERT INTO review_jobs (
 			uuid, repo_id, commit_id, git_ref, session_id, agent, model, provider, requested_model, requested_provider, reasoning, job_type, review_type, patch_id, status, agentic,
-			enqueued_at, started_at, finished_at, prompt, diff_content, error, token_usage,
+			enqueued_at, started_at, finished_at, prompt, diff_content, dirty_files, error, token_usage,
 			worktree_path, source, min_severity, backup_agent, backup_model,
 			panel_run_uuid, panel_role, panel_name, panel_member_name, panel_member_index, panel_member_config_json,
 			source_machine_id, updated_at, synced_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(uuid) DO UPDATE SET
 			status = excluded.status,
 			finished_at = excluded.finished_at,
@@ -705,6 +714,7 @@ func (db *DB) UpsertPulledJob(j PulledJob, repoID int64, commitID *int64) error 
 			session_id = COALESCE(excluded.session_id, review_jobs.session_id),
 			commit_id = excluded.commit_id,
 			patch_id = excluded.patch_id,
+			dirty_files = COALESCE(excluded.dirty_files, review_jobs.dirty_files),
 			token_usage = COALESCE(excluded.token_usage, review_jobs.token_usage),
 			worktree_path = COALESCE(excluded.worktree_path, review_jobs.worktree_path),
 			source = COALESCE(excluded.source, review_jobs.source),
@@ -730,7 +740,7 @@ func (db *DB) UpsertPulledJob(j PulledJob, repoID int64, commitID *int64) error 
 	`, j.UUID, repoID, commitID, j.GitRef, nullStr(j.SessionID), j.Agent, nullStr(j.Model), nullStr(j.Provider), nullStr(j.RequestedModel), nullStr(j.RequestedProvider), j.Reasoning, j.JobType,
 		j.ReviewType, nullStr(j.PatchID), j.Status, j.Agentic, j.EnqueuedAt.Format(time.RFC3339),
 		nullTimeStr(j.StartedAt), nullTimeStr(j.FinishedAt),
-		nullStr(j.Prompt), j.DiffContent, nullStr(j.Error), nullStr(j.TokenUsage),
+		nullStr(j.Prompt), j.DiffContent, nullStr(dirtyFilesJSON), nullStr(j.Error), nullStr(j.TokenUsage),
 		nullStr(j.WorktreePath), nullStr(j.Source), normalizeMinSeverityForWrite(j.MinSeverity), j.BackupAgent, j.BackupModel,
 		nullStr(j.PanelRunUUID), nullStr(j.PanelRole), nullStr(j.PanelName), nullStr(j.PanelMemberName), j.PanelMemberIndex, nullStr(j.PanelMemberConfigJSON),
 		j.SourceMachineID, j.UpdatedAt.Format(time.RFC3339), now, now)

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -3,10 +3,9 @@ package telemetry
 import (
 	"testing"
 
-	kittelemetry "go.kenn.io/kit/telemetry"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	kittelemetry "go.kenn.io/kit/telemetry"
 )
 
 func TestEnabledFromEnvHonorsRoborevAndGenericOptOut(t *testing.T) {


### PR DESCRIPTION
## Summary
- Preserve dependency consistency evidence in review prompts without inlining large lockfile/checksum bodies.
- Add a compact Dependency Metadata section that lists changed manifests, lockfiles, and checksums, including explicit notes when package.json or go.mod changes lack companion metadata changes.
- Restore lockfile/checksum body exclusions in review diffs while covering the new behavior with prompt and git tests.

## Context
This targets CI review false positives where roborev hid package-lock.json or go.sum changes, causing reviewers to infer dependency bumps were incomplete.