### PR TITLE
Fix agent hook Windows git -C parsing

### DIFF
--- a/internal/agenthook/state.go
+++ b/internal/agenthook/state.go
@@ -663,7 +663,13 @@ func shellFields(command string) []string {
 	expansionDepth := 0
 	inToken := false
 	pendingExpansion := false
-	for _, r := range command {
+	runes := []rune(command)
+	for i, r := range runes {
+		var next rune
+		hasNext := i+1 < len(runes)
+		if hasNext {
+			next = runes[i+1]
+		}
 		if escaped {
 			b.WriteRune(r)
 			inToken = true
@@ -676,7 +682,7 @@ func shellFields(command string) []string {
 				inToken = true
 				continue
 			}
-			if quote != '\'' && r == '\\' {
+			if quote != '\'' && r == '\\' && hasNext && backslashEscapesInQuote(quote, next) {
 				escaped = true
 				inToken = true
 				continue
@@ -706,7 +712,11 @@ func shellFields(command string) []string {
 		}
 		switch r {
 		case '\\':
-			escaped = true
+			if hasNext && backslashEscapesUnquoted(b.String(), next) {
+				escaped = true
+			} else {
+				b.WriteRune(r)
+			}
 			inToken = true
 		case '$':
 			b.WriteRune(r)
@@ -733,6 +743,45 @@ func shellFields(command string) []string {
 		fields = append(fields, b.String())
 	}
 	return fields
+}
+
+func backslashEscapesInQuote(quote, next rune) bool {
+	switch quote {
+	case '"':
+		return next == '$' || next == '`' || next == '"' || next == '\\' || next == '\n' || next == '\r'
+	case '`':
+		return next == '$' || next == '`' || next == '\\' || next == '\n' || next == '\r'
+	default:
+		return false
+	}
+}
+
+func backslashEscapesUnquoted(token string, next rune) bool {
+	if isWindowsDriveToken(token) && !isShellFieldDelimiter(next) && !isShellQuote(next) {
+		return false
+	}
+	return true
+}
+
+func isWindowsDriveToken(token string) bool {
+	return len(token) >= 2 && isASCIIAlpha(rune(token[0])) && token[1] == ':'
+}
+
+func isASCIIAlpha(r rune) bool {
+	return ('a' <= r && r <= 'z') || ('A' <= r && r <= 'Z')
+}
+
+func isShellQuote(r rune) bool {
+	return r == '\'' || r == '"' || r == '`'
+}
+
+func isShellFieldDelimiter(r rune) bool {
+	switch r {
+	case ' ', '\t', '\r', '\n', ';', '&', '|', '[', ']', '<', '>':
+		return true
+	default:
+		return false
+	}
 }
 
 func isGitToken(token string) bool {

--- a/internal/agenthook/state_test.go
+++ b/internal/agenthook/state_test.go
@@ -44,6 +44,34 @@ func TestIsCommitProducingCommand(t *testing.T) {
 	}
 }
 
+func TestShellFieldsPreservesWindowsPathSeparators(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		command string
+		want    []string
+	}{
+		{
+			name:    "unquoted windows path",
+			command: `git -C C:\Users\runneradmin\AppData\Local\Temp\repo commit -m x`,
+			want:    []string{"git", "-C", `C:\Users\runneradmin\AppData\Local\Temp\repo`, "commit", "-m", "x"},
+		},
+		{
+			name:    "double quoted windows path",
+			command: `git -C "C:\Users\runneradmin\AppData\Local\Temp\repo" commit -m x`,
+			want:    []string{"git", "-C", `C:\Users\runneradmin\AppData\Local\Temp\repo`, "commit", "-m", "x"},
+		},
+		{
+			name:    "posix escaped spaces",
+			command: `git -C repo\ with\ spaces commit -m x`,
+			want:    []string{"git", "-C", "repo with spaces", "commit", "-m", "x"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, shellFields(tc.command))
+		})
+	}
+}
+
 func TestCommandGitDir(t *testing.T) {
 	base := t.TempDir()
 	sub := filepath.Join(base, "sub")


### PR DESCRIPTION
Fixes a Windows-only CI failure in the agent hook commit-counting tests.

The hook command splitter treated every backslash as a shell escape, so Windows drive paths in `git -C` commands lost their separators before `commandGitDir` could resolve the target repository. That made commit tracking fall back to the hook cwd or miss the target repo entirely, which broke commit reminder attribution on Windows.

This keeps the existing lightweight command scanning approach, preserves POSIX escaped-space handling, and narrows backslash escaping so quoted and unquoted Windows `C:\...` paths remain intact. The new regression covers both Windows path forms plus the POSIX escaped-space case that the parser still needs to support.
