### PR TITLE
Enforce isolated git test environments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,9 @@ Test conventions:
 - ACP adapter integration tests use `//go:build integration && acp`.
 - Shared helpers live in `internal/testenv/`, `internal/testutil/`, and package-local `*_test_helpers*.go`.
 - In tests with more than three assertions, prefer `assert := assert.New(t)` to make grouped assertions cleaner.
+- Test packages that run git or use git repo helpers from `internal/testutil`
+  must define `TestMain` and call `testenv.RunIsolatedMain`; the
+  `test-git-isolation` pre-commit hook enforces this.
 - `assert.True*` / `require.True*` / `assert.False*` / `require.False*` should only be used for actual boolean values (fields, return values); never use them as comparisons (e.g., `assert.True(t, x == y)` should be `assert.Equal(t, y, x)`).
 - Do not use `assert.Fail`/`require.Fail` in tests.
 - Prefer `assert.Equal` for explicit expectations.

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ACP_TEST_DISABLE_MODE ?=
 ACP_TEST_MODE ?=
 ACP_TEST_MODEL ?=
 
-.PHONY: build install clean test test-integration test-acp-integration test-acp-integration-codex test-acp-integration-claude test-acp-integration-gemini test-postgres test-all postgres-up postgres-down test-postgres-ci lint lint-ci install-hooks
+.PHONY: build install clean test test-git-isolation test-integration test-acp-integration test-acp-integration-codex test-acp-integration-claude test-acp-integration-gemini test-postgres test-all postgres-up postgres-down test-postgres-ci lint lint-ci install-hooks
 
 build:
 	@mkdir -p bin
@@ -28,6 +28,9 @@ clean:
 # Unit tests only (excludes integration and postgres tests)
 test:
 	go test ./...
+
+test-git-isolation:
+	go test -run '^TestGitUsingTestPackagesUseIsolatedTestMain$$' .
 
 # Unit + slow integration tests (no postgres required)
 test-integration:

--- a/README.md
+++ b/README.md
@@ -130,11 +130,11 @@ go install go.kenn.io/roborev/cmd/roborev@latest
 ## Developer Setup
 
 This repo uses [`prek`](https://prek.j178.dev/) for local pre-commit checks.
-The hook is a local system hook that runs `make lint`, so pre-commit can apply
-`golangci-lint --fix` automatically instead of using the upstream
-`golangci-lint` pre-commit repository. The hook is configured with
-`always_run = true`, so it runs on every commit, not just commits that touch
-Go files.
+The hooks are local system hooks. They run a fast Git-test isolation guard and
+`make lint`, so pre-commit can apply `golangci-lint --fix` automatically
+instead of using the upstream `golangci-lint` pre-commit repository. The hooks
+are configured with `always_run = true`, so they run on every commit, not just
+commits that touch Go files.
 
 ```bash
 brew install prek     # or use your preferred prek install method

--- a/git_isolation_guard_test.go
+++ b/git_isolation_guard_test.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type gitIsolationPackage struct {
+	dir                 string
+	hasIsolatedTestMain bool
+	gitEvidence         []string
+}
+
+func TestGitUsingTestPackagesUseIsolatedTestMain(t *testing.T) {
+	root := repoRootFromWorkingDir(t)
+	packages := map[string]*gitIsolationPackage{}
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", ".direnv", "bin", "node_modules", "tmp", "vendor":
+				return filepath.SkipDir
+			default:
+				return nil
+			}
+		}
+		if !strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		relDir := filepath.Dir(relPath)
+		if relDir == "." {
+			relDir = ""
+		}
+
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return fmt.Errorf("parse %s: %w", relPath, err)
+		}
+
+		pkg := packages[relDir]
+		if pkg == nil {
+			pkg = &gitIsolationPackage{dir: relDir}
+			packages[relDir] = pkg
+		}
+
+		imports := importAliases(file)
+		if testFileCallsIsolatedMain(file, imports["go.kenn.io/roborev/internal/testenv"]) {
+			pkg.hasIsolatedTestMain = true
+		}
+		pkg.gitEvidence = append(pkg.gitEvidence, testFileGitUsage(
+			file,
+			fset,
+			relPath,
+			imports["os/exec"],
+			imports["go.kenn.io/roborev/internal/testutil"],
+		)...)
+		return nil
+	})
+	require.NoError(t, err)
+
+	var missing []string
+	for _, pkg := range packages {
+		if len(pkg.gitEvidence) == 0 || pkg.hasIsolatedTestMain {
+			continue
+		}
+		dir := pkg.dir
+		if dir == "" {
+			dir = "."
+		}
+		missing = append(missing, fmt.Sprintf("%s: %s", dir, pkg.gitEvidence[0]))
+	}
+	sort.Strings(missing)
+
+	require.Empty(t, missing, "Git-using test packages must call testenv.RunIsolatedMain in TestMain:\n%s", strings.Join(missing, "\n"))
+}
+
+func repoRootFromWorkingDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		require.NotEqual(t, dir, parent, "could not find repo root from %s", dir)
+		dir = parent
+	}
+}
+
+func importAliases(file *ast.File) map[string]map[string]bool {
+	aliases := map[string]map[string]bool{}
+	for _, spec := range file.Imports {
+		importPath, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			continue
+		}
+		name := defaultImportName(importPath)
+		if spec.Name != nil {
+			name = spec.Name.Name
+		}
+		if name == "_" || name == "." {
+			continue
+		}
+		if aliases[importPath] == nil {
+			aliases[importPath] = map[string]bool{}
+		}
+		aliases[importPath][name] = true
+	}
+	return aliases
+}
+
+func defaultImportName(importPath string) string {
+	idx := strings.LastIndex(importPath, "/")
+	if idx == -1 {
+		return importPath
+	}
+	return importPath[idx+1:]
+}
+
+func testFileCallsIsolatedMain(file *ast.File, testenvAliases map[string]bool) bool {
+	if len(testenvAliases) == 0 {
+		return false
+	}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "TestMain" || fn.Body == nil {
+			continue
+		}
+		found := false
+		ast.Inspect(fn.Body, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "RunIsolatedMain" {
+				return true
+			}
+			ident, ok := sel.X.(*ast.Ident)
+			if ok && testenvAliases[ident.Name] {
+				found = true
+				return false
+			}
+			return true
+		})
+		if found {
+			return true
+		}
+	}
+	return false
+}
+
+func testFileGitUsage(file *ast.File, fset *token.FileSet, relPath string, execAliases, testutilAliases map[string]bool) []string {
+	if len(execAliases) == 0 && len(testutilAliases) == 0 {
+		return nil
+	}
+
+	var evidence []string
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+
+		switch {
+		case execAliases[ident.Name] && gitCommandCall(sel.Sel.Name, call.Args):
+			evidence = append(evidence, fmt.Sprintf("%s:%d runs git via os/exec", relPath, fset.Position(call.Pos()).Line))
+		case testutilAliases[ident.Name] && testutilGitHelper(sel.Sel.Name):
+			evidence = append(evidence, fmt.Sprintf("%s:%d uses testutil.%s", relPath, fset.Position(call.Pos()).Line, sel.Sel.Name))
+		}
+		return true
+	})
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := call.Fun.(*ast.Ident)
+		if ok && testutilGitHelper(ident.Name) {
+			evidence = append(evidence, fmt.Sprintf("%s:%d uses %s", relPath, fset.Position(call.Pos()).Line, ident.Name))
+		}
+		return true
+	})
+	return evidence
+}
+
+func gitCommandCall(name string, args []ast.Expr) bool {
+	var commandArg ast.Expr
+	switch name {
+	case "Command":
+		if len(args) == 0 {
+			return false
+		}
+		commandArg = args[0]
+	case "CommandContext":
+		if len(args) < 2 {
+			return false
+		}
+		commandArg = args[1]
+	default:
+		return false
+	}
+	lit, ok := commandArg.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return false
+	}
+	value, err := strconv.Unquote(lit.Value)
+	return err == nil && value == "git"
+}
+
+func testutilGitHelper(name string) bool {
+	switch name {
+	case "GetHeadSHA", "InitTestGitRepo", "InitTestRepo", "NewGitRepo", "NewTestRepo", "NewTestRepoWithCommit":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/agenthook/testmain_test.go
+++ b/internal/agenthook/testmain_test.go
@@ -1,0 +1,12 @@
+package agenthook
+
+import (
+	"os"
+	"testing"
+
+	"go.kenn.io/roborev/internal/testenv"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(testenv.RunIsolatedMain(m))
+}

--- a/internal/githook/testmain_test.go
+++ b/internal/githook/testmain_test.go
@@ -1,0 +1,12 @@
+package githook
+
+import (
+	"os"
+	"testing"
+
+	"go.kenn.io/roborev/internal/testenv"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(testenv.RunIsolatedMain(m))
+}

--- a/internal/storage/testmain_test.go
+++ b/internal/storage/testmain_test.go
@@ -1,0 +1,12 @@
+package storage
+
+import (
+	"os"
+	"testing"
+
+	"go.kenn.io/roborev/internal/testenv"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(testenv.RunIsolatedMain(m))
+}

--- a/internal/testutil/testmain_test.go
+++ b/internal/testutil/testmain_test.go
@@ -1,0 +1,12 @@
+package testutil
+
+import (
+	"os"
+	"testing"
+
+	"go.kenn.io/roborev/internal/testenv"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(testenv.RunIsolatedMain(m))
+}

--- a/prek.toml
+++ b/prek.toml
@@ -4,6 +4,14 @@ minimum_prek_version = "0.3.6"
 repo = "local"
 
 [[repos.hooks]]
+id = "git-test-isolation"
+name = "git test isolation"
+language = "system"
+entry = "make test-git-isolation"
+pass_filenames = false
+always_run = true
+
+[[repos.hooks]]
 id = "golangci-lint"
 name = "golangci-lint"
 language = "system"


### PR DESCRIPTION
## Summary

- Add an AST-based guard that fails when a Git-using test package lacks `testenv.RunIsolatedMain` in `TestMain`.
- Add isolated `TestMain` wrappers for the existing Git-using test packages caught by the guard.
- Wire the guard into the local `prek` config and document the rule for future tests.

## Context

Tests that run Git can inherit global user configuration such as `commit.gpgSign`, which made fixture commits unexpectedly slow and tied test behavior to the caller's environment. The guard is intentionally narrow for now: it looks for direct `os/exec` Git calls and known `internal/testutil` Git repository helpers.
