### PR TITLE
Fix TUI freeze on multi-repo filters

### DIFF
--- a/cmd/roborev/tui/control_handlers.go
+++ b/cmd/roborev/tui/control_handlers.go
@@ -249,12 +249,7 @@ func (m model) handleCtrlSetFilter(
 		}
 	}
 
-	m.hasMore = false
-	m.selectedIdx = -1
-	m.selectedJobID = 0
-	m.fetchSeq++
-	m.queueColGen++
-	m.loadingJobs = true
+	m.resetQueueForFilterChange()
 	m.recomputeClassifyEffective()
 	return m, controlResponse{OK: true}, m.fetchJobs()
 }
@@ -295,12 +290,7 @@ func (m model) handleCtrlClearFilter(
 		m.removeFilterFromStack(filterTypeBranch)
 	}
 
-	m.hasMore = false
-	m.selectedIdx = -1
-	m.selectedJobID = 0
-	m.fetchSeq++
-	m.queueColGen++
-	m.loadingJobs = true
+	m.resetQueueForFilterChange()
 	m.recomputeClassifyEffective()
 	return m, controlResponse{OK: true}, m.fetchJobs()
 }
@@ -318,17 +308,7 @@ func (m model) handleCtrlSetHideClosed(
 	}
 
 	m.hideClosed = params.HideClosed
-	m.queueColGen++
-	if len(m.jobs) > 0 {
-		if m.selectedIdx < 0 ||
-			m.selectedIdx >= len(m.jobs) ||
-			!m.isJobVisible(m.jobs[m.selectedIdx]) {
-			m.selectedIdx = m.findFirstVisibleJob()
-			m.updateSelectedJobID()
-		}
-	}
-	m.fetchSeq++
-	m.loadingJobs = true
+	m.resetQueueForFilterChange()
 	return m, controlResponse{OK: true}, m.fetchJobs()
 }
 

--- a/cmd/roborev/tui/fetch.go
+++ b/cmd/roborev/tui/fetch.go
@@ -140,7 +140,12 @@ func listJobsParams(values neturl.Values) daemonclient.ListJobsParams {
 
 	setIntParam("id", &params.Id)
 	setStringParam("status", &params.Status)
-	setStringParam("repo", &params.Repo)
+	// repo is repeatable: a display name spanning multiple repos sends one
+	// value per path, scoped server-side via an IN clause.
+	if repos := values["repo"]; len(repos) > 0 {
+		paths := append([]string(nil), repos...)
+		params.Repo = &paths
+	}
 	setStringParam("git_ref", &params.GitRef)
 	setStringParam("branch", &params.Branch)
 	if value := values.Get("branch_include_empty"); value != "" {
@@ -179,12 +184,12 @@ func (m model) fetchJobs() tea.Cmd {
 		// limit=0 (no pagination) only when client-side filtering is required.
 		params := neturl.Values{}
 
-		// Repo filter: single repo can use API filter; multiple repos need client-side
+		// Repo filter: one ?repo= per path. A display name spanning multiple
+		// repos is scoped server-side via an IN clause, so it paginates like a
+		// single repo rather than loading every job for client-side filtering.
 		needsAllJobs := false
-		if len(m.activeRepoFilter) == 1 {
-			params.Set("repo", m.activeRepoFilter[0])
-		} else if len(m.activeRepoFilter) > 1 {
-			needsAllJobs = true // Multiple repos (shared display name) - filter client-side
+		for _, path := range m.activeRepoFilter {
+			params.Add("repo", path)
 		}
 
 		// Branch filter: use server-side for real branch names.
@@ -237,16 +242,18 @@ func (m model) fetchJobs() tea.Cmd {
 func (m model) fetchMoreJobs() tea.Cmd {
 	seq := m.fetchSeq
 	return func() tea.Msg {
-		// Only fetch more when not doing client-side filtering that loads all jobs
-		if len(m.activeRepoFilter) > 1 || m.activeBranchFilter == branchNone {
-			return nil // Multi-repo or "(none)" branch filter loads everything
+		// Only fetch more when not doing client-side filtering that loads all jobs.
+		// Multi-repo display names paginate server-side via repeated repo params;
+		// the "(none)" branch sentinel still loads everything client-side.
+		if m.activeBranchFilter == branchNone {
+			return nil
 		}
 		offset := len(m.jobs)
 		params := neturl.Values{}
 		params.Set("limit", "50")
 		params.Set("offset", fmt.Sprintf("%d", offset))
-		if len(m.activeRepoFilter) == 1 {
-			params.Set("repo", m.activeRepoFilter[0])
+		for _, path := range m.activeRepoFilter {
+			params.Add("repo", path)
 		}
 		if m.activeBranchFilter != "" && m.activeBranchFilter != branchNone {
 			params.Set("branch", m.activeBranchFilter)

--- a/cmd/roborev/tui/fetch_test.go
+++ b/cmd/roborev/tui/fetch_test.go
@@ -1,0 +1,74 @@
+package tui
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	neturl "net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListJobsParamsRepeatedRepo(t *testing.T) {
+	assert := assert.New(t)
+
+	values := neturl.Values{}
+	values.Add("repo", "/path/to/backend-dev")
+	values.Add("repo", "/path/to/backend-prod")
+
+	params := listJobsParams(values)
+
+	require.NotNil(t, params.Repo, "repeated repo values produce a slice filter")
+	assert.Equal(
+		[]string{"/path/to/backend-dev", "/path/to/backend-prod"},
+		*params.Repo,
+	)
+}
+
+func TestListJobsParamsNoRepo(t *testing.T) {
+	params := listJobsParams(neturl.Values{})
+	assert.Nil(t, params.Repo, "absent repo means no filter")
+}
+
+// A display name spanning multiple repos must scope the jobs query
+// server-side (one ?repo= per path) and keep pagination, rather than
+// falling back to limit=0 and loading every job — the regression that
+// crashed the daemon on large databases.
+func TestFetchJobsMultiRepoUsesRepeatedRepoAndPaginates(t *testing.T) {
+	assert := assert.New(t)
+
+	var jobsQuery neturl.Values
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/jobs" {
+				jobsQuery = r.URL.Query()
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"jobs": []any{}, "has_more": false,
+			})
+		},
+	))
+	defer ts.Close()
+
+	m := newModel(testEndpointFromURL(ts.URL), withExternalIODisabled())
+	m.activeRepoFilter = []string{
+		"/path/to/backend-dev", "/path/to/backend-prod",
+	}
+
+	cmd := m.fetchJobs()
+	require.NotNil(t, cmd)
+	_, ok := cmd().(jobsMsg)
+	require.True(t, ok)
+
+	require.NotNil(t, jobsQuery, "jobs endpoint should have been called")
+	assert.ElementsMatch(
+		[]string{"/path/to/backend-dev", "/path/to/backend-prod"},
+		jobsQuery["repo"],
+		"both repo paths sent as repeated params",
+	)
+	assert.NotEqual("0", jobsQuery.Get("limit"),
+		"multi-repo paginates instead of loading every job")
+}

--- a/cmd/roborev/tui/filter.go
+++ b/cmd/roborev/tui/filter.go
@@ -249,14 +249,21 @@ func (m *model) reconcileAutoRepoFilter() bool {
 	}
 
 	m.activeRepoFilter = copyStrings(rootPaths)
+	m.resetQueueForFilterChange()
+	m.recomputeClassifyEffective()
+	return true
+}
+
+func (m *model) resetQueueForFilterChange() {
+	m.jobs = nil
 	m.hasMore = false
+	m.loadingMore = false
+	m.paginateNav = 0
 	m.selectedIdx = -1
 	m.selectedJobID = 0
 	m.fetchSeq++
 	m.queueColGen++
 	m.loadingJobs = true
-	m.recomputeClassifyEffective()
-	return true
 }
 
 // isJobVisible checks if a job passes all active filters

--- a/cmd/roborev/tui/filter_queue_test.go
+++ b/cmd/roborev/tui/filter_queue_test.go
@@ -120,6 +120,11 @@ func TestTUIFilterChangeFetchesFirstPageOnly(t *testing.T) {
 }
 
 func TestTUIMultiPathFilterStatusCounts(t *testing.T) {
+	// A display name spanning multiple repos is scoped server-side via an IN
+	// clause and paginated, so the status counts come from the server
+	// aggregate (jobStats), not from counting the loaded page. The loaded
+	// page below is deliberately smaller and would yield different counts if
+	// the line still tallied client-side.
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.height = 20
 	m.daemonVersion = "test"
@@ -130,11 +135,8 @@ func TestTUIMultiPathFilterStatusCounts(t *testing.T) {
 	m.jobs = []storage.ReviewJob{
 		{ID: 1, RepoPath: "/path/to/backend-dev", Status: storage.JobStatusDone, Closed: &addrTrue},
 		{ID: 2, RepoPath: "/path/to/backend-prod", Status: storage.JobStatusDone, Closed: &addrFalse},
-		{ID: 3, RepoPath: "/path/to/backend-prod", Status: storage.JobStatusDone, Closed: &addrFalse},
-		{ID: 4, RepoPath: "/path/to/frontend", Status: storage.JobStatusDone, Closed: &addrTrue},
-		{ID: 5, RepoPath: "/path/to/frontend", Status: storage.JobStatusDone, Closed: &addrTrue},
 	}
-
+	m.jobStats = storage.JobStats{Done: 3, Closed: 1, Open: 2}
 	m.activeRepoFilter = []string{"/path/to/backend-dev", "/path/to/backend-prod"}
 
 	output := m.renderQueueView()

--- a/cmd/roborev/tui/filter_queue_test.go
+++ b/cmd/roborev/tui/filter_queue_test.go
@@ -1,10 +1,14 @@
 package tui
 
 import (
+	"encoding/json"
+	"net/http"
+	"strconv"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/roborev/internal/storage"
 )
@@ -80,6 +84,39 @@ func TestTUIFilterToZeroVisibleJobs(t *testing.T) {
 
 	assert.Equal(t, -1, m3.selectedIdx)
 	assert.EqualValues(t, 0, m3.selectedJobID)
+}
+
+func TestTUIFilterChangeFetchesFirstPageOnly(t *testing.T) {
+	var gotLimit string
+	var gotRepo string
+	_, m := mockServerModel(t, func(w http.ResponseWriter, r *http.Request) {
+		gotLimit = r.URL.Query().Get("limit")
+		gotRepo = r.URL.Query().Get("repo")
+		assert.NoError(t, json.NewEncoder(w).Encode(jobsPageResult{}))
+	})
+	m.currentView = viewFilter
+	m.heightDetected = true
+	m.height = 40
+	setupFilterTree(&m, []treeFilterNode{
+		{
+			name:      "kata",
+			rootPaths: []string{"/workspace/kata"},
+			count:     1429,
+		},
+	})
+	m.filterSelectedIdx = 1
+	m.jobs = make([]storage.ReviewJob, 1429)
+	m.loadingJobs = false
+
+	m2, cmd := pressSpecial(m, tea.KeyEnter)
+	require.NotNil(t, cmd)
+	msg := cmd()
+	_, ok := msg.(jobsMsg)
+	require.True(t, ok)
+
+	assert.Empty(t, m2.jobs)
+	assert.Equal(t, "/workspace/kata", gotRepo)
+	assert.Equal(t, strconv.Itoa(m2.queueVisibleRows()+queuePrefetchBuffer), gotLimit)
 }
 
 func TestTUIMultiPathFilterStatusCounts(t *testing.T) {

--- a/cmd/roborev/tui/filter_queue_test.go
+++ b/cmd/roborev/tui/filter_queue_test.go
@@ -210,7 +210,7 @@ func TestTUIBranchFilterCombinedWithRepoFilter(t *testing.T) {
 	assert.False(t, len(visible) > 0 && (visible[0].RepoPath != "/path/to/repo-a" || visible[0].Branch != "main"))
 }
 
-func TestTUINavigateDownNoLoadMoreWhenBranchFiltered(t *testing.T) {
+func TestTUINavigateDownLoadsMoreWhenBranchFiltered(t *testing.T) {
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 
 	m.jobs = []storage.ReviewJob{makeJob(1, withBranch("feature"))}
@@ -218,16 +218,17 @@ func TestTUINavigateDownNoLoadMoreWhenBranchFiltered(t *testing.T) {
 	m.selectedJobID = 1
 	m.hasMore = true
 	m.loadingMore = false
+	m.loadingJobs = false
 	m.activeBranchFilter = "feature"
 	m.currentView = viewQueue
 
 	m2, cmd := pressSpecial(m, tea.KeyDown)
 
-	assert.False(t, m2.loadingMore)
-	assert.Nil(t, cmd)
+	assert.True(t, m2.loadingMore)
+	assert.NotNil(t, cmd)
 }
 
-func TestTUINavigateJKeyNoLoadMoreWhenBranchFiltered(t *testing.T) {
+func TestTUINavigateJKeyLoadsMoreWhenBranchFiltered(t *testing.T) {
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 
 	m.jobs = []storage.ReviewJob{makeJob(1, withBranch("feature"))}
@@ -235,16 +236,17 @@ func TestTUINavigateJKeyNoLoadMoreWhenBranchFiltered(t *testing.T) {
 	m.selectedJobID = 1
 	m.hasMore = true
 	m.loadingMore = false
+	m.loadingJobs = false
 	m.activeBranchFilter = "feature"
 	m.currentView = viewQueue
 
 	m2, cmd := pressKey(m, 'j')
 
-	assert.False(t, m2.loadingMore)
-	assert.Nil(t, cmd)
+	assert.True(t, m2.loadingMore)
+	assert.NotNil(t, cmd)
 }
 
-func TestTUIPageDownNoLoadMoreWhenBranchFiltered(t *testing.T) {
+func TestTUIPageDownLoadsMoreWhenBranchFiltered(t *testing.T) {
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 
 	m.jobs = []storage.ReviewJob{makeJob(1, withBranch("feature"))}
@@ -252,14 +254,15 @@ func TestTUIPageDownNoLoadMoreWhenBranchFiltered(t *testing.T) {
 	m.selectedJobID = 1
 	m.hasMore = true
 	m.loadingMore = false
+	m.loadingJobs = false
 	m.activeBranchFilter = "feature"
 	m.currentView = viewQueue
 	m.height = 20
 
 	m2, cmd := pressSpecial(m, tea.KeyPgDown)
 
-	assert.False(t, m2.loadingMore)
-	assert.Nil(t, cmd)
+	assert.True(t, m2.loadingMore)
+	assert.NotNil(t, cmd)
 }
 
 func TestTUIBranchFilterClearTriggersRefetch(t *testing.T) {

--- a/cmd/roborev/tui/filter_test.go
+++ b/cmd/roborev/tui/filter_test.go
@@ -288,7 +288,7 @@ func TestTUIRightArrowRetriesAfterFailedLoad(t *testing.T) {
 	assert.NotNil(t, cmd)
 }
 
-func TestTUIWindowResizeNoLoadMoreWhenMultiRepoFiltered(t *testing.T) {
+func TestTUIWindowResizeLoadsMoreWhenMultiRepoFiltered(t *testing.T) {
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 
 	m.jobs = []storage.ReviewJob{makeJob(1, withRepoPath("/repo1"))}
@@ -303,11 +303,10 @@ func TestTUIWindowResizeNoLoadMoreWhenMultiRepoFiltered(t *testing.T) {
 	m2, cmd := updateModel(t, m, tea.WindowSizeMsg{Width: 120, Height: 50})
 
 	assert.False(t, m2.loadingMore)
-	assert.False(t, m2.loadingJobs)
+	assert.True(t, m2.loadingJobs)
 	assert.Equal(t, 50, m2.height)
 	assert.True(t, m2.heightDetected)
-
-	_ = cmd
+	assert.NotNil(t, cmd)
 }
 
 func TestTUIBKeyFallsBackToFirstRepo(t *testing.T) {

--- a/cmd/roborev/tui/handlers.go
+++ b/cmd/roborev/tui/handlers.go
@@ -652,22 +652,13 @@ func (m model) handleEscKey() (tea.Model, tea.Cmd) {
 	if m.currentView == viewQueue && len(m.filterStack) > 0 {
 		popped := m.popFilter()
 		if popped == filterTypeRepo || popped == filterTypeBranch {
-			m.hasMore = false
-			m.selectedIdx = -1
-			m.selectedJobID = 0
-			m.fetchSeq++
-			m.loadingJobs = true
+			m.resetQueueForFilterChange()
 			return m, m.fetchJobs()
 		}
 		return m, nil
 	} else if m.currentView == viewQueue && m.hideClosed {
 		m.hideClosed = false
-		m.queueColGen++
-		m.hasMore = false
-		m.selectedIdx = -1
-		m.selectedJobID = 0
-		m.fetchSeq++
-		m.loadingJobs = true
+		m.resetQueueForFilterChange()
 		return m, m.fetchJobs()
 	} else if m.currentView == viewReview {
 		// If fix panel is open (unfocused), esc closes it rather than leaving the review

--- a/cmd/roborev/tui/handlers.go
+++ b/cmd/roborev/tui/handlers.go
@@ -510,7 +510,7 @@ func (m model) handleDownKey() (tea.Model, tea.Cmd) {
 		} else if m.canPaginate() {
 			m.loadingMore = true
 			return m, m.fetchMoreJobs()
-		} else if !m.hasMore || len(m.activeRepoFilter) > 1 {
+		} else if !m.hasMore || m.activeBranchFilter == branchNone {
 			m.setFlash("No older review", 2*time.Second, viewQueue)
 		}
 	case viewReview:

--- a/cmd/roborev/tui/handlers_modal.go
+++ b/cmd/roborev/tui/handlers_modal.go
@@ -167,12 +167,7 @@ func (m model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.currentView = viewQueue
 		m.filterSearch = ""
 		m.filterBranchMode = false
-		m.hasMore = false
-		m.selectedIdx = -1
-		m.selectedJobID = 0
-		m.fetchSeq++
-		m.queueColGen++
-		m.loadingJobs = true
+		m.resetQueueForFilterChange()
 		// activeRepoFilter may have changed; refresh the cached
 		// classify visibility so the next render/fetch sees the
 		// repo-scoped value without hitting disk on the hot path.

--- a/cmd/roborev/tui/handlers_msg.go
+++ b/cmd/roborev/tui/handlers_msg.go
@@ -958,7 +958,7 @@ func (m model) handleWindowSizeMsg(
 	// If terminal can show more jobs than we have, re-fetch to fill
 	if !m.loadingMore && !m.loadingJobs &&
 		len(m.jobs) > 0 && m.hasMore &&
-		len(m.activeRepoFilter) <= 1 {
+		m.activeBranchFilter != branchNone {
 		newVisibleRows := m.queueVisibleRows() + queuePrefetchBuffer
 		if newVisibleRows > len(m.jobs) {
 			m.loadingJobs = true

--- a/cmd/roborev/tui/handlers_queue.go
+++ b/cmd/roborev/tui/handlers_queue.go
@@ -411,19 +411,7 @@ func (m model) handleHideClosedKey() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.hideClosed = !m.hideClosed
-	m.queueColGen++
-	if len(m.jobs) > 0 {
-		if m.selectedIdx < 0 || m.selectedIdx >= len(m.jobs) || !m.isJobVisible(m.jobs[m.selectedIdx]) {
-			m.selectedIdx = m.findFirstVisibleJob()
-			m.updateSelectedJobID()
-		}
-		if m.getVisibleSelectedIdx() < 0 && m.findFirstVisibleJob() >= 0 {
-			m.selectedIdx = m.findFirstVisibleJob()
-			m.updateSelectedJobID()
-		}
-	}
-	m.fetchSeq++
-	m.loadingJobs = true
+	m.resetQueueForFilterChange()
 	return m, m.fetchJobs()
 }
 
@@ -438,8 +426,6 @@ func (m model) handleToggleClassifyKey() (tea.Model, tea.Cmd) {
 	next := !m.shouldShowClassifyJobs()
 	m.classifyOverride = &next
 	m.recomputeClassifyEffective()
-	m.queueColGen++
-	m.fetchSeq++
-	m.loadingJobs = true
+	m.resetQueueForFilterChange()
 	return m, m.fetchJobs()
 }

--- a/cmd/roborev/tui/queue_test.go
+++ b/cmd/roborev/tui/queue_test.go
@@ -526,7 +526,7 @@ func TestTUIQueueNavigationBoundaries(t *testing.T) {
 	assertFlashMessage(t, m3, viewQueue, "No older review")
 }
 
-func TestTUIQueueNavigationBoundariesWithFilter(t *testing.T) {
+func TestTUIQueueNavigationBoundariesWithMultiRepoFilter(t *testing.T) {
 	m := newQueueTestModel(
 		withQueueTestJobs(makeJob(1, withRepoPath("/repo1")), makeJob(2, withRepoPath("/repo2"))),
 		withQueueTestSelection(1),
@@ -534,9 +534,10 @@ func TestTUIQueueNavigationBoundariesWithFilter(t *testing.T) {
 	)
 	m.activeRepoFilter = []string{"/repo1", "/repo2"}
 
-	m2, _ := pressSpecial(m, tea.KeyDown)
+	m2, cmd := pressSpecial(m, tea.KeyDown)
 
-	assertFlashMessage(t, m2, viewQueue, "No older review")
+	assert.True(t, m2.loadingMore)
+	assert.NotNil(t, cmd)
 }
 
 func TestTUINavigateDownTriggersLoadMore(t *testing.T) {
@@ -552,7 +553,7 @@ func TestTUINavigateDownTriggersLoadMore(t *testing.T) {
 	assert.NotNil(t, cmd)
 }
 
-func TestTUINavigateDownNoLoadMoreWhenFiltered(t *testing.T) {
+func TestTUINavigateDownLoadsMoreWhenMultiRepoFiltered(t *testing.T) {
 	m := newQueueTestModel(
 		withQueueTestJobs(makeJob(1, withRepoPath("/path/to/repo"))),
 		withQueueTestSelection(0),
@@ -562,8 +563,8 @@ func TestTUINavigateDownNoLoadMoreWhenFiltered(t *testing.T) {
 
 	m2, cmd := pressSpecial(m, tea.KeyDown)
 
-	assert.False(t, m2.loadingMore)
-	assert.Nil(t, cmd)
+	assert.True(t, m2.loadingMore)
+	assert.NotNil(t, cmd)
 }
 
 func TestTUIJobCellsContent(t *testing.T) {
@@ -964,6 +965,44 @@ func TestTUIPaginationAllowedWhenNotLoadingJobs(t *testing.T) {
 	assert.NotNil(t, cmd)
 }
 
+func TestTUIPaginationAllowedForMultiRepoFilter(t *testing.T) {
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.currentView = viewQueue
+	m.loadingJobs = false
+	m.hasMore = true
+	m.loadingMore = false
+	m.activeRepoFilter = []string{"/repo/a", "/repo/b"}
+
+	m.jobs = []storage.ReviewJob{
+		makeJob(1, withRepoPath("/repo/a")),
+	}
+	m.selectedIdx = 0
+	m.selectedJobID = 1
+
+	m2, cmd := pressKey(m, 'j')
+
+	assert.True(t, m2.loadingMore)
+	assert.NotNil(t, cmd)
+}
+
+func TestTUIPaginationBlockedForNoneBranchFilter(t *testing.T) {
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.currentView = viewQueue
+	m.loadingJobs = false
+	m.hasMore = true
+	m.loadingMore = false
+	m.activeBranchFilter = branchNone
+
+	m.jobs = []storage.ReviewJob{makeJob(1)}
+	m.selectedIdx = 0
+	m.selectedJobID = 1
+
+	m2, cmd := pressKey(m, 'j')
+
+	assert.False(t, m2.loadingMore)
+	assert.Nil(t, cmd)
+}
+
 func TestTUIPageDownBlockedWhileLoadingJobs(t *testing.T) {
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.currentView = viewQueue
@@ -1086,15 +1125,15 @@ func TestTUIResizeBehavior(t *testing.T) {
 			wantLoading:   true,
 		},
 		{
-			name:          "No Refetch Multi-Repo Filter Active",
+			name:          "Refetch Multi-Repo Filter Active",
 			initialHeight: 20,
 			jobsCount:     3,
 			loadingJobs:   false,
 			loadingMore:   false,
 			activeFilters: []string{"/repo1", "/repo2"},
 			msg:           tea.WindowSizeMsg{Height: 40},
-			wantCmd:       false,
-			wantLoading:   false,
+			wantCmd:       true,
+			wantLoading:   true,
 		},
 	}
 

--- a/cmd/roborev/tui/render_queue.go
+++ b/cmd/roborev/tui/render_queue.go
@@ -278,11 +278,12 @@ func (m model) renderQueueView() string {
 	b.WriteString("\x1b[K\n") // Clear to end of line
 
 	if !compact {
-		// Status line - use server-side aggregate counts for paginated views,
-		// fall back to client-side counting for multi-repo filters (which load all jobs)
+		// Status line - use server-side aggregate counts for paginated views
+		// (including multi-repo display names, scoped via an IN clause). Only
+		// the "(none)" branch sentinel still loads all jobs to count locally.
 		var statusLine string
 		var done, closed, open int
-		if len(m.activeRepoFilter) > 1 || m.activeBranchFilter == branchNone {
+		if m.activeBranchFilter == branchNone {
 			// Client-side filtered views load all jobs, so count locally
 			for _, job := range m.jobs {
 				if len(m.activeRepoFilter) > 0 && !m.repoMatchesFilter(job.RepoPath) {

--- a/cmd/roborev/tui/render_queue.go
+++ b/cmd/roborev/tui/render_queue.go
@@ -171,7 +171,7 @@ func (m model) queueVisibleRows() int {
 
 func (m model) canPaginate() bool {
 	return m.hasMore && !m.loadingMore && !m.loadingJobs &&
-		len(m.activeRepoFilter) <= 1 && m.activeBranchFilter != branchNone
+		m.activeBranchFilter != branchNone
 }
 
 // visibleSelectedRowIndex returns the index of selectedJobID within the
@@ -720,7 +720,7 @@ func (m model) renderQueueView() string {
 		if len(rows) > visibleRows || m.hasMore || m.loadingMore {
 			if m.loadingMore {
 				scrollInfo = fmt.Sprintf("[showing %d-%d of %d] Loading more...", start+1, end, len(rows))
-			} else if m.hasMore && len(m.activeRepoFilter) <= 1 {
+			} else if m.hasMore && m.activeBranchFilter != branchNone {
 				scrollInfo = fmt.Sprintf("[showing %d-%d of %d+] scroll down to load more", start+1, end, len(rows))
 			} else if len(rows) > visibleRows {
 				scrollInfo = fmt.Sprintf("[showing %d-%d of %d]", start+1, end, len(rows))

--- a/cmd/roborev/tui/tui_test.go
+++ b/cmd/roborev/tui/tui_test.go
@@ -1810,8 +1810,9 @@ func TestTUIHideClosed(t *testing.T) {
 		// Toggle hide closed
 		m2, _ := pressKey(m, 'h')
 
-		// Selection should move to first visible job (ID=2)
-		assertSelection(t, m2, 1, 2)
+		assertSelection(t, m2, -1, 0)
+		assert.Empty(t, m2.jobs)
+		assert.True(t, m2.loadingJobs)
 	})
 	t.Run("RefreshRevalidatesSelection", func(t *testing.T) {
 		m := newModel(testEndpoint, withExternalIODisabled())
@@ -1967,12 +1968,7 @@ func TestTUIHideClosed(t *testing.T) {
 			}, "Expected empty filter stack, got %v", m2.filterStack)
 		}
 
-		// jobs should be preserved (so fetchJobs limit stays large enough)
-		if len(m2.jobs) != 1 {
-			assert.Condition(t, func() bool {
-				return false
-			}, "Expected jobs to be preserved after escape, got %d jobs", len(m2.jobs))
-		}
+		assert.Empty(t, m2.jobs)
 
 		// A refetch command should be returned
 		if cmd == nil {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -968,9 +968,25 @@ func (s *Server) humaListJobs(
 		return resp, nil
 	}
 
-	repo := input.Repo
-	if repo != "" {
-		repo = filepath.ToSlash(filepath.Clean(repo))
+	// repo is repeatable: a display name spanning multiple repos sends one
+	// ?repo= per path. A single path uses the positional equality filter
+	// (fast path); multiple paths use an IN clause via WithRepoPaths so the
+	// daemon scopes server-side instead of returning every job.
+	var repoPaths []string
+	for _, p := range input.Repo {
+		if p != "" {
+			repoPaths = append(repoPaths, filepath.ToSlash(filepath.Clean(p)))
+		}
+	}
+	var repo string
+	var repoPathsFilter []string
+	switch len(repoPaths) {
+	case 0:
+		// no repo filter
+	case 1:
+		repo = repoPaths[0]
+	default:
+		repoPathsFilter = repoPaths
 	}
 	repoPrefix := input.RepoPrefix
 	if repoPrefix != "" {
@@ -1046,7 +1062,10 @@ func (s *Server) humaListJobs(
 	if input.HideClassifyJobs == "true" {
 		listOpts = append(listOpts, storage.WithHideClassifyJobs())
 	}
-	if repoPrefix != "" && repo == "" {
+	if len(repoPathsFilter) > 0 {
+		listOpts = append(listOpts, storage.WithRepoPaths(repoPathsFilter))
+	}
+	if repoPrefix != "" && len(repoPaths) == 0 {
 		listOpts = append(
 			listOpts, storage.WithRepoPrefix(repoPrefix),
 		)
@@ -1104,7 +1123,10 @@ func (s *Server) humaListJobs(
 			)
 		}
 	}
-	if repoPrefix != "" && repo == "" {
+	if len(repoPathsFilter) > 0 {
+		statsOpts = append(statsOpts, storage.WithRepoPaths(repoPathsFilter))
+	}
+	if repoPrefix != "" && len(repoPaths) == 0 {
 		statsOpts = append(
 			statsOpts, storage.WithRepoPrefix(repoPrefix),
 		)

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -1123,6 +1123,20 @@ func (s *Server) humaListJobs(
 			)
 		}
 	}
+	if input.JobType != "" {
+		statsOpts = append(
+			statsOpts, storage.WithJobType(input.JobType),
+		)
+	}
+	if input.ExcludeJobType != "" {
+		statsOpts = append(
+			statsOpts,
+			storage.WithExcludeJobType(input.ExcludeJobType),
+		)
+	}
+	if input.HideClassifyJobs == "true" {
+		statsOpts = append(statsOpts, storage.WithHideClassifyJobs())
+	}
 	if len(repoPathsFilter) > 0 {
 		statsOpts = append(statsOpts, storage.WithRepoPaths(repoPathsFilter))
 	}

--- a/internal/daemon/server_jobs_test.go
+++ b/internal/daemon/server_jobs_test.go
@@ -77,6 +77,34 @@ func TestHandleListJobsWithFilter(t *testing.T) {
 	}
 }
 
+func TestHandleListJobsMultiRepoFilter(t *testing.T) {
+	assert := assert.New(t)
+	server, db, tmpDir := newTestServer(t)
+
+	repo1, _ := seedRepoWithJobs(t, db, filepath.Join(tmpDir, "repo1"), 3, "repo1")
+	repo2, _ := seedRepoWithJobs(t, db, filepath.Join(tmpDir, "repo2"), 2, "repo2")
+	seedRepoWithJobs(t, db, filepath.Join(tmpDir, "repo3"), 4, "repo3") // excluded
+
+	multi := "repo=" + url.QueryEscape(repo1.RootPath) +
+		"&repo=" + url.QueryEscape(repo2.RootPath)
+
+	t.Run("repeated repo params scope server-side via IN clause", func(t *testing.T) {
+		resp := fetchJobs(t, server, multi)
+		assert.Len(resp.Jobs, 5, "only repo1 + repo2 jobs, repo3 excluded")
+		for _, job := range resp.Jobs {
+			assert.Contains([]string{"repo1", "repo2"}, job.RepoName)
+		}
+	})
+
+	t.Run("multi-repo paginates instead of loading everything", func(t *testing.T) {
+		// This is the crash fix: a display name spanning repos returns a
+		// bounded page rather than every matching job in one response.
+		resp := fetchJobs(t, server, multi+"&limit=2")
+		assert.Len(resp.Jobs, 2, "respects the page limit")
+		assert.True(resp.HasMore, "more jobs remain in the scoped set")
+	})
+}
+
 func TestListJobsPagination(t *testing.T) {
 	server, db, _ := newTestServer(t)
 

--- a/internal/daemon/server_jobs_test.go
+++ b/internal/daemon/server_jobs_test.go
@@ -27,6 +27,7 @@ import (
 type listJobsResponse struct {
 	Jobs    []storage.ReviewJob `json:"jobs"`
 	HasMore bool                `json:"has_more"`
+	Stats   storage.JobStats    `json:"stats"`
 }
 
 // fetchJobs calls GET /api/jobs via the mux, asserts HTTP 200,
@@ -2336,7 +2337,7 @@ func TestHandleListJobsJobTypeFilter(t *testing.T) {
 	})
 
 	// Create a fix job parented to the review
-	db.EnqueueJob(storage.EnqueueOpts{
+	fixJob, _ := db.EnqueueJob(storage.EnqueueOpts{
 		RepoID:      repo.ID,
 		CommitID:    commit.ID,
 		GitRef:      "jt-abc",
@@ -2344,6 +2345,13 @@ func TestHandleListJobsJobTypeFilter(t *testing.T) {
 		JobType:     storage.JobTypeFix,
 		ParentJobID: reviewJob.ID,
 	})
+	_, err := db.Exec(
+		`UPDATE review_jobs SET status = 'running' WHERE id IN (?, ?)`,
+		reviewJob.ID, fixJob.ID,
+	)
+	require.NoError(t, err)
+	require.NoError(t, db.CompleteJob(reviewJob.ID, "test", "prompt", "review done"))
+	require.NoError(t, db.CompleteJob(fixJob.ID, "test", "prompt", "fix done"))
 
 	t.Run("job_type=fix returns only fix jobs", func(t *testing.T) {
 		req := httptest.NewRequest(
@@ -2359,7 +2367,8 @@ func TestHandleListJobsJobTypeFilter(t *testing.T) {
 		}
 
 		var resp struct {
-			Jobs []storage.ReviewJob `json:"jobs"`
+			Jobs  []storage.ReviewJob `json:"jobs"`
+			Stats storage.JobStats    `json:"stats"`
 		}
 		testutil.DecodeJSON(t, w, &resp)
 
@@ -2389,7 +2398,8 @@ func TestHandleListJobsJobTypeFilter(t *testing.T) {
 		}
 
 		var resp struct {
-			Jobs []storage.ReviewJob `json:"jobs"`
+			Jobs  []storage.ReviewJob `json:"jobs"`
+			Stats storage.JobStats    `json:"stats"`
 		}
 		testutil.DecodeJSON(t, w, &resp)
 
@@ -2414,7 +2424,8 @@ func TestHandleListJobsJobTypeFilter(t *testing.T) {
 		}
 
 		var resp struct {
-			Jobs []storage.ReviewJob `json:"jobs"`
+			Jobs  []storage.ReviewJob `json:"jobs"`
+			Stats storage.JobStats    `json:"stats"`
 		}
 		testutil.DecodeJSON(t, w, &resp)
 
@@ -2428,6 +2439,11 @@ func TestHandleListJobsJobTypeFilter(t *testing.T) {
 				return false
 			}, "Expected non-fix job, got fix")
 		}
+		assert.Equal(t, storage.JobStats{
+			Done:   1,
+			Closed: 0,
+			Open:   1,
+		}, resp.Stats)
 	})
 
 	t.Run("hide_classify_jobs=true hides classify and skipped rows", func(t *testing.T) {

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -72,21 +72,21 @@ type RemapMapping struct {
 //     values like -1 are treated as unlimited, matching legacy)
 //   - Offset: default -1 (negative offsets clamp to 0)
 type ListJobsInput struct {
-	ID                 int64  `query:"id" default:"-1" doc:"Return a single job by ID"`
-	Status             string `query:"status" doc:"Filter by job status"`
-	Repo               string `query:"repo" doc:"Filter by repo root path"`
-	GitRef             string `query:"git_ref" doc:"Filter by git ref"`
-	Branch             string `query:"branch" doc:"Filter by branch name"`
-	BranchIncludeEmpty string `query:"branch_include_empty" doc:"Include jobs with no branch when filtering by branch" enum:"true,false,"`
-	Closed             string `query:"closed" doc:"Filter by review closed state" enum:"true,false,"`
-	JobType            string `query:"job_type" doc:"Filter by job type"`
-	ExcludeJobType     string `query:"exclude_job_type" doc:"Exclude jobs of this type"`
-	HideClassifyJobs   string `query:"hide_classify_jobs" doc:"Hide auto-design-router rows (job_type=classify and status=skipped)" enum:"true,false,"`
-	PanelRun           string `query:"panel_run" doc:"Return all jobs (members + synthesis) of one panel run"`
-	RepoPrefix         string `query:"repo_prefix" doc:"Filter repos by path prefix"`
-	Limit              int    `query:"limit" default:"-999999" doc:"Max results (default 50, 0=unlimited, max 10000)"`
-	Offset             int    `query:"offset" default:"-1" doc:"Skip N results (requires limit>0)"`
-	Before             int64  `query:"before" default:"-1" doc:"Cursor: return jobs with ID < this value"`
+	ID                 int64    `query:"id" default:"-1" doc:"Return a single job by ID"`
+	Status             string   `query:"status" doc:"Filter by job status"`
+	Repo               []string `query:"repo,explode" doc:"Filter by repo root path (repeatable)"`
+	GitRef             string   `query:"git_ref" doc:"Filter by git ref"`
+	Branch             string   `query:"branch" doc:"Filter by branch name"`
+	BranchIncludeEmpty string   `query:"branch_include_empty" doc:"Include jobs with no branch when filtering by branch" enum:"true,false,"`
+	Closed             string   `query:"closed" doc:"Filter by review closed state" enum:"true,false,"`
+	JobType            string   `query:"job_type" doc:"Filter by job type"`
+	ExcludeJobType     string   `query:"exclude_job_type" doc:"Exclude jobs of this type"`
+	HideClassifyJobs   string   `query:"hide_classify_jobs" doc:"Hide auto-design-router rows (job_type=classify and status=skipped)" enum:"true,false,"`
+	PanelRun           string   `query:"panel_run" doc:"Return all jobs (members + synthesis) of one panel run"`
+	RepoPrefix         string   `query:"repo_prefix" doc:"Filter repos by path prefix"`
+	Limit              int      `query:"limit" default:"-999999" doc:"Max results (default 50, 0=unlimited, max 10000)"`
+	Offset             int      `query:"offset" default:"-1" doc:"Skip N results (requires limit>0)"`
+	Before             int64    `query:"before" default:"-1" doc:"Cursor: return jobs with ID < this value"`
 }
 
 // ListJobsOutput is the response for GET /api/jobs.

--- a/internal/daemon_client/client.gen.go
+++ b/internal/daemon_client/client.gen.go
@@ -701,8 +701,8 @@ type ListJobsParams struct {
 	// Status Filter by job status
 	Status *string `form:"status,omitempty" json:"status,omitempty"`
 
-	// Repo Filter by repo root path
-	Repo *string `form:"repo,omitempty" json:"repo,omitempty"`
+	// Repo Filter by repo root path (repeatable)
+	Repo *[]string `form:"repo,omitempty" json:"repo,omitempty"`
 
 	// GitRef Filter by git ref
 	GitRef *string `form:"git_ref,omitempty" json:"git_ref,omitempty"`
@@ -2254,7 +2254,7 @@ func NewListJobsRequest(server string, params *ListJobsParams) (*http.Request, e
 
 		if params.Repo != nil {
 
-			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "repo", *params.Repo, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "repo", *params.Repo, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "array", Format: ""}); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err

--- a/internal/daemon_client/openapi-3.0.json
+++ b/internal/daemon_client/openapi-3.0.json
@@ -2507,13 +2507,17 @@
             }
           },
           {
-            "description": "Filter by repo root path",
-            "explode": false,
+            "description": "Filter by repo root path (repeatable)",
+            "explode": true,
             "in": "query",
             "name": "repo",
             "schema": {
-              "description": "Filter by repo root path",
-              "type": "string"
+              "description": "Filter by repo root path (repeatable)",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
             }
           },
           {

--- a/internal/storage/db_filter_test.go
+++ b/internal/storage/db_filter_test.go
@@ -303,6 +303,55 @@ func TestListJobsWithRepoFilter(t *testing.T) {
 	}
 }
 
+func TestListJobsWithRepoPaths(t *testing.T) {
+	assert := assert.New(t)
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo1, _ := seedJobs(t, db, "/tmp/repo1", 3)
+	repo2, _ := seedJobs(t, db, "/tmp/repo2", 2)
+	repo3, _ := seedJobs(t, db, "/tmp/repo3", 4) // excluded by the filters below
+
+	// IN clause scopes to the two named repos (3 + 2), excluding repo3.
+	jobs, err := db.ListJobs("", "", 0, 0,
+		WithRepoPaths([]string{repo1.RootPath, repo2.RootPath}))
+	require.NoError(t, err)
+	assert.Len(jobs, 5)
+	for _, job := range jobs {
+		assert.Contains([]string{"repo1", "repo2"}, job.RepoName)
+	}
+
+	// A single-element set behaves like the positional equality filter.
+	jobs, err = db.ListJobs("", "", 0, 0, WithRepoPaths([]string{repo1.RootPath}))
+	require.NoError(t, err)
+	assert.Len(jobs, 3)
+
+	// The positional repoFilter takes precedence over WithRepoPaths, so the
+	// two never compound into an empty result.
+	jobs, err = db.ListJobs("", repo1.RootPath, 0, 0,
+		WithRepoPaths([]string{repo2.RootPath}))
+	require.NoError(t, err)
+	assert.Len(jobs, 3)
+	for _, job := range jobs {
+		assert.Equal("repo1", job.RepoName)
+	}
+
+	// CountJobStats honors the same multi-repo scoping. Complete repo1's
+	// oldest job (claimed first) so exactly one done job exists.
+	claimed := claimJob(t, db, "worker-1")
+	require.Equal(t, "repo1", claimed.RepoName)
+	require.NoError(t, db.CompleteJob(claimed.ID, "codex", "prompt", "output"))
+
+	inScope, err := db.CountJobStats("",
+		WithRepoPaths([]string{repo1.RootPath, repo2.RootPath}))
+	require.NoError(t, err)
+	assert.Equal(1, inScope.Done, "repo1's done job counted when repo1 is in scope")
+
+	outOfScope, err := db.CountJobStats("", WithRepoPaths([]string{repo3.RootPath}))
+	require.NoError(t, err)
+	assert.Equal(0, outOfScope.Done, "repo1's done job excluded when only repo3 is in scope")
+}
+
 func TestListJobsWithGitRefFilter(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -850,6 +850,7 @@ type listJobsOptions struct {
 	excludeJobType     string
 	hideClassifyJobs   bool
 	repoPrefix         string
+	repoPaths          []string
 	beforeCursor       *int64
 	panelRun           string
 	excludePanelRole   string
@@ -913,6 +914,14 @@ func WithRepoPrefix(prefix string) ListJobsOption {
 	}
 }
 
+// WithRepoPaths filters jobs to the given set of repo root paths via an
+// IN clause. Used for display names that map to multiple repos, so the
+// daemon scopes the query server-side instead of returning every job for
+// the client to filter. An empty slice disables the filter.
+func WithRepoPaths(paths []string) ListJobsOption {
+	return func(o *listJobsOptions) { o.repoPaths = paths }
+}
+
 // WithPanelRun filters jobs to a single panel run (member + synthesis rows).
 func WithPanelRun(uuid string) ListJobsOption {
 	return func(o *listJobsOptions) { o.panelRun = uuid }
@@ -951,11 +960,21 @@ func buildJobFilterClause(statusFilter, repoFilter string, o listJobsOptions) (s
 		conditions = append(conditions, "j.status = ?")
 		args = append(args, statusFilter)
 	}
-	if repoFilter != "" {
+	// Repo scoping precedence: a single positional repoFilter wins, then a
+	// multi-repo IN set (display names spanning repos), then a path prefix.
+	// At most one applies so the clauses never compound into an empty result.
+	switch {
+	case repoFilter != "":
 		conditions = append(conditions, "r.root_path = ?")
 		args = append(args, repoFilter)
-	}
-	if repoFilter == "" && o.repoPrefix != "" {
+	case len(o.repoPaths) > 0:
+		placeholders := make([]string, len(o.repoPaths))
+		for i, p := range o.repoPaths {
+			placeholders[i] = "?"
+			args = append(args, p)
+		}
+		conditions = append(conditions, "r.root_path IN ("+strings.Join(placeholders, ",")+")")
+	case o.repoPrefix != "":
 		conditions = append(conditions, "r.root_path LIKE ? || '/%' ESCAPE '!'")
 		args = append(args, o.repoPrefix)
 	}


### PR DESCRIPTION
## Summary
- Fix the TUI queue reload path so filter changes reset stale pagination state before fetching a fresh first page.
- Add repeatable `repo` filtering to `/api/jobs` so display names that map to multiple repo roots are filtered and paginated server-side instead of loading the full queue.
- Align `/api/jobs` aggregate stats with the visible job-list filters for job type and classify-row filtering.