### PR TITLE
Aggregate review cost tracking

### DIFF
--- a/cmd/roborev/backfill_tokens.go
+++ b/cmd/roborev/backfill_tokens.go
@@ -82,7 +82,7 @@ will be skipped.`,
 				}
 
 				j := tokens.ToJSON(mergedUsage)
-				if err := db.SaveJobTokenUsage(job.ID, j); err != nil {
+				if err := db.SaveJobTokenUsage(job.ID, job.SessionID, j); err != nil {
 					log.Printf(
 						"job %d: save error: %v", job.ID, err,
 					)

--- a/cmd/roborev/cost.go
+++ b/cmd/roborev/cost.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	gitrepo "go.kenn.io/kit/git/repo"
+
+	"go.kenn.io/roborev/internal/storage"
+)
+
+func costCmd() *cobra.Command {
+	var (
+		repoPath   string
+		branch     string
+		since      string
+		allRepos   bool
+		jsonOutput bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "cost",
+		Args:  cobra.NoArgs,
+		Short: "Show approximate aggregate review cost for a repo or branch",
+		Long: `Show approximate aggregate agent spend from existing review data.
+
+Cost is partial: only some agents report it, so the figure is a lower bound and
+shows coverage (priced jobs / eligible jobs).
+
+Examples:
+  roborev cost                     # All-time, current repo
+  roborev cost --all               # All-time, all repos
+  roborev cost --branch main       # Filter by branch
+  roborev cost --repo /path/to/repo
+  roborev cost --since 30d         # Last 30 days
+  roborev cost --json              # Structured output for scripting`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			if err := ensureDaemon(); err != nil {
+				return fmt.Errorf("daemon not running: %w", err)
+			}
+
+			ep := getDaemonEndpoint()
+			addr := ep.BaseURL()
+
+			if !allRepos && repoPath == "" {
+				root, err := gitrepo.MainRoot(ctx, ".")
+				if err != nil {
+					return fmt.Errorf("not in a git repo; use --all for all repos or --repo to specify one")
+				}
+				repoPath = root
+			} else if repoPath != "" {
+				if root, err := gitrepo.MainRoot(ctx, repoPath); err == nil {
+					repoPath = root
+				}
+			}
+
+			params := url.Values{}
+			if repoPath != "" {
+				params.Set("repo", repoPath)
+			}
+			if branch != "" {
+				params.Set("branch", branch)
+			}
+			if since != "" {
+				params.Set("since", since)
+			}
+
+			client := ep.HTTPClient(10 * time.Second)
+			resp, err := client.Get(addr + "/api/cost?" + params.Encode())
+			if err != nil {
+				return fmt.Errorf("failed to connect to daemon: %w", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("daemon returned %s", resp.Status)
+			}
+
+			var cost storage.CostAggregate
+			if err := json.NewDecoder(resp.Body).Decode(&cost); err != nil {
+				return fmt.Errorf("failed to parse response: %w", err)
+			}
+
+			if jsonOutput {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(cost)
+			}
+
+			cmd.Println(formatCostLine(cost))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&repoPath, "repo", "", "scope to a single repo (default: current repo)")
+	cmd.Flags().StringVar(&branch, "branch", "", "scope to a single branch")
+	cmd.Flags().StringVar(&since, "since", "", "time window (e.g. 24h, 7d, 30d); default all-time")
+	cmd.Flags().BoolVar(&allRepos, "all", false, "aggregate across all repos")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "structured output for scripting")
+	cmd.MarkFlagsMutuallyExclusive("all", "repo")
+
+	return cmd
+}
+
+// formatCostLine renders the human-readable cost summary. Coverage is shown only
+// when the aggregate is partial.
+func formatCostLine(c storage.CostAggregate) string {
+	if c.JobsTotal == 0 {
+		return "No eligible agent-spend jobs in scope yet."
+	}
+	if c.Complete {
+		return fmt.Sprintf("Approx cost: ~$%.2f", c.TotalUSD)
+	}
+	return fmt.Sprintf("Approx cost: ~$%.2f  (%d/%d jobs reported cost)",
+		c.TotalUSD, c.JobsWithCost, c.JobsTotal)
+}

--- a/cmd/roborev/cost_test.go
+++ b/cmd/roborev/cost_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/storage"
+)
+
+func TestFormatCostLine(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal(
+		"Approx cost: ~$1.75  (3/4 jobs reported cost)",
+		formatCostLine(storage.CostAggregate{TotalUSD: 1.75, JobsWithCost: 3, JobsTotal: 4}),
+	)
+	assert.Equal(
+		"Approx cost: ~$0.25",
+		formatCostLine(storage.CostAggregate{TotalUSD: 0.25, JobsWithCost: 1, JobsTotal: 1, Complete: true}),
+	)
+	assert.Equal(
+		"No eligible agent-spend jobs in scope yet.",
+		formatCostLine(storage.CostAggregate{}),
+	)
+}
+
+func TestCostCmdRejectsPositionalArgs(t *testing.T) {
+	cmd := costCmd()
+
+	require.NoError(t, cmd.Args(cmd, []string{}), "no args is valid")
+	require.Error(t, cmd.Args(cmd, []string{"unexpected"}), "positional args rejected")
+}

--- a/cmd/roborev/main.go
+++ b/cmd/roborev/main.go
@@ -67,6 +67,7 @@ func main() {
 	rootCmd.AddCommand(ciCmd())
 	rootCmd.AddCommand(logCmd())
 	rootCmd.AddCommand(summaryCmd())
+	rootCmd.AddCommand(costCmd())
 	rootCmd.AddCommand(backfillVerdictsCmd())
 	rootCmd.AddCommand(configCmd())
 	rootCmd.AddCommand(backfillTokensCmd())

--- a/cmd/roborev/summary.go
+++ b/cmd/roborev/summary.go
@@ -230,6 +230,18 @@ func printSummary(cmd *cobra.Command, s storage.Summary) {
 		cmd.Println()
 	}
 
+	// Cost (windowed, like the rest of summary)
+	if s.Cost.JobsTotal > 0 {
+		cmd.Println("Cost")
+		if s.Cost.Complete {
+			cmd.Printf("  Approx: ~$%.2f\n", s.Cost.TotalUSD)
+		} else {
+			cmd.Printf("  Approx: ~$%.2f  (%d/%d jobs reported cost)\n",
+				s.Cost.TotalUSD, s.Cost.JobsWithCost, s.Cost.JobsTotal)
+		}
+		cmd.Println()
+	}
+
 	if s.Overview.Total == 0 {
 		cmd.Println("No review data for this time window.")
 	}

--- a/cmd/roborev/tui/cost_test.go
+++ b/cmd/roborev/tui/cost_test.go
@@ -1,0 +1,80 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.kenn.io/roborev/internal/storage"
+)
+
+func TestCostSegmentText(t *testing.T) {
+	assert := assert.New(t)
+
+	var m model
+	_, show := m.costSegmentText()
+	assert.False(show, "nil cost hides segment")
+
+	m.cost = &storage.CostAggregate{}
+	_, show = m.costSegmentText()
+	assert.False(show, "zero eligible hides segment")
+
+	m.cost = &storage.CostAggregate{TotalUSD: 1.23, JobsWithCost: 18, JobsTotal: 40}
+	text, show := m.costSegmentText()
+	assert.True(show)
+	assert.Equal("~$1.23 (18/40)", text)
+
+	m.cost = &storage.CostAggregate{TotalUSD: 1.23, JobsWithCost: 5, JobsTotal: 5, Complete: true}
+	text, show = m.costSegmentText()
+	assert.True(show)
+	assert.Equal("~$1.23", text)
+}
+
+func TestHandleCostMsgStaleGuard(t *testing.T) {
+	assert := assert.New(t)
+
+	m := model{fetchSeq: 5}
+	fresh := &storage.CostAggregate{TotalUSD: 2.0, JobsWithCost: 1, JobsTotal: 1}
+
+	updated, _ := m.handleCostMsg(costMsg{cost: fresh, seq: 5})
+	assert.Equal(fresh, updated.(model).cost)
+
+	// Stale response from an earlier filter is discarded.
+	stale := &storage.CostAggregate{TotalUSD: 99.0, JobsWithCost: 9, JobsTotal: 9}
+	updated, _ = updated.(model).handleCostMsg(costMsg{cost: stale, seq: 4})
+	assert.Equal(fresh, updated.(model).cost, "stale seq must not overwrite")
+}
+
+// TestCostSegmentHiddenAfterFilterChange covers the window between a filter
+// change and the arrival of the refreshed cost: a jobsMsg for the new filter may
+// already have rendered, but the stored cost still describes the old scope, so
+// the segment must hide until the matching cost response lands.
+func TestCostSegmentHiddenAfterFilterChange(t *testing.T) {
+	assert := assert.New(t)
+
+	// Cost fetched for the current filter generation (seq 2) shows.
+	m := model{fetchSeq: 2}
+	updated, _ := m.handleCostMsg(costMsg{
+		cost: &storage.CostAggregate{TotalUSD: 1.50, JobsWithCost: 1, JobsTotal: 2},
+		seq:  2,
+	})
+	m = updated.(model)
+	text, show := m.costSegmentText()
+	assert.True(show)
+	assert.Equal("~$1.50 (1/2)", text)
+
+	// A filter change bumps fetchSeq; the prior scope's cost must hide.
+	m.fetchSeq = 3
+	_, show = m.costSegmentText()
+	assert.False(show, "stale cost hidden after filter change")
+
+	// The refreshed cost for the new generation restores the segment.
+	updated, _ = m.handleCostMsg(costMsg{
+		cost: &storage.CostAggregate{TotalUSD: 0.75, JobsWithCost: 1, JobsTotal: 1, Complete: true},
+		seq:  3,
+	})
+	m = updated.(model)
+	text, show = m.costSegmentText()
+	assert.True(show)
+	assert.Equal("~$0.75", text)
+}

--- a/cmd/roborev/tui/fetch.go
+++ b/cmd/roborev/tui/fetch.go
@@ -183,7 +183,7 @@ func (m model) fetchJobs() tea.Cmd {
 	currentJobCount := len(m.jobs)
 	seq := m.fetchSeq
 
-	return func() tea.Msg {
+	jobsCmd := func() tea.Msg {
 		// Build URL with server-side filters where possible, falling back to
 		// limit=0 (no pagination) only when client-side filtering is required.
 		params := neturl.Values{}
@@ -241,6 +241,9 @@ func (m model) fetchJobs() tea.Cmd {
 		}
 		return jobsMsg{jobs: result.Jobs, hasMore: result.HasMore, append: false, seq: seq, stats: result.Stats}
 	}
+	// fetchCost must always return a non-nil command: tests (fetchJobsMessage)
+	// rely on this staying a 2-element BatchMsg whose first command is jobsCmd.
+	return tea.Batch(jobsCmd, m.fetchCost())
 }
 
 func (m model) fetchMoreJobs() tea.Cmd {
@@ -277,6 +280,40 @@ func (m model) fetchMoreJobs() tea.Cmd {
 			}
 		}
 		return jobsMsg{jobs: result.Jobs, hasMore: result.HasMore, append: true, seq: seq}
+	}
+}
+
+// fetchCost retrieves the approximate cost aggregate for the active filter scope.
+// It rides the same fetchSeq stale guard as fetchJobs so a response that arrives
+// after a filter change is discarded. Any error, non-200, or decode failure
+// yields a nil cost so the queue-header segment hides rather than showing stale
+// or bogus data.
+func (m model) fetchCost() tea.Cmd {
+	seq := m.fetchSeq
+	var query daemonclient.GetCostQuery
+	if len(m.activeRepoFilter) > 0 {
+		query.Repo = append([]string(nil), m.activeRepoFilter...)
+	}
+	if m.activeBranchFilter == branchNone {
+		be := daemonclient.True
+		query.BranchEmpty = &be
+	} else if m.activeBranchFilter != "" {
+		branch := m.activeBranchFilter
+		query.Branch = &branch
+	}
+	return func() tea.Msg {
+		resp, err := m.api.GetCostWithResponse(
+			m.apiContext(),
+			&daemonclient.GetCostRequestOptions{Query: &query},
+		)
+		if err != nil || resp == nil || resp.StatusCode != http.StatusOK {
+			return costMsg{cost: nil, seq: seq}
+		}
+		var c storage.CostAggregate
+		if err := decodeAPIBody(resp.Body, &c); err != nil {
+			return costMsg{cost: nil, seq: seq}
+		}
+		return costMsg{cost: &c, seq: seq}
 	}
 }
 

--- a/cmd/roborev/tui/fetch_test.go
+++ b/cmd/roborev/tui/fetch_test.go
@@ -60,9 +60,7 @@ func TestFetchJobsMultiRepoUsesRepeatedRepoAndPaginates(t *testing.T) {
 		"/path/to/backend-dev", "/path/to/backend-prod",
 	}
 
-	cmd := m.fetchJobs()
-	require.NotNil(t, cmd)
-	_, ok := cmd().(jobsMsg)
+	_, ok := fetchJobsMessage(t, m).(jobsMsg)
 	require.True(t, ok)
 
 	require.NotNil(t, jobsQuery, "jobs endpoint should have been called")

--- a/cmd/roborev/tui/filter_queue_test.go
+++ b/cmd/roborev/tui/filter_queue_test.go
@@ -109,9 +109,7 @@ func TestTUIFilterChangeFetchesFirstPageOnly(t *testing.T) {
 	m.loadingJobs = false
 
 	m2, cmd := pressSpecial(m, tea.KeyEnter)
-	require.NotNil(t, cmd)
-	msg := cmd()
-	_, ok := msg.(jobsMsg)
+	_, ok := jobsMsgFromBatch(t, cmd).(jobsMsg)
 	require.True(t, ok)
 
 	assert.Empty(t, m2.jobs)

--- a/cmd/roborev/tui/handlers_msg.go
+++ b/cmd/roborev/tui/handlers_msg.go
@@ -282,6 +282,19 @@ func (m model) handlePanelMembersMsg(msg panelMembersMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// handleCostMsg stores the latest cost aggregate, discarding responses from
+// before a filter change (same fetchSeq guard as handleJobsMsg). It records the
+// response's fetchSeq so costSegmentText can hide the segment after a later
+// filter change until the matching cost response arrives.
+func (m model) handleCostMsg(msg costMsg) (tea.Model, tea.Cmd) {
+	if msg.seq < m.fetchSeq {
+		return m, nil
+	}
+	m.cost = msg.cost
+	m.costSeq = msg.seq
+	return m, nil
+}
+
 // handleStatusMsg processes daemon status updates.
 func (m model) handleStatusMsg(msg statusMsg) (tea.Model, tea.Cmd) {
 	if msg.gen < m.fetchGen {

--- a/cmd/roborev/tui/helpers.go
+++ b/cmd/roborev/tui/helpers.go
@@ -72,19 +72,6 @@ func (m *model) setWarningFlash(msg string, d time.Duration, v viewKind) {
 	m.flashWarning = true
 }
 
-func (m model) renderDaemonStatus() string {
-	daemonVersion := m.daemonVersion
-	if daemonVersion == "" {
-		daemonVersion = "?"
-	}
-
-	line := statusStyle.Render("Daemon: " + daemonVersion)
-	if m.versionMismatch {
-		line += " " + errorStyle.Render("[MISMATCH]")
-	}
-	return line
-}
-
 func (m model) renderFlash(view viewKind) string {
 	if m.flashMessage == "" || !time.Now().Before(m.flashExpiresAt) || m.flashView != view {
 		return ""

--- a/cmd/roborev/tui/queue_test.go
+++ b/cmd/roborev/tui/queue_test.go
@@ -297,7 +297,7 @@ func TestTUIQueueCompactMode(t *testing.T) {
 
 	output := m.View().Content
 
-	assert.Contains(t, output, "roborev queue")
+	assert.Contains(t, output, "roborev")
 
 	assert.NotContains(t, output, "JobID")
 

--- a/cmd/roborev/tui/render_queue.go
+++ b/cmd/roborev/tui/render_queue.go
@@ -12,6 +12,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"charm.land/lipgloss/v2/table"
+	xansi "github.com/charmbracelet/x/ansi"
 	"github.com/muesli/termenv"
 
 	"go.kenn.io/roborev/internal/agent"
@@ -268,42 +269,184 @@ func (m model) queueFullRowCells(r queueRow, hasAnyPanel, treeColor bool) []stri
 	return fullRow
 }
 
-func (m model) renderQueueView() string {
-	var b strings.Builder
-	compact := m.queueCompact()
+// costSegmentText returns the bare approximate-cost text (no separator) and
+// whether to show it. Coverage is dropped when complete. The segment hides while
+// the stored cost predates the active filter generation (m.costSeq != m.fetchSeq),
+// so a filter change cannot briefly show the prior scope's spend before the
+// refreshed cost arrives.
+func (m model) costSegmentText() (string, bool) {
+	if m.cost == nil || m.cost.JobsTotal == 0 || m.costSeq != m.fetchSeq {
+		return "", false
+	}
+	if m.cost.Complete {
+		return fmt.Sprintf("~$%.2f", m.cost.TotalUSD), true
+	}
+	return fmt.Sprintf("~$%.2f (%d/%d)", m.cost.TotalUSD, m.cost.JobsWithCost, m.cost.JobsTotal), true
+}
 
-	// Title with version, optional update notification, and filter indicators (in stack order)
-	var title strings.Builder
-	fmt.Fprintf(&title, "roborev queue (%s)", version.Version)
+// statusSeg is one segment of the queue status line. Segments with a lower prio
+// are dropped first when the line does not fit the terminal width.
+type statusSeg struct {
+	rendered string // already styled; display width measured with xansi
+	prio     int
+}
+
+// fitStatusSegments joins rendered segments in slice order with sep, dropping
+// the lowest-prio segment until the result fits within width. The single
+// highest-prio segment is always kept; callers truncate as a final guard.
+func fitStatusSegments(segs []statusSeg, sep string, width int) string {
+	keep := make([]bool, len(segs))
+	for i := range keep {
+		keep[i] = true
+	}
+	join := func() string {
+		parts := make([]string, 0, len(segs))
+		for i, s := range segs {
+			if keep[i] {
+				parts = append(parts, s.rendered)
+			}
+		}
+		return strings.Join(parts, sep)
+	}
+	for width > 0 && xansi.StringWidth(join()) > width {
+		lowest, kept := -1, 0
+		for i := range segs {
+			if !keep[i] {
+				continue
+			}
+			kept++
+			if lowest == -1 || segs[i].prio < segs[lowest].prio {
+				lowest = i
+			}
+		}
+		if kept <= 1 {
+			break
+		}
+		keep[lowest] = false
+	}
+	return join()
+}
+
+// renderQueueStatusLine builds the width-adaptive status line (line 2 of the
+// queue header). Segments are dropped lowest-priority-first until the line fits
+// m.width: Completed and Closed go before Workers, while Open and approximate
+// cost are kept longest. Version info lives in the title bar, so it never
+// appears here.
+func (m model) renderQueueStatusLine(done, closed, open int) string {
+	width := m.width
+	if width <= 0 {
+		width = 100
+	}
+	sep := statusStyle.Render(" | ")
+
+	segs := []statusSeg{
+		{rendered: statusStyle.Render(fmt.Sprintf("Workers: %d/%d", m.status.ActiveWorkers, m.status.MaxWorkers)), prio: 30},
+		{rendered: statusStyle.Render(fmt.Sprintf("Completed: %d", done)), prio: 10},
+		{rendered: statusStyle.Render(fmt.Sprintf("Closed: %d", closed)), prio: 20},
+		{rendered: statusStyle.Render(fmt.Sprintf("Open: %d", open)), prio: 90},
+	}
+	if text, ok := m.costSegmentText(); ok {
+		segs = append(segs, statusSeg{rendered: statusStyle.Render(text), prio: 80})
+	}
+
+	line := fitStatusSegments(segs, sep, width)
+	if xansi.StringWidth(line) > width {
+		line = xansi.Truncate(line, width, "")
+	}
+	return line
+}
+
+// titleFilters renders the active repo/branch filter chips (in stack order) in
+// the title style, each with a leading space, or "" when no filter is active.
+func (m model) titleFilters() string {
+	var chips strings.Builder
 	for _, filterType := range m.filterStack {
 		switch filterType {
 		case filterTypeRepo:
 			if len(m.activeRepoFilter) > 0 {
-				filterName := m.repoFilterDisplayName()
-				fmt.Fprintf(&title, " [f: %s]", filterName)
+				fmt.Fprintf(&chips, " [f: %s]", m.repoFilterDisplayName())
 			}
 		case filterTypeBranch:
 			if m.activeBranchFilter != "" {
-				fmt.Fprintf(&title, " [b: %s]", m.activeBranchFilter)
+				fmt.Fprintf(&chips, " [b: %s]", m.activeBranchFilter)
 			}
 		}
 	}
+	if chips.Len() == 0 {
+		return ""
+	}
+	return titleStyle.Render(chips.String())
+}
+
+// fitTitleLeft fits the left side of the title (app + filters + the
+// hiding-closed flag) to width. On overflow it drops the hiding-closed flag
+// first, then truncates with an ellipsis so the leftmost, most important
+// filters (repo before branch) survive longest.
+func fitTitleLeft(app, filters, hideClosed string, width int) string {
+	if full := app + filters + hideClosed; xansi.StringWidth(full) <= width {
+		return full
+	}
+	if withFilters := app + filters; xansi.StringWidth(withFilters) <= width {
+		return withFilters
+	}
+	return xansi.Truncate(app+filters, width, "…")
+}
+
+// renderQueueTitle builds line 1 of the queue header. The app name and active
+// filter chips take the prominent left space; the client version is reference
+// info, right-aligned and dimmed, and is the first thing dropped when the line
+// is tight (then the hiding-closed flag, then filter text truncates). On a
+// daemon/client version mismatch the daemon version is shown in red inside the
+// parentheses ("roborev (<client>, Daemon: <daemon>)") in place of the
+// right-aligned version, so the warning is prominent and self-explanatory.
+func (m model) renderQueueTitle() string {
+	width := m.width
+	if width <= 0 {
+		width = 100
+	}
+
+	var app string
+	if m.versionMismatch {
+		daemonVersion := m.daemonVersion
+		if daemonVersion == "" {
+			daemonVersion = "?"
+		}
+		app = titleStyle.Render("roborev ("+version.Version+", ") +
+			errorStyle.Render("Daemon: "+daemonVersion) +
+			titleStyle.Render(")")
+	} else {
+		app = titleStyle.Render("roborev")
+	}
+
+	filters := m.titleFilters()
+	hideClosed := ""
 	if m.hideClosed {
-		title.WriteString(" [hiding closed]")
+		hideClosed = titleStyle.Render(" [hiding closed]")
 	}
-	b.WriteString(titleStyle.Render(title.String()))
-	// In compact mode, show version mismatch inline since the status area is hidden
-	if compact && m.versionMismatch {
-		b.WriteString(" ")
-		b.WriteString(m.renderDaemonStatus())
+
+	// Matching: right-align the dimmed version when there is room for it (with
+	// at least two spaces of separation); otherwise it drops out entirely.
+	if !m.versionMismatch {
+		right := statusStyle.Render(version.Version)
+		full := app + filters + hideClosed
+		if gap := width - xansi.StringWidth(full) - xansi.StringWidth(right); gap >= 2 {
+			return full + strings.Repeat(" ", gap) + right
+		}
 	}
+	return fitTitleLeft(app, filters, hideClosed, width)
+}
+
+func (m model) renderQueueView() string {
+	var b strings.Builder
+	compact := m.queueCompact()
+
+	b.WriteString(m.renderQueueTitle())
 	b.WriteString("\x1b[K\n") // Clear to end of line
 
 	if !compact {
 		// Status line - use server-side aggregate counts for paginated views
 		// (including multi-repo display names, scoped via an IN clause). Only
 		// the "(none)" branch sentinel still loads all jobs to count locally.
-		var statusLine string
 		var done, closed, open int
 		if m.activeBranchFilter == branchNone {
 			// Client-side filtered views load all jobs, so count locally
@@ -330,16 +473,7 @@ func (m model) renderQueueView() string {
 			closed = m.jobStats.Closed
 			open = m.jobStats.Open
 		}
-		b.WriteString(m.renderDaemonStatus())
-		if len(m.activeRepoFilter) > 0 || m.activeBranchFilter != "" {
-			statusLine = fmt.Sprintf(" | Completed: %d | Closed: %d | Open: %d",
-				done, closed, open)
-		} else {
-			statusLine = fmt.Sprintf(" | Workers: %d/%d | Completed: %d | Closed: %d | Open: %d",
-				m.status.ActiveWorkers, m.status.MaxWorkers,
-				done, closed, open)
-		}
-		b.WriteString(statusStyle.Render(statusLine))
+		b.WriteString(m.renderQueueStatusLine(done, closed, open))
 		b.WriteString("\x1b[K\n") // Clear status line
 
 		// Update notification on line 3 (above the table)

--- a/cmd/roborev/tui/status_line_test.go
+++ b/cmd/roborev/tui/status_line_test.go
@@ -1,0 +1,142 @@
+package tui
+
+import (
+	"testing"
+
+	xansi "github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+
+	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/version"
+)
+
+func TestFitStatusSegments(t *testing.T) {
+	assert := assert.New(t)
+	segs := []statusSeg{
+		{rendered: "Daemon: v1", prio: 0},
+		{rendered: "Workers: 0/4", prio: 30},
+		{rendered: "Completed: 5", prio: 10},
+		{rendered: "Closed: 4", prio: 20},
+		{rendered: "Open: 1", prio: 90},
+		{rendered: "~$1.00", prio: 80},
+	}
+	sep := " | "
+
+	full := "Daemon: v1 | Workers: 0/4 | Completed: 5 | Closed: 4 | Open: 1 | ~$1.00"
+	assert.Equal(full, fitStatusSegments(segs, sep, 200), "wide width keeps every segment")
+
+	// Tight width drops lowest-prio first (Daemon, Completed, Closed) and keeps
+	// Workers, Open, and cost.
+	got := fitStatusSegments(segs, sep, 40)
+	assert.LessOrEqual(xansi.StringWidth(got), 40)
+	assert.NotContains(got, "Daemon", "redundant daemon version drops first")
+	assert.NotContains(got, "Completed")
+	assert.NotContains(got, "Closed")
+	assert.Contains(got, "Workers: 0/4")
+	assert.Contains(got, "Open: 1")
+	assert.Contains(got, "~$1.00")
+
+	// Below any single segment's width, the highest-prio segment survives;
+	// the caller truncates as a final guard.
+	assert.Equal("Open: 1", fitStatusSegments(segs, sep, 3), "highest-prio segment always kept")
+
+	// Unknown width (0) keeps everything rather than dropping blindly.
+	assert.Equal(full, fitStatusSegments(segs, sep, 0))
+}
+
+func TestRenderQueueStatusLineAdaptsToWidth(t *testing.T) {
+	assert := assert.New(t)
+	m := model{
+		width:         200,
+		daemonVersion: "v1.0.0",
+		cost:          &storage.CostAggregate{TotalUSD: 12.50, JobsWithCost: 8, JobsTotal: 10},
+	}
+	m.status.ActiveWorkers = 1
+	m.status.MaxWorkers = 4
+
+	wide := m.renderQueueStatusLine(100, 90, 5)
+	assert.NotContains(wide, "Daemon", "version info lives in the title, not the metric line")
+	assert.Contains(wide, "Workers: 1/4")
+	assert.Contains(wide, "Completed: 100")
+	assert.Contains(wide, "Closed: 90")
+	assert.Contains(wide, "Open: 5")
+	assert.Contains(wide, "~$12.50 (8/10)")
+
+	m.width = 40
+	narrow := m.renderQueueStatusLine(100, 90, 5)
+	assert.LessOrEqual(xansi.StringWidth(narrow), 40, "must fit the terminal width")
+	assert.NotContains(narrow, "Completed")
+	assert.NotContains(narrow, "Closed")
+	assert.Contains(narrow, "Open: 5")
+	assert.Contains(narrow, "~$12.50", "cost is kept longer than Completed/Closed")
+}
+
+func TestRenderQueueTitleShowsMismatch(t *testing.T) {
+	assert := assert.New(t)
+
+	// Matching daemon: client version right-aligned, no daemon callout anywhere.
+	m := model{width: 200, daemonVersion: version.Version}
+	title := m.renderQueueTitle()
+	assert.Contains(title, "roborev")
+	assert.Contains(title, version.Version, "client version is still shown (right-aligned)")
+	assert.NotContains(title, "Daemon:")
+
+	// Mismatch: the daemon version is shown inside the parens alongside the
+	// client version (rendered red), and "queue"/"[MISMATCH]" are gone.
+	m = model{width: 200, daemonVersion: "v0.0.1-old", versionMismatch: true}
+	title = m.renderQueueTitle()
+	assert.Contains(title, "Daemon: v0.0.1-old")
+	assert.Contains(title, version.Version, "client version still shown")
+	assert.NotContains(title, "[MISMATCH]")
+	assert.NotContains(title, "queue")
+}
+
+func TestFitTitleLeft(t *testing.T) {
+	assert := assert.New(t)
+	app := "roborev"
+	filters := " [f: roborev] [b: feat/aggregate-cost]"
+	hideClosed := " [hiding closed]"
+	full := app + filters + hideClosed
+
+	// Wide: everything kept.
+	assert.Equal(full, fitTitleLeft(app, filters, hideClosed, 200))
+
+	// Medium: the hiding-closed flag drops as a unit; filters stay intact.
+	assert.Equal(app+filters, fitTitleLeft(app, filters, hideClosed, len(app+filters)+2))
+
+	// Narrow: truncates with an ellipsis; app + the leftmost filter survive.
+	got := fitTitleLeft(app, filters, hideClosed, 25)
+	assert.LessOrEqual(xansi.StringWidth(got), 25)
+	assert.Contains(got, "roborev")
+	assert.Contains(got, "[f: roborev")
+	assert.Contains(got, "…")
+}
+
+func TestRenderQueueTitleRightAlignsVersion(t *testing.T) {
+	assert := assert.New(t)
+
+	// Wide: the version is pushed to the far right and the line fits the width.
+	m := model{width: 200, daemonVersion: version.Version}
+	wide := m.renderQueueTitle()
+	assert.LessOrEqual(xansi.StringWidth(wide), 200)
+	assert.Contains(wide, "roborev")
+	assert.Contains(wide, version.Version)
+
+	// Too narrow for the version: it drops out entirely; the app name stays.
+	m.width = len("roborev") + 1
+	narrow := m.renderQueueTitle()
+	assert.LessOrEqual(xansi.StringWidth(narrow), len("roborev")+1)
+	assert.Contains(narrow, "roborev")
+}
+
+func TestRenderQueueStatusLineOmitsStaleCost(t *testing.T) {
+	assert := assert.New(t)
+	m := model{
+		width:    200,
+		fetchSeq: 3,
+		costSeq:  2, // stale: predates the active filter generation
+		cost:     &storage.CostAggregate{TotalUSD: 9.99, JobsWithCost: 1, JobsTotal: 2},
+	}
+	got := m.renderQueueStatusLine(0, 0, 0)
+	assert.NotContains(got, "~$", "stale cost segment omitted from the status line")
+}

--- a/cmd/roborev/tui/tui.go
+++ b/cmd/roborev/tui/tui.go
@@ -263,7 +263,9 @@ type model struct {
 	api              *roborevclient.Client
 	glamourStyle     gansi.StyleConfig // detected once at init
 	jobs             []storage.ReviewJob
-	jobStats         storage.JobStats // aggregate done/closed/open from server
+	jobStats         storage.JobStats       // aggregate done/closed/open from server
+	cost             *storage.CostAggregate // approx agent spend for the active filter scope; nil = hidden
+	costSeq          int                    // fetchSeq of the stored cost; segment hides until it matches m.fetchSeq
 	status           storage.DaemonStatus
 	selectedIdx      int
 	selectedJobID    int64                          // Track selected job by ID to maintain position on refresh
@@ -849,6 +851,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		result, cmd = m.handleJobsMsg(msg)
 	case statusMsg:
 		result, cmd = m.handleStatusMsg(msg)
+	case costMsg:
+		result, cmd = m.handleCostMsg(msg)
 	case updateCheckMsg:
 		result, cmd = m.handleUpdateCheckMsg(msg)
 	case reviewMsg:

--- a/cmd/roborev/tui/tui_test.go
+++ b/cmd/roborev/tui/tui_test.go
@@ -87,6 +87,28 @@ func mockServerModel(t *testing.T, handler http.HandlerFunc) (*httptest.Server, 
 	return ts, newModel(testEndpointFromURL(ts.URL), withExternalIODisabled())
 }
 
+// jobsMsgFromBatch executes a fetchJobs-derived command and returns the message
+// from its jobs command. fetchJobs batches the jobs fetch with a cost fetch
+// (tea.Batch(jobsCmd, fetchCost)), so the command yields a tea.BatchMsg whose
+// first command is the jobs fetch. Running only batch[0] keeps the cost request
+// from overwriting query params recorded by tests that inspect the jobs request.
+func jobsMsgFromBatch(t *testing.T, cmd tea.Cmd) tea.Msg {
+	t.Helper()
+	require.NotNil(t, cmd, "expected a fetch command")
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	require.True(t, ok, "fetchJobs should return a tea.BatchMsg, got %T", msg)
+	require.NotEmpty(t, batch, "batch should contain the jobs command")
+	return batch[0]()
+}
+
+// fetchJobsMessage runs fetchJobs and returns the jobs message. These tests
+// assert on the jobs result, so it executes only the jobs command in the batch.
+func fetchJobsMessage(t *testing.T, m model) tea.Msg {
+	t.Helper()
+	return jobsMsgFromBatch(t, m.fetchJobs())
+}
+
 // pressKey simulates pressing a rune key and returns the updated model.
 func pressKey(m model, r rune) (model, tea.Cmd) {
 	updated, cmd := m.Update(keyPressMsg(r))
@@ -253,8 +275,7 @@ func TestTUIFetchJobsSuccess(t *testing.T) {
 		jobs := []storage.ReviewJob{{ID: 1, GitRef: "abc123", Agent: "test"}}
 		json.NewEncoder(w).Encode(map[string]any{"jobs": jobs})
 	})
-	cmd := m.fetchJobs()
-	msg := cmd()
+	msg := fetchJobsMessage(t, m)
 
 	jobs, ok := msg.(jobsMsg)
 	if !ok {
@@ -273,8 +294,7 @@ func TestTUIFetchJobsError(t *testing.T) {
 	_, m := mockServerModel(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
-	cmd := m.fetchJobs()
-	msg := cmd()
+	msg := fetchJobsMessage(t, m)
 
 	_, ok := msg.(jobsErrMsg)
 	if !ok {
@@ -293,8 +313,7 @@ func TestTUIHTTPTimeout(t *testing.T) {
 	// Override with short timeout for test (10x shorter than server delay)
 	m.client.Timeout = 50 * time.Millisecond
 
-	cmd := m.fetchJobs()
-	msg := cmd()
+	msg := fetchJobsMessage(t, m)
 
 	_, ok := msg.(jobsErrMsg)
 	if !ok {
@@ -863,7 +882,7 @@ func TestTUIVersionMismatchDetection(t *testing.T) {
 		}
 	})
 
-	t.Run("displays error banner in queue view when mismatched", func(t *testing.T) {
+	t.Run("shows daemon version in title when mismatched", func(t *testing.T) {
 		m := newModel(testEndpoint, withExternalIODisabled())
 		m.width = 100
 		m.height = 30
@@ -873,21 +892,8 @@ func TestTUIVersionMismatchDetection(t *testing.T) {
 
 		output := m.View().Content
 
-		if !strings.Contains(output, "Daemon: old-version") {
-			assert.Condition(t, func() bool {
-				return false
-			}, "Expected queue view to show daemon version")
-		}
-		if !strings.Contains(output, "[MISMATCH]") {
-			assert.Condition(t, func() bool {
-				return false
-			}, "Expected queue view to show mismatch badge")
-		}
-		if strings.Contains(output, "VERSION MISMATCH") {
-			assert.Condition(t, func() bool {
-				return false
-			}, "Expected queue view to move mismatch warning out of footer")
-		}
+		assert.Contains(t, output, "Daemon: old-version", "queue title must show the daemon version on mismatch")
+		assert.NotContains(t, output, "[MISMATCH]", "the [MISMATCH] badge was replaced by the red title callout")
 	})
 
 	t.Run("does not display daemon status in review view when mismatched", func(t *testing.T) {

--- a/cmd/roborev/tui/types.go
+++ b/cmd/roborev/tui/types.go
@@ -138,6 +138,10 @@ type statusMsg struct {
 	status storage.DaemonStatus
 	gen    uint64 // fetch generation — discard if < model.fetchGen
 }
+type costMsg struct {
+	cost *storage.CostAggregate // nil = hide segment (error or unexpressible scope)
+	seq  int                    // fetch sequence — stale responses (seq < model.fetchSeq) discarded
+}
 type reviewMsg struct {
 	review     *storage.Review
 	responses  []storage.Response // Responses for this review

--- a/internal/backfill/tokens.go
+++ b/internal/backfill/tokens.go
@@ -141,7 +141,7 @@ func ApplyTokenUsage(
 			result.Agent = job.Agent
 			result.Summary = merged.FormatSummary()
 			if !dryRun {
-				if err := db.SaveJobTokenUsage(job.ID, tokens.ToJSON(merged)); err != nil {
+				if err := db.SaveJobTokenUsage(job.ID, job.SessionID, tokens.ToJSON(merged)); err != nil {
 					result.Status = ResultFailed
 					result.Reason = err.Error()
 					summary.Failed++

--- a/internal/daemon/panel_posting_test.go
+++ b/internal/daemon/panel_posting_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -73,6 +74,17 @@ func setJobTiming(t *testing.T, db *storage.DB, jobID int64, startedAt, finished
 	t.Helper()
 	_, err := db.Exec(`UPDATE review_jobs SET started_at = ?, finished_at = ? WHERE id = ?`, startedAt, finishedAt, jobID)
 	require.NoError(t, err)
+}
+
+// seedJobCost prices a job the way the worker does — token usage scoped to the
+// job's captured session — by assigning a session id and storing the usage
+// blob against it.
+func seedJobCost(t *testing.T, db *storage.DB, jobID int64, tokenUsageJSON string) {
+	t.Helper()
+	sessionID := fmt.Sprintf("sess-%d", jobID)
+	_, err := db.Exec(`UPDATE review_jobs SET session_id = ? WHERE id = ?`, sessionID, jobID)
+	require.NoError(t, err)
+	require.NoError(t, db.SaveJobTokenUsage(jobID, sessionID, tokenUsageJSON))
 }
 
 // panelPostedAt reports whether the panel row's posted_at is set.
@@ -511,9 +523,9 @@ func TestPanelWrapperNoDoubleHeader(t *testing.T) {
 		setJobTiming(t, h.DB, members[0].ID, "2026-06-01T18:00:00Z", "2026-06-01T18:04:32Z")
 		setJobTiming(t, h.DB, members[1].ID, "2026-06-01T18:00:00Z", "2026-06-01T18:02:08Z")
 		setJobTiming(t, h.DB, synth.ID, "2026-06-01T18:04:40Z", "2026-06-01T18:04:58Z")
-		require.NoError(t, h.DB.SaveJobTokenUsage(members[0].ID, `{"cost_usd":0.11,"has_cost":true}`))
-		require.NoError(t, h.DB.SaveJobTokenUsage(members[1].ID, `{"cost_usd":0.06,"has_cost":true}`))
-		require.NoError(t, h.DB.SaveJobTokenUsage(synth.ID, `{"cost_usd":0.03,"has_cost":true}`))
+		seedJobCost(t, h.DB, members[0].ID, `{"cost_usd":0.11,"has_cost":true}`)
+		seedJobCost(t, h.DB, members[1].ID, `{"cost_usd":0.06,"has_cost":true}`)
+		seedJobCost(t, h.DB, synth.ID, `{"cost_usd":0.03,"has_cost":true}`)
 		h.completeSynthesisWithReview(t, synth.ID, "Medium issue found.")
 
 		h.Poller.handleReviewCompleted(ciEvent(synth.ID, "review.completed"))
@@ -540,9 +552,9 @@ func TestPanelWrapperNoDoubleHeader(t *testing.T) {
 		setJobTiming(t, h.DB, members[0].ID, "2026-06-01T18:00:00Z", "2026-06-01T18:04:32Z")
 		setJobTiming(t, h.DB, members[1].ID, "2026-06-01T18:00:00Z", "2026-06-01T18:02:08Z")
 		setJobTiming(t, h.DB, synth.ID, "2026-06-01T18:04:40Z", "2026-06-01T18:04:58Z")
-		require.NoError(t, h.DB.SaveJobTokenUsage(members[0].ID, `{"cost_usd":0.11,"has_cost":true}`))
-		require.NoError(t, h.DB.SaveJobTokenUsage(members[1].ID, `{"cost_usd":0.06,"has_cost":true}`))
-		require.NoError(t, h.DB.SaveJobTokenUsage(synth.ID, `{"cost_usd":0.03,"has_cost":true}`))
+		seedJobCost(t, h.DB, members[0].ID, `{"cost_usd":0.11,"has_cost":true}`)
+		seedJobCost(t, h.DB, members[1].ID, `{"cost_usd":0.06,"has_cost":true}`)
+		seedJobCost(t, h.DB, synth.ID, `{"cost_usd":0.03,"has_cost":true}`)
 		h.completeSynthesisWithReview(t, synth.ID, "Medium issue found.")
 
 		h.Poller.handleReviewCompleted(ciEvent(synth.ID, "review.completed"))
@@ -566,7 +578,7 @@ func TestPanelWrapperNoDoubleHeader(t *testing.T) {
 			})
 		setJobTiming(t, h.DB, members[0].ID, "2026-06-01T18:00:00Z", "2026-06-01T18:04:32Z")
 		setJobTiming(t, h.DB, members[1].ID, "2026-06-01T18:00:00Z", "2026-06-01T18:01:14Z")
-		require.NoError(t, h.DB.SaveJobTokenUsage(members[0].ID, `{"cost_usd":0.11,"has_cost":true}`))
+		seedJobCost(t, h.DB, members[0].ID, `{"cost_usd":0.11,"has_cost":true}`)
 		h.completeSynthesisWithReview(t, synth.ID, "Medium issue found.")
 
 		h.Poller.handleReviewCompleted(ciEvent(synth.ID, "review.completed"))

--- a/internal/daemon/routes.go
+++ b/internal/daemon/routes.go
@@ -89,6 +89,13 @@ func (s *Server) registerHumaAPI(mux *http.ServeMux) huma.API {
 			o.Tags = []string{"daemon"}
 		})
 
+	huma.Get(api, "/api/cost", s.humaGetCost,
+		func(o *huma.Operation) {
+			o.OperationID = "get-cost"
+			o.Summary = "Get aggregate review cost"
+			o.Tags = []string{"daemon"}
+		})
+
 	huma.Get(api, "/api/health", s.humaGetHealth,
 		func(o *huma.Operation) {
 			o.OperationID = "get-health"

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -1399,6 +1399,44 @@ func (s *Server) humaGetSummary(
 	return &GetSummaryOutput{Body: summary}, nil
 }
 
+// costOptionsFromInput maps request params to storage.CostOptions. An empty
+// since means all-time (zero Time); a malformed since is an error.
+func costOptionsFromInput(input *GetCostInput) (storage.CostOptions, error) {
+	opts := storage.CostOptions{
+		RepoPaths:   input.Repo,
+		Branch:      input.Branch,
+		BranchEmpty: input.BranchEmpty == "true",
+	}
+	if input.Since != "" {
+		d, err := parseDuration(input.Since)
+		if err != nil {
+			return storage.CostOptions{}, err
+		}
+		opts.Since = time.Now().Add(-d)
+	}
+	return opts, nil
+}
+
+func (s *Server) humaGetCost(
+	ctx context.Context, input *GetCostInput,
+) (*GetCostOutput, error) {
+	opts, err := costOptionsFromInput(input)
+	if err != nil {
+		return nil, huma.Error400BadRequest(
+			fmt.Sprintf("invalid since value: %s", input.Since),
+		)
+	}
+
+	cost, err := s.db.GetCostAggregate(opts)
+	if err != nil {
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("get cost: %v", err),
+		)
+	}
+
+	return &GetCostOutput{Body: cost}, nil
+}
+
 func (s *Server) humaCancelJob(
 	ctx context.Context, input *CancelJobInput,
 ) (*CancelJobOutput, error) {

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -659,3 +659,25 @@ func TestServerStop_StopsCIPoller(t *testing.T) {
 		}, "expected poller stopped after Server.Stop, got (%v, %q)", healthy, msg)
 	}
 }
+
+func TestCostOptionsFromInput(t *testing.T) {
+	assert := assert.New(t)
+
+	opts, err := costOptionsFromInput(&GetCostInput{
+		Repo:        []string{"/a", "/b"},
+		BranchEmpty: "true",
+	})
+	require.NoError(t, err)
+	assert.Equal([]string{"/a", "/b"}, opts.RepoPaths)
+	assert.True(opts.BranchEmpty)
+	assert.True(opts.Since.IsZero(), "empty since means all-time")
+
+	opts, err = costOptionsFromInput(&GetCostInput{Branch: "main", Since: "7d"})
+	require.NoError(t, err)
+	assert.Equal("main", opts.Branch)
+	assert.False(opts.BranchEmpty)
+	assert.False(opts.Since.IsZero())
+
+	_, err = costOptionsFromInput(&GetCostInput{Since: "bogus"})
+	assert.Error(err)
+}

--- a/internal/daemon/synthesis_worker.go
+++ b/internal/daemon/synthesis_worker.go
@@ -235,6 +235,10 @@ func (wp *WorkerPool) runSynthesisAgent(
 
 	var output string
 	if synthAgent, ok := a.(agent.SynthesisAgent); ok {
+		// No pre-agent gate on this path; mark immediately before the agent runs
+		// to keep the "set only when an agent actually runs" invariant adjacent
+		// to the call.
+		wp.markAgentInvoked(workerID, job, a)
 		output, err = synthAgent.Synthesize(ctx, prompt, agentOutput)
 	} else {
 		// Verify findings against the reviewed checkout: a panel enqueued from a
@@ -249,6 +253,9 @@ func (wp *WorkerPool) runSynthesisAgent(
 			wp.failOrRetry(workerID, job, agentName, fmt.Sprintf("prepare checkout: %v", checkoutErr))
 			return "", agentName, checkoutErr
 		}
+		// Checkout succeeded and the agent is about to run; mark it invoked only
+		// now so a checkout failure above is never miscounted as an agent run.
+		wp.markAgentInvoked(workerID, job, a)
 		output, err = a.Review(ctx, checkout.agentRepoPath, job.GitRef, prompt, agentOutput)
 	}
 	sessionWriter.Flush()
@@ -306,9 +313,6 @@ func (wp *WorkerPool) configureSynthesisAgent(
 	}
 
 	agentName := a.Name()
-	if err := wp.db.SaveJobCommandLine(job.ID, a.CommandLine()); err != nil {
-		log.Printf("[%s] Error saving command line for job %d: %v", workerID, job.ID, err)
-	}
 	return a, agentName, nil
 }
 

--- a/internal/daemon/synthesis_worker_test.go
+++ b/internal/daemon/synthesis_worker_test.go
@@ -17,6 +17,7 @@ import (
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/testutil"
 	"go.kenn.io/roborev/internal/tokens"
 )
 
@@ -86,6 +87,76 @@ func registerNeverCalledAgent(t *testing.T, name string, called *bool) {
 		},
 	})
 	t.Cleanup(func() { agent.Unregister(name) })
+}
+
+// jobAgentInvoked reads the raw agent_invoked cost-eligibility marker for a job.
+func jobAgentInvoked(t *testing.T, tc *workerTestContext, jobID int64) bool {
+	t.Helper()
+	var invoked int
+	require.NoError(t, tc.DB.QueryRow(
+		`SELECT agent_invoked FROM review_jobs WHERE id = ?`, jobID).Scan(&invoked))
+	return invoked == 1
+}
+
+// TestRunSynthesisAgentMarksInvokedOnlyWhenAgentRuns is the regression for the
+// pre-agent over-count: a synthesis job whose checkout fails before the agent
+// runs must not be marked agent_invoked, while one whose agent actually runs
+// must be. The marker moved out of configureSynthesisAgent (which precedes the
+// checkout gate) to immediately before each agent call.
+func TestRunSynthesisAgentMarksInvokedOnlyWhenAgentRuns(t *testing.T) {
+	t.Run("checkout failure is not counted as an agent run", func(t *testing.T) {
+		tc := newWorkerTestContext(t, 1)
+		const synthAgent = "synth-checkout-fail"
+		registerPassingAgent(t, synthAgent)
+
+		_, _, synth := enqueuePanelRun(t, tc, "checkout-fail-panel", []memberSpec{
+			{name: "m0", agent: "test"},
+		})
+		// The passing agent is not a SynthesisAgent, so the regular Review path
+		// runs prepareJobCheckout. Force a CI exact checkout (source=ci) at a head
+		// that cannot resolve so the checkout fails before the agent runs, with
+		// retries pre-exhausted and no backup so the failure is terminal: FailJob
+		// preserves agent_invoked, whereas a requeue would clear it and mask a
+		// marker leaked during agent configuration.
+		_, err := tc.DB.Exec(
+			`UPDATE review_jobs SET status='running', worker_id=?, retry_count=?, agent=?, backup_agent='', source=?, git_ref=? WHERE id=?`,
+			testWorkerID, maxRetries, synthAgent, storage.JobSourceCI,
+			"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", synth.ID)
+		require.NoError(t, err)
+		job, err := tc.DB.GetJobByID(synth.ID)
+		require.NoError(t, err)
+
+		_, _, runErr := tc.Pool.runSynthesisAgent(context.Background(), testWorkerID, job, "prompt")
+		require.Error(t, runErr, "checkout must fail before the agent runs")
+
+		failed, err := tc.DB.GetJobByID(synth.ID)
+		require.NoError(t, err)
+		assert.Equal(t, storage.JobStatusFailed, failed.Status, "retries exhausted -> terminal failed")
+		assert.False(t, jobAgentInvoked(t, tc, synth.ID),
+			"a checkout failure that never ran an agent must not be counted, even at terminal failure")
+	})
+
+	t.Run("successful synthesis run is counted", func(t *testing.T) {
+		tc := newWorkerTestContext(t, 1)
+		const synthAgent = "synth-runs-ok"
+		registerPassingAgent(t, synthAgent)
+
+		_, _, synth := enqueuePanelRun(t, tc, "runs-ok-panel", []memberSpec{
+			{name: "m0", agent: "test"},
+		})
+		sha := testutil.GetHeadSHA(t, tc.TmpDir)
+		_, err := tc.DB.Exec(
+			`UPDATE review_jobs SET status='running', worker_id=?, agent=?, source='', git_ref=? WHERE id=?`,
+			testWorkerID, synthAgent, sha, synth.ID)
+		require.NoError(t, err)
+		job, err := tc.DB.GetJobByID(synth.ID)
+		require.NoError(t, err)
+
+		_, _, runErr := tc.Pool.runSynthesisAgent(context.Background(), testWorkerID, job, "prompt")
+		require.NoError(t, runErr)
+		assert.True(t, jobAgentInvoked(t, tc, synth.ID),
+			"a synthesis agent that actually runs must be marked agent_invoked")
+	})
 }
 
 type synthesisEntrypointTestAgent struct {

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -298,6 +298,21 @@ type GetSummaryOutput struct {
 	Body *storage.Summary
 }
 
+// -- GET /api/cost --
+
+// GetCostInput holds query parameters for the cost endpoint.
+type GetCostInput struct {
+	Repo        []string `query:"repo,explode" doc:"Repo root paths (repeatable)"`
+	Branch      string   `query:"branch" doc:"Filter by branch name"`
+	BranchEmpty string   `query:"branch_empty" doc:"Only jobs with empty/unset branch" enum:"true,false"`
+	Since       string   `query:"since" doc:"Time window (e.g. 7d); default all-time"`
+}
+
+// GetCostOutput is the response for GET /api/cost.
+type GetCostOutput struct {
+	Body storage.CostAggregate
+}
+
 // RawJSONOutput is used by endpoints with union response shapes while their
 // core behavior is represented by Huma request types.
 type RawJSONOutput struct {

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -343,6 +343,17 @@ func (wp *WorkerPool) prepareJobCheckout(
 	}, nil
 }
 
+// markAgentInvoked records that an agent is being invoked for this attempt. Call
+// it only after all pre-agent gates pass, immediately before the agent runs, so
+// a job that fails a gate is never counted as an agent run. This is the synced
+// cost-eligibility signal (and stores the command line for TUI display); a
+// failed write only under-reports cost, so it is logged, not fatal.
+func (wp *WorkerPool) markAgentInvoked(workerID string, job *storage.ReviewJob, a agent.Agent) {
+	if err := wp.db.MarkJobAgentInvoked(job.ID, workerID, a.CommandLine()); err != nil {
+		log.Printf("[%s] Error marking agent invoked for job %d: %v", workerID, job.ID, err)
+	}
+}
+
 func (wp *WorkerPool) jobRequiresCIExactCheckout(job *storage.ReviewJob) (bool, error) {
 	if job == nil || job.PanelRunUUID == "" || job.IsFixJob() {
 		return false, nil
@@ -698,12 +709,6 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 		log.Printf("[%s] Agent %s not available, using %s", workerID, job.Agent, agentName)
 	}
 
-	// Store the actual command line so the TUI displays what the
-	// daemon executes, not a client-side reconstruction.
-	if err := wp.db.SaveJobCommandLine(job.ID, a.CommandLine()); err != nil {
-		log.Printf("[%s] Error saving command line: %v", workerID, err)
-	}
-
 	// Enforce the final submission size after all prompt transformations.
 	// Oversized prompts are deterministic and should never be sent to any
 	// agent just to discover a context-window failure.
@@ -784,6 +789,10 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 		reviewRepoPath = wt.Dir
 		log.Printf("[%s] Fix job %d: running agent in worktree %s", workerID, job.ID, wt.Dir)
 	}
+
+	// Record that an agent is being invoked, now that all pre-agent gates
+	// (prompt size, worktree creation) have passed.
+	wp.markAgentInvoked(workerID, job, a)
 
 	// Run the review
 	log.Printf("[%s] Running %s %sreview (job %d)...",
@@ -1289,7 +1298,7 @@ func (wp *WorkerPool) captureTokenUsageForSession(
 	if usage == nil {
 		return
 	}
-	if err := wp.db.SaveJobTokenUsage(job.ID, tokens.ToJSON(usage)); err != nil {
+	if err := wp.db.SaveJobTokenUsage(job.ID, capturedSession, tokens.ToJSON(usage)); err != nil {
 		log.Printf("[%s] Warning: save token usage for job %d: %v",
 			workerID, job.ID, err)
 	}

--- a/internal/daemon/worker_classify.go
+++ b/internal/daemon/worker_classify.go
@@ -166,9 +166,7 @@ func (wp *WorkerPool) processClassifyJob(ctx context.Context, workerID string, j
 		if !ok {
 			return false, "", selectedName, fmt.Errorf("classify_agent %q lost SchemaAgent capability after WithReasoning/WithModel", name)
 		}
-		if err := wp.db.SaveJobCommandLine(job.ID, sa.CommandLine()); err != nil {
-			log.Printf("[%s] Error saving classifier command line for job %d: %v", workerID, job.ID, err)
-		}
+		wp.markAgentInvoked(workerID, job, sa)
 		yes, reason, err := newClassifierAdapter(sa, maxBytes, jobLog).Decide(classifyCtx, in)
 		return yes, reason, selectedName, err
 	}

--- a/internal/daemon_client/client.gen.go
+++ b/internal/daemon_client/client.gen.go
@@ -17,6 +17,24 @@ import (
 	"github.com/oapi-codegen/runtime"
 )
 
+// Defines values for GetCostParamsBranchEmpty.
+const (
+	GetCostParamsBranchEmptyFalse GetCostParamsBranchEmpty = "false"
+	GetCostParamsBranchEmptyTrue  GetCostParamsBranchEmpty = "true"
+)
+
+// Valid indicates whether the value is a known member of the GetCostParamsBranchEmpty enum.
+func (e GetCostParamsBranchEmpty) Valid() bool {
+	switch e {
+	case GetCostParamsBranchEmptyFalse:
+		return true
+	case GetCostParamsBranchEmptyTrue:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ListJobsParamsBranchIncludeEmpty.
 const (
 	ListJobsParamsBranchIncludeEmptyEmpty ListJobsParamsBranchIncludeEmpty = ""
@@ -82,16 +100,16 @@ func (e ListJobsParamsHideClassifyJobs) Valid() bool {
 
 // Defines values for GetSummaryParamsAll.
 const (
-	GetSummaryParamsAllFalse GetSummaryParamsAll = "false"
-	GetSummaryParamsAllTrue  GetSummaryParamsAll = "true"
+	False GetSummaryParamsAll = "false"
+	True  GetSummaryParamsAll = "true"
 )
 
 // Valid indicates whether the value is a known member of the GetSummaryParamsAll enum.
 func (e GetSummaryParamsAll) Valid() bool {
 	switch e {
-	case GetSummaryParamsAllFalse:
+	case False:
 		return true
-	case GetSummaryParamsAllTrue:
+	case True:
 		return true
 	default:
 		return false
@@ -201,6 +219,16 @@ type ComponentHealth struct {
 	Name    string  `json:"name"`
 }
 
+// CostAggregate defines model for CostAggregate.
+type CostAggregate struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema       *string `json:"$schema,omitempty"`
+	Complete     bool    `json:"complete"`
+	JobsTotal    int64   `json:"jobs_total"`
+	JobsWithCost int64   `json:"jobs_with_cost"`
+	TotalUsd     float64 `json:"total_usd"`
+}
+
 // DaemonStatus defines model for DaemonStatus.
 type DaemonStatus struct {
 	// Schema A URL to the JSON Schema for this object.
@@ -238,23 +266,26 @@ type DurationStats struct {
 // EnqueueRequest defines model for EnqueueRequest.
 type EnqueueRequest struct {
 	// Schema A URL to the JSON Schema for this object.
-	Schema       *string `json:"$schema,omitempty"`
-	Agent        *string `json:"agent,omitempty"`
-	Agentic      *bool   `json:"agentic,omitempty"`
-	Branch       *string `json:"branch,omitempty"`
-	CommitSha    *string `json:"commit_sha,omitempty"`
-	CustomPrompt *string `json:"custom_prompt,omitempty"`
-	DiffContent  *string `json:"diff_content,omitempty"`
-	GitRef       *string `json:"git_ref,omitempty"`
-	JobType      *string `json:"job_type,omitempty"`
-	MinSeverity  *string `json:"min_severity,omitempty"`
-	Model        *string `json:"model,omitempty"`
-	OutputPrefix *string `json:"output_prefix,omitempty"`
-	Provider     *string `json:"provider,omitempty"`
-	Reasoning    *string `json:"reasoning,omitempty"`
-	RepoPath     string  `json:"repo_path"`
-	ReviewType   *string `json:"review_type,omitempty"`
-	Since        *string `json:"since,omitempty"`
+	Schema       *string   `json:"$schema,omitempty"`
+	Agent        *string   `json:"agent,omitempty"`
+	Agentic      *bool     `json:"agentic,omitempty"`
+	Branch       *string   `json:"branch,omitempty"`
+	CommitSha    *string   `json:"commit_sha,omitempty"`
+	CustomPrompt *string   `json:"custom_prompt,omitempty"`
+	DiffContent  *string   `json:"diff_content,omitempty"`
+	DirtyFiles   *[]string `json:"dirty_files,omitempty"`
+	GitRef       *string   `json:"git_ref,omitempty"`
+	JobType      *string   `json:"job_type,omitempty"`
+	MinSeverity  *string   `json:"min_severity,omitempty"`
+	Model        *string   `json:"model,omitempty"`
+	OutputPrefix *string   `json:"output_prefix,omitempty"`
+	Panel        *string   `json:"panel,omitempty"`
+	Provider     *string   `json:"provider,omitempty"`
+	Reasoning    *string   `json:"reasoning,omitempty"`
+	RepoPath     string    `json:"repo_path"`
+	ReviewType   *string   `json:"review_type,omitempty"`
+	Since        *string   `json:"since,omitempty"`
+	Source       *string   `json:"source,omitempty"`
 }
 
 // EnqueueSkippedResponse defines model for EnqueueSkippedResponse.
@@ -424,6 +455,19 @@ type OverviewStats struct {
 	Total    int64 `json:"total"`
 }
 
+// PanelSummary defines model for PanelSummary.
+type PanelSummary struct {
+	MembersCanceled     int64    `json:"members_canceled"`
+	MembersCostComplete *bool    `json:"members_cost_complete,omitempty"`
+	MembersCostUsd      *float64 `json:"members_cost_usd,omitempty"`
+	MembersFailed       int64    `json:"members_failed"`
+	MembersSkipped      int64    `json:"members_skipped"`
+	MembersSucceeded    int64    `json:"members_succeeded"`
+	MembersTerminal     int64    `json:"members_terminal"`
+	MembersTotal        int64    `json:"members_total"`
+	PanelRunUuid        string   `json:"panel_run_uuid"`
+}
+
 // PingInfo defines model for PingInfo.
 type PingInfo struct {
 	// Schema A URL to the JSON Schema for this object.
@@ -510,6 +554,21 @@ type RerunJobRequest struct {
 	JobId  int64   `json:"job_id"`
 }
 
+// ResolveRepoOutputBody defines model for ResolveRepoOutputBody.
+type ResolveRepoOutputBody struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema  *string       `json:"$schema,omitempty"`
+	Repo    *ResolvedRepo `json:"repo,omitempty"`
+	Tracked bool          `json:"tracked"`
+}
+
+// ResolvedRepo defines model for ResolvedRepo.
+type ResolvedRepo struct {
+	Identity string `json:"identity"`
+	Name     string `json:"name"`
+	RootPath string `json:"root_path"`
+}
+
 // Response defines model for Response.
 type Response struct {
 	// Schema A URL to the JSON Schema for this object.
@@ -547,51 +606,62 @@ type Review struct {
 // ReviewJob defines model for ReviewJob.
 type ReviewJob struct {
 	// Schema A URL to the JSON Schema for this object.
-	Schema            *string    `json:"$schema,omitempty"`
-	Agent             string     `json:"agent"`
-	Agentic           bool       `json:"agentic"`
-	Branch            *string    `json:"branch,omitempty"`
-	Closed            *bool      `json:"closed,omitempty"`
-	CommandLine       *string    `json:"command_line,omitempty"`
-	CommitId          *int64     `json:"commit_id,omitempty"`
-	CommitSubject     *string    `json:"commit_subject,omitempty"`
-	DiffContent       *string    `json:"diff_content,omitempty"`
-	EnqueuedAt        time.Time  `json:"enqueued_at"`
-	Error             *string    `json:"error,omitempty"`
-	FinishedAt        *time.Time `json:"finished_at,omitempty"`
-	GitRef            string     `json:"git_ref"`
-	Id                int64      `json:"id"`
-	JobType           string     `json:"job_type"`
-	MinSeverity       *string    `json:"min_severity,omitempty"`
-	Model             *string    `json:"model,omitempty"`
-	OutputPrefix      *string    `json:"output_prefix,omitempty"`
-	ParentJobId       *int64     `json:"parent_job_id,omitempty"`
-	Patch             *string    `json:"patch,omitempty"`
-	PatchId           *string    `json:"patch_id,omitempty"`
-	Prompt            *string    `json:"prompt,omitempty"`
-	PromptPrebuilt    bool       `json:"prompt_prebuilt"`
-	Provider          *string    `json:"provider,omitempty"`
-	Reasoning         *string    `json:"reasoning,omitempty"`
-	RepoId            int64      `json:"repo_id"`
-	RepoName          *string    `json:"repo_name,omitempty"`
-	RepoPath          *string    `json:"repo_path,omitempty"`
-	RequestedModel    *string    `json:"requested_model,omitempty"`
-	RequestedProvider *string    `json:"requested_provider,omitempty"`
-	RetryCount        int64      `json:"retry_count"`
-	ReviewType        *string    `json:"review_type,omitempty"`
-	SessionId         *string    `json:"session_id,omitempty"`
-	SkipReason        *string    `json:"skip_reason,omitempty"`
-	Source            *string    `json:"source,omitempty"`
-	SourceMachineId   *string    `json:"source_machine_id,omitempty"`
-	StartedAt         *time.Time `json:"started_at,omitempty"`
-	Status            string     `json:"status"`
-	SyncedAt          *time.Time `json:"synced_at,omitempty"`
-	TokenUsage        *string    `json:"token_usage,omitempty"`
-	UpdatedAt         *time.Time `json:"updated_at,omitempty"`
-	Uuid              *string    `json:"uuid,omitempty"`
-	Verdict           *string    `json:"verdict,omitempty"`
-	WorkerId          *string    `json:"worker_id,omitempty"`
-	WorktreePath      *string    `json:"worktree_path,omitempty"`
+	Schema                *string       `json:"$schema,omitempty"`
+	Agent                 string        `json:"agent"`
+	Agentic               bool          `json:"agentic"`
+	BackupAgent           *string       `json:"backup_agent,omitempty"`
+	BackupModel           *string       `json:"backup_model,omitempty"`
+	Branch                *string       `json:"branch,omitempty"`
+	ClaimBlocked          *bool         `json:"claim_blocked,omitempty"`
+	Closed                *bool         `json:"closed,omitempty"`
+	CommandLine           *string       `json:"command_line,omitempty"`
+	CommitId              *int64        `json:"commit_id,omitempty"`
+	CommitSubject         *string       `json:"commit_subject,omitempty"`
+	DiffContent           *string       `json:"diff_content,omitempty"`
+	DirtyFiles            *[]string     `json:"dirty_files,omitempty"`
+	EnqueuedAt            time.Time     `json:"enqueued_at"`
+	Error                 *string       `json:"error,omitempty"`
+	FinishedAt            *time.Time    `json:"finished_at,omitempty"`
+	GitRef                string        `json:"git_ref"`
+	Id                    int64         `json:"id"`
+	JobType               string        `json:"job_type"`
+	MinSeverity           *string       `json:"min_severity,omitempty"`
+	Model                 *string       `json:"model,omitempty"`
+	OutputPrefix          *string       `json:"output_prefix,omitempty"`
+	PanelMemberConfigJson *string       `json:"panel_member_config_json,omitempty"`
+	PanelMemberIndex      *int64        `json:"panel_member_index,omitempty"`
+	PanelMemberName       *string       `json:"panel_member_name,omitempty"`
+	PanelName             *string       `json:"panel_name,omitempty"`
+	PanelRole             *string       `json:"panel_role,omitempty"`
+	PanelRunUuid          *string       `json:"panel_run_uuid,omitempty"`
+	PanelSummary          *PanelSummary `json:"panel_summary,omitempty"`
+	ParentJobId           *int64        `json:"parent_job_id,omitempty"`
+	Patch                 *string       `json:"patch,omitempty"`
+	PatchId               *string       `json:"patch_id,omitempty"`
+	Prompt                *string       `json:"prompt,omitempty"`
+	PromptPrebuilt        bool          `json:"prompt_prebuilt"`
+	Provider              *string       `json:"provider,omitempty"`
+	Reasoning             *string       `json:"reasoning,omitempty"`
+	RepoId                int64         `json:"repo_id"`
+	RepoName              *string       `json:"repo_name,omitempty"`
+	RepoPath              *string       `json:"repo_path,omitempty"`
+	RequestedModel        *string       `json:"requested_model,omitempty"`
+	RequestedProvider     *string       `json:"requested_provider,omitempty"`
+	RetryCount            int64         `json:"retry_count"`
+	ReviewType            *string       `json:"review_type,omitempty"`
+	SessionId             *string       `json:"session_id,omitempty"`
+	SkipReason            *string       `json:"skip_reason,omitempty"`
+	Source                *string       `json:"source,omitempty"`
+	SourceMachineId       *string       `json:"source_machine_id,omitempty"`
+	StartedAt             *time.Time    `json:"started_at,omitempty"`
+	Status                string        `json:"status"`
+	SyncedAt              *time.Time    `json:"synced_at,omitempty"`
+	TokenUsage            *string       `json:"token_usage,omitempty"`
+	UpdatedAt             *time.Time    `json:"updated_at,omitempty"`
+	Uuid                  *string       `json:"uuid,omitempty"`
+	Verdict               *string       `json:"verdict,omitempty"`
+	WorkerId              *string       `json:"worker_id,omitempty"`
+	WorktreePath          *string       `json:"worktree_path,omitempty"`
 }
 
 // Summary defines model for Summary.
@@ -600,6 +670,7 @@ type Summary struct {
 	Schema   *string         `json:"$schema,omitempty"`
 	Agents   *[]AgentStats   `json:"agents"`
 	Branch   *string         `json:"branch,omitempty"`
+	Cost     CostAggregate   `json:"cost"`
 	Duration DurationStats   `json:"duration"`
 	Failures FailureStats    `json:"failures"`
 	JobTypes *[]JobTypeStats `json:"job_types"`
@@ -669,6 +740,24 @@ type ListCommentsParams struct {
 	Sha *string `form:"sha,omitempty" json:"sha,omitempty"`
 }
 
+// GetCostParams defines parameters for GetCost.
+type GetCostParams struct {
+	// Repo Repo root paths (repeatable)
+	Repo *[]string `form:"repo,omitempty" json:"repo,omitempty"`
+
+	// Branch Filter by branch name
+	Branch *string `form:"branch,omitempty" json:"branch,omitempty"`
+
+	// BranchEmpty Only jobs with empty/unset branch
+	BranchEmpty *GetCostParamsBranchEmpty `form:"branch_empty,omitempty" json:"branch_empty,omitempty"`
+
+	// Since Time window (e.g. 7d); default all-time
+	Since *string `form:"since,omitempty" json:"since,omitempty"`
+}
+
+// GetCostParamsBranchEmpty defines parameters for GetCost.
+type GetCostParamsBranchEmpty string
+
 // GetJobLogParams defines parameters for GetJobLog.
 type GetJobLogParams struct {
 	// JobId Job ID
@@ -725,6 +814,9 @@ type ListJobsParams struct {
 	// HideClassifyJobs Hide auto-design-router rows (job_type=classify and status=skipped)
 	HideClassifyJobs *ListJobsParamsHideClassifyJobs `form:"hide_classify_jobs,omitempty" json:"hide_classify_jobs,omitempty"`
 
+	// PanelRun Return all jobs (members + synthesis) of one panel run
+	PanelRun *string `form:"panel_run,omitempty" json:"panel_run,omitempty"`
+
 	// RepoPrefix Filter repos by path prefix
 	RepoPrefix *string `form:"repo_prefix,omitempty" json:"repo_prefix,omitempty"`
 
@@ -754,6 +846,12 @@ type ListReposParams struct {
 
 	// Prefix Filter repos by path prefix
 	Prefix *string `form:"prefix,omitempty" json:"prefix,omitempty"`
+}
+
+// ResolveRepoParams defines parameters for ResolveRepo.
+type ResolveRepoParams struct {
+	// Path Absolute path or path inside a repository
+	Path *string `form:"path,omitempty" json:"path,omitempty"`
 }
 
 // GetReviewParams defines parameters for GetReview.
@@ -918,6 +1016,9 @@ type ClientInterface interface {
 	// ListComments request
 	ListComments(ctx context.Context, params *ListCommentsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetCost request
+	GetCost(ctx context.Context, params *GetCostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// EnqueueJobWithBody request with any body
 	EnqueueJobWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -988,6 +1089,9 @@ type ClientInterface interface {
 	RegisterRepoWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	RegisterRepo(ctx context.Context, body RegisterRepoJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ResolveRepo request
+	ResolveRepo(ctx context.Context, params *ResolveRepoParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetReview request
 	GetReview(ctx context.Context, params *GetReviewParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1063,6 +1167,18 @@ func (c *Client) AddComment(ctx context.Context, body AddCommentJSONRequestBody,
 
 func (c *Client) ListComments(ctx context.Context, params *ListCommentsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListCommentsRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetCost(ctx context.Context, params *GetCostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetCostRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -1397,6 +1513,18 @@ func (c *Client) RegisterRepo(ctx context.Context, body RegisterRepoJSONRequestB
 	return c.Client.Do(req)
 }
 
+func (c *Client) ResolveRepo(ctx context.Context, params *ResolveRepoParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewResolveRepoRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) GetReview(ctx context.Context, params *GetReviewParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetReviewRequest(c.Server, params)
 	if err != nil {
@@ -1688,6 +1816,103 @@ func NewListCommentsRequest(server string, params *ListCommentsParams) (*http.Re
 		if params.Sha != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "sha", *params.Sha, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetCostRequest generates requests for GetCost
+func NewGetCostRequest(server string, params *GetCostParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/cost")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Repo != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "repo", *params.Repo, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "array", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Branch != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "branch", *params.Branch, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.BranchEmpty != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "branch_empty", *params.BranchEmpty, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Since != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "since", *params.Since, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err
@@ -2380,6 +2605,22 @@ func NewListJobsRequest(server string, params *ListJobsParams) (*http.Request, e
 
 		}
 
+		if params.PanelRun != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "panel_run", *params.PanelRun, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		if params.RepoPrefix != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "repo_prefix", *params.RepoPrefix, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
@@ -2663,6 +2904,55 @@ func NewRegisterRepoRequestWithBody(server string, contentType string, body io.R
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewResolveRepoRequest generates requests for ResolveRepo
+func NewResolveRepoRequest(server string, params *ResolveRepoParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/repos/resolve")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Path != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "path", *params.Path, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return req, nil
 }
@@ -3078,6 +3368,9 @@ type ClientWithResponsesInterface interface {
 	// ListCommentsWithResponse request
 	ListCommentsWithResponse(ctx context.Context, params *ListCommentsParams, reqEditors ...RequestEditorFn) (*ListCommentsResponse, error)
 
+	// GetCostWithResponse request
+	GetCostWithResponse(ctx context.Context, params *GetCostParams, reqEditors ...RequestEditorFn) (*GetCostResponse, error)
+
 	// EnqueueJobWithBodyWithResponse request with any body
 	EnqueueJobWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EnqueueJobResponse, error)
 
@@ -3148,6 +3441,9 @@ type ClientWithResponsesInterface interface {
 	RegisterRepoWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RegisterRepoResponse, error)
 
 	RegisterRepoWithResponse(ctx context.Context, body RegisterRepoJSONRequestBody, reqEditors ...RequestEditorFn) (*RegisterRepoResponse, error)
+
+	// ResolveRepoWithResponse request
+	ResolveRepoWithResponse(ctx context.Context, params *ResolveRepoParams, reqEditors ...RequestEditorFn) (*ResolveRepoResponse, error)
 
 	// GetReviewWithResponse request
 	GetReviewWithResponse(ctx context.Context, params *GetReviewParams, reqEditors ...RequestEditorFn) (*GetReviewResponse, error)
@@ -3259,6 +3555,29 @@ func (r ListCommentsResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ListCommentsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetCostResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *CostAggregate
+	ApplicationproblemJSONDefault *ErrorModel
+}
+
+// Status returns HTTPResponse.Status
+func (r GetCostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetCostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -3664,6 +3983,29 @@ func (r RegisterRepoResponse) StatusCode() int {
 	return 0
 }
 
+type ResolveRepoResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *ResolveRepoOutputBody
+	ApplicationproblemJSONDefault *ErrorModel
+}
+
+// Status returns HTTPResponse.Status
+func (r ResolveRepoResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ResolveRepoResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetReviewResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
@@ -3865,6 +4207,15 @@ func (c *ClientWithResponses) ListCommentsWithResponse(ctx context.Context, para
 		return nil, err
 	}
 	return ParseListCommentsResponse(rsp)
+}
+
+// GetCostWithResponse request returning *GetCostResponse
+func (c *ClientWithResponses) GetCostWithResponse(ctx context.Context, params *GetCostParams, reqEditors ...RequestEditorFn) (*GetCostResponse, error) {
+	rsp, err := c.GetCost(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetCostResponse(rsp)
 }
 
 // EnqueueJobWithBodyWithResponse request with arbitrary body returning *EnqueueJobResponse
@@ -4100,6 +4451,15 @@ func (c *ClientWithResponses) RegisterRepoWithResponse(ctx context.Context, body
 	return ParseRegisterRepoResponse(rsp)
 }
 
+// ResolveRepoWithResponse request returning *ResolveRepoResponse
+func (c *ClientWithResponses) ResolveRepoWithResponse(ctx context.Context, params *ResolveRepoParams, reqEditors ...RequestEditorFn) (*ResolveRepoResponse, error) {
+	rsp, err := c.ResolveRepo(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseResolveRepoResponse(rsp)
+}
+
 // GetReviewWithResponse request returning *GetReviewResponse
 func (c *ClientWithResponses) GetReviewWithResponse(ctx context.Context, params *GetReviewParams, reqEditors ...RequestEditorFn) (*GetReviewResponse, error) {
 	rsp, err := c.GetReview(ctx, params, reqEditors...)
@@ -4286,6 +4646,39 @@ func ParseListCommentsResponse(rsp *http.Response) (*ListCommentsResponse, error
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest ListCommentsOutputBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetCostResponse parses an HTTP response from a GetCostWithResponse call
+func ParseGetCostResponse(rsp *http.Response) (*GetCostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetCostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CostAggregate
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -4879,6 +5272,39 @@ func ParseRegisterRepoResponse(rsp *http.Response) (*RegisterRepoResponse, error
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest Repo
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseResolveRepoResponse parses an HTTP response from a ResolveRepoWithResponse call
+func ParseResolveRepoResponse(rsp *http.Response) (*ResolveRepoResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ResolveRepoResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ResolveRepoOutputBody
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/daemon_client/openapi-3.0.json
+++ b/internal/daemon_client/openapi-3.0.json
@@ -328,6 +328,40 @@
         ],
         "type": "object"
       },
+      "CostAggregate": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/CostAggregate.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "complete": {
+            "type": "boolean"
+          },
+          "jobs_total": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "jobs_with_cost": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "total_usd": {
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "total_usd",
+          "jobs_with_cost",
+          "jobs_total",
+          "complete"
+        ],
+        "type": "object"
+      },
       "DaemonStatus": {
         "additionalProperties": false,
         "properties": {
@@ -487,6 +521,13 @@
           "diff_content": {
             "type": "string"
           },
+          "dirty_files": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
           "git_ref": {
             "type": "string"
           },
@@ -502,6 +543,9 @@
           "output_prefix": {
             "type": "string"
           },
+          "panel": {
+            "type": "string"
+          },
           "provider": {
             "type": "string"
           },
@@ -515,6 +559,9 @@
             "type": "string"
           },
           "since": {
+            "type": "string"
+          },
+          "source": {
             "type": "string"
           }
         },
@@ -1022,6 +1069,55 @@
         ],
         "type": "object"
       },
+      "PanelSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "members_canceled": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "members_cost_complete": {
+            "type": "boolean"
+          },
+          "members_cost_usd": {
+            "format": "double",
+            "type": "number"
+          },
+          "members_failed": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "members_skipped": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "members_succeeded": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "members_terminal": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "members_total": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "panel_run_uuid": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "panel_run_uuid",
+          "members_total",
+          "members_terminal",
+          "members_succeeded",
+          "members_failed",
+          "members_canceled",
+          "members_skipped"
+        ],
+        "type": "object"
+      },
       "PingInfo": {
         "additionalProperties": false,
         "properties": {
@@ -1291,6 +1387,48 @@
         ],
         "type": "object"
       },
+      "ResolveRepoOutputBody": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/ResolveRepoOutputBody.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "repo": {
+            "$ref": "#/components/schemas/ResolvedRepo"
+          },
+          "tracked": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "tracked"
+        ],
+        "type": "object"
+      },
+      "ResolvedRepo": {
+        "additionalProperties": false,
+        "properties": {
+          "identity": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "root_path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "root_path",
+          "identity",
+          "name"
+        ],
+        "type": "object"
+      },
       "Response": {
         "additionalProperties": false,
         "properties": {
@@ -1425,8 +1563,17 @@
           "agentic": {
             "type": "boolean"
           },
+          "backup_agent": {
+            "type": "string"
+          },
+          "backup_model": {
+            "type": "string"
+          },
           "branch": {
             "type": "string"
+          },
+          "claim_blocked": {
+            "type": "boolean"
           },
           "closed": {
             "type": "boolean"
@@ -1443,6 +1590,13 @@
           },
           "diff_content": {
             "type": "string"
+          },
+          "dirty_files": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "enqueued_at": {
             "format": "date-time",
@@ -1473,6 +1627,28 @@
           },
           "output_prefix": {
             "type": "string"
+          },
+          "panel_member_config_json": {
+            "type": "string"
+          },
+          "panel_member_index": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "panel_member_name": {
+            "type": "string"
+          },
+          "panel_name": {
+            "type": "string"
+          },
+          "panel_role": {
+            "type": "string"
+          },
+          "panel_run_uuid": {
+            "type": "string"
+          },
+          "panel_summary": {
+            "$ref": "#/components/schemas/PanelSummary"
           },
           "parent_job_id": {
             "format": "int64",
@@ -1596,6 +1772,9 @@
           "branch": {
             "type": "string"
           },
+          "cost": {
+            "$ref": "#/components/schemas/CostAggregate"
+          },
           "duration": {
             "$ref": "#/components/schemas/DurationStats"
           },
@@ -1637,7 +1816,8 @@
           "agents",
           "duration",
           "job_types",
-          "failures"
+          "failures",
+          "cost"
         ],
         "type": "object"
       },
@@ -1956,6 +2136,87 @@
         "summary": "List comments for a job or commit",
         "tags": [
           "comments"
+        ]
+      }
+    },
+    "/api/cost": {
+      "get": {
+        "operationId": "get-cost",
+        "parameters": [
+          {
+            "description": "Repo root paths (repeatable)",
+            "explode": true,
+            "in": "query",
+            "name": "repo",
+            "schema": {
+              "description": "Repo root paths (repeatable)",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            }
+          },
+          {
+            "description": "Filter by branch name",
+            "explode": false,
+            "in": "query",
+            "name": "branch",
+            "schema": {
+              "description": "Filter by branch name",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Only jobs with empty/unset branch",
+            "explode": false,
+            "in": "query",
+            "name": "branch_empty",
+            "schema": {
+              "description": "Only jobs with empty/unset branch",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Time window (e.g. 7d); default all-time",
+            "explode": false,
+            "in": "query",
+            "name": "since",
+            "schema": {
+              "description": "Time window (e.g. 7d); default all-time",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CostAggregate"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Get aggregate review cost",
+        "tags": [
+          "daemon"
         ]
       }
     },
@@ -2606,6 +2867,16 @@
             }
           },
           {
+            "description": "Return all jobs (members + synthesis) of one panel run",
+            "explode": false,
+            "in": "query",
+            "name": "panel_run",
+            "schema": {
+              "description": "Return all jobs (members + synthesis) of one panel run",
+              "type": "string"
+            }
+          },
+          {
             "description": "Filter repos by path prefix",
             "explode": false,
             "in": "query",
@@ -2882,6 +3153,49 @@
           }
         },
         "summary": "Register a repository",
+        "tags": [
+          "repos"
+        ]
+      }
+    },
+    "/api/repos/resolve": {
+      "get": {
+        "operationId": "resolve-repo",
+        "parameters": [
+          {
+            "description": "Absolute path or path inside a repository",
+            "explode": false,
+            "in": "query",
+            "name": "path",
+            "schema": {
+              "description": "Absolute path or path inside a repository",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResolveRepoOutputBody"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Resolve whether a path belongs to a tracked repo",
         "tags": [
           "repos"
         ]

--- a/internal/storage/cost.go
+++ b/internal/storage/cost.go
@@ -1,0 +1,112 @@
+package storage
+
+import (
+	"strings"
+	"time"
+)
+
+// CostAggregate is the approximate agent spend for a scope. It is partial by
+// nature: JobsWithCost <= JobsTotal because only some agents report cost.
+type CostAggregate struct {
+	TotalUSD     float64 `json:"total_usd"`
+	JobsWithCost int     `json:"jobs_with_cost"`
+	JobsTotal    int     `json:"jobs_total"`
+	Complete     bool    `json:"complete"` // JobsTotal > 0 && JobsWithCost == JobsTotal
+}
+
+// CostOptions scopes a cost aggregate. The zero value selects all repos, all
+// branches, and all time.
+type CostOptions struct {
+	RepoPaths   []string  // empty = all repos; multiple = OR over repos.root_path
+	Branch      string    // exact branch; ignored when BranchEmpty is true
+	BranchEmpty bool      // true = only jobs with empty/NULL branch
+	Since       time.Time // zero = all time; else enqueued_at >= Since
+}
+
+// hasCost is the SQL predicate for a row carrying a recorded dollar cost. It
+// gates the priced numerator (jobs_with_cost) and total_usd. Requires
+// review_jobs aliased as "j".
+const hasCost = "json_valid(j.token_usage) AND json_extract(j.token_usage, '$.has_cost')"
+
+// agentRanByUsage is the fallback agent-ran signal: a token_usage blob that
+// records real consumption — a cost flag, output tokens, peak context, or a
+// dollar figure. Only an agent run can produce any of these, so it backs
+// eligibility for rows whose agent_invoked marker is absent: rows from before
+// the column existed, rows backfilled from token_usage, or remote rows synced
+// before the marker was added. Requires review_jobs aliased as "j".
+const agentRanByUsage = "json_valid(j.token_usage) AND (" +
+	"json_extract(j.token_usage, '$.has_cost') " +
+	"OR json_extract(j.token_usage, '$.total_output_tokens') > 0 " +
+	"OR json_extract(j.token_usage, '$.peak_context_tokens') > 0 " +
+	"OR json_extract(j.token_usage, '$.cost_usd') > 0)"
+
+// costEligible is the shared eligibility predicate: a terminal job where an
+// agent actually ran. It gates total_usd, jobs_with_cost, and jobs_total so
+// coverage cannot exceed 100%. Requires review_jobs aliased as "j".
+//
+// "An agent ran" is the agent_invoked marker — the worker sets it immediately
+// before the agent call, after all pre-agent gates, and it syncs across
+// machines — or a token_usage blob proving consumption (agentRanByUsage), which
+// covers rows predating the marker. Terminal rows that never run an agent (panel
+// synthesis passthrough/all-failed/all-passed, or a job that failed a pre-agent
+// gate) carry neither signal and stay out of the denominator, so coverage is not
+// dragged below 100% by rows that could never report cost.
+const costEligible = "j.started_at IS NOT NULL AND j.finished_at IS NOT NULL " +
+	"AND j.status != 'skipped' AND (j.agent_invoked = 1 OR (" + agentRanByUsage + "))"
+
+// GetCostAggregate computes approximate agent spend for the given scope on a
+// fresh read.
+func (db *DB) GetCostAggregate(opts CostOptions) (CostAggregate, error) {
+	return costAggregate(db, opts)
+}
+
+// costAggregate computes approximate agent spend against any querier, so callers
+// can share a read snapshot (e.g. GetSummary's transaction). Panel member rows
+// are included — spend is per-row, not row-count.
+func costAggregate(q querier, opts CostOptions) (CostAggregate, error) {
+	var conditions []string
+	var args []any
+
+	if len(opts.RepoPaths) > 0 {
+		placeholders := make([]string, len(opts.RepoPaths))
+		for i, p := range opts.RepoPaths {
+			placeholders[i] = "?"
+			args = append(args, p)
+		}
+		conditions = append(conditions, "r.root_path IN ("+strings.Join(placeholders, ",")+")")
+	}
+	if opts.BranchEmpty {
+		conditions = append(conditions, "(j.branch = '' OR j.branch IS NULL)")
+	} else if opts.Branch != "" {
+		conditions = append(conditions, "j.branch = ?")
+		args = append(args, opts.Branch)
+	}
+	if !opts.Since.IsZero() {
+		conditions = append(conditions, "datetime(j.enqueued_at) >= datetime(?)")
+		args = append(args, opts.Since.UTC().Format("2006-01-02 15:04:05"))
+	}
+
+	where := ""
+	if len(conditions) > 0 {
+		where = "WHERE " + strings.Join(conditions, " AND ")
+	}
+
+	query := `
+		SELECT
+			COALESCE(SUM(CASE WHEN ` + costEligible + ` THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN ` + costEligible + `
+				AND ` + hasCost + ` THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN ` + costEligible + `
+				AND ` + hasCost + `
+				THEN json_extract(j.token_usage, '$.cost_usd') ELSE 0 END), 0)
+		FROM review_jobs j
+		JOIN repos r ON r.id = j.repo_id
+		` + where
+
+	var c CostAggregate
+	if err := q.QueryRow(query, args...).Scan(&c.JobsTotal, &c.JobsWithCost, &c.TotalUSD); err != nil {
+		return CostAggregate{}, err
+	}
+	c.Complete = c.JobsTotal > 0 && c.JobsWithCost == c.JobsTotal
+	return c, nil
+}

--- a/internal/storage/cost_test.go
+++ b/internal/storage/cost_test.go
@@ -1,0 +1,409 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCostAggregate(t *testing.T) {
+	assert := assert.New(t)
+	db := openTestDB(t)
+	t.Cleanup(func() { db.Close() })
+
+	repo := createRepo(t, db, "/tmp/cost-repo")
+
+	mkJob := func(sha, branch string, status JobStatus, costJSON string) *ReviewJob {
+		commit := createCommit(t, db, repo.ID, sha)
+		job := enqueueJob(t, db, repo.ID, commit.ID, sha)
+		setJobStatus(t, db, job.ID, status)
+		// Done/failed/canceled rows represent an agent that actually ran, so
+		// they carry the agent_invoked marker and count toward cost eligibility.
+		// Priced rows also get it via seedCost below; this covers the unpriced
+		// ones.
+		switch status {
+		case JobStatusDone, JobStatusFailed, JobStatusCanceled:
+			setJobAgentInvoked(t, db, job.ID)
+		}
+		if branch != "" {
+			setJobBranch(t, db, job.ID, branch)
+		}
+		if costJSON != "" {
+			seedCost(t, db, job.ID, costJSON)
+		}
+		return job
+	}
+
+	// Eligible jobs on branch "feat":
+	mkJob("sha-done", "feat", JobStatusDone, `{"cost_usd":1.00,"has_cost":true}`)           // priced
+	mkJob("sha-failed", "feat", JobStatusFailed, "")                                        // eligible, unpriced
+	mkJob("sha-cancel-run", "feat", JobStatusCanceled, `{"cost_usd":0.50,"has_cost":true}`) // priced
+	// Eligible + priced on empty branch:
+	mkJob("sha-empty", "", JobStatusDone, `{"cost_usd":0.25,"has_cost":true}`)
+
+	// Ineligible jobs:
+	mkJob("sha-running", "feat", JobStatusRunning, "") // no finished_at
+	mkJob("sha-queued", "feat", JobStatusQueued, "")   // never ran
+
+	skipped := mkJob("sha-skip", "feat", JobStatusDone, `{"cost_usd":9.99,"has_cost":true}`)
+	_, err := db.Exec(`UPDATE review_jobs SET status='skipped' WHERE id=?`, skipped.ID)
+	require.NoError(t, err)
+
+	cq := mkJob("sha-cancel-queue", "feat", JobStatusQueued, "")
+	_, err = db.Exec(`UPDATE review_jobs SET status='canceled', started_at=NULL, finished_at=datetime('now') WHERE id=?`, cq.ID)
+	require.NoError(t, err)
+
+	// Whole repo: 4 eligible (done, failed, cancel-run, empty), 3 priced, $1.75.
+	all, err := db.GetCostAggregate(CostOptions{RepoPaths: []string{repo.RootPath}})
+	require.NoError(t, err)
+	assert.Equal(4, all.JobsTotal)
+	assert.Equal(3, all.JobsWithCost)
+	assert.InDelta(1.75, all.TotalUSD, 0.0001)
+	assert.False(all.Complete)
+
+	// Branch "feat": 3 eligible, 2 priced, $1.50.
+	feat, err := db.GetCostAggregate(CostOptions{RepoPaths: []string{repo.RootPath}, Branch: "feat"})
+	require.NoError(t, err)
+	assert.Equal(3, feat.JobsTotal)
+	assert.Equal(2, feat.JobsWithCost)
+	assert.InDelta(1.50, feat.TotalUSD, 0.0001)
+
+	// Empty branch only: 1 eligible, 1 priced, $0.25, complete.
+	empty, err := db.GetCostAggregate(CostOptions{RepoPaths: []string{repo.RootPath}, BranchEmpty: true})
+	require.NoError(t, err)
+	assert.Equal(1, empty.JobsTotal)
+	assert.Equal(1, empty.JobsWithCost)
+	assert.InDelta(0.25, empty.TotalUSD, 0.0001)
+	assert.True(empty.Complete)
+
+	// Empty scope: no eligible jobs.
+	none, err := db.GetCostAggregate(CostOptions{RepoPaths: []string{"/tmp/does-not-exist"}})
+	require.NoError(t, err)
+	assert.Equal(0, none.JobsTotal)
+	assert.False(none.Complete)
+}
+
+// TestGetCostAggregateExcludesNoAgentRows verifies a terminal row that never
+// invoked an agent (a panel synthesis passthrough, an all-failed/all-passed
+// synthesis, or a job that failed before any agent was available) is left out
+// of the denominator, so coverage is not dragged below 100% by a row that can
+// never report cost.
+func TestGetCostAggregateExcludesNoAgentRows(t *testing.T) {
+	assert := assert.New(t)
+	db := openTestDB(t)
+	t.Cleanup(func() { db.Close() })
+
+	repo := createRepo(t, db, "/tmp/cost-no-agent")
+
+	// An agent ran and reported cost (seedCost sets the agent_invoked marker).
+	agentJob := enqueueJob(t, db, repo.ID,
+		createCommit(t, db, repo.ID, "agent-sha").ID, "agent-sha")
+	setJobStatus(t, db, agentJob.ID, JobStatusDone)
+	seedCost(t, db, agentJob.ID, `{"cost_usd":0.50,"has_cost":true}`)
+
+	// A no-agent synthesis row: terminal and finished, but no agent_invoked
+	// marker and no token usage. It can never report cost, so it must not be
+	// counted.
+	noAgent := enqueueJob(t, db, repo.ID,
+		createCommit(t, db, repo.ID, "passthrough-sha").ID, "passthrough-sha")
+	setJobStatus(t, db, noAgent.ID, JobStatusDone)
+
+	got, err := db.GetCostAggregate(CostOptions{RepoPaths: []string{repo.RootPath}})
+	require.NoError(t, err)
+	assert.Equal(1, got.JobsTotal, "no-agent row excluded from the denominator")
+	assert.Equal(1, got.JobsWithCost)
+	assert.InDelta(0.50, got.TotalUSD, 0.0001)
+	assert.True(got.Complete, "coverage is complete despite the no-agent row")
+}
+
+func TestGetCostAggregateMultiRepo(t *testing.T) {
+	assert := assert.New(t)
+	db := openTestDB(t)
+	t.Cleanup(func() { db.Close() })
+
+	mkJob := func(repoID int64, sha, costJSON string) {
+		commit := createCommit(t, db, repoID, sha)
+		job := enqueueJob(t, db, repoID, commit.ID, sha)
+		setJobStatus(t, db, job.ID, JobStatusDone)
+		setJobBranch(t, db, job.ID, "feat")
+		seedCost(t, db, job.ID, costJSON)
+	}
+
+	repoA := createRepo(t, db, "/tmp/cost-multi-a")
+	repoB := createRepo(t, db, "/tmp/cost-multi-b")
+	mkJob(repoA.ID, "multi-a-sha", `{"cost_usd":1.50,"has_cost":true}`)
+	mkJob(repoB.ID, "multi-b-sha", `{"cost_usd":2.00,"has_cost":true}`)
+
+	// Both repos on branch "feat": 2 eligible, 2 priced, $3.50, complete.
+	both, err := db.GetCostAggregate(CostOptions{
+		RepoPaths: []string{repoA.RootPath, repoB.RootPath},
+		Branch:    "feat",
+	})
+	require.NoError(t, err)
+	assert.Equal(2, both.JobsTotal)
+	assert.Equal(2, both.JobsWithCost)
+	assert.InDelta(3.50, both.TotalUSD, 0.0001)
+	assert.True(both.Complete)
+
+	// Scoping to one repo proves the IN clause filters.
+	onlyA, err := db.GetCostAggregate(CostOptions{
+		RepoPaths: []string{repoA.RootPath},
+		Branch:    "feat",
+	})
+	require.NoError(t, err)
+	assert.InDelta(1.50, onlyA.TotalUSD, 0.0001)
+}
+
+func TestGetCostAggregateIncludesPanelMembers(t *testing.T) {
+	assert := assert.New(t)
+	db := openTestDB(t)
+	t.Cleanup(func() { db.Close() })
+
+	repo := createRepo(t, db, "/tmp/cost-panel")
+	commit := createCommit(t, db, repo.ID, "panel-sha")
+
+	mkPanelJob := func(role string, costJSON string) *ReviewJob {
+		job, err := db.EnqueueJob(EnqueueOpts{
+			RepoID: repo.ID, CommitID: commit.ID, GitRef: "panel-sha", Agent: "test",
+			PanelRunUUID: "run-1", PanelRole: role,
+		})
+		require.NoError(t, err)
+		setJobStatus(t, db, job.ID, JobStatusDone)
+		seedCost(t, db, job.ID, costJSON)
+		return job
+	}
+
+	mkPanelJob("member", `{"cost_usd":0.30,"has_cost":true}`)
+	mkPanelJob("member", `{"cost_usd":0.40,"has_cost":true}`)
+	mkPanelJob("synthesis", `{"cost_usd":0.10,"has_cost":true}`)
+
+	got, err := db.GetCostAggregate(CostOptions{RepoPaths: []string{repo.RootPath}})
+	require.NoError(t, err)
+	assert.Equal(3, got.JobsTotal, "members + synthesis all counted")
+	assert.Equal(3, got.JobsWithCost)
+	assert.InDelta(0.80, got.TotalUSD, 0.0001)
+	assert.True(got.Complete)
+}
+
+// TestGetCostAggregateIncludesPricedRowsWithoutMarker guards the agentRanByUsage
+// fallback: a priced row carrying neither the agent_invoked marker nor a command
+// line — historical, backfilled, or synced from a machine that wrote it before
+// the marker existed — still proves an agent ran via its cost JSON, so it must
+// count toward coverage.
+func TestGetCostAggregateIncludesPricedRowsWithoutMarker(t *testing.T) {
+	assert := assert.New(t)
+	db := openTestDB(t)
+	t.Cleanup(func() { db.Close() })
+
+	repo := createRepo(t, db, "/tmp/cost-no-marker")
+	commit := createCommit(t, db, repo.ID, "no-marker-sha")
+	job := enqueueJob(t, db, repo.ID, commit.ID, "no-marker-sha")
+	setJobStatus(t, db, job.ID, JobStatusDone)
+
+	// Priced row, but the agent_invoked marker was never set. seedCost would
+	// set it, so write the usage directly against the session.
+	sessionID := "sess-no-marker"
+	setJobSession(t, db, job.ID, sessionID)
+	require.NoError(t, db.SaveJobTokenUsage(
+		job.ID, sessionID, `{"cost_usd":0.75,"has_cost":true}`))
+
+	c, err := db.GetCostAggregate(CostOptions{RepoPaths: []string{repo.RootPath}})
+	require.NoError(t, err)
+	assert.Equal(1, c.JobsTotal, "priced row counts even without the agent_invoked marker")
+	assert.Equal(1, c.JobsWithCost)
+	assert.InDelta(0.75, c.TotalUSD, 0.0001)
+	assert.True(c.Complete, "coverage is complete when the only row is priced")
+}
+
+// TestGetCostAggregateRerunClearsStaleCost guards against attributing a prior
+// run's spend to a re-run job. Re-enqueuing must clear token_usage and the
+// agent_invoked marker, so a second run that reports no cost is counted as
+// eligible-but-unpriced, not as priced.
+func TestGetCostAggregateRerunClearsStaleCost(t *testing.T) {
+	assert := assert.New(t)
+	db := openTestDB(t)
+	t.Cleanup(func() { db.Close() })
+
+	repo := createRepo(t, db, "/tmp/cost-rerun")
+	commit := createCommit(t, db, repo.ID, "rerun-sha")
+	job := enqueueJob(t, db, repo.ID, commit.ID, "rerun-sha")
+
+	// First run completes with reported cost.
+	setJobStatus(t, db, job.ID, JobStatusDone)
+	seedCost(t, db, job.ID, `{"cost_usd":5.00,"has_cost":true}`)
+
+	opts := CostOptions{RepoPaths: []string{repo.RootPath}}
+	before, err := db.GetCostAggregate(opts)
+	require.NoError(t, err)
+	assert.Equal(1, before.JobsWithCost, "first run is priced")
+	assert.InDelta(5.00, before.TotalUSD, 0.0001)
+
+	// Re-enqueue: this clears the prior attempt's cost and agent-ran marker.
+	require.NoError(t, db.ReenqueueJob(job.ID, ReenqueueOpts{}))
+	assert.False(getJobAgentInvoked(t, db, job.ID),
+		"rerun clears the prior attempt's agent-ran marker")
+
+	// The second run's agent runs (agent_invoked set) but reports no cost.
+	setJobStatus(t, db, job.ID, JobStatusDone)
+	setJobAgentInvoked(t, db, job.ID)
+
+	after, err := db.GetCostAggregate(opts)
+	require.NoError(t, err)
+	assert.Equal(1, after.JobsTotal, "still eligible after rerun")
+	assert.Equal(0, after.JobsWithCost, "stale cost cleared on rerun")
+	assert.InDelta(0.0, after.TotalUSD, 0.0001)
+	assert.False(after.Complete)
+}
+
+// TestSaveJobTokenUsageIgnoresStaleSession guards the late-write race: a
+// delayed token-usage fetch from a completed attempt must not stamp its cost
+// onto the row after a rerun cleared it and a new attempt took over under a
+// different session.
+func TestSaveJobTokenUsageIgnoresStaleSession(t *testing.T) {
+	assert := assert.New(t)
+	db := openTestDB(t)
+	t.Cleanup(func() { db.Close() })
+
+	repo := createRepo(t, db, "/tmp/cost-stale-session")
+	commit := createCommit(t, db, repo.ID, "stale-sha")
+	job := enqueueJob(t, db, repo.ID, commit.ID, "stale-sha")
+
+	// Attempt A runs under "sess-A" and completes; its usage write lands.
+	setJobStatus(t, db, job.ID, JobStatusDone)
+	setJobSession(t, db, job.ID, "sess-A")
+	require.NoError(t, db.SaveJobTokenUsage(
+		job.ID, "sess-A", `{"cost_usd":5.00,"has_cost":true}`))
+
+	// The job is re-enqueued (clearing session_id + token_usage) and a new
+	// attempt claims it under "sess-B".
+	require.NoError(t, db.ReenqueueJob(job.ID, ReenqueueOpts{}))
+	setJobSession(t, db, job.ID, "sess-B")
+
+	// Attempt A's delayed usage fetch finally writes back, keyed by the old
+	// session. It must not land.
+	require.NoError(t, db.SaveJobTokenUsage(
+		job.ID, "sess-A", `{"cost_usd":5.00,"has_cost":true}`))
+	reloaded, err := db.GetJobByID(job.ID)
+	require.NoError(t, err)
+	assert.Empty(reloaded.TokenUsage, "stale write from the prior session is ignored")
+
+	// A write under the current session still updates.
+	require.NoError(t, db.SaveJobTokenUsage(
+		job.ID, "sess-B", `{"cost_usd":1.00,"has_cost":true}`))
+	reloaded, err = db.GetJobByID(job.ID)
+	require.NoError(t, err)
+	assert.Contains(reloaded.TokenUsage, "1.00", "current-session write lands")
+}
+
+// TestResetStaleJobsClearsCostMetadata verifies restart recovery does not
+// carry a prior attempt's session id or cost into the requeued run.
+func TestResetStaleJobsClearsCostMetadata(t *testing.T) {
+	assert := assert.New(t)
+	db := openTestDB(t)
+	t.Cleanup(func() { db.Close() })
+
+	repo := createRepo(t, db, "/tmp/reset-stale")
+	commit := createCommit(t, db, repo.ID, "reset-sha")
+	job := enqueueJob(t, db, repo.ID, commit.ID, "reset-sha")
+
+	// A running job that already carries a session id, the agent_invoked marker,
+	// and a cost (e.g. from a late write that landed on the running re-attempt).
+	setJobStatus(t, db, job.ID, JobStatusRunning)
+	setJobSession(t, db, job.ID, "sess-stale")
+	setJobAgentInvoked(t, db, job.ID)
+	require.NoError(t, db.SaveJobTokenUsage(
+		job.ID, "sess-stale", `{"cost_usd":3.00,"has_cost":true}`))
+
+	require.NoError(t, db.ResetStaleJobs())
+
+	reloaded, err := db.GetJobByID(job.ID)
+	require.NoError(t, err)
+	assert.Equal(JobStatusQueued, reloaded.Status, "running job requeued")
+	assert.Empty(reloaded.SessionID, "session id cleared on restart recovery")
+	assert.Empty(reloaded.TokenUsage, "stale cost cleared on restart recovery")
+	assert.Empty(reloaded.CommandLine, "stale command line cleared on restart recovery")
+	assert.False(getJobAgentInvoked(t, db, job.ID),
+		"stale agent-ran marker cleared on restart recovery")
+}
+
+// TestGetCostAggregateExcludesPreAgentFailure verifies a job that reached a
+// terminal failed state before any agent ran — a pre-agent gate failure such as
+// an oversized prompt or a worktree-creation error — is left out of the
+// denominator. The worker never reached MarkJobAgentInvoked, so the marker is
+// unset and no usage was captured; the row can never report cost and must not
+// drag coverage below 100%.
+func TestGetCostAggregateExcludesPreAgentFailure(t *testing.T) {
+	assert := assert.New(t)
+	db := openTestDB(t)
+	t.Cleanup(func() { db.Close() })
+
+	repo := createRepo(t, db, "/tmp/cost-pre-agent-fail")
+
+	// A priced row that did run an agent (seedCost sets the marker).
+	ran := enqueueJob(t, db, repo.ID,
+		createCommit(t, db, repo.ID, "ran-sha").ID, "ran-sha")
+	setJobStatus(t, db, ran.ID, JobStatusDone)
+	seedCost(t, db, ran.ID, `{"cost_usd":0.40,"has_cost":true}`)
+
+	// A job that failed before an agent ran: terminal and finished, but with no
+	// agent_invoked marker and no token usage.
+	failed := enqueueJob(t, db, repo.ID,
+		createCommit(t, db, repo.ID, "gate-fail-sha").ID, "gate-fail-sha")
+	setJobStatus(t, db, failed.ID, JobStatusFailed)
+
+	got, err := db.GetCostAggregate(CostOptions{RepoPaths: []string{repo.RootPath}})
+	require.NoError(t, err)
+	assert.Equal(1, got.JobsTotal, "pre-agent failure excluded from the denominator")
+	assert.Equal(1, got.JobsWithCost)
+	assert.InDelta(0.40, got.TotalUSD, 0.0001)
+	assert.True(got.Complete, "coverage complete despite the pre-agent failure")
+}
+
+// TestGetCostAggregateCountsPulledUnpricedJob verifies the agent_invoked marker
+// survives a pull from another machine and that a pulled terminal row which ran
+// an agent but reported no cost still counts toward the denominator. command_line
+// is not synced, so without the synced marker such a row (no usage locally) would
+// be invisible to cost coverage. A pulled row that never ran an agent stays out.
+func TestGetCostAggregateCountsPulledUnpricedJob(t *testing.T) {
+	assert := assert.New(t)
+	db := openTestDB(t)
+	t.Cleanup(func() { db.Close() })
+
+	repo, err := db.GetOrCreateRepo("/test/repo-pulled-unpriced")
+	require.NoError(t, err)
+
+	ran := time.Now().UTC()
+
+	// A terminal row pulled from another machine that ran an agent but reported
+	// no cost. UpsertPulledJob writes the synced agent_invoked marker.
+	invoked := PulledJob{
+		UUID:            "pulled-invoked-uuid",
+		RepoIdentity:    "/test/repo-pulled-unpriced",
+		GitRef:          "HEAD",
+		Agent:           "codex",
+		Status:          string(JobStatusDone),
+		AgentInvoked:    true,
+		StartedAt:       &ran,
+		FinishedAt:      &ran,
+		SourceMachineID: "machine-a",
+		EnqueuedAt:      ran,
+		UpdatedAt:       ran,
+	}
+	require.NoError(t, db.UpsertPulledJob(invoked, repo.ID, nil))
+
+	// A terminal row that never ran an agent (no marker, no usage) stays out of
+	// the denominator even though it synced from the same machine.
+	noAgent := invoked
+	noAgent.UUID = "pulled-no-agent-uuid"
+	noAgent.AgentInvoked = false
+	require.NoError(t, db.UpsertPulledJob(noAgent, repo.ID, nil))
+
+	got, err := db.GetCostAggregate(CostOptions{RepoPaths: []string{repo.RootPath}})
+	require.NoError(t, err)
+	assert.Equal(1, got.JobsTotal, "pulled agent-invoked row counts; no-agent row excluded")
+	assert.Equal(0, got.JobsWithCost, "row ran an agent but reported no cost")
+	assert.InDelta(0.0, got.TotalUSD, 0.0001)
+	assert.False(got.Complete, "coverage is incomplete with an unpriced eligible row")
+}

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -847,6 +847,25 @@ func (db *DB) migrate() error {
 		}
 	}
 
+	// Migration: add agent_invoked column to review_jobs if missing.
+	// agent_invoked is the authoritative "an agent actually ran this attempt"
+	// signal for cost eligibility: the worker sets it immediately before the agent
+	// call (after all pre-agent gates) and it syncs across machines. Rows that
+	// predate the column keep the default 0 and are not backfilled — a historical
+	// run that recorded token usage is still counted via the token_usage fallback
+	// in costEligible, and command_line is too unreliable a signal to seed from
+	// (it is written before some pre-agent failures, so it would re-introduce the
+	// over-count this marker exists to avoid).
+	err = db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('review_jobs') WHERE name = 'agent_invoked'`).Scan(&count)
+	if err != nil {
+		return fmt.Errorf("check agent_invoked column: %w", err)
+	}
+	if count == 0 {
+		if _, err = db.Exec(`ALTER TABLE review_jobs ADD COLUMN agent_invoked INTEGER NOT NULL DEFAULT 0`); err != nil {
+			return fmt.Errorf("add agent_invoked column: %w", err)
+		}
+	}
+
 	// Migration: add min_severity column to review_jobs if missing
 	err = db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('review_jobs') WHERE name = 'min_severity'`).Scan(&count)
 	if err != nil {
@@ -1727,7 +1746,11 @@ func demoteConflictingAutoDesignJobs(tx *sql.Tx, sourceRepoID, targetRepoID int6
 	return nil
 }
 
-// ResetStaleJobs marks all running jobs as queued (for daemon restart)
+// ResetStaleJobs marks all running jobs as queued (for daemon restart).
+// session_id and token_usage are cleared so a job interrupted mid-run (which
+// may have streamed a session id, or had a late usage write land on it) does
+// not carry the prior attempt's cost into the requeued run, matching the
+// other requeue paths (ReenqueueJob, RetryJob, FailoverJob).
 func (db *DB) ResetStaleJobs() error {
 	if _, err := db.Exec(`
 		UPDATE ci_pr_panels
@@ -1745,7 +1768,8 @@ func (db *DB) ResetStaleJobs() error {
 	}
 	_, err := db.Exec(`
 		UPDATE review_jobs
-		SET status = 'queued', worker_id = NULL, started_at = NULL
+		SET status = 'queued', worker_id = NULL, started_at = NULL,
+		    session_id = NULL, token_usage = NULL, command_line = NULL, agent_invoked = 0, synced_at = NULL
 		WHERE status = 'running'
 	`)
 	return err

--- a/internal/storage/db_helper_test.go
+++ b/internal/storage/db_helper_test.go
@@ -144,6 +144,45 @@ func setJobBranch(t *testing.T, db *DB, jobID int64, branch string) {
 	require.NoError(t, err, "failed to set job branch: %v")
 }
 
+// setJobAgentInvoked marks a job as having actually invoked an agent, which is
+// what cost eligibility keys on. Cost-eligible test jobs must set it; no-agent
+// rows leave it unset. It writes the marker directly (like the other seed
+// helpers) rather than through MarkJobAgentInvoked: that method scopes the write
+// to the running attempt (status='running' + worker_id), but cost tests seed
+// terminal rows that no longer satisfy that scope. The scoping itself is covered
+// by TestMarkJobAgentInvoked_StaleWorkerIgnored.
+func setJobAgentInvoked(t *testing.T, db *DB, jobID int64) {
+	t.Helper()
+	_, err := db.Exec(
+		`UPDATE review_jobs SET command_line = ?, agent_invoked = 1 WHERE id = ?`,
+		fmt.Sprintf("test-agent review %d", jobID), jobID)
+	require.NoError(t, err, "failed to mark job agent-invoked")
+}
+
+// getJobAgentInvoked reads the raw agent_invoked marker for a job. The
+// ReviewJob model does not expose it (it gates cost eligibility, it is not a
+// display field), so attempt-reset tests read the column directly.
+func getJobAgentInvoked(t *testing.T, db *DB, jobID int64) bool {
+	t.Helper()
+	var invoked int
+	require.NoError(t, db.QueryRow(
+		`SELECT agent_invoked FROM review_jobs WHERE id = ?`, jobID).Scan(&invoked),
+		"failed to read agent_invoked")
+	return invoked == 1
+}
+
+// seedCost prices a job the way the worker does: an agent ran (agent_invoked
+// set) and token usage is written scoped to the attempt's captured session, so
+// the helper assigns a session id (via setJobSession, defined in
+// reviews_test.go) and stores the usage blob against it.
+func seedCost(t *testing.T, db *DB, jobID int64, tokenUsageJSON string) {
+	t.Helper()
+	setJobAgentInvoked(t, db, jobID)
+	sessionID := fmt.Sprintf("sess-%d", jobID)
+	setJobSession(t, db, jobID, sessionID)
+	require.NoError(t, db.SaveJobTokenUsage(jobID, sessionID, tokenUsageJSON))
+}
+
 func createJobChain(t *testing.T, db *DB, repoPath, sha string) (*Repo, *Commit, *ReviewJob) {
 	t.Helper()
 	repo := createRepo(t, db, repoPath)

--- a/internal/storage/db_job_test.go
+++ b/internal/storage/db_job_test.go
@@ -368,15 +368,22 @@ func TestRetryJob(t *testing.T) {
 	// Claim the job (makes it running)
 	claimJob(t, db, "worker-1")
 
+	// A prior attempt's agent_invoked marker must not survive the retry: it
+	// gates cost eligibility, so a stale marker could miscount a re-attempt
+	// that fails before selecting an agent.
+	require.NoError(t, db.MarkJobAgentInvoked(job.ID, "worker-1", "codex review retry123"))
+
 	// Retry should succeed (retry_count: 0 -> 1)
 	retried, err := db.RetryJob(job.ID, "", 3, 0)
 	require.NoError(t, err, "RetryJob failed: %v")
 
 	assert.True(t, retried)
 
-	// Verify job is queued with retry_count=1
+	// Verify job is queued with retry_count=1 and the agent-ran marker cleared
 	updatedJob, _ := db.GetJobByID(job.ID)
 	assert.Equal(t, JobStatusQueued, updatedJob.Status)
+	assert.Empty(t, updatedJob.CommandLine, "retry clears the prior attempt's command line")
+	assert.False(t, getJobAgentInvoked(t, db, job.ID), "retry clears the agent_invoked marker")
 	count, _ := db.GetJobRetryCount(job.ID)
 	assert.Equal(t, 1, count)
 
@@ -513,6 +520,7 @@ func TestFailoverJob(t *testing.T) {
 
 		// Claim to make it running
 		claimJob(t, db, "worker-1")
+		require.NoError(t, db.MarkJobAgentInvoked(job.ID, "worker-1", "primary review fo-abc123"))
 
 		// Failover should succeed
 		ok, err := db.FailoverJob(job.ID, "worker-1", "backup", "")
@@ -520,12 +528,14 @@ func TestFailoverJob(t *testing.T) {
 
 		assert.True(t, ok)
 
-		// Verify: agent swapped, retry_count reset, status queued
+		// Verify: agent swapped, retry_count reset, status queued, marker cleared
 		updated, err := db.GetJobByID(job.ID)
 		require.NoError(t, err, "GetJobByID: %v")
 
 		assert.Equal(t, "backup", updated.Agent)
 		assert.Equal(t, JobStatusQueued, updated.Status)
+		assert.Empty(t, updated.CommandLine, "failover clears the prior agent's command line")
+		assert.False(t, getJobAgentInvoked(t, db, job.ID), "failover clears the agent_invoked marker")
 		count, _ := db.GetJobRetryCount(job.ID)
 		assert.Equal(t, 0, count)
 	})
@@ -1380,6 +1390,41 @@ func TestSaveJobSessionID_StaleWorkerIgnored(t *testing.T) {
 	assert.Equal(t, "session-B", j.SessionID)
 }
 
+// TestMarkJobAgentInvoked_StaleWorkerIgnored verifies the agent-ran marker is
+// scoped to the current attempt: a worker that calls MarkJobAgentInvoked after
+// its attempt was canceled and re-claimed by another worker must not set the
+// marker on the new attempt's row, which would wrongly make it cost-eligible.
+func TestMarkJobAgentInvoked_StaleWorkerIgnored(t *testing.T) {
+	assert := assert.New(t)
+	db := openTestDB(t)
+	defer db.Close()
+
+	_, _, job := createJobChain(t, db, "/tmp/test-repo", "invoked-race")
+
+	claimJob(t, db, "worker-A")
+	require.NoError(t, db.MarkJobAgentInvoked(job.ID, "worker-A", "codex review x"),
+		"MarkJobAgentInvoked (worker-A)")
+	assert.True(getJobAgentInvoked(t, db, job.ID), "owning worker sets the marker")
+
+	// Cancel + reenqueue hands the row to a new attempt and clears the marker.
+	require.NoError(t, db.CancelJob(job.ID), "CancelJob")
+	require.NoError(t, db.ReenqueueJob(job.ID, ReenqueueOpts{}), "ReenqueueJob")
+	assert.False(getJobAgentInvoked(t, db, job.ID), "reenqueue clears the marker")
+
+	claimJob(t, db, "worker-B")
+
+	// The stale worker-A write must not land on the row worker-B now owns.
+	require.NoError(t, db.MarkJobAgentInvoked(job.ID, "worker-A", "stale review x"),
+		"MarkJobAgentInvoked (stale worker-A)")
+	assert.False(getJobAgentInvoked(t, db, job.ID),
+		"stale worker does not set the marker on the new attempt")
+
+	// The current owner can still set it.
+	require.NoError(t, db.MarkJobAgentInvoked(job.ID, "worker-B", "codex review x"),
+		"MarkJobAgentInvoked (worker-B)")
+	assert.True(getJobAgentInvoked(t, db, job.ID), "current owner sets the marker")
+}
+
 func TestMinSeverityRoundTrip(t *testing.T) {
 	assert := assert.New(t)
 	db := openTestDB(t)
@@ -1493,6 +1538,13 @@ func TestPromoteClassifyToDesignReview_HappyPath(t *testing.T) {
 		"classifier retry: timeout", jobID)
 	require.NoError(t, err)
 
+	// The classifier attempt left a session id and the agent_invoked marker
+	// behind. Both must clear on promotion so the design attempt captures a
+	// fresh session (the token-usage write is session-scoped) and is not counted
+	// as having run an agent until it actually selects one.
+	setJobSession(t, db, jobID, "classify-sess")
+	require.NoError(t, db.MarkJobAgentInvoked(jobID, "w1", "codex classify abc"))
+
 	require.NoError(t, db.PromoteClassifyToDesignReview(jobID, "w1", "claude-code", ""))
 
 	j, err := db.GetJobByID(jobID)
@@ -1504,6 +1556,10 @@ func TestPromoteClassifyToDesignReview_HappyPath(t *testing.T) {
 	assert.Empty(t, j.WorkerID, "worker_id cleared so a new worker can claim")
 	assert.Nil(t, j.StartedAt, "started_at cleared")
 	assert.Empty(t, j.Error, "error cleared")
+	assert.Empty(t, j.SessionID, "session id cleared so the design attempt captures a fresh one")
+	assert.Empty(t, j.CommandLine, "command line cleared on promotion")
+	assert.False(t, getJobAgentInvoked(t, db, jobID),
+		"agent_invoked marker cleared so promotion is not counted as an agent run")
 }
 
 func TestPromoteClassifyToDesignReview_StaleWorkerNoOps(t *testing.T) {

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -396,10 +396,23 @@ func (db *DB) SaveJobPrompt(jobID int64, prompt string) error {
 	return err
 }
 
-// SaveJobCommandLine stores the actual agent command line used for
-// this execution. Purely informational — reconstructed on each run.
-func (db *DB) SaveJobCommandLine(jobID int64, cmdLine string) error {
-	_, err := db.Exec(`UPDATE review_jobs SET command_line = ? WHERE id = ?`, cmdLine, jobID)
+// MarkJobAgentInvoked records that an agent was actually invoked for this
+// attempt and stores the command line that was executed. The worker calls it
+// immediately before the agent runs — after all pre-agent gates (prompt size,
+// worktree creation) — so jobs that fail a gate are never marked. agent_invoked
+// is the authoritative, synced "an agent ran" signal for cost eligibility (see
+// costEligible); command_line stays a local display/debug field. Attempt resets
+// clear both. Set fresh on each run.
+//
+// The update is scoped to the current attempt (status='running' and the given
+// workerID), so a stale worker unwinding after a cancel/retry cannot stamp the
+// marker onto a row a new attempt now owns — that would wrongly make the
+// terminal row cost-eligible. Mirrors SaveJobSessionID.
+func (db *DB) MarkJobAgentInvoked(jobID int64, workerID, cmdLine string) error {
+	_, err := db.Exec(
+		`UPDATE review_jobs SET command_line = ?, agent_invoked = 1
+		 WHERE id = ? AND status = 'running' AND worker_id = ?`,
+		cmdLine, jobID, workerID)
 	return err
 }
 
@@ -433,15 +446,26 @@ func (db *DB) SaveJobPatch(jobID int64, patch string) error {
 	return err
 }
 
-// SaveJobTokenUsage stores a JSON blob of token consumption data.
-func (db *DB) SaveJobTokenUsage(jobID int64, tokenUsageJSON string) error {
+// SaveJobTokenUsage stores a JSON blob of token consumption data, scoped to
+// the attempt that produced it. The write only lands if the row still carries
+// sessionID, so a delayed usage fetch from a prior attempt cannot stamp its
+// cost onto a row that was re-enqueued (and cleared) and is now running or
+// done under a different session.
+//
+// It also clears synced_at to invalidate the push cursor directly. A job is
+// marked terminal before its cost is captured, so this write can land in the
+// same RFC3339 second as a prior sync mark; updated_at vs synced_at is only
+// second-precise, so the cursor would compare equal and never re-select the
+// row. A NULL synced_at always re-selects it, so the cost reaches PostgreSQL.
+func (db *DB) SaveJobTokenUsage(jobID int64, sessionID, tokenUsageJSON string) error {
 	if tokenUsageJSON == "" {
 		return nil
 	}
 	now := time.Now().Format(time.RFC3339)
 	_, err := db.Exec(
-		`UPDATE review_jobs SET token_usage = ?, updated_at = ? WHERE id = ?`,
-		tokenUsageJSON, now, jobID,
+		`UPDATE review_jobs SET token_usage = ?, updated_at = ?, synced_at = NULL
+		 WHERE id = ? AND session_id = ?`,
+		tokenUsageJSON, now, jobID, sessionID,
 	)
 	return err
 }
@@ -728,9 +752,18 @@ func (db *DB) ReenqueueJob(jobID int64, opts ReenqueueOpts) error {
 	// only for review jobs so they rebuild from current git/config state.
 	// Stored-prompt jobs (task, compact, fix, insights) keep their prompt
 	// since the worker needs it and cannot regenerate it from git.
+	//
+	// synced_at is cleared because this attempt's cost metadata is cleared: if
+	// the rerun completes unpriced in the same RFC3339 second as the prior
+	// sync, the second-precise updated_at vs synced_at comparison would compare
+	// equal and never re-push, leaving stale spend in PostgreSQL. A NULL
+	// synced_at always re-selects the row (see SaveJobTokenUsage, which clears
+	// it on the symmetric cost-write path). The other attempt resets (RetryJob,
+	// FailoverJob, ResetStaleJobs, PromoteClassifyToDesignReview) clear it for
+	// the same reason.
 	result, err := conn.ExecContext(ctx, `
 		UPDATE review_jobs
-		SET status = 'queued', worker_id = NULL, started_at = NULL, finished_at = NULL, error = NULL, retry_count = 0, patch = NULL, session_id = NULL, model = ?, provider = ?,
+		SET status = 'queued', worker_id = NULL, started_at = NULL, finished_at = NULL, error = NULL, retry_count = 0, patch = NULL, session_id = NULL, token_usage = NULL, command_line = NULL, agent_invoked = 0, synced_at = NULL, model = ?, provider = ?,
 		    prompt_prebuilt = 0,
 		    prompt = CASE WHEN job_type IN ('task', 'compact', 'fix', 'insights') THEN prompt ELSE NULL END,
 		    skip_reason = NULL,
@@ -775,13 +808,13 @@ func (db *DB) RetryJob(jobID int64, workerID string, maxRetries int, retryBackof
 	if workerID != "" {
 		result, err = db.Exec(`
 			UPDATE review_jobs
-			SET status = 'queued', worker_id = NULL, started_at = NULL, finished_at = NULL, error = NULL, retry_count = retry_count + 1, session_id = NULL, retry_not_before = ?
+			SET status = 'queued', worker_id = NULL, started_at = NULL, finished_at = NULL, error = NULL, retry_count = retry_count + 1, session_id = NULL, token_usage = NULL, command_line = NULL, agent_invoked = 0, synced_at = NULL, retry_not_before = ?
 			WHERE id = ? AND retry_count < ? AND status = 'running' AND worker_id = ?
 		`, notBefore, jobID, maxRetries, workerID)
 	} else {
 		result, err = db.Exec(`
 			UPDATE review_jobs
-			SET status = 'queued', worker_id = NULL, started_at = NULL, finished_at = NULL, error = NULL, retry_count = retry_count + 1, session_id = NULL, retry_not_before = ?
+			SET status = 'queued', worker_id = NULL, started_at = NULL, finished_at = NULL, error = NULL, retry_count = retry_count + 1, session_id = NULL, token_usage = NULL, command_line = NULL, agent_invoked = 0, synced_at = NULL, retry_not_before = ?
 			WHERE id = ? AND retry_count < ? AND status = 'running'
 		`, notBefore, jobID, maxRetries)
 	}
@@ -818,6 +851,10 @@ func (db *DB) FailoverJob(jobID int64, workerID, backupAgent, backupModel string
 		    finished_at = NULL,
 		    error = NULL,
 		    session_id = NULL,
+		    token_usage = NULL,
+		    command_line = NULL,
+		    agent_invoked = 0,
+		    synced_at = NULL,
 		    retry_not_before = NULL
 		WHERE id = ?
 		  AND status = 'running'
@@ -1487,6 +1524,11 @@ func (db *DB) PromoteClassifyToDesignReview(classifyJobID int64, workerID, agent
 		    worker_id = NULL,
 		    started_at = NULL,
 		    finished_at = NULL,
+		    session_id = NULL,
+		    token_usage = NULL,
+		    command_line = NULL,
+		    agent_invoked = 0,
+		    synced_at = NULL,
 		    prompt = NULL,
 		    prompt_prebuilt = 0,
 		    error = NULL,

--- a/internal/storage/panels_test.go
+++ b/internal/storage/panels_test.go
@@ -434,15 +434,15 @@ func TestGetPanelSummaries(t *testing.T) {
 	setStatus(t, db, a[0].ID, JobStatusDone)
 	setStatus(t, db, a[1].ID, JobStatusFailed)
 	setStatus(t, db, a[2].ID, JobStatusSkipped)
-	require.NoError(t, db.SaveJobTokenUsage(a[0].ID, `{"cost_usd":0.10,"has_cost":true}`))
-	require.NoError(t, db.SaveJobTokenUsage(a[1].ID, `{"cost_usd":0.25,"has_cost":true}`))
-	require.NoError(t, db.SaveJobTokenUsage(a[2].ID, `{"cost_usd":0.05,"has_cost":true}`))
+	seedCost(t, db, a[0].ID, `{"cost_usd":0.10,"has_cost":true}`)
+	seedCost(t, db, a[1].ID, `{"cost_usd":0.25,"has_cost":true}`)
+	seedCost(t, db, a[2].ID, `{"cost_usd":0.05,"has_cost":true}`)
 
 	// Run B: 2 members — done + canceled (all terminal; 1 succeeded).
 	_, b := enqueuePanelRun(t, db, repo.ID, "run-B", 2)
 	setStatus(t, db, b[0].ID, JobStatusDone)
 	setStatus(t, db, b[1].ID, JobStatusCanceled)
-	require.NoError(t, db.SaveJobTokenUsage(b[0].ID, `{"cost_usd":0.20,"has_cost":true}`))
+	seedCost(t, db, b[0].ID, `{"cost_usd":0.20,"has_cost":true}`)
 
 	// Run C: 2 members — done + running (1 terminal of 2).
 	_, c := enqueuePanelRun(t, db, repo.ID, "run-C", 2)

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -15,12 +15,12 @@ import (
 )
 
 // PostgreSQL schema version - increment when schema changes
-const pgSchemaVersion = 16
+const pgSchemaVersion = 17
 
 // pgSchemaName is the PostgreSQL schema used to isolate roborev tables
 const pgSchemaName = "roborev"
 
-//go:embed schemas/postgres_v16.sql
+//go:embed schemas/postgres_v17.sql
 var pgSchemaSQL string
 
 // pgSchemaStatements returns the individual DDL statements for schema creation.
@@ -388,6 +388,15 @@ func (p *PgPool) EnsureSchema(ctx context.Context) error {
 				return fmt.Errorf("v16 migration (add dirty_files): %w", err)
 			}
 		}
+		if currentVersion < 17 {
+			// agent_invoked: authoritative, synced "an agent ran" signal for cost
+			// eligibility. Rows that predate the column keep the default FALSE and
+			// are not backfilled — a historical run that recorded token usage is
+			// still counted via the token_usage fallback in costEligible.
+			if _, err = p.pool.Exec(ctx, `ALTER TABLE review_jobs ADD COLUMN IF NOT EXISTS agent_invoked BOOLEAN NOT NULL DEFAULT FALSE`); err != nil {
+				return fmt.Errorf("v17 migration (add agent_invoked): %w", err)
+			}
+		}
 		// Update version
 		_, err = p.pool.Exec(ctx, `INSERT INTO schema_version (version) VALUES ($1) ON CONFLICT (version) DO NOTHING`, pgSchemaVersion)
 		if err != nil {
@@ -698,8 +707,8 @@ func (p *PgPool) UpsertJob(ctx context.Context, j SyncableJob, pgRepoID int64, p
 			enqueued_at, started_at, finished_at, prompt, diff_content, dirty_files, error, token_usage,
 			worktree_path, source, min_severity,
 			panel_run_uuid, panel_role, panel_name, panel_member_name, panel_member_index, panel_member_config_json,
-			source_machine_id, backup_agent, backup_model, updated_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, clock_timestamp())
+			source_machine_id, backup_agent, backup_model, agent_invoked, updated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, clock_timestamp())
 		ON CONFLICT (uuid) DO UPDATE SET
 			status = EXCLUDED.status,
 			finished_at = EXCLUDED.finished_at,
@@ -709,11 +718,12 @@ func (p *PgPool) UpsertJob(ctx context.Context, j SyncableJob, pgRepoID int64, p
 			requested_model = EXCLUDED.requested_model,
 			requested_provider = EXCLUDED.requested_provider,
 			git_ref = EXCLUDED.git_ref,
-			session_id = COALESCE(EXCLUDED.session_id, review_jobs.session_id),
+			session_id = CASE WHEN EXCLUDED.status IN ('done', 'failed', 'canceled', 'skipped', 'applied', 'rebased') THEN EXCLUDED.session_id ELSE COALESCE(EXCLUDED.session_id, review_jobs.session_id) END,
 			commit_id = EXCLUDED.commit_id,
 			patch_id = EXCLUDED.patch_id,
 			dirty_files = COALESCE(EXCLUDED.dirty_files, review_jobs.dirty_files),
-			token_usage = COALESCE(EXCLUDED.token_usage, review_jobs.token_usage),
+			token_usage = CASE WHEN EXCLUDED.status IN ('done', 'failed', 'canceled', 'skipped', 'applied', 'rebased') THEN EXCLUDED.token_usage ELSE COALESCE(EXCLUDED.token_usage, review_jobs.token_usage) END,
+			agent_invoked = CASE WHEN EXCLUDED.status IN ('done', 'failed', 'canceled', 'skipped', 'applied', 'rebased') THEN EXCLUDED.agent_invoked ELSE (review_jobs.agent_invoked OR EXCLUDED.agent_invoked) END,
 			worktree_path = COALESCE(EXCLUDED.worktree_path, review_jobs.worktree_path),
 			source = COALESCE(EXCLUDED.source, review_jobs.source),
 			min_severity = EXCLUDED.min_severity,
@@ -730,7 +740,7 @@ func (p *PgPool) UpsertJob(ctx context.Context, j SyncableJob, pgRepoID int64, p
 		defaultStr(j.JobType, "review"), j.ReviewType, nullString(j.PatchID), j.Status, j.Agentic, j.EnqueuedAt, j.StartedAt, j.FinishedAt,
 		nullString(j.Prompt), j.DiffContent, nullString(dirtyFilesJSON), nullString(j.Error), nullString(j.TokenUsage), nullString(j.WorktreePath), nullString(j.Source), normalizeMinSeverityForWrite(j.MinSeverity),
 		nullString(j.PanelRunUUID), nullString(j.PanelRole), nullString(j.PanelName), nullString(j.PanelMemberName), j.PanelMemberIndex, nullString(j.PanelMemberConfigJSON),
-		j.SourceMachineID, j.BackupAgent, j.BackupModel)
+		j.SourceMachineID, j.BackupAgent, j.BackupModel, j.AgentInvoked)
 	return err
 }
 
@@ -782,6 +792,7 @@ type PulledJob struct {
 	PatchID               string
 	Status                string
 	Agentic               bool
+	AgentInvoked          bool
 	EnqueuedAt            time.Time
 	StartedAt             *time.Time
 	FinishedAt            *time.Time
@@ -823,7 +834,7 @@ func (p *PgPool) PullJobs(ctx context.Context, excludeMachineID string, cursor s
 	rows, err := p.pool.Query(ctx, `
 		SELECT
 			j.uuid, r.identity, COALESCE(c.sha, ''), COALESCE(c.author, ''), COALESCE(c.subject, ''), COALESCE(c.timestamp, '1970-01-01'::timestamptz),
-			j.git_ref, COALESCE(j.session_id, ''), j.agent, COALESCE(j.model, ''), COALESCE(j.provider, ''), COALESCE(j.requested_model, ''), COALESCE(j.requested_provider, ''), COALESCE(j.reasoning, ''), COALESCE(j.job_type, 'review'), COALESCE(j.review_type, ''), COALESCE(j.patch_id, ''), j.status, j.agentic,
+			j.git_ref, COALESCE(j.session_id, ''), j.agent, COALESCE(j.model, ''), COALESCE(j.provider, ''), COALESCE(j.requested_model, ''), COALESCE(j.requested_provider, ''), COALESCE(j.reasoning, ''), COALESCE(j.job_type, 'review'), COALESCE(j.review_type, ''), COALESCE(j.patch_id, ''), j.status, j.agentic, COALESCE(j.agent_invoked, FALSE),
 			j.enqueued_at, j.started_at, j.finished_at,
 			COALESCE(j.prompt, ''), j.diff_content, j.dirty_files, COALESCE(j.error, ''), COALESCE(j.token_usage, ''),
 			COALESCE(j.worktree_path, ''), COALESCE(j.source, ''), COALESCE(j.min_severity, ''), COALESCE(j.backup_agent, ''), COALESCE(j.backup_model, ''),
@@ -853,7 +864,7 @@ func (p *PgPool) PullJobs(ctx context.Context, excludeMachineID string, cursor s
 
 		err := rows.Scan(
 			&j.UUID, &j.RepoIdentity, &j.CommitSHA, &j.CommitAuthor, &j.CommitSubject, &j.CommitTimestamp,
-			&j.GitRef, &j.SessionID, &j.Agent, &j.Model, &j.Provider, &j.RequestedModel, &j.RequestedProvider, &j.Reasoning, &j.JobType, &j.ReviewType, &j.PatchID, &j.Status, &j.Agentic,
+			&j.GitRef, &j.SessionID, &j.Agent, &j.Model, &j.Provider, &j.RequestedModel, &j.RequestedProvider, &j.Reasoning, &j.JobType, &j.ReviewType, &j.PatchID, &j.Status, &j.Agentic, &j.AgentInvoked,
 			&j.EnqueuedAt, &j.StartedAt, &j.FinishedAt,
 			&j.Prompt, &diffContent, &dirtyFiles, &j.Error, &j.TokenUsage,
 			&j.WorktreePath, &j.Source, &j.MinSeverity, &j.BackupAgent, &j.BackupModel,
@@ -1154,8 +1165,8 @@ func (p *PgPool) BatchUpsertJobs(ctx context.Context, jobs []JobWithPgIDs) ([]bo
 				enqueued_at, started_at, finished_at, prompt, diff_content, dirty_files, error, token_usage,
 				worktree_path, source, min_severity,
 				panel_run_uuid, panel_role, panel_name, panel_member_name, panel_member_index, panel_member_config_json,
-				source_machine_id, backup_agent, backup_model, updated_at
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, clock_timestamp())
+				source_machine_id, backup_agent, backup_model, agent_invoked, updated_at
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, clock_timestamp())
 			ON CONFLICT (uuid) DO UPDATE SET
 				status = EXCLUDED.status,
 				finished_at = EXCLUDED.finished_at,
@@ -1165,11 +1176,12 @@ func (p *PgPool) BatchUpsertJobs(ctx context.Context, jobs []JobWithPgIDs) ([]bo
 				requested_model = EXCLUDED.requested_model,
 				requested_provider = EXCLUDED.requested_provider,
 				git_ref = EXCLUDED.git_ref,
-				session_id = COALESCE(EXCLUDED.session_id, review_jobs.session_id),
+				session_id = CASE WHEN EXCLUDED.status IN ('done', 'failed', 'canceled', 'skipped', 'applied', 'rebased') THEN EXCLUDED.session_id ELSE COALESCE(EXCLUDED.session_id, review_jobs.session_id) END,
 				commit_id = EXCLUDED.commit_id,
 				patch_id = EXCLUDED.patch_id,
 				dirty_files = COALESCE(EXCLUDED.dirty_files, review_jobs.dirty_files),
-				token_usage = COALESCE(EXCLUDED.token_usage, review_jobs.token_usage),
+				token_usage = CASE WHEN EXCLUDED.status IN ('done', 'failed', 'canceled', 'skipped', 'applied', 'rebased') THEN EXCLUDED.token_usage ELSE COALESCE(EXCLUDED.token_usage, review_jobs.token_usage) END,
+				agent_invoked = CASE WHEN EXCLUDED.status IN ('done', 'failed', 'canceled', 'skipped', 'applied', 'rebased') THEN EXCLUDED.agent_invoked ELSE (review_jobs.agent_invoked OR EXCLUDED.agent_invoked) END,
 				worktree_path = COALESCE(EXCLUDED.worktree_path, review_jobs.worktree_path),
 				source = COALESCE(EXCLUDED.source, review_jobs.source),
 				min_severity = EXCLUDED.min_severity,
@@ -1186,7 +1198,7 @@ func (p *PgPool) BatchUpsertJobs(ctx context.Context, jobs []JobWithPgIDs) ([]bo
 			defaultStr(j.JobType, "review"), j.ReviewType, nullString(j.PatchID), j.Status, j.Agentic, j.EnqueuedAt, j.StartedAt, j.FinishedAt,
 			nullString(j.Prompt), j.DiffContent, nullString(dirtyFilesJSON), nullString(j.Error), nullString(j.TokenUsage), nullString(j.WorktreePath), nullString(j.Source), normalizeMinSeverityForWrite(j.MinSeverity),
 			nullString(j.PanelRunUUID), nullString(j.PanelRole), nullString(j.PanelName), nullString(j.PanelMemberName), j.PanelMemberIndex, nullString(j.PanelMemberConfigJSON),
-			j.SourceMachineID, j.BackupAgent, j.BackupModel)
+			j.SourceMachineID, j.BackupAgent, j.BackupModel, j.AgentInvoked)
 	}
 
 	br := p.pool.SendBatch(ctx, batch)

--- a/internal/storage/schemas/postgres_v17.sql
+++ b/internal/storage/schemas/postgres_v17.sql
@@ -1,0 +1,160 @@
+-- PostgreSQL schema version 17
+-- On top of v16 (dirty_files), adds agent_invoked to review_jobs: the
+-- authoritative, synced "an agent actually ran this attempt" signal for cost
+-- eligibility. It is set immediately before the agent call (after all pre-agent
+-- gates) and cleared on attempt resets. command_line is intentionally NOT
+-- synced (it stays a local display field), so agent_invoked is what carries the
+-- agent-ran signal across machines.
+-- Note: Version is managed by EnsureSchema(), not this file.
+
+CREATE SCHEMA IF NOT EXISTS roborev;
+
+CREATE TABLE IF NOT EXISTS roborev.schema_version (
+  version INTEGER PRIMARY KEY,
+  applied_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.machines (
+  id SERIAL PRIMARY KEY,
+  machine_id UUID UNIQUE NOT NULL,
+  name TEXT,
+  last_seen_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.repos (
+  id SERIAL PRIMARY KEY,
+  identity TEXT UNIQUE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.commits (
+  id SERIAL PRIMARY KEY,
+  repo_id INTEGER REFERENCES roborev.repos(id),
+  sha TEXT NOT NULL,
+  author TEXT NOT NULL,
+  subject TEXT NOT NULL,
+  timestamp TIMESTAMP WITH TIME ZONE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  UNIQUE(repo_id, sha)
+);
+
+CREATE TABLE IF NOT EXISTS roborev.review_jobs (
+  id SERIAL PRIMARY KEY,
+  uuid UUID UNIQUE NOT NULL,
+  repo_id INTEGER NOT NULL REFERENCES roborev.repos(id),
+  commit_id INTEGER REFERENCES roborev.commits(id),
+  git_ref TEXT NOT NULL,
+  branch TEXT,
+  session_id TEXT,
+  agent TEXT NOT NULL,
+  model TEXT,
+  provider TEXT,
+  requested_model TEXT,
+  requested_provider TEXT,
+  reasoning TEXT,
+  job_type TEXT NOT NULL DEFAULT 'review',
+  review_type TEXT NOT NULL DEFAULT '',
+  patch_id TEXT,
+  status TEXT NOT NULL CHECK(status IN ('queued', 'running', 'done', 'failed', 'canceled', 'applied', 'rebased', 'skipped')),
+  agentic BOOLEAN DEFAULT FALSE,
+  agent_invoked BOOLEAN NOT NULL DEFAULT FALSE,
+  enqueued_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  started_at TIMESTAMP WITH TIME ZONE,
+  finished_at TIMESTAMP WITH TIME ZONE,
+  retry_not_before TIMESTAMP WITH TIME ZONE,
+  prompt TEXT,
+  diff_content TEXT,
+  dirty_files TEXT,
+  error TEXT,
+  token_usage TEXT,
+  worktree_path TEXT,
+  min_severity TEXT NOT NULL DEFAULT '',
+  backup_agent TEXT NOT NULL DEFAULT '',
+  backup_model TEXT NOT NULL DEFAULT '',
+  skip_reason TEXT,
+  source TEXT,
+  panel_run_uuid TEXT,
+  panel_role TEXT,
+  panel_name TEXT,
+  panel_member_name TEXT,
+  panel_member_index INTEGER,
+  panel_member_config_json TEXT,
+  source_machine_id UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.reviews (
+  id SERIAL PRIMARY KEY,
+  uuid UUID UNIQUE NOT NULL,
+  job_uuid UUID NOT NULL REFERENCES roborev.review_jobs(uuid),
+  agent TEXT NOT NULL,
+  prompt TEXT NOT NULL,
+  output TEXT NOT NULL,
+  closed BOOLEAN NOT NULL DEFAULT FALSE,
+  updated_by_machine_id UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.responses (
+  id SERIAL PRIMARY KEY,
+  uuid UUID UNIQUE NOT NULL,
+  job_uuid UUID NOT NULL REFERENCES roborev.review_jobs(uuid),
+  responder TEXT NOT NULL,
+  response TEXT NOT NULL,
+  source_machine_id UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  inserted_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp()
+);
+
+-- ci_pr_review_attempts holds local CI-poller retry state keyed by
+-- (github_repo, pr_number, head_sha). It is the durable source of truth for
+-- whether a HEAD is being reviewed and, when an AI-provider outage defers it,
+-- when to retry. One row per reviewed HEAD. next_attempt_at is NULL while a
+-- run is in-flight or pending and set once deferred. state is one of
+-- 'pending', 'deferred', or 'done'. This table is created in both the SQLite
+-- and Postgres backends for schema parity per the design, but it is NOT
+-- registered in any sync cursor (not sync-replicated). Avoid inline
+-- semicolons in this comment -- pgSchemaStatements splits the embedded
+-- Postgres schema on semicolons, so a literal one here would fragment the
+-- comment into a bad statement.
+CREATE TABLE IF NOT EXISTS roborev.ci_pr_review_attempts (
+  id BIGSERIAL PRIMARY KEY,
+  github_repo TEXT NOT NULL,
+  pr_number INTEGER NOT NULL,
+  head_sha TEXT NOT NULL,
+  attempt INTEGER NOT NULL DEFAULT 1,
+  first_attempt_at TIMESTAMPTZ NOT NULL,
+  next_attempt_at TIMESTAMPTZ,
+  last_error_class TEXT NOT NULL DEFAULT '',
+  consecutive_genuine_attempts INTEGER NOT NULL DEFAULT 0,
+  last_error_excerpt TEXT NOT NULL DEFAULT '',
+  last_panel_run_uuid TEXT NOT NULL DEFAULT '',
+  state TEXT NOT NULL DEFAULT 'pending',
+  updated_at TIMESTAMPTZ NOT NULL,
+  UNIQUE(github_repo, pr_number, head_sha)
+);
+
+CREATE INDEX IF NOT EXISTS idx_review_jobs_source ON roborev.review_jobs(source_machine_id);
+CREATE INDEX IF NOT EXISTS idx_review_jobs_updated ON roborev.review_jobs(updated_at);
+-- Note: idx_review_jobs_branch, idx_review_jobs_job_type,
+-- idx_review_jobs_patch_id, and idx_review_jobs_panel are created by
+-- migration code, not here (to support upgrades from older versions
+-- where those columns don't exist yet — the embedded schema is replayed
+-- on every startup, including against older databases).
+CREATE INDEX IF NOT EXISTS idx_reviews_job_uuid ON roborev.reviews(job_uuid);
+CREATE INDEX IF NOT EXISTS idx_reviews_updated ON roborev.reviews(updated_at);
+CREATE INDEX IF NOT EXISTS idx_responses_job_uuid ON roborev.responses(job_uuid);
+CREATE INDEX IF NOT EXISTS idx_responses_id ON roborev.responses(id);
+-- idx_responses_inserted is created by EnsureSchema after migrations so
+-- upgrades from older schemas do not try to index a column before it exists.
+-- Partial unique indexes for auto-design dedup are created by EnsureSchema
+-- (fresh-init block + v12 migration step) — placing them here would break
+-- v1->v12 migrations where the source column doesn't yet exist when this
+-- schema is replayed.
+
+CREATE TABLE IF NOT EXISTS roborev.sync_metadata (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);

--- a/internal/storage/summary.go
+++ b/internal/storage/summary.go
@@ -25,6 +25,7 @@ type Summary struct {
 	JobTypes []JobTypeStats `json:"job_types"`
 	Failures FailureStats   `json:"failures"`
 	Repos    []RepoSummary  `json:"repos,omitempty"`
+	Cost     CostAggregate  `json:"cost"`
 }
 
 // OverviewStats contains job counts by status.
@@ -172,6 +173,19 @@ func (db *DB) GetSummary(opts SummaryOptions) (*Summary, error) {
 	}
 
 	s.Failures, err = summaryFailures(tx, where, args)
+	if err != nil {
+		return nil, err
+	}
+
+	var costRepos []string
+	if opts.RepoPath != "" {
+		costRepos = []string{opts.RepoPath}
+	}
+	s.Cost, err = costAggregate(tx, CostOptions{
+		RepoPaths: costRepos,
+		Branch:    opts.Branch,
+		Since:     opts.Since,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/summary_cost_test.go
+++ b/internal/storage/summary_cost_test.go
@@ -1,0 +1,39 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSummaryIncludesCost(t *testing.T) {
+	assert := assert.New(t)
+	db := openTestDB(t)
+	t.Cleanup(func() { db.Close() })
+
+	repo := createRepo(t, db, "/tmp/summary-cost")
+	commit := createCommit(t, db, repo.ID, "sum-sha")
+	job := enqueueJob(t, db, repo.ID, commit.ID, "sum-sha")
+	setJobStatus(t, db, job.ID, JobStatusDone)
+	seedCost(t, db, job.ID, `{"cost_usd":0.42,"has_cost":true}`)
+
+	// Priced, eligible job enqueued before the window. It must be excluded by
+	// Since; if Since propagation were dropped, it would inflate the totals.
+	old := enqueueJob(t, db, repo.ID, createCommit(t, db, repo.ID, "old-sha").ID, "old-sha")
+	setJobStatus(t, db, old.ID, JobStatusDone)
+	_, err := db.Exec(`UPDATE review_jobs SET enqueued_at = datetime('now','-48 hours') WHERE id = ?`, old.ID)
+	require.NoError(t, err)
+	seedCost(t, db, old.ID, `{"cost_usd":9.99,"has_cost":true}`)
+
+	s, err := db.GetSummary(SummaryOptions{
+		RepoPath: repo.RootPath,
+		Since:    time.Now().Add(-24 * time.Hour),
+	})
+	require.NoError(t, err)
+	assert.Equal(1, s.Cost.JobsTotal)
+	assert.Equal(1, s.Cost.JobsWithCost)
+	assert.InDelta(0.42, s.Cost.TotalUSD, 0.0001)
+	assert.True(s.Cost.Complete)
+}

--- a/internal/storage/sync.go
+++ b/internal/storage/sync.go
@@ -375,6 +375,7 @@ type SyncableJob struct {
 	PatchID               string
 	Status                string
 	Agentic               bool
+	AgentInvoked          bool
 	EnqueuedAt            time.Time
 	StartedAt             *time.Time
 	FinishedAt            *time.Time
@@ -396,6 +397,9 @@ type SyncableJob struct {
 	PanelMemberConfigJSON string
 	SourceMachineID       string
 	UpdatedAt             time.Time
+	UpdatedAtRaw          string
+	StartedAtRaw          string
+	FinishedAtRaw         string
 }
 
 // GetJobsToSync returns terminal jobs that need to be pushed to PostgreSQL.
@@ -405,7 +409,7 @@ func (db *DB) GetJobsToSync(machineID string, limit int) ([]SyncableJob, error) 
 		SELECT
 			j.id, j.uuid, j.repo_id, COALESCE(r.identity, ''),
 			j.commit_id, COALESCE(c.sha, ''), COALESCE(c.author, ''), COALESCE(c.subject, ''), COALESCE(c.timestamp, ''),
-			j.git_ref, COALESCE(j.session_id, ''), j.agent, COALESCE(j.model, ''), COALESCE(j.provider, ''), COALESCE(j.requested_model, ''), COALESCE(j.requested_provider, ''), COALESCE(j.reasoning, ''), COALESCE(j.job_type, 'review'), COALESCE(j.review_type, ''), COALESCE(j.patch_id, ''), j.status, j.agentic,
+			j.git_ref, COALESCE(j.session_id, ''), j.agent, COALESCE(j.model, ''), COALESCE(j.provider, ''), COALESCE(j.requested_model, ''), COALESCE(j.requested_provider, ''), COALESCE(j.reasoning, ''), COALESCE(j.job_type, 'review'), COALESCE(j.review_type, ''), COALESCE(j.patch_id, ''), j.status, j.agentic, j.agent_invoked,
 			j.enqueued_at, COALESCE(j.started_at, ''), COALESCE(j.finished_at, ''),
 			COALESCE(j.prompt, ''), j.diff_content, j.dirty_files, COALESCE(j.error, ''), COALESCE(j.token_usage, ''),
 			COALESCE(j.worktree_path, ''), COALESCE(j.source, ''), COALESCE(j.min_severity, ''), COALESCE(j.backup_agent, ''), COALESCE(j.backup_model, ''),
@@ -443,7 +447,7 @@ func (db *DB) GetJobsToSync(machineID string, limit int) ([]SyncableJob, error) 
 		err := rows.Scan(
 			&j.ID, &j.UUID, &j.RepoID, &j.RepoIdentity,
 			&commitID, &j.CommitSHA, &j.CommitAuthor, &j.CommitSubject, &commitTimestamp,
-			&j.GitRef, &j.SessionID, &j.Agent, &j.Model, &j.Provider, &j.RequestedModel, &j.RequestedProvider, &j.Reasoning, &j.JobType, &j.ReviewType, &j.PatchID, &j.Status, &j.Agentic,
+			&j.GitRef, &j.SessionID, &j.Agent, &j.Model, &j.Provider, &j.RequestedModel, &j.RequestedProvider, &j.Reasoning, &j.JobType, &j.ReviewType, &j.PatchID, &j.Status, &j.Agentic, &j.AgentInvoked,
 			&enqueuedAt, &startedAt, &finishedAt,
 			&j.Prompt, &diffContent, &dirtyFiles, &j.Error, &j.TokenUsage,
 			&j.WorktreePath, &j.Source, &j.MinSeverity, &j.BackupAgent, &j.BackupModel,
@@ -470,16 +474,19 @@ func (db *DB) GetJobsToSync(machineID string, limit int) ([]SyncableJob, error) 
 				j.StartedAt = &t
 			}
 		}
+		j.StartedAtRaw = startedAt
 		if finishedAt != "" {
 			t := parseSQLiteTime(finishedAt)
 			if !t.IsZero() {
 				j.FinishedAt = &t
 			}
 		}
+		j.FinishedAtRaw = finishedAt
 		if commitTimestamp != "" {
 			j.CommitTimestamp = parseSQLiteTime(commitTimestamp)
 		}
 		j.UpdatedAt = parseSQLiteTime(updatedAt)
+		j.UpdatedAtRaw = updatedAt
 
 		jobs = append(jobs, j)
 	}
@@ -493,23 +500,107 @@ func (db *DB) MarkJobSynced(jobID int64) error {
 	return err
 }
 
-// MarkJobsSynced updates the synced_at timestamp for multiple jobs
-func (db *DB) MarkJobsSynced(jobIDs []int64) error {
-	if len(jobIDs) == 0 {
+// JobSyncMark identifies a pushed job by the snapshot fields that distinguish
+// the exact terminal attempt that was pushed. MarkJobsSynced restores synced_at
+// only when the row still matches all of them.
+type JobSyncMark struct {
+	ID            int64
+	UpdatedAt     string // raw updated_at string from the pushed snapshot
+	TokenUsage    string // token_usage from the pushed snapshot ("" when NULL)
+	Status        string // status from the pushed snapshot (always terminal)
+	SessionID     string // session_id from the pushed snapshot ("" when NULL)
+	AgentInvoked  bool   // agent_invoked from the pushed snapshot
+	Agent         string // agent from the pushed snapshot
+	Model         string // model from the pushed snapshot ("" when NULL)
+	Provider      string // provider from the pushed snapshot ("" when NULL)
+	Error         string // error from the pushed snapshot ("" when NULL)
+	StartedAtRaw  string // raw started_at string from the pushed snapshot ("" when NULL)
+	FinishedAtRaw string // raw finished_at string from the pushed snapshot ("" when NULL)
+}
+
+// NewJobSyncMark captures the snapshot fields MarkJobsSynced compares to confirm
+// a row still matches what was pushed. Keeping the field set in one place keeps
+// the push loop and the WHERE clause in agreement.
+func NewJobSyncMark(j SyncableJob) JobSyncMark {
+	return JobSyncMark{
+		ID:            j.ID,
+		UpdatedAt:     j.UpdatedAtRaw,
+		TokenUsage:    j.TokenUsage,
+		Status:        j.Status,
+		SessionID:     j.SessionID,
+		AgentInvoked:  j.AgentInvoked,
+		Agent:         j.Agent,
+		Model:         j.Model,
+		Provider:      j.Provider,
+		Error:         j.Error,
+		StartedAtRaw:  j.StartedAtRaw,
+		FinishedAtRaw: j.FinishedAtRaw,
+	}
+}
+
+// MarkJobsSynced advances synced_at only for jobs whose pushed snapshot still
+// matches the current row. Any change since the snapshot leaves the row eligible
+// for the next push instead of stranding it behind an advanced cursor; a missed
+// match only costs a redundant re-push next cycle, which is safe.
+//
+// The guard compares fields that distinguish the pushed terminal attempt:
+//
+//   - updated_at and token_usage: a job is marked terminal before its token usage
+//     is captured, and both writes use second precision, so a capture in the same
+//     second leaves updated_at byte-identical while token_usage changes from NULL
+//     to the cost. A capture that lands after this mark is handled at the source:
+//     SaveJobTokenUsage clears synced_at so the row re-selects regardless.
+//   - status, session_id, agent_invoked: an attempt reset (ReenqueueJob, RetryJob,
+//     FailoverJob, ResetStaleJobs, PromoteClassifyToDesignReview) clears cost
+//     metadata and synced_at in the same second. updated_at and token_usage alone
+//     can still match the snapshot (e.g. an unpriced row re-enqueued in the same
+//     second leaves both unchanged), so without these the stale mark would
+//     overwrite the reset's synced_at = NULL and strand the cleared-cost state.
+//     status moves off the terminal push set on every reset; session_id and
+//     agent_invoked further pin the attempt against a same-second re-completion.
+//   - agent, model, provider, error, started_at, finished_at: for sessionless,
+//     unpriced attempts, the fields above can all match again after a reset plus
+//     same-second terminal re-completion. These attempt metadata fields keep a
+//     stale pushed snapshot from marking the new terminal attempt synced.
+//
+// All compared fields are stable on a terminal row that was not reset, so the
+// tighter guard never wrongly skips an unchanged row.
+func (db *DB) MarkJobsSynced(marks []JobSyncMark) error {
+	if len(marks) == 0 {
 		return nil
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
-	placeholders := make([]string, len(jobIDs))
-	args := make([]any, len(jobIDs)+1)
-	args[0] = now
-	for i, id := range jobIDs {
-		placeholders[i] = "?"
-		args[i+1] = id
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin mark jobs synced: %w", err)
 	}
-	query := fmt.Sprintf(`UPDATE review_jobs SET synced_at = ? WHERE id IN (%s)`,
-		strings.Join(placeholders, ","))
-	_, err := db.Exec(query, args...)
-	return err
+	defer func() { _ = tx.Rollback() }()
+
+	stmt, err := tx.Prepare(
+		`UPDATE review_jobs SET synced_at = ?
+		 WHERE id = ? AND updated_at = ? AND COALESCE(token_usage, '') = ?
+		   AND status = ? AND COALESCE(session_id, '') = ? AND agent_invoked = ?
+		   AND agent = ? AND COALESCE(model, '') = ? AND COALESCE(provider, '') = ?
+		   AND COALESCE(error, '') = ? AND COALESCE(started_at, '') = ?
+		   AND COALESCE(finished_at, '') = ?`)
+	if err != nil {
+		return fmt.Errorf("prepare mark jobs synced: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, m := range marks {
+		invoked := 0
+		if m.AgentInvoked {
+			invoked = 1
+		}
+		if _, err := stmt.Exec(
+			now, m.ID, m.UpdatedAt, m.TokenUsage, m.Status, m.SessionID, invoked,
+			m.Agent, m.Model, m.Provider, m.Error, m.StartedAtRaw, m.FinishedAtRaw,
+		); err != nil {
+			return fmt.Errorf("mark job %d synced: %w", m.ID, err)
+		}
+	}
+	return tx.Commit()
 }
 
 // SyncableReview contains review data needed for sync
@@ -696,12 +787,12 @@ func (db *DB) UpsertPulledJob(j PulledJob, repoID int64, commitID *int64) error 
 	}
 	_, err = db.Exec(`
 		INSERT INTO review_jobs (
-			uuid, repo_id, commit_id, git_ref, session_id, agent, model, provider, requested_model, requested_provider, reasoning, job_type, review_type, patch_id, status, agentic,
+			uuid, repo_id, commit_id, git_ref, session_id, agent, model, provider, requested_model, requested_provider, reasoning, job_type, review_type, patch_id, status, agentic, agent_invoked,
 			enqueued_at, started_at, finished_at, prompt, diff_content, dirty_files, error, token_usage,
 			worktree_path, source, min_severity, backup_agent, backup_model,
 			panel_run_uuid, panel_role, panel_name, panel_member_name, panel_member_index, panel_member_config_json,
 			source_machine_id, updated_at, synced_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(uuid) DO UPDATE SET
 			status = excluded.status,
 			finished_at = excluded.finished_at,
@@ -711,11 +802,12 @@ func (db *DB) UpsertPulledJob(j PulledJob, repoID int64, commitID *int64) error 
 			requested_model = excluded.requested_model,
 			requested_provider = excluded.requested_provider,
 			git_ref = excluded.git_ref,
-			session_id = COALESCE(excluded.session_id, review_jobs.session_id),
+			session_id = CASE WHEN excluded.status IN ('done', 'failed', 'canceled', 'skipped', 'applied', 'rebased') THEN excluded.session_id ELSE COALESCE(excluded.session_id, review_jobs.session_id) END,
 			commit_id = excluded.commit_id,
 			patch_id = excluded.patch_id,
 			dirty_files = COALESCE(excluded.dirty_files, review_jobs.dirty_files),
-			token_usage = COALESCE(excluded.token_usage, review_jobs.token_usage),
+			token_usage = CASE WHEN excluded.status IN ('done', 'failed', 'canceled', 'skipped', 'applied', 'rebased') THEN excluded.token_usage ELSE COALESCE(excluded.token_usage, review_jobs.token_usage) END,
+			agent_invoked = CASE WHEN excluded.status IN ('done', 'failed', 'canceled', 'skipped', 'applied', 'rebased') THEN excluded.agent_invoked ELSE (review_jobs.agent_invoked OR excluded.agent_invoked) END,
 			worktree_path = COALESCE(excluded.worktree_path, review_jobs.worktree_path),
 			source = COALESCE(excluded.source, review_jobs.source),
 			min_severity = excluded.min_severity,
@@ -738,7 +830,7 @@ func (db *DB) UpsertPulledJob(j PulledJob, repoID int64, commitID *int64) error 
 					THEN excluded.updated_at ELSE excluded.updated_at || 'Z' END
 			)
 	`, j.UUID, repoID, commitID, j.GitRef, nullStr(j.SessionID), j.Agent, nullStr(j.Model), nullStr(j.Provider), nullStr(j.RequestedModel), nullStr(j.RequestedProvider), j.Reasoning, j.JobType,
-		j.ReviewType, nullStr(j.PatchID), j.Status, j.Agentic, j.EnqueuedAt.Format(time.RFC3339),
+		j.ReviewType, nullStr(j.PatchID), j.Status, j.Agentic, j.AgentInvoked, j.EnqueuedAt.Format(time.RFC3339),
 		nullTimeStr(j.StartedAt), nullTimeStr(j.FinishedAt),
 		nullStr(j.Prompt), j.DiffContent, nullStr(dirtyFilesJSON), nullStr(j.Error), nullStr(j.TokenUsage),
 		nullStr(j.WorktreePath), nullStr(j.Source), normalizeMinSeverityForWrite(j.MinSeverity), j.BackupAgent, j.BackupModel,

--- a/internal/storage/sync_backfill_test.go
+++ b/internal/storage/sync_backfill_test.go
@@ -293,6 +293,60 @@ func TestGetJobsToSync_IncludesSource(t *testing.T) {
 	assert.Equal(t, JobSourceCI, found.Source)
 }
 
+// TestUpsertPulledJob_TerminalRerunClearsStaleCost guards the priced-to-unpriced
+// rerun across sync. A cleared token_usage binds as NULL, so a plain COALESCE
+// upsert would preserve a prior attempt's cost; since command_line is not synced,
+// the cost fallback in costEligible would then count that stale value. A terminal
+// pull must overwrite token_usage, while a non-terminal (requeued) pull preserves
+// it until the re-attempt completes.
+func TestUpsertPulledJob_TerminalRerunClearsStaleCost(t *testing.T) {
+	assert := assert.New(t)
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo, err := db.GetOrCreateRepo("/test/repo-cost-sync")
+	require.NoError(t, err)
+
+	base := time.Now().UTC()
+	uuid := "cost-sync-rerun-uuid"
+	priced := PulledJob{
+		UUID:            uuid,
+		RepoIdentity:    "/test/repo-cost-sync",
+		GitRef:          "HEAD",
+		Agent:           "codex",
+		Status:          string(JobStatusDone),
+		TokenUsage:      `{"cost_usd":2.50,"has_cost":true}`,
+		SourceMachineID: "machine-a",
+		EnqueuedAt:      base,
+		UpdatedAt:       base,
+	}
+	require.NoError(t, db.UpsertPulledJob(priced, repo.ID, nil))
+
+	tokenUsage := func() string {
+		var tu string
+		require.NoError(t, db.QueryRow(
+			`SELECT COALESCE(token_usage, '') FROM review_jobs WHERE uuid = ?`, uuid).Scan(&tu))
+		return tu
+	}
+	require.Contains(t, tokenUsage(), "2.50", "priced cost stored on first pull")
+
+	// A newer non-terminal (requeued) pull must not wipe a recorded cost: the
+	// re-attempt has not completed, so the prior cost stands until it does.
+	requeued := priced
+	requeued.Status = string(JobStatusQueued)
+	requeued.TokenUsage = ""
+	requeued.UpdatedAt = base.Add(1 * time.Minute)
+	require.NoError(t, db.UpsertPulledJob(requeued, repo.ID, nil))
+	assert.Contains(tokenUsage(), "2.50", "queued rerun pull preserves the prior cost")
+
+	// A newer terminal pull that reports no cost clears the stale value.
+	rerunDone := priced
+	rerunDone.TokenUsage = ""
+	rerunDone.UpdatedAt = base.Add(2 * time.Minute)
+	require.NoError(t, db.UpsertPulledJob(rerunDone, repo.ID, nil))
+	assert.Empty(tokenUsage(), "terminal unpriced rerun pull clears the stale cost")
+}
+
 func TestUpsertPulledJob_PreservesWorktreePath(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()

--- a/internal/storage/sync_ordering_test.go
+++ b/internal/storage/sync_ordering_test.go
@@ -188,11 +188,15 @@ func TestBatchMarkSynced(t *testing.T) {
 
 		assert.Len(t, toSync, 5)
 
-		// Mark first 3 as synced
-		jobIDs := []int64{jobs[0].ID, jobs[1].ID, jobs[2].ID}
-		if err := h.db.MarkJobsSynced(jobIDs); err != nil {
-			require.NoError(t, err, "MarkJobsSynced failed: %v")
+		// Mark first 3 as synced, carrying each job's snapshot updated_at.
+		markIDs := map[int64]bool{jobs[0].ID: true, jobs[1].ID: true, jobs[2].ID: true}
+		var marks []JobSyncMark
+		for _, j := range toSync {
+			if markIDs[j.ID] {
+				marks = append(marks, NewJobSyncMark(j))
+			}
 		}
+		require.NoError(t, h.db.MarkJobsSynced(marks), "MarkJobsSynced failed")
 
 		// Verify only 2 jobs left to sync
 		toSync, err = h.db.GetJobsToSync(h.machineID, 100)
@@ -249,7 +253,7 @@ func TestBatchMarkSynced(t *testing.T) {
 
 	t.Run("empty slice is no-op", func(t *testing.T) {
 		// Empty slices should not error
-		if err := h.db.MarkJobsSynced([]int64{}); err != nil {
+		if err := h.db.MarkJobsSynced([]JobSyncMark{}); err != nil {
 			require.NoError(t, err)
 		}
 		if err := h.db.MarkReviewsSynced([]int64{}); err != nil {
@@ -259,6 +263,282 @@ func TestBatchMarkSynced(t *testing.T) {
 			require.NoError(t, err)
 		}
 	})
+}
+
+// TestMarkJobsSyncedSkipsRowsChangedSinceSnapshot verifies the push-cursor
+// guard: when a job's updated_at changes between the pushed snapshot and the
+// mark (as happens when token usage is captured just after the job goes
+// terminal), MarkJobsSynced must not advance synced_at, so the newer value is
+// re-pushed on the next cycle instead of being stranded behind the cursor.
+func TestMarkJobsSyncedSkipsRowsChangedSinceSnapshot(t *testing.T) {
+	h := newSyncTestHelper(t)
+	job := h.createCompletedJob("cursor-race-sha")
+
+	// Snapshot the job as the push loop would.
+	snapshot, err := h.db.GetJobsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	require.Len(t, snapshot, 1)
+	snapshotUpdatedAt := snapshot[0].UpdatedAtRaw
+	require.NotEmpty(t, snapshotUpdatedAt)
+
+	// A concurrent write (e.g. SaveJobTokenUsage capturing cost) bumps
+	// updated_at after the snapshot was taken but before the mark runs.
+	const laterUpdatedAt = "2026-06-01T00:00:00Z"
+	h.setJobTimestamps(job.ID, sql.NullString{}, laterUpdatedAt)
+
+	// Marking with the stale snapshot value must not advance synced_at.
+	require.NoError(t, h.db.MarkJobsSynced([]JobSyncMark{NewJobSyncMark(snapshot[0])}))
+
+	var syncedAt sql.NullString
+	require.NoError(t, h.db.QueryRow(`SELECT synced_at FROM review_jobs WHERE id = ?`, job.ID).Scan(&syncedAt))
+	assert.False(t, syncedAt.Valid, "synced_at must stay NULL for a row changed since the snapshot")
+
+	stillToSync, err := h.db.GetJobsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	assert.Len(t, stillToSync, 1, "changed job must remain eligible for the next push")
+
+	// Marking with the current updated_at advances the cursor as normal.
+	currentMark := NewJobSyncMark(snapshot[0])
+	currentMark.UpdatedAt = laterUpdatedAt
+	require.NoError(t, h.db.MarkJobsSynced([]JobSyncMark{currentMark}))
+	done, err := h.db.GetJobsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	assert.Empty(t, done, "job marked with the matching updated_at must be synced")
+}
+
+// TestMarkJobsSyncedSkipsCostWrittenInSameSecond covers the same-second case:
+// a job is marked terminal and its token usage is captured within the same
+// RFC3339 second, so updated_at is byte-identical between the pushed snapshot
+// and the post-capture row. The token_usage change alone must still keep the
+// row eligible so the cost is re-pushed instead of stranded.
+func TestMarkJobsSyncedSkipsCostWrittenInSameSecond(t *testing.T) {
+	h := newSyncTestHelper(t)
+	job := h.createCompletedJob("same-second-cost-sha")
+
+	// Pin the row to a fixed second with no token usage, as the terminal write
+	// leaves it during the capture window.
+	const terminalUpdatedAt = "2026-06-07T15:26:10Z"
+	_, err := h.db.Exec(
+		`UPDATE review_jobs SET updated_at = ?, token_usage = NULL, synced_at = NULL WHERE id = ?`,
+		terminalUpdatedAt, job.ID)
+	require.NoError(t, err)
+
+	// Snapshot the transient terminal row (token_usage NULL).
+	snapshot, err := h.db.GetJobsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	require.Len(t, snapshot, 1)
+	require.Equal(t, terminalUpdatedAt, snapshot[0].UpdatedAtRaw)
+	require.Empty(t, snapshot[0].TokenUsage)
+
+	// Token usage is captured in the same second: token_usage changes but the
+	// formatted updated_at second is unchanged (identical string).
+	_, err = h.db.Exec(
+		`UPDATE review_jobs SET token_usage = ?, updated_at = ? WHERE id = ?`,
+		`{"has_cost":true,"total_cost_usd":0.5}`, terminalUpdatedAt, job.ID)
+	require.NoError(t, err)
+
+	// Marking with the snapshot (no token usage) must not advance synced_at.
+	require.NoError(t, h.db.MarkJobsSynced([]JobSyncMark{NewJobSyncMark(snapshot[0])}))
+
+	var syncedAt sql.NullString
+	require.NoError(t, h.db.QueryRow(`SELECT synced_at FROM review_jobs WHERE id = ?`, job.ID).Scan(&syncedAt))
+	assert.False(t, syncedAt.Valid, "synced_at must stay NULL when token usage changed in the same second")
+
+	stillToSync, err := h.db.GetJobsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	assert.Len(t, stillToSync, 1, "cost write must keep the job eligible for re-push")
+	assert.NotEmpty(t, stillToSync[0].TokenUsage, "re-pushed snapshot must carry the captured cost")
+}
+
+// TestMarkJobsSyncedSkipsReenqueuedRowInSameSecond covers the reset race: an
+// unpriced terminal job is pushed, then re-enqueued (clearing cost metadata and
+// synced_at) in the same RFC3339 second, leaving updated_at and token_usage
+// matching the snapshot. The status change (done -> queued) must keep the stale
+// mark from restoring synced_at over the reset's NULL, so the cleared-cost rerun
+// stays eligible and PostgreSQL does not keep stale spend.
+func TestMarkJobsSyncedSkipsReenqueuedRowInSameSecond(t *testing.T) {
+	h := newSyncTestHelper(t)
+	job := h.createCompletedJob("reenqueue-mark-race-sha")
+
+	// Pin the terminal row to a fixed second with no cost (unpriced done).
+	const sameSecond = "2026-06-07T15:26:10Z"
+	_, err := h.db.Exec(
+		`UPDATE review_jobs SET updated_at = ?, token_usage = NULL, synced_at = NULL WHERE id = ?`,
+		sameSecond, job.ID)
+	require.NoError(t, err)
+
+	// Snapshot it as the push loop would.
+	snapshot, err := h.db.GetJobsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	require.Len(t, snapshot, 1)
+	mark := NewJobSyncMark(snapshot[0])
+
+	// Re-enqueue in the same second: clears cost metadata and synced_at.
+	// ReenqueueJob also sets updated_at, so pin it back to the same second; now
+	// updated_at and token_usage alone would still match the snapshot.
+	require.NoError(t, h.db.ReenqueueJob(job.ID, ReenqueueOpts{}))
+	_, err = h.db.Exec(`UPDATE review_jobs SET updated_at = ? WHERE id = ?`, sameSecond, job.ID)
+	require.NoError(t, err)
+
+	require.NoError(t, h.db.MarkJobsSynced([]JobSyncMark{mark}))
+
+	var syncedAt sql.NullString
+	require.NoError(t, h.db.QueryRow(`SELECT synced_at FROM review_jobs WHERE id = ?`, job.ID).Scan(&syncedAt))
+	assert.False(t, syncedAt.Valid,
+		"reset synced_at=NULL must survive: a stale mark cannot match the re-enqueued row")
+}
+
+// TestMarkJobsSyncedSkipsRowWithChangedAttemptMarkers verifies the snapshot guard
+// also pins the specific attempt: if session_id or agent_invoked changed since
+// the push (as a same-second re-completion would) while updated_at, token_usage,
+// and status stay identical, MarkJobsSynced must not advance synced_at.
+func TestMarkJobsSyncedSkipsRowWithChangedAttemptMarkers(t *testing.T) {
+	const fixedSecond = "2026-06-07T15:26:10Z"
+	cases := []struct {
+		name    string
+		diverge func(t *testing.T, h *syncTestHelper, jobID int64)
+	}{
+		{
+			name: "session_id changed",
+			diverge: func(t *testing.T, h *syncTestHelper, jobID int64) {
+				_, err := h.db.Exec(`UPDATE review_jobs SET session_id = 's2' WHERE id = ?`, jobID)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "agent_invoked changed",
+			diverge: func(t *testing.T, h *syncTestHelper, jobID int64) {
+				_, err := h.db.Exec(`UPDATE review_jobs SET agent_invoked = 0 WHERE id = ?`, jobID)
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newSyncTestHelper(t)
+			job := h.createCompletedJob("attempt-marker-sha")
+
+			// A pushed terminal attempt with a known session and agent marker.
+			_, err := h.db.Exec(
+				`UPDATE review_jobs SET updated_at = ?, token_usage = NULL,
+				     session_id = 's1', agent_invoked = 1, synced_at = NULL WHERE id = ?`,
+				fixedSecond, job.ID)
+			require.NoError(t, err)
+
+			snapshot, err := h.db.GetJobsToSync(h.machineID, 100)
+			require.NoError(t, err)
+			require.Len(t, snapshot, 1)
+			mark := NewJobSyncMark(snapshot[0])
+
+			// The attempt marker changes in the same second; nothing else does.
+			tc.diverge(t, h, job.ID)
+
+			require.NoError(t, h.db.MarkJobsSynced([]JobSyncMark{mark}))
+
+			var syncedAt sql.NullString
+			require.NoError(t, h.db.QueryRow(
+				`SELECT synced_at FROM review_jobs WHERE id = ?`, job.ID).Scan(&syncedAt))
+			assert.False(t, syncedAt.Valid,
+				"synced_at must stay NULL when %s since the snapshot", tc.name)
+		})
+	}
+}
+
+// TestMarkJobsSyncedSkipsSameSecondRecompletionWithChangedAttemptMetadata covers
+// a stale push snapshot followed by a same-second terminal re-completion from an
+// unpriced, sessionless agent. The existing cost guard fields can all match the
+// stale snapshot, so attempt metadata must also pin the exact row that was pushed.
+func TestMarkJobsSyncedSkipsSameSecondRecompletionWithChangedAttemptMetadata(t *testing.T) {
+	const fixedSecond = "2026-06-07T15:26:10Z"
+	const originalStartedAt = "2026-06-07T15:26:09Z"
+	const changedStartedAt = "2026-06-07T15:26:10Z"
+	const changedFinishedAt = "2026-06-07T15:26:11Z"
+
+	cases := []struct {
+		name    string
+		diverge string
+	}{
+		{name: "agent changed", diverge: `agent = 'claude'`},
+		{name: "model changed", diverge: `model = 'gpt-5'`},
+		{name: "provider changed", diverge: `provider = 'anthropic'`},
+		{name: "error changed", diverge: `error = 'new failure'`},
+		{name: "started_at changed", diverge: `started_at = '` + changedStartedAt + `'`},
+		{name: "finished_at changed", diverge: `finished_at = '` + changedFinishedAt + `'`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newSyncTestHelper(t)
+			job := h.createCompletedJob("same-second-recompletion-sha")
+
+			_, err := h.db.Exec(
+				`UPDATE review_jobs SET updated_at = ?, token_usage = NULL,
+				     status = 'failed', session_id = NULL, agent_invoked = 1,
+				     agent = 'codex', model = 'o3', provider = 'openai',
+				     error = 'old failure', started_at = ?, finished_at = ?,
+				     synced_at = NULL
+				 WHERE id = ?`,
+				fixedSecond, originalStartedAt, fixedSecond, job.ID)
+			require.NoError(t, err)
+
+			snapshot, err := h.db.GetJobsToSync(h.machineID, 100)
+			require.NoError(t, err)
+			require.Len(t, snapshot, 1)
+			mark := NewJobSyncMark(snapshot[0])
+
+			_, err = h.db.Exec(
+				`UPDATE review_jobs SET `+tc.diverge+`,
+				     updated_at = ?, token_usage = NULL,
+				     status = 'failed', session_id = NULL, agent_invoked = 1
+				 WHERE id = ?`,
+				fixedSecond, job.ID)
+			require.NoError(t, err)
+
+			require.NoError(t, h.db.MarkJobsSynced([]JobSyncMark{mark}))
+
+			var syncedAt sql.NullString
+			require.NoError(t, h.db.QueryRow(
+				`SELECT synced_at FROM review_jobs WHERE id = ?`, job.ID).Scan(&syncedAt))
+			assert.False(t, syncedAt.Valid,
+				"synced_at must stay NULL when %s since the pushed snapshot", tc.name)
+		})
+	}
+}
+
+// TestSaveJobTokenUsageInvalidatesSyncCursor covers the ordering where the cost
+// capture lands after MarkJobsSynced. The job is already marked synced with
+// updated_at in the same RFC3339 second as synced_at, so the cursor comparison
+// alone (updated_at > synced_at) can never re-select it. SaveJobTokenUsage must
+// clear synced_at so the cost still reaches PostgreSQL.
+func TestSaveJobTokenUsageInvalidatesSyncCursor(t *testing.T) {
+	h := newSyncTestHelper(t)
+	job := h.createCompletedJob("post-mark-cost-sha")
+
+	// Model a job already marked synced under a known session, with updated_at
+	// in the same second as synced_at, so the cursor would never re-select it
+	// on its own.
+	const sameSecond = "2026-06-07T15:26:10Z"
+	_, err := h.db.Exec(
+		`UPDATE review_jobs SET session_id = ?, synced_at = ?, updated_at = ? WHERE id = ?`,
+		"sess-1", sameSecond, sameSecond, job.ID)
+	require.NoError(t, err)
+
+	before, err := h.db.GetJobsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	require.Empty(t, before, "precondition: synced_at == updated_at must not re-select")
+
+	// A token-usage capture lands after the mark, in the same second.
+	require.NoError(t, h.db.SaveJobTokenUsage(job.ID, "sess-1", `{"has_cost":true,"total_cost_usd":0.5}`))
+
+	var syncedAt sql.NullString
+	require.NoError(t, h.db.QueryRow(`SELECT synced_at FROM review_jobs WHERE id = ?`, job.ID).Scan(&syncedAt))
+	assert.False(t, syncedAt.Valid, "token-usage write must clear synced_at")
+
+	after, err := h.db.GetJobsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	require.Len(t, after, 1, "cost write after marking synced must re-select the job")
+	assert.NotEmpty(t, after[0].TokenUsage, "re-selected snapshot carries the captured cost")
 }
 
 // TestGetReviewsToSync_RequiresJobSynced verifies that reviews are only

--- a/internal/storage/sync_queries_test.go
+++ b/internal/storage/sync_queries_test.go
@@ -385,6 +385,336 @@ func TestSessionID_SyncRoundTrip(t *testing.T) {
 	assert.False(t, !gotSessionID.Valid || gotSessionID.String != "agent-session-abc")
 }
 
+// TestAgentInvoked_SyncRoundTrip verifies the agent_invoked marker survives a
+// full push/pull cycle: GetJobsToSync must export it (push side) and
+// UpsertPulledJob must import it (pull side). The marker carries the "an agent
+// ran" cost-eligibility signal across machines, since command_line is not synced.
+func TestAgentInvoked_SyncRoundTrip(t *testing.T) {
+	src := newSyncTestHelper(t)
+
+	job := src.createCompletedJob("agent-invoked-sync-sha")
+	setJobAgentInvoked(t, src.db, job.ID)
+
+	exported, err := src.db.GetJobsToSync(src.machineID, 10)
+	require.NoError(t, err, "GetJobsToSync: %v")
+
+	var syncJob *SyncableJob
+	for i := range exported {
+		if exported[i].ID == job.ID {
+			syncJob = &exported[i]
+			break
+		}
+	}
+	require.NotNil(t, syncJob)
+	assert.True(t, syncJob.AgentInvoked, "push side exports the agent_invoked marker")
+
+	dst := newSyncTestHelper(t)
+	pulled := PulledJob{
+		UUID:            syncJob.UUID,
+		RepoIdentity:    syncJob.RepoIdentity,
+		CommitSHA:       syncJob.CommitSHA,
+		CommitAuthor:    syncJob.CommitAuthor,
+		CommitSubject:   syncJob.CommitSubject,
+		CommitTimestamp: syncJob.CommitTimestamp,
+		GitRef:          syncJob.GitRef,
+		SessionID:       syncJob.SessionID,
+		Agent:           syncJob.Agent,
+		Model:           syncJob.Model,
+		Reasoning:       syncJob.Reasoning,
+		JobType:         syncJob.JobType,
+		ReviewType:      syncJob.ReviewType,
+		PatchID:         syncJob.PatchID,
+		Status:          syncJob.Status,
+		Agentic:         syncJob.Agentic,
+		AgentInvoked:    syncJob.AgentInvoked,
+		EnqueuedAt:      syncJob.EnqueuedAt,
+		StartedAt:       syncJob.StartedAt,
+		FinishedAt:      syncJob.FinishedAt,
+		Prompt:          syncJob.Prompt,
+		DiffContent:     syncJob.DiffContent,
+		Error:           syncJob.Error,
+		SourceMachineID: syncJob.SourceMachineID,
+		UpdatedAt:       syncJob.UpdatedAt,
+	}
+	require.NoError(t, dst.db.UpsertPulledJob(pulled, dst.repo.ID, nil),
+		"UpsertPulledJob: %v")
+
+	var gotInvoked int
+	require.NoError(t, dst.db.QueryRow(
+		`SELECT agent_invoked FROM review_jobs WHERE uuid = ?`, syncJob.UUID).Scan(&gotInvoked),
+		"query imported agent_invoked: %v")
+	assert.Equal(t, 1, gotInvoked, "pull side imports the agent_invoked marker")
+}
+
+// TestUpsertPulledJob_SessionTerminalOverwrite verifies the SQLite pull path
+// treats session_id like token_usage and agent_invoked: a terminal row
+// overwrites it (including to empty), so a rerun whose terminal attempt captured
+// no session cannot retain the prior attempt's session id and reattach stale
+// cost to it. A non-terminal row still preserves an existing session.
+func TestUpsertPulledJob_SessionTerminalOverwrite(t *testing.T) {
+	assert := assert.New(t)
+	dst := newSyncTestHelper(t)
+
+	t1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+
+	pull := func(uuid, sessionID, status string, updatedAt time.Time) {
+		started := updatedAt.Add(-time.Minute)
+		var finished *time.Time
+		if status != "running" && status != "queued" {
+			finished = &updatedAt
+		}
+		pj := PulledJob{
+			UUID:            uuid,
+			GitRef:          "ref-" + uuid,
+			SessionID:       sessionID,
+			Agent:           "test",
+			JobType:         "review",
+			Status:          status,
+			EnqueuedAt:      t1,
+			StartedAt:       &started,
+			FinishedAt:      finished,
+			SourceMachineID: "remote-machine",
+			UpdatedAt:       updatedAt,
+		}
+		require.NoError(t, dst.db.UpsertPulledJob(pj, dst.repo.ID, nil),
+			"UpsertPulledJob(%s, status=%s)", uuid, status)
+	}
+
+	sessionOf := func(uuid string) string {
+		var s sql.NullString
+		require.NoError(t, dst.db.QueryRow(
+			`SELECT session_id FROM review_jobs WHERE uuid = ?`, uuid).Scan(&s))
+		return s.String
+	}
+
+	// A terminal rerun overwrites the synced session, even when empty.
+	pull("term-uuid", "session-1", "done", t1)
+	require.Equal(t, "session-1", sessionOf("term-uuid"), "first sync stores the session")
+	pull("term-uuid", "", "done", t2)
+	assert.Empty(sessionOf("term-uuid"),
+		"terminal rerun with no session clears the stale session id")
+
+	// A non-terminal update preserves an existing session.
+	pull("run-uuid", "keep-me", "done", t1)
+	pull("run-uuid", "", "running", t2)
+	assert.Equal("keep-me", sessionOf("run-uuid"),
+		"non-terminal update preserves the existing session id")
+}
+
+// TestUpsertPulledJob_SkippedRerunOverwritesStaleMarkers verifies that a
+// skipped row — a synced, rerun-eligible terminal state — overwrites the
+// per-attempt markers (session_id, token_usage, agent_invoked) instead of
+// merging them. A rerun that ends in skip after a priced attempt must not
+// retain the prior attempt's cost, session, or agent-ran markers.
+func TestUpsertPulledJob_SkippedRerunOverwritesStaleMarkers(t *testing.T) {
+	assert := assert.New(t)
+	dst := newSyncTestHelper(t)
+
+	t1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+	started := t1.Add(-time.Minute)
+	const uuid = "skip-rerun-uuid"
+
+	// Attempt 1: a priced agent run synced as done.
+	require.NoError(t, dst.db.UpsertPulledJob(PulledJob{
+		UUID:            uuid,
+		GitRef:          "ref",
+		SessionID:       "session-1",
+		Agent:           "test",
+		JobType:         "review",
+		Status:          "done",
+		AgentInvoked:    true,
+		TokenUsage:      `{"cost_usd":5.0,"has_cost":true}`,
+		EnqueuedAt:      t1,
+		StartedAt:       &started,
+		FinishedAt:      &t1,
+		SourceMachineID: "remote-machine",
+		UpdatedAt:       t1,
+	}, dst.repo.ID, nil), "UpsertPulledJob (done)")
+
+	// Attempt 2: a rerun that ends in skip, with the markers cleared at source.
+	require.NoError(t, dst.db.UpsertPulledJob(PulledJob{
+		UUID:            uuid,
+		GitRef:          "ref",
+		SessionID:       "",
+		Agent:           "test",
+		JobType:         "review",
+		Status:          "skipped",
+		AgentInvoked:    false,
+		TokenUsage:      "",
+		EnqueuedAt:      t1,
+		FinishedAt:      &t2,
+		SourceMachineID: "remote-machine",
+		UpdatedAt:       t2,
+	}, dst.repo.ID, nil), "UpsertPulledJob (skipped)")
+
+	var session, tokenUsage sql.NullString
+	var invoked int
+	require.NoError(t, dst.db.QueryRow(
+		`SELECT session_id, token_usage, agent_invoked FROM review_jobs WHERE uuid = ?`,
+		uuid).Scan(&session, &tokenUsage, &invoked))
+
+	assert.Empty(session.String, "skipped rerun clears the stale session id")
+	assert.Empty(tokenUsage.String, "skipped rerun clears the stale token usage")
+	assert.Equal(0, invoked, "skipped rerun clears the stale agent_invoked marker")
+}
+
+// TestReenqueueClearsSyncedAtForSameSecondRerun reproduces the priced-to-unpriced
+// rerun race: an attempt synced as priced, then rerun and completed unpriced
+// within the same RFC3339 second, must still be pushed so PostgreSQL drops the
+// stale cost. The second-precise updated_at vs synced_at comparison compares
+// equal in that window; ReenqueueJob clears synced_at so the row re-selects
+// regardless of timestamp granularity.
+func TestReenqueueClearsSyncedAtForSameSecondRerun(t *testing.T) {
+	assert := assert.New(t)
+	h := newSyncTestHelper(t)
+
+	pending := func() []int64 {
+		jobs, err := h.db.GetJobsToSync(h.machineID, 100)
+		require.NoError(t, err)
+		ids := make([]int64, len(jobs))
+		for i, j := range jobs {
+			ids[i] = j.ID
+		}
+		return ids
+	}
+
+	job := h.createCompletedJob("same-second-rerun-sha")
+	// Attempt 1 ran an agent and recorded cost.
+	seedCost(t, h.db, job.ID, `{"cost_usd":5.0,"has_cost":true}`)
+
+	// It was synced. Pin updated_at and synced_at to the same RFC3339 second —
+	// the worst case for the second-precise sync comparison.
+	const sameSecond = "2024-01-01T00:00:00Z"
+	_, err := h.db.Exec(
+		`UPDATE review_jobs SET updated_at = ?, synced_at = ? WHERE id = ?`,
+		sameSecond, sameSecond, job.ID)
+	require.NoError(t, err)
+	assert.NotContains(pending(), job.ID,
+		"a fully-synced row (updated_at == synced_at) is not pending")
+
+	// Rerun clears the prior attempt's cost metadata, and with it synced_at.
+	require.NoError(t, h.db.ReenqueueJob(job.ID, ReenqueueOpts{}))
+	assert.False(getJobAgentInvoked(t, h.db, job.ID), "rerun clears the agent-ran marker")
+
+	// Attempt 2 completes unpriced, in the same second as the prior sync mark.
+	claimed, err := h.db.ClaimJob("worker")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	require.NoError(t, h.db.CompleteJob(job.ID, "test", "prompt", "output"))
+	_, err = h.db.Exec(`UPDATE review_jobs SET updated_at = ? WHERE id = ?`, sameSecond, job.ID)
+	require.NoError(t, err)
+
+	assert.Contains(pending(), job.ID,
+		"cleared cost state must re-sync even when updated_at == prior synced_at")
+}
+
+// TestResetPathsClearSyncedAt guards the invariant for every attempt reset that
+// clears cost metadata: clearing token_usage/agent_invoked must also clear
+// synced_at, or a same-second rerun can leave stale spend in PostgreSQL (see
+// TestReenqueueClearsSyncedAtForSameSecondRerun for the end-to-end behavior).
+func TestResetPathsClearSyncedAt(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(t *testing.T, db *DB) int64
+		reset func(t *testing.T, db *DB, jobID int64)
+	}{
+		{
+			name: "reenqueue",
+			setup: func(t *testing.T, db *DB) int64 {
+				_, _, job := createJobChain(t, db, "/tmp/reset-reenqueue", "sha")
+				setJobStatus(t, db, job.ID, JobStatusDone)
+				return job.ID
+			},
+			reset: func(t *testing.T, db *DB, jobID int64) {
+				require.NoError(t, db.ReenqueueJob(jobID, ReenqueueOpts{}))
+			},
+		},
+		{
+			name: "retry-scoped",
+			setup: func(t *testing.T, db *DB) int64 {
+				_, _, job := createJobChain(t, db, "/tmp/reset-retry-scoped", "sha")
+				claimJob(t, db, "worker-1")
+				return job.ID
+			},
+			reset: func(t *testing.T, db *DB, jobID int64) {
+				ok, err := db.RetryJob(jobID, "worker-1", 3, 0)
+				require.NoError(t, err)
+				require.True(t, ok)
+			},
+		},
+		{
+			// RetryJob has a separate unscoped SQL branch (empty workerID) that
+			// must clear synced_at too.
+			name: "retry-unscoped",
+			setup: func(t *testing.T, db *DB) int64 {
+				_, _, job := createJobChain(t, db, "/tmp/reset-retry-unscoped", "sha")
+				claimJob(t, db, "worker-1")
+				return job.ID
+			},
+			reset: func(t *testing.T, db *DB, jobID int64) {
+				ok, err := db.RetryJob(jobID, "", 3, 0)
+				require.NoError(t, err)
+				require.True(t, ok)
+			},
+		},
+		{
+			name: "failover",
+			setup: func(t *testing.T, db *DB) int64 {
+				_, _, job := createJobChain(t, db, "/tmp/reset-failover", "sha")
+				claimJob(t, db, "worker-1")
+				return job.ID
+			},
+			reset: func(t *testing.T, db *DB, jobID int64) {
+				ok, err := db.FailoverJob(jobID, "worker-1", "backup", "")
+				require.NoError(t, err)
+				require.True(t, ok)
+			},
+		},
+		{
+			name: "promote-classify",
+			setup: func(t *testing.T, db *DB) int64 {
+				return seedRunningClassify(t, db, "/tmp/reset-promote", "sha", "w1")
+			},
+			reset: func(t *testing.T, db *DB, jobID int64) {
+				require.NoError(t, db.PromoteClassifyToDesignReview(jobID, "w1", "claude-code", ""))
+			},
+		},
+		{
+			name: "reset-stale",
+			setup: func(t *testing.T, db *DB) int64 {
+				_, _, job := createJobChain(t, db, "/tmp/reset-stale", "sha")
+				claimJob(t, db, "worker-1")
+				return job.ID
+			},
+			reset: func(t *testing.T, db *DB, jobID int64) {
+				require.NoError(t, db.ResetStaleJobs())
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := openTestDB(t)
+			defer db.Close()
+
+			jobID := tc.setup(t, db)
+			_, err := db.Exec(`UPDATE review_jobs SET synced_at = ? WHERE id = ?`,
+				"2024-01-01T00:00:00Z", jobID)
+			require.NoError(t, err)
+
+			tc.reset(t, db, jobID)
+
+			var syncedAt sql.NullString
+			require.NoError(t, db.QueryRow(
+				`SELECT synced_at FROM review_jobs WHERE id = ?`, jobID).Scan(&syncedAt))
+			assert.False(t, syncedAt.Valid,
+				"%s must clear synced_at when it clears cost metadata", tc.name)
+		})
+	}
+}
+
 func TestGetCommentsToSync_LegacyCommentsExcluded(t *testing.T) {
 	h := newSyncTestHelper(t)
 	job := h.createCompletedJob("legacy-resp-sha")

--- a/internal/storage/syncworker.go
+++ b/internal/storage/syncworker.go
@@ -582,7 +582,6 @@ func (w *SyncWorker) pushChangesWithStats(ctx context.Context, pool *PgPool) (pu
 	if len(jobs) > 0 {
 		// Resolve PostgreSQL repo and commit IDs for each job
 		var preparedJobs []JobWithPgIDs
-		var preparedJobIDs []int64
 		for _, j := range jobs {
 			if j.RepoIdentity == "" {
 				log.Printf("Sync: job %s has no repo identity, skipping", j.UUID)
@@ -610,7 +609,6 @@ func (w *SyncWorker) pushChangesWithStats(ctx context.Context, pool *PgPool) (pu
 				PgRepoID:   pgRepoID,
 				PgCommitID: pgCommitID,
 			})
-			preparedJobIDs = append(preparedJobIDs, j.ID)
 		}
 
 		// Batch insert jobs
@@ -620,16 +618,19 @@ func (w *SyncWorker) pushChangesWithStats(ctx context.Context, pool *PgPool) (pu
 				log.Printf("Sync: batch upsert jobs error: %v", err)
 			}
 
-			// Only mark successfully synced jobs
-			var syncedJobIDs []int64
+			// Only mark successfully synced jobs. Carry each job's pushed
+			// snapshot so MarkJobsSynced skips rows changed since (a token-usage
+			// capture that lands after the job went terminal, or an attempt reset
+			// in the same second).
+			var syncedMarks []JobSyncMark
 			for i, ok := range success {
 				if ok {
-					syncedJobIDs = append(syncedJobIDs, preparedJobIDs[i])
+					syncedMarks = append(syncedMarks, NewJobSyncMark(preparedJobs[i].Job))
 					stats.Jobs++
 				}
 			}
-			if len(syncedJobIDs) > 0 {
-				if err := w.db.MarkJobsSynced(syncedJobIDs); err != nil {
+			if len(syncedMarks) > 0 {
+				if err := w.db.MarkJobsSynced(syncedMarks); err != nil {
 					log.Printf("Sync: failed to mark jobs synced: %v", err)
 				}
 			}

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -47,6 +47,10 @@ type ClientInterface interface {
 	ListComments(ctx context.Context, options *ListCommentsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListCommentsResponse, error)
 	ListCommentsWithResponse(ctx context.Context, options *ListCommentsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListCommentsResp, error)
 
+	// GetCost Get aggregate review cost
+	GetCost(ctx context.Context, options *GetCostRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetCostResponse, error)
+	GetCostWithResponse(ctx context.Context, options *GetCostRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetCostResp, error)
+
 	// EnqueueJob Enqueue a daemon job
 	EnqueueJob(ctx context.Context, options *EnqueueJobRequestOptions, reqEditors ...runtime.RequestEditorFn) (*EnqueueJobResponseJSON, error)
 	EnqueueJobWithResponse(ctx context.Context, options *EnqueueJobRequestOptions, reqEditors ...runtime.RequestEditorFn) (*EnqueueJobResp, error)
@@ -411,6 +415,76 @@ func (c *Client) ListComments(ctx context.Context, options *ListCommentsRequestO
 	}
 
 	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/comments")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// GetCost Get aggregate review cost
+func (c *Client) GetCost(ctx context.Context, options *GetCostRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetCostResponse, error) {
+	var err error
+
+	queryEncoding := map[string]runtime.QueryEncoding{
+		"branch":       {Style: "form", Explode: &[]bool{false}[0]},
+		"branch_empty": {Style: "form", Explode: &[]bool{false}[0]},
+		"since":        {Style: "form", Explode: &[]bool{false}[0]},
+	}
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:    c.apiClient.GetBaseURL() + "/api/cost",
+		Method:        "GET",
+		Options:       options,
+		QueryEncoding: queryEncoding,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*GetCostResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(GetCostErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "GetCostErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(GetCostResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetCostResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/cost")
 	if err != nil {
 		return nil, fmt.Errorf("error executing request: %w", err)
 	}

--- a/pkg/client/generated/client_options.go
+++ b/pkg/client/generated/client_options.go
@@ -182,6 +182,50 @@ func (o *ListCommentsRequestOptions) GetHeader() (map[string]string, error) {
 	return nil, nil
 }
 
+// GetCostRequestOptions is the options needed to make a request to GetCost.
+type GetCostRequestOptions struct {
+	Query *GetCostQuery
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *GetCostRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.Query != nil {
+		if v, ok := any(o.Query).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Query", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *GetCostRequestOptions) GetPathParams() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetQuery returns the query params as a map.
+func (o *GetCostRequestOptions) GetQuery() (map[string]any, error) {
+	return runtime.AsMap[any](o.Query)
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *GetCostRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *GetCostRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
 // EnqueueJobRequestOptions is the options needed to make a request to EnqueueJob.
 type EnqueueJobRequestOptions struct {
 	Body *EnqueueJobBody

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -207,6 +207,55 @@ func (c *Client) ListCommentsWithResponse(ctx context.Context, options *ListComm
 	}
 }
 
+// GetCost Get aggregate review cost
+func (c *Client) GetCostWithResponse(ctx context.Context, options *GetCostRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetCostResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/cost",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/cost")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &GetCostResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(GetCostResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetCostResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
 // EnqueueJob Enqueue a daemon job
 func (c *Client) EnqueueJobWithResponse(ctx context.Context, options *EnqueueJobRequestOptions, reqEditors ...runtime.RequestEditorFn) (*EnqueueJobResp, error) {
 	var err error

--- a/pkg/client/generated/enums.go
+++ b/pkg/client/generated/enums.go
@@ -8,19 +8,37 @@ import (
 	"github.com/doordash-oss/oapi-codegen-dd/v3/pkg/runtime"
 )
 
+// GetCostQueryBranchEmpty Only jobs with empty/unset branch
+type GetCostQueryBranchEmpty string
+
+const (
+	False GetCostQueryBranchEmpty = "false"
+	True  GetCostQueryBranchEmpty = "true"
+)
+
+// Validate checks if the GetCostQueryBranchEmpty value is valid
+func (g GetCostQueryBranchEmpty) Validate() error {
+	switch g {
+	case False, True:
+		return nil
+	default:
+		return runtime.NewValidationErrorsFromString("Enum", fmt.Sprintf("must be a valid GetCostQueryBranchEmpty value, got: %v", g))
+	}
+}
+
 // ListJobsQueryBranchIncludeEmpty Include jobs with no branch when filtering by branch
 type ListJobsQueryBranchIncludeEmpty string
 
 const (
-	Empty ListJobsQueryBranchIncludeEmpty = ""
-	False ListJobsQueryBranchIncludeEmpty = "false"
-	True  ListJobsQueryBranchIncludeEmpty = "true"
+	Empty                                ListJobsQueryBranchIncludeEmpty = ""
+	ListJobsQueryBranchIncludeEmptyFalse ListJobsQueryBranchIncludeEmpty = "false"
+	ListJobsQueryBranchIncludeEmptyTrue  ListJobsQueryBranchIncludeEmpty = "true"
 )
 
 // Validate checks if the ListJobsQueryBranchIncludeEmpty value is valid
 func (l ListJobsQueryBranchIncludeEmpty) Validate() error {
 	switch l {
-	case Empty, False, True:
+	case Empty, ListJobsQueryBranchIncludeEmptyFalse, ListJobsQueryBranchIncludeEmptyTrue:
 		return nil
 	default:
 		return runtime.NewValidationErrorsFromString("Enum", fmt.Sprintf("must be a valid ListJobsQueryBranchIncludeEmpty value, got: %v", l))

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -27,6 +27,35 @@ type ListCommentsQuery struct {
 	Sha *string `json:"sha,omitempty"`
 }
 
+type GetCostQuery struct {
+	// Repo Repo root paths (repeatable)
+	Repo []string `json:"repo,omitempty"`
+
+	// Branch Filter by branch name
+	Branch *string `json:"branch,omitempty"`
+
+	// BranchEmpty Only jobs with empty/unset branch
+	BranchEmpty *GetCostQueryBranchEmpty `json:"branch_empty,omitempty"`
+
+	// Since Time window (e.g. 7d); default all-time
+	Since *string `json:"since,omitempty"`
+}
+
+func (g GetCostQuery) Validate() error {
+	var errors runtime.ValidationErrors
+	if g.BranchEmpty != nil {
+		if v, ok := any(g.BranchEmpty).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("BranchEmpty", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
 type GetJobLogQuery struct {
 	// JobID Job ID
 	JobID *string `json:"job_id,omitempty"`

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -27,6 +27,10 @@ type ListCommentsResponse = ListCommentsOutputBody
 
 type ListCommentsErrorResponse = ErrorModel
 
+type GetCostResponse = CostAggregate
+
+type GetCostErrorResponse = ErrorModel
+
 type EnqueueJobResponse struct {
 	EnqueueJob_Response_OneOf *EnqueueJob_Response_OneOf `json:"-"`
 }
@@ -235,6 +239,13 @@ type ListCommentsResp struct {
 	Body         []byte
 	StatusCode   int
 	JSON200      *ListCommentsResponse
+}
+
+type GetCostResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *GetCostResponse
 }
 
 type EnqueueJobResp struct {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -175,6 +175,15 @@ func (c ComponentHealth) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(c))
 }
 
+type CostAggregate struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema       *string `json:"$schema,omitempty"`
+	Complete     bool    `json:"complete"`
+	JobsTotal    int64   `json:"jobs_total"`
+	JobsWithCost int64   `json:"jobs_with_cost"`
+	TotalUsd     float64 `json:"total_usd"`
+}
+
 type DaemonStatus struct {
 	// Schema A URL to the JSON Schema for this object.
 	Schema              *string           `json:"$schema,omitempty"`
@@ -904,6 +913,7 @@ type Summary struct {
 	Schema   *string        `json:"$schema,omitempty"`
 	Agents   []AgentStats   `json:"agents,omitempty" validate:"required"`
 	Branch   *string        `json:"branch,omitempty"`
+	Cost     CostAggregate  `json:"cost"`
 	Duration DurationStats  `json:"duration"`
 	Failures FailureStats   `json:"failures"`
 	JobTypes []JobTypeStats `json:"job_types,omitempty" validate:"required"`
@@ -921,6 +931,11 @@ func (s Summary) Validate() error {
 			if err := v.Validate(); err != nil {
 				errors = errors.Append(fmt.Sprintf("Agents[%d]", i), err)
 			}
+		}
+	}
+	if v, ok := any(s.Cost).(runtime.Validator); ok {
+		if err := v.Validate(); err != nil {
+			errors = errors.Append("Cost", err)
 		}
 	}
 	if v, ok := any(s.Duration).(runtime.Validator); ok {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -272,6 +272,33 @@ components:
         - name
         - healthy
       type: object
+    CostAggregate:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - https://example.com/CostAggregate.json
+          format: uri
+          readOnly: true
+          type: string
+        complete:
+          type: boolean
+        jobs_total:
+          format: int64
+          type: integer
+        jobs_with_cost:
+          format: int64
+          type: integer
+        total_usd:
+          format: double
+          type: number
+      required:
+        - total_usd
+        - jobs_with_cost
+        - jobs_total
+        - complete
+      type: object
     DaemonStatus:
       additionalProperties: false
       properties:
@@ -1382,6 +1409,8 @@ components:
             - "null"
         branch:
           type: string
+        cost:
+          $ref: "#/components/schemas/CostAggregate"
         duration:
           $ref: "#/components/schemas/DurationStats"
         failures:
@@ -1415,6 +1444,7 @@ components:
         - duration
         - job_types
         - failures
+        - cost
       type: object
     SyncStatusOutputBody:
       additionalProperties: false
@@ -1691,6 +1721,61 @@ paths:
       summary: List comments for a job or commit
       tags:
         - comments
+  /api/cost:
+    get:
+      operationId: get-cost
+      parameters:
+        - description: Repo root paths (repeatable)
+          explode: true
+          in: query
+          name: repo
+          schema:
+            description: Repo root paths (repeatable)
+            items:
+              type: string
+            type:
+              - array
+              - "null"
+        - description: Filter by branch name
+          explode: false
+          in: query
+          name: branch
+          schema:
+            description: Filter by branch name
+            type: string
+        - description: Only jobs with empty/unset branch
+          explode: false
+          in: query
+          name: branch_empty
+          schema:
+            description: Only jobs with empty/unset branch
+            enum:
+              - "true"
+              - "false"
+            type: string
+        - description: Time window (e.g. 7d); default all-time
+          explode: false
+          in: query
+          name: since
+          schema:
+            description: Time window (e.g. 7d); default all-time
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CostAggregate"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      summary: Get aggregate review cost
+      tags:
+        - daemon
   /api/enqueue:
     post:
       operationId: enqueue-job


### PR DESCRIPTION
## Summary

- Add `GetCostAggregate` (storage): a streaming `SUM` over `token_usage` scoped by repo paths and branch, returning total USD, eligible/priced job counts, and whether every eligible job is priced.
- Add `GET /api/cost` (daemon) with repeatable `repo=` params and a `since` window; regenerate the daemon client.
- Add the `roborev cost` CLI command and a cost section in `roborev summary`.
- Show an approximate cost figure in the TUI queue header, gated by filter generation so a stale figure is never shown across filter changes.
- Make the TUI queue header adapt to terminal width: priority-ordered status segments drop to fit, and the client version (plus any daemon-version mismatch) moves into the title line, right-aligned.
- Harden cost accuracy across reruns and restarts: clear `token_usage` on every job-reset path, scope token-usage writes to the captured session so a delayed fetch from a prior attempt cannot stamp stale cost, and clear session/cost metadata during restart recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)