### PR TITLE
Stop version-gating agentsview usage

### DIFF
--- a/cmd/roborev/backfill_tokens.go
+++ b/cmd/roborev/backfill_tokens.go
@@ -119,8 +119,9 @@ func backfillCostFetchConfig(cfg *config.Config) tokens.FetchConfig {
 		cfg = config.DefaultConfig()
 	}
 	return tokens.FetchConfig{
-		Endpoint: cfg.Cost.Endpoint,
-		Timeout:  cfg.Cost.ResolvedTimeout(),
+		Endpoint:   cfg.Cost.Endpoint,
+		Timeout:    cfg.Cost.ResolvedTimeout(),
+		RequireCLI: true,
 	}
 }
 

--- a/cmd/roborev/backfill_tokens_test.go
+++ b/cmd/roborev/backfill_tokens_test.go
@@ -194,6 +194,7 @@ func TestBackfillCostFetchConfig(t *testing.T) {
 
 	assert.Equal(t, "https://usage.example.test/api/v1/sessions/{session_id}/usage", got.Endpoint)
 	assert.Equal(t, 250*time.Millisecond, got.Timeout)
+	assert.True(t, got.RequireCLI)
 }
 
 func TestMergeBackfillTokenUsagePreservesExistingCountsForCostOnlyFetch(t *testing.T) {

--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -9,10 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os/exec"
-	"regexp"
-	"strconv"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -33,12 +30,14 @@ type FetchConfig struct {
 	Endpoint string
 	Timeout  time.Duration
 	Client   *http.Client
+	// RequireCLI reports a missing agentsview binary as an error when
+	// Endpoint is empty. By default CLI lookup is best-effort.
+	RequireCLI bool
 }
 
-// agentsviewResponse is the JSON shape returned by both
+// agentsviewResponse is the JSON shape returned by
 // `agentsview session usage <id> --format json` and the deprecated
-// `agentsview token-use <id>`. The session-usage shape is a strict
-// superset of token-use, adding the cost fields.
+// `agentsview token-use <id>` command.
 type agentsviewResponse struct {
 	SessionID         string  `json:"session_id"`
 	Agent             string  `json:"agent"`
@@ -103,167 +102,13 @@ func formatCount(n int64) string {
 	}
 }
 
-// capability describes which agentsview usage command the installed
-// binary supports.
-type capability int
-
-const (
-	// capNone means agentsview is missing or too old to query.
-	capNone capability = iota
-	// capTokenUse means only the deprecated `token-use` command is
-	// available.
-	capTokenUse
-	// capSessionUsage means `session usage` is available. It returns a
-	// cost estimate and supersedes token-use.
-	capSessionUsage
-)
-
-// minVersion is the minimum agentsview version that supports the
-// (deprecated) token-use subcommand (0.15.0).
-var minVersion = [3]int{0, 15, 0}
-
-// sessionUsageMinVersion is the tagged agentsview version that
-// supports `session usage`, which returns a cost estimate and replaces
-// token-use. Some prerelease builds below this tag also support the
-// command, so resolveAgentsview probes for it before falling back.
-var sessionUsageMinVersion = [3]int{0, 30, 0}
-
-// versionRe extracts major.minor.patch from "agentsview vX.Y.Z...".
-var versionRe = regexp.MustCompile(
-	`agentsview v(\d+)\.(\d+)\.(\d+)`,
-)
-
-// geVersion reports whether version a is >= version b, comparing
-// major, then minor, then patch.
-func geVersion(a, b [3]int) bool {
-	for i := range 3 {
-		if a[i] != b[i] {
-			return a[i] > b[i]
-		}
-	}
-	return true
-}
-
-// parseVersion inspects the output of `agentsview version` and reports
-// the capability level it supports plus whether a version string was
-// found at all. parsed is false only when no version could be matched,
-// so callers can distinguish "too old" from "unparseable" and retry
-// the latter.
-func parseVersion(out []byte) (level capability, parsed bool) {
-	m := versionRe.FindSubmatch(out)
-	if m == nil {
-		return capNone, false
-	}
-	var ver [3]int
-	for i := range 3 {
-		ver[i], _ = strconv.Atoi(string(m[i+1]))
-	}
-	switch {
-	case geVersion(ver, sessionUsageMinVersion):
-		return capSessionUsage, true
-	case geVersion(ver, minVersion):
-		return capTokenUse, true
-	default:
-		return capNone, true
-	}
-}
-
-var (
-	versionMu     sync.Mutex
-	cachedChecked bool
-	cachedCap     capability
-	cachedBin     string
-)
-
-// ResetVersionCache clears the cached version check result.
-// Exposed for testing only.
-func ResetVersionCache() {
-	versionMu.Lock()
-	defer versionMu.Unlock()
-	cachedChecked = false
-	cachedCap = capNone
-	cachedBin = ""
-}
-
-// resolveAgentsview checks whether agentsview is installed and which
-// usage capability it supports. The result is cached keyed to the
-// resolved binary path, so a PATH change triggers a fresh probe.
-// Transient failures (binary not found, timeout, exec error,
-// unparseable output) leave the cache unchecked so the next call
-// retries. Returns ("", capNone) when agentsview cannot be used.
-func resolveAgentsview(ctx context.Context) (string, capability) {
-	// LookPath is cheap (PATH scan, no exec) — always run it so we
-	// detect installs and PATH changes.
-	bin, err := exec.LookPath("agentsview")
-	if err != nil {
-		return "", capNone
-	}
-
-	versionMu.Lock()
-	if cachedChecked && cachedBin == bin {
-		level := cachedCap
-		versionMu.Unlock()
-		if level == capNone {
-			return "", capNone
-		}
-		return bin, level
-	}
-	versionMu.Unlock()
-
-	// Exec runs without holding the lock so concurrent callers are not
-	// blocked by the 5 s command timeout.
-	cmdCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	out, err := exec.CommandContext(cmdCtx, bin, "version").Output()
-	if err != nil {
-		return "", capNone
-	}
-
-	level, parsed := parseVersion(out)
-	if level == capTokenUse && hasSessionUsageCommand(ctx, bin) {
-		level = capSessionUsage
-	}
-
-	versionMu.Lock()
-	defer versionMu.Unlock()
-
-	// Re-check: another goroutine may have updated the cache.
-	if cachedChecked && cachedBin == bin {
-		if cachedCap == capNone {
-			return "", capNone
-		}
-		return bin, cachedCap
-	}
-
-	// Only cache a parsed result. Unparseable output (parsed=false) is
-	// treated as transient and left unchecked so the next call retries.
-	if parsed {
-		cachedChecked = true
-		cachedCap = level
-		cachedBin = bin
-	}
-	if level == capNone {
-		return "", capNone
-	}
-	return bin, level
-}
-
-func hasSessionUsageCommand(ctx context.Context, binPath string) bool {
-	cmdCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	cmd := exec.CommandContext(
-		cmdCtx, binPath, "session", "usage", "--help",
-	)
-	return cmd.Run() == nil
+func resolveAgentsview() (string, error) {
+	return exec.LookPath("agentsview")
 }
 
 // FetchForSession queries agentsview for a session's token usage and
-// cost estimate. It calls `session usage` when supported and falls back
-// to the deprecated `token-use` on older versions. Returns nil (no
-// error) when agentsview is not installed, is too old, or the session
-// has no usage data.
+// cost estimate. Returns nil (no error) when agentsview is not installed
+// or the session has no usage data.
 func FetchForSession(
 	ctx context.Context, sessionID string,
 ) (*Usage, error) {
@@ -278,57 +123,43 @@ func FetchForSessionWithConfig(
 	if cfg.Endpoint != "" {
 		return fetchForSessionHTTP(ctx, sessionID, cfg)
 	}
-	return fetchForSessionCLI(ctx, sessionID)
+	return fetchForSessionCLI(ctx, sessionID, cfg)
 }
 
 func fetchForSessionCLI(
-	ctx context.Context, sessionID string,
+	ctx context.Context, sessionID string, cfg FetchConfig,
 ) (*Usage, error) {
 	if sessionID == "" {
 		return nil, nil
 	}
 
-	binPath, level := resolveAgentsview(ctx)
-	if level == capNone {
+	binPath, err := resolveAgentsview()
+	if err != nil {
+		if cfg.RequireCLI {
+			return nil, fmt.Errorf("agentsview lookup: %w", err)
+		}
 		return nil, nil
 	}
 
-	cmdCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
-	var cmd *exec.Cmd
-	if level == capSessionUsage {
-		cmd = exec.CommandContext(
-			cmdCtx, binPath, "session", "usage", sessionID,
-			"--format", "json",
-		)
-	} else {
-		cmd = exec.CommandContext(
-			cmdCtx, binPath, "token-use", sessionID,
-		)
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = 10 * time.Second
 	}
-
-	out, err := cmd.Output()
+	out, err := runAgentsviewCommand(
+		ctx, timeout, binPath,
+		"session", "usage", sessionID, "--format", "json",
+	)
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			// agentsview usage exit codes: 2 = session not found,
-			// 3 = found but no token/cost data. Both mean "no usage",
-			// not an error. Legacy token-use (< 0.30.0) signalled
-			// not-found with exit 1 and empty stdout+stderr.
-			switch code := exitErr.ExitCode(); {
-			case code == 2 || code == 3:
-				return nil, nil
-			case code == 1 && len(out) == 0 && len(exitErr.Stderr) == 0:
-				return nil, nil
-			default:
-				return nil, fmt.Errorf(
-					"agentsview usage: exit %d: %s",
-					code, exitErr.Stderr,
-				)
+		if shouldFallbackToTokenUse(err) {
+			out, err = runAgentsviewCommand(
+				ctx, timeout, binPath, "token-use", sessionID,
+			)
+			if err != nil {
+				return nil, handleTokenUseError(out, err)
 			}
+		} else {
+			return nil, handleSessionUsageError(err)
 		}
-		return nil, fmt.Errorf("agentsview usage: %w", err)
 	}
 
 	var resp agentsviewResponse
@@ -346,6 +177,65 @@ func fetchForSessionCLI(
 		CostUSD:           resp.CostUSD,
 		HasCost:           resp.HasCost,
 	}, nil
+}
+
+func runAgentsviewCommand(
+	ctx context.Context, timeout time.Duration, binPath string, args ...string,
+) ([]byte, error) {
+	cmdCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	return exec.CommandContext(cmdCtx, binPath, args...).Output()
+}
+
+func shouldFallbackToTokenUse(err error) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	if exitErr.ExitCode() != 1 {
+		return false
+	}
+	stderr := strings.ToLower(string(exitErr.Stderr))
+	return strings.Contains(stderr, "unknown command") ||
+		strings.Contains(stderr, "unknown subcommand")
+}
+
+func handleSessionUsageError(err error) error {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		// agentsview usage exit codes: 2 = session not found,
+		// 3 = found but no token/cost data. Both mean "no usage",
+		// not an error.
+		switch code := exitErr.ExitCode(); code {
+		case 2, 3:
+			return nil
+		default:
+			return fmt.Errorf(
+				"agentsview usage: exit %d: %s",
+				code, exitErr.Stderr,
+			)
+		}
+	}
+	return fmt.Errorf("agentsview usage: %w", err)
+}
+
+func handleTokenUseError(out []byte, err error) error {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		// Legacy token-use signalled not-found with exit 1 and empty
+		// stdout+stderr.
+		if exitErr.ExitCode() == 1 &&
+			len(out) == 0 &&
+			len(exitErr.Stderr) == 0 {
+			return nil
+		}
+		return fmt.Errorf(
+			"agentsview token-use: exit %d: %s",
+			exitErr.ExitCode(), exitErr.Stderr,
+		)
+	}
+	return fmt.Errorf("agentsview token-use: %w", err)
 }
 
 func fetchForSessionHTTP(

--- a/internal/tokens/tokens_test.go
+++ b/internal/tokens/tokens_test.go
@@ -82,26 +82,6 @@ func TestFormatCost(t *testing.T) {
 		"a genuine zero cost still renders")
 }
 
-func TestGeVersion(t *testing.T) {
-	tests := []struct {
-		a, b [3]int
-		want bool
-	}{
-		{[3]int{0, 30, 0}, [3]int{0, 30, 0}, true},
-		{[3]int{0, 30, 1}, [3]int{0, 30, 0}, true},
-		{[3]int{0, 29, 9}, [3]int{0, 30, 0}, false},
-		{[3]int{1, 0, 0}, [3]int{0, 30, 0}, true},
-		{[3]int{0, 15, 0}, [3]int{0, 15, 0}, true},
-		{[3]int{0, 14, 9}, [3]int{0, 15, 0}, false},
-		{[3]int{2, 0, 0}, [3]int{1, 99, 99}, true},
-	}
-	for _, tt := range tests {
-		t.Run(fmt.Sprintf("%v_ge_%v", tt.a, tt.b), func(t *testing.T) {
-			assert.Equal(t, tt.want, geVersion(tt.a, tt.b))
-		})
-	}
-}
-
 func TestParseJSON(t *testing.T) {
 	t.Run("empty string", func(t *testing.T) {
 		assert.Nil(t, ParseJSON(""))
@@ -144,77 +124,15 @@ func TestParseJSON(t *testing.T) {
 	})
 }
 
-func TestParseVersion(t *testing.T) {
-	tests := []struct {
-		name       string
-		output     string
-		wantLevel  capability
-		wantParsed bool
-	}{
-		{
-			"below token-use min",
-			"agentsview v0.14.9 (commit abc, built 2026-01-01)",
-			capNone, true,
-		},
-		{
-			"token-use min",
-			"agentsview v0.15.0 (commit abc, built 2026-01-01)",
-			capTokenUse, true,
-		},
-		{
-			"token-use range",
-			"agentsview v0.29.0 (commit abc, built 2026-05-10)",
-			capTokenUse, true,
-		},
-		{
-			"session usage min",
-			"agentsview v0.30.0 (commit abc, built 2026-05-23)",
-			capSessionUsage, true,
-		},
-		{
-			"session usage newer patch",
-			"agentsview v0.31.2 (commit abc, built 2026-06-01)",
-			capSessionUsage, true,
-		},
-		{
-			"major bump",
-			"agentsview v1.0.0 (commit abc, built 2026-01-01)",
-			capSessionUsage, true,
-		},
-		{
-			"dev suffix at session min",
-			"agentsview v0.30.0-1-g891cb62 (commit 891cb62, built 2026-05-23)",
-			capSessionUsage, true,
-		},
-		{
-			"very old",
-			"agentsview v0.10.0 (commit abc, built 2026-01-01)",
-			capNone, true,
-		},
-		{"unparseable", "something unexpected", capNone, false},
-		{"empty", "", capNone, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			level, parsed := parseVersion([]byte(tt.output))
-			assert.Equal(t, tt.wantLevel, level, "level")
-			assert.Equal(t, tt.wantParsed, parsed, "parsed")
-		})
-	}
-}
-
 // installFakeAgentsview writes an executable "agentsview" shell script
-// into a fresh temp dir, prepends it to PATH, and resets the version
-// cache. Lets FetchForSession/resolveAgentsview run without a real
-// agentsview install. Skips on Windows (scripts are POSIX shell).
+// into a fresh temp dir and prepends it to PATH. Lets FetchForSession
+// run without a real agentsview install. Skips on Windows (scripts are
+// POSIX shell).
 func installFakeAgentsview(t *testing.T, script string) {
 	t.Helper()
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses shell scripts")
 	}
-	ResetVersionCache()
-	t.Cleanup(ResetVersionCache)
 
 	dir := t.TempDir()
 	bin := filepath.Join(dir, "agentsview")
@@ -225,32 +143,27 @@ func installFakeAgentsview(t *testing.T, script string) {
 	require.NoError(t, err)
 }
 
-func TestFetchForSessionSkipsOldVersion(t *testing.T) {
-	// agentsview too old (< 0.15.0): FetchForSession returns nil
-	// without invoking any usage command (which could spawn a server).
+func TestFetchForSessionSurfacesTokenUseFailureAfterSessionUsageFallback(t *testing.T) {
 	installFakeAgentsview(t, `#!/bin/sh
-if [ "$1" = "version" ]; then
-  echo "agentsview v0.14.0 (commit abc, built 2026-01-01)"
-  exit 0
+if [ "$1" = "session" ] && [ "$2" = "usage" ]; then
+  echo "unknown command: session usage" >&2
+  exit 1
 fi
-echo "ERROR: should not be called" >&2
+echo "unexpected args: $@" >&2
 exit 99
 `)
 
 	usage, err := FetchForSession(context.Background(), "test-session-id")
-	require.NoError(t, err)
+	require.Error(t, err)
 	assert.Nil(t, usage)
+	assert.Contains(t, err.Error(), "agentsview token-use: exit 99")
+	assert.Contains(t, err.Error(), "unexpected args: token-use test-session-id")
 }
 
-func TestFetchForSessionUsesSessionUsageOnNewVersion(t *testing.T) {
-	// agentsview >= 0.30.0: FetchForSession calls `session usage` and
-	// captures the cost estimate. The script errors on any other
-	// subcommand, so reaching the JSON proves command selection.
+func TestFetchForSessionUsesSessionUsage(t *testing.T) {
+	// The script errors on any other subcommand, so reaching the JSON
+	// proves command selection.
 	installFakeAgentsview(t, `#!/bin/sh
-if [ "$1" = "version" ]; then
-  echo "agentsview v0.30.0 (commit abc, built 2026-05-23)"
-  exit 0
-fi
 if [ "$1" = "session" ] && [ "$2" = "usage" ]; then
   echo '{"session_id":"s","agent":"codex","total_output_tokens":28800,"peak_context_tokens":118000,"cost_usd":0.42,"has_cost":true}'
   exit 0
@@ -440,15 +353,55 @@ exit 99
 	assert.InDelta(t, 0.42, usage.CostUSD, 1e-9)
 }
 
-func TestFetchForSessionFallsBackToTokenUse(t *testing.T) {
-	// agentsview in [0.15.0, before session usage support):
-	// FetchForSession falls back to the deprecated token-use command.
-	// The legacy output here has no cost, matching older builds. The
-	// script errors on `session usage`, so success proves the fallback.
+func TestFetchForSessionUsesSessionUsageForHeadBuild(t *testing.T) {
 	installFakeAgentsview(t, `#!/bin/sh
 if [ "$1" = "version" ]; then
-  echo "agentsview v0.15.0 (commit abc, built 2026-01-01)"
+  echo "agentsview HEAD (commit a31468b4, built 2026-06-07)"
   exit 0
+fi
+if [ "$1" = "session" ] && [ "$2" = "usage" ]; then
+  echo '{"session_id":"s","agent":"codex","total_output_tokens":28800,"peak_context_tokens":118000,"cost_usd":0.42,"has_cost":true}'
+  exit 0
+fi
+echo "unexpected args: $@" >&2
+exit 99
+`)
+
+	usage, err := FetchForSession(context.Background(), "s")
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	assert.Equal(t, int64(28800), usage.OutputTokens)
+	assert.Equal(t, int64(118000), usage.PeakContextTokens)
+	assert.True(t, usage.HasCost)
+	assert.InDelta(t, 0.42, usage.CostUSD, 1e-9)
+}
+
+func TestFetchForSessionSurfacesSessionUsageFailureForHeadBuild(t *testing.T) {
+	installFakeAgentsview(t, `#!/bin/sh
+if [ "$1" = "version" ]; then
+  echo "agentsview HEAD (commit a31468b4, built 2026-06-07)"
+  exit 0
+fi
+if [ "$1" = "session" ] && [ "$2" = "usage" ]; then
+  echo "usage exploded" >&2
+  exit 42
+fi
+echo "unexpected args: $@" >&2
+exit 99
+`)
+
+	usage, err := FetchForSession(context.Background(), "s")
+	require.Error(t, err)
+	assert.Nil(t, usage)
+	assert.Contains(t, err.Error(), "agentsview usage: exit 42")
+	assert.Contains(t, err.Error(), "usage exploded")
+}
+
+func TestFetchForSessionFallsBackToTokenUseWhenSessionUsageIsMissing(t *testing.T) {
+	installFakeAgentsview(t, `#!/bin/sh
+if [ "$1" = "session" ] && [ "$2" = "usage" ]; then
+  echo "unknown command: session usage" >&2
+  exit 1
 fi
 if [ "$1" = "token-use" ]; then
   echo '{"session_id":"s","agent":"codex","total_output_tokens":1000,"peak_context_tokens":2000}'
@@ -463,7 +416,7 @@ exit 99
 	require.NotNil(t, usage)
 	assert.Equal(t, int64(1000), usage.OutputTokens)
 	assert.Equal(t, int64(2000), usage.PeakContextTokens)
-	assert.False(t, usage.HasCost, "token-use output carries no cost")
+	assert.False(t, usage.HasCost)
 }
 
 func TestFetchForSessionExitCodesMeanNoUsage(t *testing.T) {
@@ -486,138 +439,33 @@ exit %d
 	}
 }
 
-func TestResolveAgentsviewRetriesAfterTransientFailure(t *testing.T) {
+func TestFetchForSessionSkipsMissingAgentsviewByDefault(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("test uses shell scripts")
+		t.Skip("PATH handling differs on Windows")
 	}
 
-	ResetVersionCache()
-	t.Cleanup(ResetVersionCache)
-
-	// First call: agentsview not on PATH → transient failure.
 	t.Setenv("PATH", t.TempDir())
-	_, level := resolveAgentsview(context.Background())
-	assert.Equal(t, capNone, level, "should fail when binary is absent")
 
-	// Install a valid agentsview and retry — should succeed.
-	dir := t.TempDir()
-	bin := filepath.Join(dir, "agentsview")
-	script := `#!/bin/sh
-if [ "$1" = "version" ]; then
-  echo "agentsview v0.15.0 (commit abc, built 2026-01-01)"
-  exit 0
-fi
-if [ "$1" = "token-use" ]; then
-  exit 0
-fi
-exit 99
-`
-	require.NoError(t, os.WriteFile(bin, []byte(script), 0o755))
+	usage, err := FetchForSession(context.Background(), "s")
 
-	origPath := os.Getenv("PATH")
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+origPath)
-
-	path, level := resolveAgentsview(context.Background())
-	assert.Equal(t, capTokenUse, level, "should succeed after binary appears")
-	assert.Equal(t, bin, path)
+	require.NoError(t, err)
+	assert.Nil(t, usage)
 }
 
-func TestResolveAgentsviewCachesTooOldPermanently(t *testing.T) {
+func TestFetchForSessionWithConfigRequiresAgentsviewWhenRequested(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("test uses shell scripts")
+		t.Skip("PATH handling differs on Windows")
 	}
 
-	ResetVersionCache()
-	t.Cleanup(ResetVersionCache)
+	t.Setenv("PATH", t.TempDir())
 
-	dir := t.TempDir()
-	bin := filepath.Join(dir, "agentsview")
-	script := `#!/bin/sh
-echo "agentsview v0.14.0 (commit abc, built 2026-01-01)"
-`
-	require.NoError(t, os.WriteFile(bin, []byte(script), 0o755))
+	usage, err := FetchForSessionWithConfig(
+		context.Background(), "s", FetchConfig{RequireCLI: true},
+	)
 
-	origPath := os.Getenv("PATH")
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+origPath)
-
-	_, level := resolveAgentsview(context.Background())
-	assert.Equal(t, capNone, level)
-
-	// Even if we "upgrade" the script, the too-old result is cached.
-	script2 := `#!/bin/sh
-echo "agentsview v0.30.0 (commit abc, built 2026-05-23)"
-`
-	require.NoError(t, os.WriteFile(bin, []byte(script2), 0o755))
-
-	_, level = resolveAgentsview(context.Background())
-	assert.Equal(t, capNone, level, "too-old should be cached permanently")
-}
-
-func TestResolveAgentsviewInvalidatesCacheOnPathChange(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test uses shell scripts")
-	}
-
-	ResetVersionCache()
-	t.Cleanup(ResetVersionCache)
-
-	// First call: agentsview at dir1 is too old → cached.
-	dir1 := t.TempDir()
-	bin1 := filepath.Join(dir1, "agentsview")
-	script1 := "#!/bin/sh\necho 'agentsview v0.14.0 (commit abc)'\n"
-	require.NoError(t, os.WriteFile(bin1, []byte(script1), 0o755))
-
-	origPath := os.Getenv("PATH")
-	t.Setenv("PATH", dir1+string(os.PathListSeparator)+origPath)
-
-	_, level := resolveAgentsview(context.Background())
-	assert.Equal(t, capNone, level)
-
-	// "Upgrade" by placing a new binary earlier in PATH.
-	dir2 := t.TempDir()
-	bin2 := filepath.Join(dir2, "agentsview")
-	script2 := "#!/bin/sh\necho 'agentsview v0.30.0 (commit def)'\n"
-	require.NoError(t, os.WriteFile(bin2, []byte(script2), 0o755))
-
-	t.Setenv("PATH", dir2+string(os.PathListSeparator)+origPath)
-
-	path, level := resolveAgentsview(context.Background())
-	assert.Equal(t, capSessionUsage, level, "new path should trigger re-probe")
-	assert.Equal(t, bin2, path)
-}
-
-func TestResolveAgentsviewRetriesAfterUnparseableOutput(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test uses shell scripts")
-	}
-
-	ResetVersionCache()
-	t.Cleanup(ResetVersionCache)
-
-	// First call: agentsview returns unparseable version output.
-	dir := t.TempDir()
-	bin := filepath.Join(dir, "agentsview")
-	script := "#!/bin/sh\necho 'something unexpected'\n"
-	require.NoError(t, os.WriteFile(bin, []byte(script), 0o755))
-
-	origPath := os.Getenv("PATH")
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+origPath)
-
-	_, level := resolveAgentsview(context.Background())
-	assert.Equal(t, capNone, level, "unparseable should fail")
-
-	// Replace with valid version — should succeed because unparseable
-	// output was NOT cached as too-old.
-	dir2 := t.TempDir()
-	bin2 := filepath.Join(dir2, "agentsview")
-	script2 := "#!/bin/sh\necho 'agentsview v0.15.0 (commit abc)'\n"
-	require.NoError(t, os.WriteFile(bin2, []byte(script2), 0o755))
-
-	t.Setenv("PATH", dir2+string(os.PathListSeparator)+origPath)
-
-	path, level := resolveAgentsview(context.Background())
-	assert.NotEqual(t, capNone, level, "should succeed after valid version appears")
-	assert.NotEmpty(t, path)
+	require.Error(t, err)
+	assert.Nil(t, usage)
+	assert.Contains(t, err.Error(), "agentsview lookup")
 }
 
 func TestToJSON(t *testing.T) {


### PR DESCRIPTION
## Summary

- Remove the `agentsview version` gate from token usage lookup.
- Try `agentsview session usage <id> --format json` first so HEAD and prerelease agentsview builds can provide cost data without a parseable semver string.
- Fall back to `agentsview token-use <id>` only when `session usage` is unavailable, preserving token-count lookup for users who upgrade roborev before agentsview.
- Make `backfill-tokens` report a missing agentsview binary instead of silently treating it as skipped work.

## Context

The previous version parsing rejected agentsview builds that live at HEAD even though those builds support the newer session usage command needed for cost backfill. Probing the command behavior directly keeps the foreground backfill path honest while avoiding a hard dependency on version string format.

Older agentsview binaries cannot produce cost data through `token-use`, but they can still provide token counts. This keeps that compatibility path while surfacing real `session usage` failures when the command exists and fails for another reason.
