### PR TITLE
Add AgentsView token backfill route

### DIFF
--- a/cmd/roborev/backfill_tokens.go
+++ b/cmd/roborev/backfill_tokens.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"go.kenn.io/roborev/internal/backfill"
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/tokens"
@@ -44,7 +45,7 @@ will be skipped.`,
 				return fmt.Errorf("list jobs: %w", err)
 			}
 
-			candidates := backfillCandidates(jobs)
+			candidates := backfill.TokenCandidates(jobs)
 
 			var total, updated, skipped, failed int
 			for _, job := range candidates {
@@ -69,7 +70,7 @@ will be skipped.`,
 					skipped++
 					continue
 				}
-				mergedUsage := mergeBackfillTokenUsage(job.TokenUsage, usage)
+				mergedUsage := backfill.MergeTokenUsage(job.TokenUsage, usage)
 
 				if dryRun {
 					fmt.Printf(
@@ -123,66 +124,4 @@ func backfillCostFetchConfig(cfg *config.Config) tokens.FetchConfig {
 		Timeout:    cfg.Cost.ResolvedTimeout(),
 		RequireCLI: true,
 	}
-}
-
-// backfillCandidates filters jobs to those eligible for token
-// backfill: completed, has a session ID, missing cost data, and the
-// session was not reused by another started job.
-func backfillCandidates(
-	jobs []storage.ReviewJob,
-) []storage.ReviewJob {
-	// Count jobs that actually started per session ID. If
-	// multiple jobs ran on the same session, it was resumed
-	// and agentsview totals are cumulative — skip to avoid
-	// overcounting.
-	sessionCount := make(map[string]int)
-	for _, job := range jobs {
-		if job.SessionID != "" && job.StartedAt != nil {
-			sessionCount[job.SessionID]++
-		}
-	}
-
-	var out []storage.ReviewJob
-	for _, job := range jobs {
-		if !job.HasViewableOutput() {
-			continue
-		}
-		if !needsTokenCostBackfill(job.TokenUsage) {
-			continue
-		}
-		if job.SessionID == "" {
-			continue
-		}
-		if sessionCount[job.SessionID] > 1 {
-			continue
-		}
-		out = append(out, job)
-	}
-	return out
-}
-
-func mergeBackfillTokenUsage(existingJSON string, fetched *tokens.Usage) *tokens.Usage {
-	if fetched == nil {
-		return tokens.ParseJSON(existingJSON)
-	}
-	merged := *fetched
-	existing := tokens.ParseJSON(existingJSON)
-	if existing == nil {
-		return &merged
-	}
-
-	if merged.OutputTokens == 0 && merged.PeakContextTokens == 0 {
-		merged.OutputTokens = existing.OutputTokens
-		merged.PeakContextTokens = existing.PeakContextTokens
-	}
-	if !merged.HasCost && existing.HasCost {
-		merged.CostUSD = existing.CostUSD
-		merged.HasCost = true
-	}
-	return &merged
-}
-
-func needsTokenCostBackfill(tokenUsage string) bool {
-	usage := tokens.ParseJSON(tokenUsage)
-	return usage == nil || !usage.HasCost
 }

--- a/cmd/roborev/backfill_tokens_test.go
+++ b/cmd/roborev/backfill_tokens_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"go.kenn.io/roborev/internal/backfill"
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/tokens"
@@ -175,7 +176,7 @@ func TestBackfillCandidates(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := backfillCandidates(tt.jobs)
+			got := backfill.TokenCandidates(tt.jobs)
 			var gotIDs []int64
 			for _, j := range got {
 				gotIDs = append(gotIDs, j.ID)
@@ -201,7 +202,7 @@ func TestMergeBackfillTokenUsagePreservesExistingCountsForCostOnlyFetch(t *testi
 	existing := `{"total_output_tokens":28800,"peak_context_tokens":118000}`
 	fetched := &tokens.Usage{CostUSD: 0.42, HasCost: true}
 
-	got := mergeBackfillTokenUsage(existing, fetched)
+	got := backfill.MergeTokenUsage(existing, fetched)
 
 	assert.Equal(t, int64(28800), got.OutputTokens)
 	assert.Equal(t, int64(118000), got.PeakContextTokens)

--- a/internal/backfill/tokens.go
+++ b/internal/backfill/tokens.go
@@ -1,0 +1,158 @@
+package backfill
+
+import (
+	"fmt"
+
+	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/tokens"
+)
+
+const (
+	ResultUpdated = "updated"
+	ResultSkipped = "skipped"
+	ResultFailed  = "failed"
+)
+
+type SessionUsage struct {
+	SessionID string
+	Usage     *tokens.Usage
+}
+
+type TokenResult struct {
+	SessionID string `json:"session_id"`
+	JobID     int64  `json:"job_id,omitempty"`
+	Agent     string `json:"agent,omitempty"`
+	Status    string `json:"status"`
+	Reason    string `json:"reason,omitempty"`
+	Summary   string `json:"summary,omitempty"`
+}
+
+type TokenSummary struct {
+	Total   int           `json:"total"`
+	Updated int           `json:"updated"`
+	Skipped int           `json:"skipped"`
+	Failed  int           `json:"failed"`
+	Results []TokenResult `json:"results"`
+}
+
+// TokenCandidates filters jobs to those eligible for token backfill:
+// completed, has a session ID, missing cost data, and the session was
+// not reused by another started job.
+func TokenCandidates(jobs []storage.ReviewJob) []storage.ReviewJob {
+	sessionCount := make(map[string]int)
+	for _, job := range jobs {
+		if job.SessionID != "" && job.StartedAt != nil {
+			sessionCount[job.SessionID]++
+		}
+	}
+
+	var out []storage.ReviewJob
+	for _, job := range jobs {
+		if !job.HasViewableOutput() {
+			continue
+		}
+		if !NeedsTokenCostBackfill(job.TokenUsage) {
+			continue
+		}
+		if job.SessionID == "" {
+			continue
+		}
+		if sessionCount[job.SessionID] > 1 {
+			continue
+		}
+		out = append(out, job)
+	}
+	return out
+}
+
+func MergeTokenUsage(existingJSON string, fetched *tokens.Usage) *tokens.Usage {
+	if fetched == nil {
+		return tokens.ParseJSON(existingJSON)
+	}
+	merged := *fetched
+	existing := tokens.ParseJSON(existingJSON)
+	if existing == nil {
+		return &merged
+	}
+
+	if merged.OutputTokens == 0 && merged.PeakContextTokens == 0 {
+		merged.OutputTokens = existing.OutputTokens
+		merged.PeakContextTokens = existing.PeakContextTokens
+	}
+	if !merged.HasCost && existing.HasCost {
+		merged.CostUSD = existing.CostUSD
+		merged.HasCost = true
+	}
+	return &merged
+}
+
+func NeedsTokenCostBackfill(tokenUsage string) bool {
+	usage := tokens.ParseJSON(tokenUsage)
+	return usage == nil || !usage.HasCost
+}
+
+func ApplyTokenUsage(
+	db *storage.DB, sessions []SessionUsage, dryRun bool,
+) (TokenSummary, error) {
+	jobs, err := db.ListJobs("", "", 0, 0)
+	if err != nil {
+		return TokenSummary{}, fmt.Errorf("list jobs: %w", err)
+	}
+
+	candidates := make(map[string]storage.ReviewJob)
+	for _, job := range TokenCandidates(jobs) {
+		candidates[job.SessionID] = job
+	}
+
+	summary := TokenSummary{
+		Total:   len(sessions),
+		Results: make([]TokenResult, 0, len(sessions)),
+	}
+	seen := make(map[string]bool)
+	for _, session := range sessions {
+		result := TokenResult{SessionID: session.SessionID}
+		switch {
+		case session.SessionID == "":
+			result.Status = ResultSkipped
+			result.Reason = "missing session ID"
+			summary.Skipped++
+		case seen[session.SessionID]:
+			result.Status = ResultSkipped
+			result.Reason = "duplicate session"
+			summary.Skipped++
+		case session.Usage == nil:
+			seen[session.SessionID] = true
+			result.Status = ResultSkipped
+			result.Reason = "no usage"
+			summary.Skipped++
+		default:
+			seen[session.SessionID] = true
+			job, ok := candidates[session.SessionID]
+			if !ok {
+				result.Status = ResultSkipped
+				result.Reason = "no eligible job"
+				summary.Skipped++
+				summary.Results = append(summary.Results, result)
+				continue
+			}
+
+			merged := MergeTokenUsage(job.TokenUsage, session.Usage)
+			result.JobID = job.ID
+			result.Agent = job.Agent
+			result.Summary = merged.FormatSummary()
+			if !dryRun {
+				if err := db.SaveJobTokenUsage(job.ID, tokens.ToJSON(merged)); err != nil {
+					result.Status = ResultFailed
+					result.Reason = err.Error()
+					summary.Failed++
+					summary.Results = append(summary.Results, result)
+					continue
+				}
+			}
+			result.Status = ResultUpdated
+			summary.Updated++
+		}
+		summary.Results = append(summary.Results, result)
+	}
+	return summary, nil
+}

--- a/internal/daemon/routes.go
+++ b/internal/daemon/routes.go
@@ -8,6 +8,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humago"
 
+	"go.kenn.io/roborev/internal/backfill"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/version"
 )
@@ -172,6 +173,19 @@ func (s *Server) registerHumaAPI(mux *http.ServeMux) huma.API {
 			o.OperationID = "sync-now"
 			o.Summary = "Run an immediate sync"
 			o.Tags = []string{"sync"}
+		})
+
+	huma.Post(api, "/api/tokens/backfill", s.humaBackfillTokens,
+		func(o *huma.Operation) {
+			o.OperationID = "backfill-tokens"
+			o.Summary = "Backfill token usage from AgentsView payloads"
+			o.Tags = []string{"jobs"}
+			o.MaxBodyBytes = 10 << 20
+			o.Responses = jsonResponses(map[string]*huma.Schema{
+				"200": jsonSchema(api, backfill.TokenSummary{}),
+				"400": errorSchema,
+				"500": errorSchema,
+			})
 		})
 
 	huma.Post(api, "/api/job/cancel", s.humaCancelJob,

--- a/internal/daemon/routes_test.go
+++ b/internal/daemon/routes_test.go
@@ -14,6 +14,7 @@ import (
 
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testutil"
+	"go.kenn.io/roborev/internal/tokens"
 )
 
 // serveHuma sends a request through the server's mux (which
@@ -272,6 +273,130 @@ func TestHumaCloseReview(t *testing.T) {
 	})
 }
 
+func TestHumaBackfillTokensUpdatesMatchingEligibleJob(t *testing.T) {
+	srv, db, _ := newTestServer(t)
+	repo := testutil.CreateTestRepo(t, db)
+	job := testutil.CreateCompletedReview(
+		t, db, repo.ID, "usage-sha", "test-agent", "review text",
+	)
+	existing := `{"total_output_tokens":28800,"peak_context_tokens":118000}`
+	_, err := db.Exec(
+		`UPDATE review_jobs SET session_id = ?, token_usage = ? WHERE id = ?`,
+		"session-1", existing, job.ID,
+	)
+	require.NoError(t, err)
+
+	body, err := json.Marshal(map[string]any{
+		"sessions": []map[string]any{
+			{
+				"session_id":     "session-1",
+				"has_token_data": false,
+				"has_cost":       true,
+				"cost_usd":       0.42,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	rr := serveHuma(
+		t, srv, http.MethodPost, "/api/tokens/backfill", body,
+	)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp struct {
+		Total   int `json:"total"`
+		Updated int `json:"updated"`
+		Skipped int `json:"skipped"`
+		Failed  int `json:"failed"`
+		Results []struct {
+			SessionID string `json:"session_id"`
+			JobID     int64  `json:"job_id"`
+			Status    string `json:"status"`
+		} `json:"results"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.Total)
+	assert.Equal(t, 1, resp.Updated)
+	assert.Zero(t, resp.Skipped)
+	assert.Zero(t, resp.Failed)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, "session-1", resp.Results[0].SessionID)
+	assert.Equal(t, job.ID, resp.Results[0].JobID)
+	assert.Equal(t, "updated", resp.Results[0].Status)
+
+	updated, err := db.GetJobByID(job.ID)
+	require.NoError(t, err)
+	usage := tokens.ParseJSON(updated.TokenUsage)
+	require.NotNil(t, usage)
+	assert.Equal(t, int64(28800), usage.OutputTokens)
+	assert.Equal(t, int64(118000), usage.PeakContextTokens)
+	assert.True(t, usage.HasCost)
+	assert.InDelta(t, 0.42, usage.CostUSD, 1e-9)
+}
+
+func TestHumaBackfillTokensSkipsReusedSession(t *testing.T) {
+	srv, db, _ := newTestServer(t)
+	repo := testutil.CreateTestRepo(t, db)
+	first := testutil.CreateCompletedReview(
+		t, db, repo.ID, "reuse-1", "test-agent", "review text",
+	)
+	second := testutil.CreateCompletedReview(
+		t, db, repo.ID, "reuse-2", "test-agent", "review text",
+	)
+	_, err := db.Exec(
+		`UPDATE review_jobs SET session_id = ? WHERE id IN (?, ?)`,
+		"reused-session", first.ID, second.ID,
+	)
+	require.NoError(t, err)
+
+	body, err := json.Marshal(map[string]any{
+		"sessions": []map[string]any{
+			{
+				"session_id":          "reused-session",
+				"has_token_data":      true,
+				"total_output_tokens": 100,
+				"peak_context_tokens": 200,
+				"has_cost":            true,
+				"cost_usd":            0.10,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	rr := serveHuma(
+		t, srv, http.MethodPost, "/api/tokens/backfill", body,
+	)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp struct {
+		Total   int `json:"total"`
+		Updated int `json:"updated"`
+		Skipped int `json:"skipped"`
+		Failed  int `json:"failed"`
+		Results []struct {
+			SessionID string `json:"session_id"`
+			Status    string `json:"status"`
+			Reason    string `json:"reason"`
+		} `json:"results"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.Total)
+	assert.Zero(t, resp.Updated)
+	assert.Equal(t, 1, resp.Skipped)
+	assert.Zero(t, resp.Failed)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, "reused-session", resp.Results[0].SessionID)
+	assert.Equal(t, "skipped", resp.Results[0].Status)
+	assert.Equal(t, "no eligible job", resp.Results[0].Reason)
+
+	firstUpdated, err := db.GetJobByID(first.ID)
+	require.NoError(t, err)
+	secondUpdated, err := db.GetJobByID(second.ID)
+	require.NoError(t, err)
+	assert.Empty(t, firstUpdated.TokenUsage)
+	assert.Empty(t, secondUpdated.TokenUsage)
+}
+
 func TestHumaOpenAPISpec(t *testing.T) {
 	srv, _, _ := newTestServer(t)
 
@@ -318,6 +443,7 @@ func TestHumaOpenAPISpec(t *testing.T) {
 		"/api/job/fix":           "post",
 		"/api/job/applied":       "post",
 		"/api/job/rebased":       "post",
+		"/api/tokens/backfill":   "post",
 	}
 	for p, method := range wantPaths {
 		pathObj, exists := paths[p]

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -23,12 +23,14 @@ import (
 	gitrepo "go.kenn.io/kit/git/repo"
 
 	"go.kenn.io/roborev/internal/agent"
+	"go.kenn.io/roborev/internal/backfill"
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/githook"
 	"go.kenn.io/roborev/internal/prompt"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/telemetry"
+	"go.kenn.io/roborev/internal/tokens"
 	"go.kenn.io/roborev/internal/version"
 )
 
@@ -1609,6 +1611,40 @@ func (s *Server) humaAddComment(
 	}
 
 	return &AddCommentOutput{Body: resp}, nil
+}
+
+func (s *Server) humaBackfillTokens(
+	_ context.Context, input *BackfillTokensInput,
+) (*BackfillTokensOutput, error) {
+	if len(input.Body.Sessions) == 0 {
+		return nil, huma.Error400BadRequest("sessions are required")
+	}
+
+	sessions := make([]backfill.SessionUsage, 0, len(input.Body.Sessions))
+	for _, payload := range input.Body.Sessions {
+		payload.SessionID = strings.TrimSpace(payload.SessionID)
+		if payload.SessionID == "" {
+			return nil, huma.Error400BadRequest("session_id is required")
+		}
+		usage, err := tokens.UsageFromSessionPayload(payload)
+		if err != nil {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
+		sessions = append(sessions, backfill.SessionUsage{
+			SessionID: payload.SessionID,
+			Usage:     usage,
+		})
+	}
+
+	summary, err := backfill.ApplyTokenUsage(
+		s.db, sessions, input.Body.DryRun,
+	)
+	if err != nil {
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("backfill tokens: %v", err),
+		)
+	}
+	return &BackfillTokensOutput{Body: summary}, nil
 }
 
 func (s *Server) humaEnqueue(

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -1,6 +1,10 @@
 package daemon
 
-import "go.kenn.io/roborev/internal/storage"
+import (
+	"go.kenn.io/roborev/internal/backfill"
+	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/tokens"
+)
 
 type EnqueueRequest struct {
 	RepoPath     string   `json:"repo_path"`
@@ -448,6 +452,22 @@ type JobPatchInput struct {
 // SyncNowInput holds query parameters for POST /api/sync/now.
 type SyncNowInput struct {
 	Stream string `query:"stream" doc:"Stream sync progress as NDJSON when set to 1"`
+}
+
+// BackfillTokensRequest is the request body for POST /api/tokens/backfill.
+type BackfillTokensRequest struct {
+	DryRun   bool                         `json:"dry_run,omitempty"`
+	Sessions []tokens.SessionUsagePayload `json:"sessions"`
+}
+
+// BackfillTokensInput is the request body for POST /api/tokens/backfill.
+type BackfillTokensInput struct {
+	Body BackfillTokensRequest
+}
+
+// BackfillTokensOutput is the response for POST /api/tokens/backfill.
+type BackfillTokensOutput struct {
+	Body backfill.TokenSummary
 }
 
 // StreamEventsInput holds query parameters for GET /api/stream/events.

--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -49,14 +49,16 @@ type agentsviewResponse struct {
 	HasCost           bool    `json:"has_cost"`
 }
 
-type httpUsageResponse struct {
+// SessionUsagePayload is the JSON shape returned by AgentsView's
+// session-usage API and accepted by roborev's token backfill endpoint.
+type SessionUsagePayload struct {
 	SessionID         string   `json:"session_id"`
-	Agent             string   `json:"agent"`
-	Project           string   `json:"project"`
-	OutputTokens      *int64   `json:"total_output_tokens"`
-	PeakContextTokens *int64   `json:"peak_context_tokens"`
+	Agent             string   `json:"agent,omitempty"`
+	Project           string   `json:"project,omitempty"`
+	OutputTokens      *int64   `json:"total_output_tokens,omitempty"`
+	PeakContextTokens *int64   `json:"peak_context_tokens,omitempty"`
 	HasTokenData      *bool    `json:"has_token_data"`
-	CostUSD           *float64 `json:"cost_usd"`
+	CostUSD           *float64 `json:"cost_usd,omitempty"`
 	HasCost           *bool    `json:"has_cost"`
 }
 
@@ -283,11 +285,11 @@ func fetchForSessionHTTP(
 		return nil, fmt.Errorf("usage endpoint HTTP %s: %s", resp.Status, detail)
 	}
 
-	var respBody httpUsageResponse
+	var respBody SessionUsagePayload
 	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
 		return nil, fmt.Errorf("parse usage endpoint output: %w", err)
 	}
-	return usageFromHTTPResponse(respBody)
+	return UsageFromSessionPayload(respBody)
 }
 
 func expandEndpoint(template, sessionID string) (string, error) {
@@ -304,7 +306,9 @@ func expandEndpoint(template, sessionID string) (string, error) {
 	return endpoint, nil
 }
 
-func usageFromHTTPResponse(resp httpUsageResponse) (*Usage, error) {
+// UsageFromSessionPayload validates an AgentsView session-usage payload
+// and converts it to roborev's stored usage shape.
+func UsageFromSessionPayload(resp SessionUsagePayload) (*Usage, error) {
 	if resp.HasTokenData == nil {
 		return nil, fmt.Errorf("usage endpoint schema: missing has_token_data")
 	}


### PR DESCRIPTION
Adds a daemon `POST /api/tokens/backfill` endpoint so AgentsView can send session-usage payloads into roborev without roborev shelling out to the `agentsview` CLI.

The route writes to the existing `review_jobs.token_usage` field only. It shares the CLI backfill eligibility and merge rules through `internal/backfill`, including preserving existing token counts for cost-only payloads and skipping reused sessions to avoid cumulative overcounting.

The main review areas are `internal/backfill/tokens.go` for the shared rules, `internal/daemon/server.go` for request handling, and `internal/tokens/tokens.go` for the shared AgentsView payload parser.
