### PR TITLE
Add queue pause controls

### DIFF
--- a/cmd/roborev/daemon_lifecycle.go
+++ b/cmd/roborev/daemon_lifecycle.go
@@ -243,6 +243,15 @@ func startDaemon() error {
 		fmt.Println("Starting daemon...")
 	}
 
+	// Persist any pending queue-pause state before the daemon's workers start.
+	// startDaemon runs only after any previous daemon has been stopped (restart)
+	// or when none was running (cold start), so this never migrates a live DB.
+	if pendingStartPause != nil {
+		if err := writeLocalQueuePaused(*pendingStartPause); err != nil {
+			return fmt.Errorf("persist initial queue pause state: %w", err)
+		}
+	}
+
 	manager := kitdaemon.Manager{
 		Store:    daemon.RuntimeStore(),
 		Discover: daemon.DiscoverOptions(1 * time.Second),

--- a/cmd/roborev/main.go
+++ b/cmd/roborev/main.go
@@ -41,6 +41,8 @@ func main() {
 	rootCmd.AddCommand(enqueueCmd()) // hidden alias for backward compatibility
 	rootCmd.AddCommand(waitCmd())
 	rootCmd.AddCommand(statusCmd())
+	rootCmd.AddCommand(pauseCmd())
+	rootCmd.AddCommand(unpauseCmd())
 	rootCmd.AddCommand(listCmd())
 	rootCmd.AddCommand(showCmd())
 	rootCmd.AddCommand(commentCmd())

--- a/cmd/roborev/pause.go
+++ b/cmd/roborev/pause.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"go.kenn.io/roborev/internal/storage"
+)
+
+type queuePauseResponse struct {
+	QueuePaused bool `json:"queue_paused"`
+}
+
+func pauseCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "pause",
+		Short: "Pause queue processing",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return setQueuePaused(true)
+		},
+	}
+}
+
+func unpauseCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "unpause",
+		Short: "Resume queue processing",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return setQueuePaused(false)
+		},
+	}
+}
+
+func setQueuePaused(paused bool) error {
+	// For a local daemon, carry the desired pause state into daemon startup so a
+	// cold-started or restarted daemon comes up with the flag already applied,
+	// before its workers can claim jobs. startDaemon persists it in the safe
+	// window after any previous daemon has stopped, so the CLI never migrates a
+	// live database. A healthy, current-version daemon is left running and picks
+	// up the state from the POST below instead.
+	if serverAddr == "" {
+		pendingStartPause = &paused
+		defer func() { pendingStartPause = nil }()
+	}
+	if err := ensureDaemon(); err != nil {
+		return err
+	}
+
+	ep := getDaemonEndpoint()
+	addr := ep.BaseURL()
+	path := "/api/queue/unpause"
+	if paused {
+		path = "/api/queue/pause"
+	}
+
+	resp, err := ep.HTTPClient(2*time.Second).Post(addr+path, "application/json", nil)
+	if err != nil {
+		return fmt.Errorf("update queue pause state: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("update queue pause state: daemon returned %s", resp.Status)
+	}
+
+	var result queuePauseResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("parse queue pause response: %w", err)
+	}
+
+	if result.QueuePaused {
+		fmt.Println("Queue paused. Running jobs will continue; no new jobs will start.")
+	} else {
+		fmt.Println("Queue unpaused. Workers will start queued jobs again.")
+	}
+	return nil
+}
+
+// pendingStartPause carries the queue-pause state that startDaemon must persist
+// to the local database immediately before launching a daemon. It lets a
+// cold-started or restarted daemon come up with the pause flag already applied
+// without the CLI opening the database while an older daemon still owns it.
+var pendingStartPause *bool
+
+// writeLocalQueuePaused persists the queue-pause flag to the default local
+// database. The caller must ensure no daemon currently owns the database (for
+// example, immediately before startDaemon launches a new one).
+func writeLocalQueuePaused(paused bool) error {
+	db, err := storage.Open(storage.DefaultDBPath())
+	if err != nil {
+		return fmt.Errorf("open local daemon database: %w", err)
+	}
+	defer db.Close()
+	if err := db.SetQueuePaused(paused); err != nil {
+		return fmt.Errorf("persist local queue pause state: %w", err)
+	}
+	return nil
+}

--- a/cmd/roborev/pause_test.go
+++ b/cmd/roborev/pause_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/storage"
+)
+
+func TestWriteLocalQueuePaused(t *testing.T) {
+	t.Setenv("ROBOREV_DATA_DIR", t.TempDir())
+
+	require.NoError(t, writeLocalQueuePaused(true))
+
+	db, err := storage.Open(storage.DefaultDBPath())
+	require.NoError(t, err)
+	defer db.Close()
+
+	paused, err := db.IsQueuePaused()
+	require.NoError(t, err)
+	assert.True(t, paused)
+}
+
+func TestStartDaemonPersistsPendingPauseState(t *testing.T) {
+	exe, err := os.Executable()
+	require.NoError(t, err)
+	if !isGoTestBinaryPath(exe) {
+		t.Skipf("expected go test binary path, got %q", exe)
+	}
+
+	setupIsolatedDataDir(t)
+	t.Setenv("ROBOREV_TEST_ALLOW_AUTOSTART", "")
+
+	paused := true
+	pendingStartPause = &paused
+	t.Cleanup(func() { pendingStartPause = nil })
+
+	// startDaemon refuses to spawn the ephemeral test binary, but it must
+	// persist the pending pause state first, in the safe pre-launch window
+	// (no daemon owns the DB), before its workers could claim jobs.
+	_ = startDaemon()
+
+	db, err := storage.Open(storage.DefaultDBPath())
+	require.NoError(t, err)
+	defer db.Close()
+
+	got, err := db.IsQueuePaused()
+	require.NoError(t, err)
+	assert.True(t, got,
+		"startDaemon must persist the pending pause flag before launch")
+}
+
+func TestPauseCmdPostsQueuePause(t *testing.T) {
+	var called bool
+	md := NewMockDaemon(t, MockRefineHooks{
+		OnUnhandled: func(w http.ResponseWriter, r *http.Request, _ *mockRefineState) bool {
+			if r.Method != http.MethodPost || r.URL.Path != "/api/queue/pause" {
+				return false
+			}
+			called = true
+			_ = json.NewEncoder(w).Encode(queuePauseResponse{QueuePaused: true})
+			return true
+		},
+	})
+	defer md.Close()
+
+	output := captureStdout(t, func() {
+		cmd := pauseCmd()
+		require.NoError(t, cmd.Execute())
+	})
+
+	assert.True(t, called)
+	assert.Contains(t, output, "Queue paused")
+}
+
+func TestUnpauseCmdPostsQueueUnpause(t *testing.T) {
+	var called bool
+	md := NewMockDaemon(t, MockRefineHooks{
+		OnUnhandled: func(w http.ResponseWriter, r *http.Request, _ *mockRefineState) bool {
+			if r.Method != http.MethodPost || r.URL.Path != "/api/queue/unpause" {
+				return false
+			}
+			called = true
+			_ = json.NewEncoder(w).Encode(queuePauseResponse{QueuePaused: false})
+			return true
+		},
+	})
+	defer md.Close()
+
+	output := captureStdout(t, func() {
+		cmd := unpauseCmd()
+		require.NoError(t, cmd.Execute())
+	})
+
+	assert.True(t, called)
+	assert.Contains(t, output, "Queue unpaused")
+}

--- a/cmd/roborev/status.go
+++ b/cmd/roborev/status.go
@@ -111,7 +111,11 @@ func statusCmd() *cobra.Command {
 				daemonLine += fmt.Sprintf(" [%s]", status.Version)
 			}
 			fmt.Println(daemonLine)
-			fmt.Printf("Workers: %d/%d active\n", status.ActiveWorkers, status.MaxWorkers)
+			workersLine := fmt.Sprintf("Workers: %d/%d active", status.ActiveWorkers, status.MaxWorkers)
+			if status.QueuePaused {
+				workersLine += " (paused)"
+			}
+			fmt.Println(workersLine)
 			fmt.Printf("Jobs:    %d queued, %d running, %d completed, %d failed, %d skipped\n",
 				status.QueuedJobs, status.RunningJobs, status.CompletedJobs, status.FailedJobs, status.SkippedJobs)
 			fmt.Println()

--- a/cmd/roborev/tui/actions.go
+++ b/cmd/roborev/tui/actions.go
@@ -181,6 +181,29 @@ func (m model) cancelJob(
 	}
 }
 
+// togglePauseCmd pauses or resumes daemon queue processing, reporting the
+// outcome so the optimistic badge update can be reconciled or rolled back.
+func (m model) togglePauseCmd(paused bool) tea.Cmd {
+	return func() tea.Msg {
+		return pauseResultMsg{paused: paused, err: m.callPauseAPI(paused)}
+	}
+}
+
+func (m model) callPauseAPI(paused bool) error {
+	if paused {
+		resp, err := m.api.PauseQueueWithResponse(m.apiContext())
+		if resp != nil && resp.StatusCode != http.StatusOK {
+			err = apiStatusError(resp.StatusCode, apiStatus(resp.StatusCode), resp.Body)
+		}
+		return err
+	}
+	resp, err := m.api.UnpauseQueueWithResponse(m.apiContext())
+	if resp != nil && resp.StatusCode != http.StatusOK {
+		err = apiStatusError(resp.StatusCode, apiStatus(resp.StatusCode), resp.Body)
+	}
+	return err
+}
+
 // rerunJob sends a rerun request to the server for failed/canceled jobs.
 func (m model) rerunJob(snap rerunSnapshot) tea.Cmd {
 	return func() tea.Msg {

--- a/cmd/roborev/tui/handlers.go
+++ b/cmd/roborev/tui/handlers.go
@@ -168,10 +168,30 @@ func (m model) handleGlobalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleColumnOptionsKey()
 	case "D":
 		return m.handleDistractionFreeKey()
+	case "P":
+		return m.handleTogglePauseKey()
 	case "tab":
 		return m.handleTabKey()
 	}
 	return m, nil
+}
+
+// handleTogglePauseKey pauses or resumes daemon queue processing. Pause is a
+// global daemon state, so this toggle and the [PAUSED] badge work from any
+// view sharing the global keymap. The badge flips optimistically and is
+// reconciled (or rolled back) once the daemon responds.
+func (m model) handleTogglePauseKey() (tea.Model, tea.Cmd) {
+	paused := !m.status.QueuePaused
+	m.status.QueuePaused = paused
+	if paused {
+		m.setWarningFlash(
+			"Queue paused - running jobs finish, no new jobs start",
+			3*time.Second, m.currentView,
+		)
+	} else {
+		m.setFlash("Queue resumed", 3*time.Second, m.currentView)
+	}
+	return m, m.togglePauseCmd(paused)
 }
 
 func (m model) handleQuitKey() (tea.Model, tea.Cmd) {

--- a/cmd/roborev/tui/handlers_msg.go
+++ b/cmd/roborev/tui/handlers_msg.go
@@ -773,6 +773,25 @@ func (m model) handleCancelResultMsg(
 	return m, nil
 }
 
+// handlePauseResultMsg reconciles the queue-pause badge with the daemon. On
+// success it refetches status so worker counts settle; on failure it rolls
+// back the optimistic toggle and surfaces the error.
+func (m model) handlePauseResultMsg(msg pauseResultMsg) (tea.Model, tea.Cmd) {
+	if msg.err != nil {
+		m.status.QueuePaused = !msg.paused
+		verb := "pause"
+		if !msg.paused {
+			verb = "resume"
+		}
+		m.setWarningFlash(
+			fmt.Sprintf("Failed to %s queue: %v", verb, msg.err),
+			4*time.Second, m.currentView,
+		)
+		return m, nil
+	}
+	return m, m.fetchStatus()
+}
+
 // handleRerunResultMsg processes job re-run results.
 func (m model) handleRerunResultMsg(
 	msg rerunResultMsg,

--- a/cmd/roborev/tui/queue_test.go
+++ b/cmd/roborev/tui/queue_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"image/color"
 	"maps"
@@ -686,6 +687,83 @@ func TestTUIQueueShowsCostColumnByDefault(t *testing.T) {
 		"Cost header should be visible by default")
 	assert.Contains(t, out, "~$0.42",
 		"cost value should render in the row")
+}
+
+func TestTUIQueueHeaderShowsPausedQueueState(t *testing.T) {
+	assert := assert.New(t)
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.width = 200
+	m.height = 30
+	m.status = storage.DaemonStatus{Version: "test", ActiveWorkers: 0, MaxWorkers: 4, QueuePaused: true}
+
+	out := stripTestANSI(m.renderQueueView())
+	assert.Contains(out, "[PAUSED]", "paused queue should show a badge on the daemon status line")
+	assert.Contains(out, "Workers: 0/4", "worker counts should still render alongside the badge")
+}
+
+func TestTUIQueueHeaderShowsPausedBadgeWhenFiltered(t *testing.T) {
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.width = 200
+	m.height = 30
+	m.activeBranchFilter = "main"
+	m.status = storage.DaemonStatus{Version: "test", QueuePaused: true}
+
+	out := stripTestANSI(m.renderQueueView())
+	assert.Contains(t, out, "[PAUSED]",
+		"pause is a global daemon state and must show even under an active filter")
+}
+
+func TestTUIQueueCompactShowsPausedBadge(t *testing.T) {
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.width = 200
+	m.height = 10 // height < 15 triggers compact mode
+	m.status = storage.DaemonStatus{Version: "test", QueuePaused: true}
+
+	out := stripTestANSI(m.renderQueueView())
+	assert.Contains(t, out, "[PAUSED]",
+		"compact mode hides the status area but must still surface a paused queue")
+}
+
+func TestTUITogglePauseKeyFlipsBadgeOptimistically(t *testing.T) {
+	assert := assert.New(t)
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.currentView = viewQueue
+	require.False(t, m.status.QueuePaused)
+
+	updated, cmd := m.handleTogglePauseKey()
+	m = updated.(model)
+	assert.True(m.status.QueuePaused, "pressing P should optimistically pause the queue")
+	assert.NotNil(cmd, "pressing P should issue a pause request")
+
+	updated, cmd = m.handleTogglePauseKey()
+	m = updated.(model)
+	assert.False(m.status.QueuePaused, "pressing P again should resume the queue")
+	assert.NotNil(cmd, "pressing P again should issue a resume request")
+}
+
+func TestTUIPauseResultRollsBackOnError(t *testing.T) {
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.currentView = viewQueue
+	m.status.QueuePaused = true // optimistic pause already applied
+
+	updated, _ := m.handlePauseResultMsg(pauseResultMsg{paused: true, err: errors.New("boom")})
+	m = updated.(model)
+	assert.False(t, m.status.QueuePaused,
+		"a failed pause request should roll the badge back to running")
+}
+
+func TestTUIQueueHelpShowsPauseToggleLabel(t *testing.T) {
+	assert := assert.New(t)
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.width = 200
+	m.height = 30
+
+	assert.Contains(stripTestANSI(m.renderQueueView()), "pause",
+		"running queue should offer a pause action in the help footer")
+
+	m.status.QueuePaused = true
+	assert.Contains(stripTestANSI(m.renderQueueView()), "resume",
+		"paused queue should offer a resume action in the help footer")
 }
 
 func TestTUIQueueCollapsedPanelShowsAggregatedMemberCost(t *testing.T) {
@@ -3059,12 +3137,12 @@ func TestExpandHintOnlyWhenParentSelected(t *testing.T) {
 // TestQueueHelpLinesAccountForExpandHint proves the help-height reservation
 // (queueHelpLines) counts the same rows renderQueueView draws: the base rows
 // when a non-parent is selected, and the rows plus the "space — expand" hint
-// when a panel parent is selected. width=100 is chosen because the hint reflows
+// when a panel parent is selected. width=110 is chosen because the hint reflows
 // the help onto one more line there (base 2 lines vs hinted 3) — the case the
 // off-by-one bug bit; width=120 (the seeded default) is the no-reflow case where
 // the two counts coincide.
 func TestQueueHelpLinesAccountForExpandHint(t *testing.T) {
-	for _, w := range []int{100, 120} {
+	for _, w := range []int{110, 120} {
 		t.Run(fmt.Sprintf("width=%d", w), func(t *testing.T) {
 			m := seededPanelModel(t) // jobs = [20 standalone, 10 parent]
 			m.width = w
@@ -3085,13 +3163,13 @@ func TestQueueHelpLinesAccountForExpandHint(t *testing.T) {
 		})
 	}
 
-	// At width=100 the hint genuinely costs an extra reflowed line, so the two
+	// At width=110 the hint genuinely costs an extra reflowed line, so the two
 	// reservations differ — this is the regression the fix addresses.
 	m := seededPanelModel(t)
-	m.width = 100
-	assert.Less(t, len(reflowHelpRows(m.queueHelpRows(), 100)),
-		len(reflowHelpRows(withExpandHint(m.queueHelpRows()), 100)),
-		"width=100 must be a width where the expand hint adds a reflow line")
+	m.width = 110
+	assert.Less(t, len(reflowHelpRows(m.queueHelpRows(), 110)),
+		len(reflowHelpRows(withExpandHint(m.queueHelpRows()), 110)),
+		"width=110 must be a width where the expand hint adds a reflow line")
 }
 
 func TestEnterOnInProgressParentFlashesProgress(t *testing.T) {

--- a/cmd/roborev/tui/render_queue.go
+++ b/cmd/roborev/tui/render_queue.go
@@ -133,6 +133,11 @@ func (m model) queueHelpRows() [][]helpItem {
 		row2 = append(row2, helpItem{"s", "show classify"})
 	}
 	row2 = append(row2, helpItem{"D", "focus"})
+	pauseLabel := "pause"
+	if m.status.QueuePaused {
+		pauseLabel = "resume"
+	}
+	row2 = append(row2, helpItem{"P", pauseLabel})
 	if m.tasksWorkflowEnabled() {
 		row2 = append(row2, helpItem{"T", "tasks"})
 	}
@@ -398,7 +403,8 @@ func fitTitleLeft(app, filters, hideClosed string, width int) string {
 // is tight (then the hiding-closed flag, then filter text truncates). On a
 // daemon/client version mismatch the daemon version is shown in red inside the
 // parentheses ("roborev (<client>, Daemon: <daemon>)") in place of the
-// right-aligned version, so the warning is prominent and self-explanatory.
+// right-aligned version, so the warning is prominent and self-explanatory. A
+// paused queue adds a yellow [PAUSED] marker to the app name.
 func (m model) renderQueueTitle() string {
 	width := m.width
 	if width <= 0 {
@@ -416,6 +422,12 @@ func (m model) renderQueueTitle() string {
 			titleStyle.Render(")")
 	} else {
 		app = titleStyle.Render("roborev")
+	}
+	// A paused queue is a global daemon state the operator just chose. Mark it
+	// in the title's leftmost, never-dropped span so it stays visible under
+	// filters and in compact mode, where the status line is hidden.
+	if m.status.QueuePaused {
+		app += " " + warningFlashStyle.Render("[PAUSED]")
 	}
 
 	filters := m.titleFilters()

--- a/cmd/roborev/tui/tui.go
+++ b/cmd/roborev/tui/tui.go
@@ -869,6 +869,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		result, cmd = m.handleCancelResultMsg(msg)
 	case rerunResultMsg:
 		result, cmd = m.handleRerunResultMsg(msg)
+	case pauseResultMsg:
+		result, cmd = m.handlePauseResultMsg(msg)
 	case repoNamesMsg:
 		result, cmd = m.handleRepoNamesMsg(msg)
 	case reposMsg:

--- a/cmd/roborev/tui/types.go
+++ b/cmd/roborev/tui/types.go
@@ -173,6 +173,10 @@ type cancelResultMsg struct {
 	restoreSelection bool
 	err              error
 }
+type pauseResultMsg struct {
+	paused bool
+	err    error
+}
 type rerunResultMsg struct {
 	jobID         int64
 	oldState      storage.JobStatus

--- a/internal/daemon/routes.go
+++ b/internal/daemon/routes.go
@@ -82,6 +82,20 @@ func (s *Server) registerHumaAPI(mux *http.ServeMux) huma.API {
 			o.Tags = []string{"daemon"}
 		})
 
+	huma.Post(api, "/api/queue/pause", s.humaPauseQueue,
+		func(o *huma.Operation) {
+			o.OperationID = "pause-queue"
+			o.Summary = "Pause queue processing"
+			o.Tags = []string{"daemon"}
+		})
+
+	huma.Post(api, "/api/queue/unpause", s.humaUnpauseQueue,
+		func(o *huma.Operation) {
+			o.OperationID = "unpause-queue"
+			o.Summary = "Resume queue processing"
+			o.Tags = []string{"daemon"}
+		})
+
 	huma.Get(api, "/api/summary", s.humaGetSummary,
 		func(o *huma.Operation) {
 			o.OperationID = "get-summary"

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -1340,6 +1340,13 @@ func (s *Server) humaGetStatus(
 	}
 	configReloadCounter := s.configWatcher.ReloadCounter()
 
+	queuePaused, err := s.db.IsQueuePaused()
+	if err != nil {
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("get queue paused state: %v", err),
+		)
+	}
+
 	s.endpointMu.Lock()
 	ep := s.endpoint
 	s.endpointMu.Unlock()
@@ -1358,6 +1365,7 @@ func (s *Server) humaGetStatus(
 		AutoDesign:          s.autoDesignStatusForResponse(),
 		ActiveWorkers:       s.workerPool.ActiveWorkers(),
 		MaxWorkers:          s.workerPool.MaxWorkers(),
+		QueuePaused:         queuePaused,
 		Network:             ep.Network,
 		Address:             ep.Address,
 		Port:                ep.Port(),
@@ -1365,6 +1373,32 @@ func (s *Server) humaGetStatus(
 		ConfigReloadedAt:    configReloadedAt,
 		ConfigReloadCounter: configReloadCounter,
 	}
+	return resp, nil
+}
+
+func (s *Server) humaPauseQueue(
+	ctx context.Context, input *QueuePauseInput,
+) (*QueuePauseOutput, error) {
+	if err := s.db.SetQueuePaused(true); err != nil {
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("pause queue: %v", err),
+		)
+	}
+	resp := &QueuePauseOutput{}
+	resp.Body.QueuePaused = true
+	return resp, nil
+}
+
+func (s *Server) humaUnpauseQueue(
+	ctx context.Context, input *QueuePauseInput,
+) (*QueuePauseOutput, error) {
+	if err := s.db.SetQueuePaused(false); err != nil {
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("unpause queue: %v", err),
+		)
+	}
+	resp := &QueuePauseOutput{}
+	resp.Body.QueuePaused = false
 	return resp, nil
 }
 

--- a/internal/daemon/server_actions_test.go
+++ b/internal/daemon/server_actions_test.go
@@ -45,7 +45,7 @@ func (a *commandTestAgent) CommandLine() string { return a.command }
 func (a *commandTestAgent) CommandName() string { return a.command }
 
 func TestHandleStatus(t *testing.T) {
-	server, _, _ := newTestServer(t)
+	server, db, _ := newTestServer(t)
 
 	t.Run("returns status with version", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
@@ -101,6 +101,19 @@ func TestHandleStatus(t *testing.T) {
 		}
 	})
 
+	t.Run("includes queue paused state", func(t *testing.T) {
+		require.NoError(t, db.SetQueuePaused(true))
+		req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+		w := httptest.NewRecorder()
+
+		server.httpServer.Handler.ServeHTTP(w, req)
+
+		var status storage.DaemonStatus
+		testutil.DecodeJSON(t, w, &status)
+		assert.True(t, status.QueuePaused)
+		require.NoError(t, db.SetQueuePaused(false))
+	})
+
 	t.Run("config_reloaded_at empty initially", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
 		w := httptest.NewRecorder()
@@ -117,6 +130,28 @@ func TestHandleStatus(t *testing.T) {
 			}, "Expected ConfigReloadedAt to be empty initially, got %q", status.ConfigReloadedAt)
 		}
 	})
+}
+
+func TestHandleQueuePause(t *testing.T) {
+	server, db, _ := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/queue/pause", nil)
+	w := httptest.NewRecorder()
+	server.httpServer.Handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	paused, err := db.IsQueuePaused()
+	require.NoError(t, err)
+	assert.True(t, paused)
+
+	req = httptest.NewRequest(http.MethodPost, "/api/queue/unpause", nil)
+	w = httptest.NewRecorder()
+	server.httpServer.Handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	paused, err = db.IsQueuePaused()
+	require.NoError(t, err)
+	assert.False(t, paused)
 }
 
 func TestHandlePing(t *testing.T) {

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -283,6 +283,16 @@ type GetStatusOutput struct {
 	Body storage.DaemonStatus
 }
 
+// QueuePauseInput is an empty input for queue pause/unpause endpoints.
+type QueuePauseInput struct{}
+
+// QueuePauseOutput is the response for queue pause/unpause endpoints.
+type QueuePauseOutput struct {
+	Body struct {
+		QueuePaused bool `json:"queue_paused"`
+	}
+}
+
 // -- GET /api/summary --
 
 // GetSummaryInput holds query parameters for the summary endpoint.

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -429,6 +429,30 @@ func (wp *WorkerPool) worker(id int) {
 		default:
 		}
 
+		paused, err := wp.db.IsQueuePaused()
+		if err != nil {
+			log.Printf("[%s] Error checking queue pause state: %v", workerID, err)
+			if wp.errorLog != nil {
+				wp.errorLog.LogError("worker", fmt.Sprintf("check queue pause state: %v", err), 0)
+			}
+			select {
+			case <-wp.stopCh:
+				log.Printf("[%s] Shutting down", workerID)
+				return
+			case <-time.After(5 * time.Second):
+			}
+			continue
+		}
+		if paused {
+			select {
+			case <-wp.stopCh:
+				log.Printf("[%s] Shutting down", workerID)
+				return
+			case <-time.After(2 * time.Second):
+			}
+			continue
+		}
+
 		// Try to claim a job
 		job, err := wp.db.ClaimJob(workerID)
 		if err != nil {

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -2582,6 +2582,22 @@ func TestWorker_ClassifyJob_Yes_PromotesToDesignReview(t *testing.T) {
 	assert.Equal(1, n, "exactly one auto_design row must exist (no second INSERT)")
 }
 
+func TestWorkerPoolDoesNotClaimNewJobsWhenQueuePaused(t *testing.T) {
+	tc := newWorkerTestContext(t, 1)
+	require.NoError(t, tc.DB.SetQueuePaused(true))
+	job := tc.createJob(t, "pausedsha")
+
+	tc.Pool.Start()
+	t.Cleanup(tc.Pool.Stop)
+	time.Sleep(150 * time.Millisecond)
+
+	after, err := tc.DB.GetJobByID(job.ID)
+	require.NoError(t, err)
+	assert.Equal(t, storage.JobStatusQueued, after.Status)
+	assert.Empty(t, after.WorkerID)
+	assert.Equal(t, 0, tc.Pool.ActiveWorkers())
+}
+
 func TestWorker_ClassifyJob_No_MarksSkipped(t *testing.T) {
 	tc := newWorkerTestContext(t, 0)
 

--- a/internal/storage/daemon_state.go
+++ b/internal/storage/daemon_state.go
@@ -1,0 +1,37 @@
+package storage
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+const queuePausedStateKey = "queue_paused"
+
+// IsQueuePaused returns whether daemon workers should stop claiming new jobs.
+func (db *DB) IsQueuePaused() (bool, error) {
+	var value string
+	err := db.QueryRow(`SELECT value FROM daemon_state WHERE key = ?`, queuePausedStateKey).Scan(&value)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, fmt.Errorf("get queue paused state: %w", err)
+	}
+	return value == "true" || value == "1", nil
+}
+
+// SetQueuePaused persists whether daemon workers should stop claiming new jobs.
+func (db *DB) SetQueuePaused(paused bool) error {
+	value := "false"
+	if paused {
+		value = "true"
+	}
+	_, err := db.Exec(`
+		INSERT INTO daemon_state (key, value, updated_at) VALUES (?, ?, datetime('now'))
+		ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at
+	`, queuePausedStateKey, value)
+	if err != nil {
+		return fmt.Errorf("set queue paused state: %w", err)
+	}
+	return nil
+}

--- a/internal/storage/daemon_state_test.go
+++ b/internal/storage/daemon_state_test.go
@@ -1,0 +1,54 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClaimJobReturnsNilWhenQueuePaused(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo := createRepo(t, db, t.TempDir())
+	commit := createCommit(t, db, repo.ID, "abc123")
+	_, err := db.EnqueueJob(EnqueueOpts{RepoID: repo.ID, CommitID: commit.ID, GitRef: commit.SHA, Agent: "test"})
+	require.NoError(t, err)
+	require.NoError(t, db.SetQueuePaused(true))
+
+	claimed, err := db.ClaimJob("worker-1")
+	require.NoError(t, err)
+	assert.Nil(t, claimed)
+}
+
+func TestQueuePauseStateDefaultsAndPersists(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	db, err := Open(dbPath)
+	require.NoError(t, err)
+
+	paused, err := db.IsQueuePaused()
+	require.NoError(t, err)
+	assert.False(t, paused)
+
+	require.NoError(t, db.SetQueuePaused(true))
+	paused, err = db.IsQueuePaused()
+	require.NoError(t, err)
+	assert.True(t, paused)
+	require.NoError(t, db.Close())
+
+	reopened, err := Open(dbPath)
+	require.NoError(t, err)
+	defer reopened.Close()
+
+	paused, err = reopened.IsQueuePaused()
+	require.NoError(t, err)
+	assert.True(t, paused)
+
+	require.NoError(t, reopened.SetQueuePaused(false))
+	paused, err = reopened.IsQueuePaused()
+	require.NoError(t, err)
+	assert.False(t, paused)
+}

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -144,6 +144,12 @@ CREATE TABLE IF NOT EXISTS ci_pr_review_attempts (
   UNIQUE(github_repo, pr_number, head_sha)
 );
 
+CREATE TABLE IF NOT EXISTS daemon_state (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
 CREATE INDEX IF NOT EXISTS idx_review_jobs_status ON review_jobs(status);
 CREATE INDEX IF NOT EXISTS idx_review_jobs_repo ON review_jobs(repo_id);
 CREATE INDEX IF NOT EXISTS idx_review_jobs_git_ref ON review_jobs(git_ref);
@@ -1448,6 +1454,18 @@ func (db *DB) migrateSyncColumns() error {
 	`)
 	if err != nil {
 		return fmt.Errorf("create sync_state table: %w", err)
+	}
+
+	// Migration: Create daemon_state table for durable local daemon controls.
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS daemon_state (
+			key TEXT PRIMARY KEY,
+			value TEXT NOT NULL,
+			updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("create daemon_state table: %w", err)
 	}
 
 	// Migration: Align commits uniqueness to UNIQUE(repo_id, sha) instead of just UNIQUE(sha)

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -348,7 +348,11 @@ func (db *DB) ClaimJob(workerID string) (*ReviewJob, error) {
 			ORDER BY enqueued_at, id
 			LIMIT 1
 		)
-	`, workerID, nowStr, nowStr, nowNano)
+		AND NOT EXISTS (
+			SELECT 1 FROM daemon_state
+			WHERE key = ? AND value IN ('true', '1')
+		)
+	`, workerID, nowStr, nowStr, nowNano, queuePausedStateKey)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -318,6 +318,7 @@ type DaemonStatus struct {
 	SkippedJobs         int    `json:"skipped_jobs"`
 	ActiveWorkers       int    `json:"active_workers"`
 	MaxWorkers          int    `json:"max_workers"`
+	QueuePaused         bool   `json:"queue_paused"`
 	Network             string `json:"network,omitempty"`
 	Address             string `json:"address,omitempty"`
 	Port                int    `json:"port,omitempty"`

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -107,6 +107,14 @@ type ClientInterface interface {
 	Ping(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*PingResponse, error)
 	PingWithResponse(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*PingResp, error)
 
+	// PauseQueue Pause queue processing
+	PauseQueue(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*PauseQueueResponse, error)
+	PauseQueueWithResponse(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*PauseQueueResp, error)
+
+	// UnpauseQueue Resume queue processing
+	UnpauseQueue(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*UnpauseQueueResponse, error)
+	UnpauseQueueWithResponse(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*UnpauseQueueResp, error)
+
 	// RemapJobs Remap jobs after git history rewrite
 	RemapJobs(ctx context.Context, options *RemapJobsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*RemapJobsResponse, error)
 	RemapJobsWithResponse(ctx context.Context, options *RemapJobsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*RemapJobsResp, error)
@@ -1408,6 +1416,130 @@ func (c *Client) Ping(ctx context.Context, reqEditors ...runtime.RequestEditorFn
 	}
 
 	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/ping")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// PauseQueue Pause queue processing
+func (c *Client) PauseQueue(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*PauseQueueResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/queue/pause",
+		Method:     "POST",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*PauseQueueResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(PauseQueueErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "PauseQueueErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(PauseQueueResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "PauseQueueResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/queue/pause")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// UnpauseQueue Resume queue processing
+func (c *Client) UnpauseQueue(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*UnpauseQueueResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/queue/unpause",
+		Method:     "POST",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*UnpauseQueueResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(UnpauseQueueErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "UnpauseQueueErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(UnpauseQueueResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "UnpauseQueueResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/queue/unpause")
 	if err != nil {
 		return nil, fmt.Errorf("error executing request: %w", err)
 	}

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -1046,6 +1046,102 @@ func (c *Client) PingWithResponse(ctx context.Context, reqEditors ...runtime.Req
 	}
 }
 
+// PauseQueue Pause queue processing
+func (c *Client) PauseQueueWithResponse(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*PauseQueueResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/queue/pause",
+		Method:     "POST",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/queue/pause")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &PauseQueueResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(PauseQueueResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "PauseQueueResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// UnpauseQueue Resume queue processing
+func (c *Client) UnpauseQueueWithResponse(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*UnpauseQueueResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/queue/unpause",
+		Method:     "POST",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/queue/unpause")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &UnpauseQueueResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(UnpauseQueueResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "UnpauseQueueResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
 // RemapJobs Remap jobs after git history rewrite
 func (c *Client) RemapJobsWithResponse(ctx context.Context, options *RemapJobsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*RemapJobsResp, error) {
 	var err error

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -167,6 +167,14 @@ type PingResponse = PingInfo
 
 type PingErrorResponse = ErrorModel
 
+type PauseQueueResponse = QueuePauseOutputBody
+
+type PauseQueueErrorResponse = ErrorModel
+
+type UnpauseQueueResponse = QueuePauseOutputBody
+
+type UnpauseQueueErrorResponse = ErrorModel
+
 type RemapJobsResponse = RemapResult
 
 type RemapJobsErrorResponse = ErrorModel
@@ -350,6 +358,20 @@ type PingResp struct {
 	Body         []byte
 	StatusCode   int
 	JSON200      *PingResponse
+}
+
+type PauseQueueResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *PauseQueueResponse
+}
+
+type UnpauseQueueResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *UnpauseQueueResponse
 }
 
 type RemapJobsResp struct {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -200,6 +200,7 @@ type DaemonStatus struct {
 	MaxWorkers          int64             `json:"max_workers"`
 	Network             *string           `json:"network,omitempty"`
 	Port                *int64            `json:"port,omitempty"`
+	QueuePaused         bool              `json:"queue_paused"`
 	QueuedJobs          int64             `json:"queued_jobs"`
 	RebasedJobs         int64             `json:"rebased_jobs"`
 	RunningJobs         int64             `json:"running_jobs"`
@@ -601,6 +602,12 @@ type PingInfo struct {
 
 func (p PingInfo) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(p))
+}
+
+type QueuePauseOutputBody struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema      *string `json:"$schema,omitempty"`
+	QueuePaused bool    `json:"queue_paused"`
 }
 
 type RegisterRepoRequest struct {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -344,6 +344,8 @@ components:
         port:
           format: int64
           type: integer
+        queue_paused:
+          type: boolean
         queued_jobs:
           format: int64
           type: integer
@@ -370,6 +372,7 @@ components:
         - skipped_jobs
         - active_workers
         - max_workers
+        - queue_paused
       type: object
     DurationStats:
       additionalProperties: false
@@ -908,6 +911,21 @@ components:
         - ok
         - service
         - version
+      type: object
+    QueuePauseOutputBody:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - https://example.com/QueuePauseOutputBody.json
+          format: uri
+          readOnly: true
+          type: string
+        queue_paused:
+          type: boolean
+      required:
+        - queue_paused
       type: object
     RegisterRepoRequest:
       additionalProperties: false
@@ -2281,6 +2299,44 @@ paths:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
       summary: Get daemon liveness identity
+      tags:
+        - daemon
+  /api/queue/pause:
+    post:
+      operationId: pause-queue
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QueuePauseOutputBody"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      summary: Pause queue processing
+      tags:
+        - daemon
+  /api/queue/unpause:
+    post:
+      operationId: unpause-queue
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QueuePauseOutputBody"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      summary: Resume queue processing
       tags:
         - daemon
   /api/remap:


### PR DESCRIPTION
Adds an explicit way to pause daemon queue processing without changing worker counts or restarting the daemon.

Summary:
- Adds `roborev pause` and `roborev unpause` commands backed by daemon API endpoints.
- Persists the pause state in SQLite so it survives daemon restarts.
- Makes workers skip claiming new jobs while paused, while allowing already-running jobs to finish.
- Includes `queue_paused` in daemon status JSON and shows the paused state in the TUI worker header.

Checked locally with `TMPDIR=/tmp go test ./...` and `TMPDIR=/tmp go vet ./...`.
