### PR TITLE
Fix slow TUI queue startup from repeated display-name lookups

### DIFF
--- a/cmd/roborev/tui/display_name_test.go
+++ b/cmd/roborev/tui/display_name_test.go
@@ -1,0 +1,22 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.kenn.io/roborev/internal/storage"
+)
+
+func TestUniqueJobRepoPathsDedupesInOrder(t *testing.T) {
+	jobs := []storage.ReviewJob{
+		{RepoPath: "/repo/a"},
+		{RepoPath: ""},
+		{RepoPath: "/repo/a"},
+		{RepoPath: "/repo/b"},
+		{RepoPath: "/repo/b"},
+		{RepoPath: "/repo/c"},
+	}
+
+	assert.Equal(t, []string{"/repo/a", "/repo/b", "/repo/c"}, uniqueJobRepoPaths(jobs))
+}

--- a/cmd/roborev/tui/tui.go
+++ b/cmd/roborev/tui/tui.go
@@ -747,13 +747,26 @@ func (m *model) getDisplayName(repoPath, defaultName string) string {
 // updateDisplayNameCache refreshes display names for the given repo paths.
 // Called on each jobs fetch to pick up config changes without restart.
 func (m *model) updateDisplayNameCache(jobs []storage.ReviewJob) {
+	for _, repoPath := range uniqueJobRepoPaths(jobs) {
+		// Always refresh to pick up config changes
+		m.displayNames[repoPath] = config.GetDisplayName(repoPath)
+	}
+}
+
+func uniqueJobRepoPaths(jobs []storage.ReviewJob) []string {
+	seen := make(map[string]struct{})
+	paths := make([]string, 0)
 	for _, job := range jobs {
 		if job.RepoPath == "" {
 			continue
 		}
-		// Always refresh to pick up config changes
-		m.displayNames[job.RepoPath] = config.GetDisplayName(job.RepoPath)
+		if _, ok := seen[job.RepoPath]; ok {
+			continue
+		}
+		seen[job.RepoPath] = struct{}{}
+		paths = append(paths, job.RepoPath)
 	}
+	return paths
 }
 
 // getBranchForJob returns the branch name for a job, falling back to git lookup


### PR DESCRIPTION
  Summary:
  - Deduplicate repo paths before refreshing TUI display-name cache during job list updates.
  - Avoid repeated synchronous `.roborev.toml` lookups for many jobs from the same repo.
  - Add a focused regression test for stable repo-path deduping.

  Context:
  On live queue data, `/api/jobs` returned quickly, but the TUI spent several seconds refreshing display names once
  per job row before first paint. With many rows from the same repo, startup stayed on `Loading...` unnecessarily and would stutter while navigating the entries.
  This change refreshes each repo path once per jobs update while preserving the ability to pick up display-name
  config changes.