### PR TITLE
Harden git-isolation guard and pin golangci-lint version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,10 +118,14 @@ jobs:
         with:
           go-version: '1.26.3'
 
+      - name: Resolve pinned golangci-lint version
+        id: golangci
+        run: echo "version=v$(make -s print-golangci-lint-version)" >> "$GITHUB_OUTPUT"
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee  # v9.2.1
         with:
-          version: v2.10.1
+          version: ${{ steps.golangci.outputs.version }}
 
   nix:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,13 @@ ACP_TEST_DISABLE_MODE ?=
 ACP_TEST_MODE ?=
 ACP_TEST_MODEL ?=
 
-.PHONY: build install clean test test-git-isolation test-integration test-acp-integration test-acp-integration-codex test-acp-integration-claude test-acp-integration-gemini test-postgres test-all postgres-up postgres-down test-postgres-ci lint lint-ci install-hooks
+# Pinned golangci-lint version. Single source of truth: CI reads it via
+# `make print-golangci-lint-version` (see .github/workflows/ci.yml), and
+# `make lint`/`make lint-ci` refuse to run unless the local binary matches.
+# A mismatched version can silently apply different formatting/fixes.
+GOLANGCI_LINT_VERSION := 2.12.2
+
+.PHONY: build install clean test test-git-isolation test-integration test-acp-integration test-acp-integration-codex test-acp-integration-claude test-acp-integration-gemini test-postgres test-all postgres-up postgres-down test-postgres-ci lint lint-ci check-golangci-lint print-golangci-lint-version install-hooks
 
 build:
 	@mkdir -p bin
@@ -125,19 +131,34 @@ test-postgres: postgres-up
 test-all: test-integration test-postgres
 
 # Lint Go code and auto-fix where possible (local development)
-lint:
+# Verify golangci-lint is installed and exactly matches the pinned version.
+# Fails loudly on mismatch rather than letting a different version silently
+# reformat files or report different findings than CI.
+check-golangci-lint:
 	@if ! command -v golangci-lint >/dev/null 2>&1; then \
-		echo "golangci-lint not found. Install with: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1" >&2; \
+		echo "golangci-lint not found. Install the pinned version:" >&2; \
+		echo "  go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v$(GOLANGCI_LINT_VERSION)" >&2; \
+		exit 1; \
+	fi; \
+	have="$$(golangci-lint version --short 2>/dev/null)"; \
+	if [ "$$have" != "$(GOLANGCI_LINT_VERSION)" ]; then \
+		echo "Error: golangci-lint version mismatch (must match CI)." >&2; \
+		echo "  found:    $${have:-unknown}" >&2; \
+		echo "  required: $(GOLANGCI_LINT_VERSION)" >&2; \
+		echo "Install the pinned version:" >&2; \
+		echo "  go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v$(GOLANGCI_LINT_VERSION)" >&2; \
 		exit 1; \
 	fi
+
+# Print the pinned golangci-lint version (consumed by CI to stay in lockstep).
+print-golangci-lint-version:
+	@echo "$(GOLANGCI_LINT_VERSION)"
+
+lint: check-golangci-lint
 	golangci-lint run --fix ./...
 
 # Lint Go code without fixing (for CI)
-lint-ci:
-	@if ! command -v golangci-lint >/dev/null 2>&1; then \
-		echo "golangci-lint not found. Install with: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1" >&2; \
-		exit 1; \
-	fi
+lint-ci: check-golangci-lint
 	golangci-lint run ./...
 
 # Install pre-commit hooks via prek.

--- a/git_isolation_guard_test.go
+++ b/git_isolation_guard_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,12 +32,10 @@ func TestGitUsingTestPackagesUseIsolatedTestMain(t *testing.T) {
 			return walkErr
 		}
 		if d.IsDir() {
-			switch d.Name() {
-			case ".git", ".direnv", "bin", "node_modules", "tmp", "vendor":
+			if path != root && shouldSkipWalkDir(d.Name()) {
 				return filepath.SkipDir
-			default:
-				return nil
 			}
+			return nil
 		}
 		if !strings.HasSuffix(path, "_test.go") {
 			return nil
@@ -92,6 +91,43 @@ func TestGitUsingTestPackagesUseIsolatedTestMain(t *testing.T) {
 	sort.Strings(missing)
 
 	require.Empty(t, missing, "Git-using test packages must call testenv.RunIsolatedMain in TestMain:\n%s", strings.Join(missing, "\n"))
+}
+
+// shouldSkipWalkDir reports whether the repository walk should skip a directory
+// instead of descending into it. The go tool ignores directories whose names
+// begin with "." or "_" and any directory named "testdata"; none of those hold
+// buildable packages. We additionally skip dependency and build caches that can
+// contain third-party *_test.go files (for example the module cache under
+// .gocache or agent worktrees under .claude/worktrees), which are not part of
+// this repository's own source tree.
+func shouldSkipWalkDir(name string) bool {
+	if name == "testdata" {
+		return true
+	}
+	if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") {
+		return true
+	}
+	switch name {
+	case "bin", "node_modules", "tmp", "vendor":
+		return true
+	default:
+		return false
+	}
+}
+
+func TestShouldSkipWalkDir(t *testing.T) {
+	assert := assert.New(t)
+	skip := []string{
+		".git", ".direnv", ".claude", ".gocache", ".github", ".ruff_cache",
+		"_build", "testdata", "bin", "node_modules", "tmp", "vendor",
+	}
+	keep := []string{"cmd", "internal", "scripts", "agent", "daemon", "git", "roborev"}
+	for _, name := range skip {
+		assert.True(shouldSkipWalkDir(name), "expected %q to be skipped", name)
+	}
+	for _, name := range keep {
+		assert.False(shouldSkipWalkDir(name), "expected %q to be walked", name)
+	}
 }
 
 func repoRootFromWorkingDir(t *testing.T) string {


### PR DESCRIPTION
## Summary

- Fix the git-isolation guard (`TestGitUsingTestPackagesUseIsolatedTestMain`) so it stops descending into directories that are not part of the repo's source tree. It walked the whole working tree skipping only a short hardcoded list, so it descended into `.gocache` (the Go module cache) and `.claude/worktrees` (agent worktrees) and flagged third-party and copied `_test.go` files, failing the pre-commit hook. It now skips dot/underscore-prefixed and `testdata` directories — the same directories the go tool itself ignores — plus the known build/dependency caches, and never skips the repo root.
- Pin golangci-lint to `2.12.2` in the Makefile as a single source of truth. `make lint` and `make lint-ci` now hard-error when the local binary's version does not match the pin, instead of silently applying a different version's formatters/fixes (a mismatched local version had reformatted a generated file during pre-commit).
- CI reads the pinned version from the Makefile via `make print-golangci-lint-version`, so local and CI stay in lockstep (bumped from `2.10.1` to `2.12.2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)