### PR TITLE
fix(agent): hint Pi classifier extension setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,17 @@ See [configuration guide](https://roborev.io/configuration/) for all options.
 
 roborev auto-detects installed agents.
 
+To use Pi as the auto-design routing classifier (`classify_agent = "pi"`),
+install the JSON Schema output extension too:
+
+```bash
+pi install npm:@nqbao/pi-json-schema
+```
+
+roborev loads this extension explicitly when it invokes the classifier. Keeping
+it installed in Pi makes the classifier setup visible in `pi list` and avoids
+runtime package-fetch surprises in offline or locked-down environments.
+
 ### Routing Claude Code to a proxy (Ollama, LiteLLM, etc.)
 
 The `claude-code` agent accepts a model spec of the form `<model>@<base_url>`.

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -15,6 +15,8 @@ import (
 	"go.kenn.io/roborev/internal/config"
 )
 
+const piJSONSchemaInstallCommand = "pi install npm:@nqbao/pi-json-schema"
+
 // PiAgent runs code reviews using the pi CLI
 type PiAgent struct {
 	Command             string         // The pi command to run (default: "pi")
@@ -212,7 +214,13 @@ func (a *PiAgent) ClassifyWithSchema(
 		if ctxErr := contextProcessError(ctx, tracker, err, nil); ctxErr != nil {
 			return nil, ctxErr
 		}
-		return nil, fmt.Errorf("pi classifier failed: %w\nstderr: %s", err, strings.TrimSpace(stderrBuf.String()))
+		stderr := strings.TrimSpace(stderrBuf.String())
+		if piMissingJSONSchemaExtension(stderr) {
+			return nil, fmt.Errorf(
+				"pi classifier failed: %w\nstderr: %s\n\nPi JSON Schema extension is required for classify_agent = \"pi\". Install it with: %s",
+				err, stderr, piJSONSchemaInstallCommand)
+		}
+		return nil, fmt.Errorf("pi classifier failed: %w\nstderr: %s", err, stderr)
 	}
 
 	result, err := os.ReadFile(outputPath)
@@ -224,6 +232,16 @@ func (a *PiAgent) ClassifyWithSchema(
 		return nil, fmt.Errorf("pi classifier output is not valid JSON: %q", string(result))
 	}
 	return json.RawMessage(result), nil
+}
+
+func piMissingJSONSchemaExtension(stderr string) bool {
+	msg := strings.ToLower(stderr)
+	if !strings.Contains(msg, "unknown option") && !strings.Contains(msg, "unrecognized option") {
+		return false
+	}
+	return strings.Contains(msg, "--json-schema") ||
+		strings.Contains(msg, "--json-output") ||
+		strings.Contains(msg, "--json-fallback")
 }
 
 func (a *PiAgent) Review(

--- a/internal/agent/pi_test.go
+++ b/internal/agent/pi_test.go
@@ -216,6 +216,28 @@ exit 12
 	assert.Contains(t, err.Error(), "boom")
 }
 
+func TestPiClassifyWithSchemaHintsMissingJSONSchemaExtension(t *testing.T) {
+	skipIfWindows(t)
+
+	script := `#!/bin/sh
+case "$1" in *etxtbsy*) exit 0;; esac
+echo "unknown option --json-schema" >&2
+exit 2
+`
+
+	_, err := NewPiAgent(writeTempCommand(t, script)).ClassifyWithSchema(
+		context.Background(),
+		t.TempDir(),
+		"HEAD",
+		"classify me",
+		jsonRaw(`{"type":"object"}`),
+		nil,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Pi JSON Schema extension")
+	assert.Contains(t, err.Error(), "pi install npm:@nqbao/pi-json-schema")
+}
+
 func jsonRaw(s string) []byte {
 	return []byte(s)
 }


### PR DESCRIPTION
Pi classifier setup failures can currently look like generic unsupported-classifier errors when the JSON Schema extension flags are not registered. That sends users toward agent selection even though the actionable fix is installing the Pi schema output extension.

This adds a narrow Pi CLI stderr detector for unrecognized schema-output flags and appends the unversioned `pi install npm:@nqbao/pi-json-schema` setup hint. The README now calls out the same requirement for `classify_agent = "pi"`.
