### PR TITLE
ci: rely on workflow for Renovate Nix hashes

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,15 +17,7 @@
       "matchManagers": ["gomod"],
       "groupName": "Go dependencies",
       "groupSlug": "go-dependencies",
-      "postUpdateOptions": ["gomodTidy"],
-      "postUpgradeTasks": {
-        "commands": ["bash scripts/update-nix-vendor-hash.sh"],
-        "fileFilters": ["go.mod", "go.sum", "flake.nix"],
-        "executionMode": "branch",
-        "installTools": {
-          "nix": {}
-        }
-      }
+      "postUpdateOptions": ["gomodTidy"]
     }
   ]
 }


### PR DESCRIPTION
Mend-hosted Renovate rejected the repo-level Nix hash post-upgrade task because its hosted `allowedCommands` list only permits a small fixed set of commands. Keeping that command in `renovate.json` leaves the repository with a persistent Renovate problem even though the repo already has a GitHub Actions path that can do the work.

This removes the blocked `postUpgradeTasks` block from the Go dependency package rule and keeps `gomodTidy` in Renovate. Same-repo Renovate PRs that touch `go.mod` or `go.sum` continue through the existing `Update Nix Vendor Hash` workflow, which installs Nix, runs `scripts/update-nix-vendor-hash.sh`, and commits any resulting `go.mod`, `go.sum`, or `flake.nix` changes back to the Renovate branch.
