### PR TITLE
fix(ci): retry on synthesis quota failure instead of degraded post

### DIFF
--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -1793,7 +1793,7 @@ func (p *CIPoller) finalizePanelRun(row *storage.CIPanel, members []storage.Batc
 	}
 	consecutiveGenuine := attempt.ConsecutiveGenuineAttempts
 
-	out := classifyPanelOutcome(results, consecutiveGenuine)
+	out := classifyPanelOutcome(results, p.synthesisFailureResult(row), consecutiveGenuine)
 	switch out.Kind {
 	case OutcomePost, OutcomeAllSkip:
 		p.postPanelComment(row, members)
@@ -1805,6 +1805,26 @@ func (p *CIPoller) finalizePanelRun(row *storage.CIPanel, members []storage.Batc
 		p.deferTransientPanel(row, attempt, out.LastErrorExcerpt)
 	case OutcomeDeferGenuine:
 		p.deferGenuinePanel(row, attempt, out.LastErrorExcerpt)
+	}
+}
+
+// synthesisFailureResult returns the panel's synthesis job as a ReviewResult
+// when that job is in a FAILED state, so finalize can defer (rather than post
+// the degraded raw-member fallback) when the consolidation step failed on quota
+// exhaustion or a transient provider outage. It returns nil when the synthesis
+// job is done, missing, or unreadable: a done synthesis posts, and a load error
+// must never block posting on a transient DB hiccup. classifyPanelOutcome only
+// acts on the quota/transient sub-cases, so a genuine synthesis failure still
+// falls through to the raw fallback.
+func (p *CIPoller) synthesisFailureResult(row *storage.CIPanel) *reviewpkg.ReviewResult {
+	synth, err := p.db.GetSynthesisJob(row.PanelRunUUID)
+	if err != nil || synth == nil || synth.Status != storage.JobStatusFailed {
+		return nil
+	}
+	return &reviewpkg.ReviewResult{
+		Agent:  synth.Agent,
+		Status: reviewpkg.ResultFailed,
+		Error:  synth.Error,
 	}
 }
 

--- a/internal/daemon/panel_outcome.go
+++ b/internal/daemon/panel_outcome.go
@@ -42,11 +42,21 @@ type PanelOutcome struct {
 }
 
 // classifyPanelOutcome decides a panel run's finalize outcome from its member
-// results and the HEAD's consecutive-genuine streak. It is PURE: no DB, no
-// network, so it unit-tests fast. consecutiveGenuine is the streak recorded
-// BEFORE this attempt (0 when no attempt row exists yet).
+// results, the synthesis job's outcome, and the HEAD's consecutive-genuine
+// streak. It is PURE: no DB, no network, so it unit-tests fast.
+// consecutiveGenuine is the streak recorded BEFORE this attempt (0 when no
+// attempt row exists yet). synthesis is the synthesis job's outcome as a
+// ReviewResult, or nil when it is not in a failed state (done/missing).
 //
 // Precedence, applied in order:
+//  0. synthesis failed on quota exhaustion or a transient provider outage ->
+//     OutcomeDeferTransient. The consolidation step could not run, not that the
+//     reviews are unusable, so wait for the real synthesis (when quota resets or
+//     the provider recovers) rather than post the degraded "Synthesis
+//     unavailable" raw fallback. A genuine synthesis failure is NOT caught here;
+//     it falls through to the member rules below, where a member with output
+//     still posts the raw fallback (retrying a deterministic error would not
+//     help).
 //  1. any done member with non-empty output -> OutcomePost (a partial review is
 //     better than nothing once any reviewer landed real output).
 //  2. else any transient-outage failure -> OutcomeDeferTransient (wait for the
@@ -54,7 +64,13 @@ type PanelOutcome struct {
 //  3. else any genuine failure -> OutcomeGenuineGiveUp when this attempt would
 //     hit the give-up cap (consecutiveGenuine+1), otherwise OutcomeDeferGenuine.
 //  4. else (all quota/timeout skips, or empty) -> OutcomeAllSkip.
-func classifyPanelOutcome(results []reviewpkg.ReviewResult, consecutiveGenuine int) PanelOutcome {
+func classifyPanelOutcome(
+	results []reviewpkg.ReviewResult, synthesis *reviewpkg.ReviewResult, consecutiveGenuine int,
+) PanelOutcome {
+	if synthesis != nil &&
+		(reviewpkg.IsQuotaFailure(*synthesis) || reviewpkg.IsTransientFailure(*synthesis)) {
+		return PanelOutcome{Kind: OutcomeDeferTransient, LastErrorExcerpt: synthesis.Error}
+	}
 	if hasReviewOutput(results) {
 		return PanelOutcome{Kind: OutcomePost}
 	}

--- a/internal/daemon/panel_outcome_test.go
+++ b/internal/daemon/panel_outcome_test.go
@@ -15,11 +15,38 @@ func TestClassifyPanelOutcome(t *testing.T) {
 	genuine := reviewpkg.ReviewResult{Status: reviewpkg.ResultFailed, Error: "bad model"}
 	quota := reviewpkg.ReviewResult{Status: reviewpkg.ResultFailed, Error: reviewpkg.QuotaErrorPrefix + "quota"}
 
-	assert.Equal(OutcomePost, classifyPanelOutcome([]reviewpkg.ReviewResult{ok, transient}, 0).Kind)
-	assert.Equal(OutcomeDeferTransient, classifyPanelOutcome([]reviewpkg.ReviewResult{transient}, 0).Kind)
-	assert.Equal(OutcomeDeferGenuine, classifyPanelOutcome([]reviewpkg.ReviewResult{genuine}, 1).Kind)
-	assert.Equal(OutcomeGenuineGiveUp, classifyPanelOutcome([]reviewpkg.ReviewResult{genuine}, 3).Kind)
-	assert.Equal(OutcomeAllSkip, classifyPanelOutcome([]reviewpkg.ReviewResult{quota}, 0).Kind)
+	assert.Equal(OutcomePost, classifyPanelOutcome([]reviewpkg.ReviewResult{ok, transient}, nil, 0).Kind)
+	assert.Equal(OutcomeDeferTransient, classifyPanelOutcome([]reviewpkg.ReviewResult{transient}, nil, 0).Kind)
+	assert.Equal(OutcomeDeferGenuine, classifyPanelOutcome([]reviewpkg.ReviewResult{genuine}, nil, 1).Kind)
+	assert.Equal(OutcomeGenuineGiveUp, classifyPanelOutcome([]reviewpkg.ReviewResult{genuine}, nil, 3).Kind)
+	assert.Equal(OutcomeAllSkip, classifyPanelOutcome([]reviewpkg.ReviewResult{quota}, nil, 0).Kind)
+}
+
+// TestClassifyPanelOutcomeSynthesisFailure verifies the synthesis-failure
+// precedence: a synthesis that failed on quota or a transient outage defers the
+// whole run even when members produced output (rule 0), so the degraded raw
+// fallback is never posted; a genuine synthesis failure falls through to the
+// member rules and still posts; a nil synthesis leaves member classification
+// unchanged.
+func TestClassifyPanelOutcomeSynthesisFailure(t *testing.T) {
+	assert := assert.New(t)
+	ok := reviewpkg.ReviewResult{Status: reviewpkg.ResultDone, Output: "Member findings"}
+	quota := reviewpkg.ReviewResult{Status: reviewpkg.ResultFailed, Error: reviewpkg.QuotaErrorPrefix + "quota exhausted"}
+	transient := reviewpkg.ReviewResult{Status: reviewpkg.ResultFailed, Error: reviewpkg.OutageErrorPrefix + "429"}
+	genuine := reviewpkg.ReviewResult{Status: reviewpkg.ResultFailed, Error: "synthesis crashed"}
+	members := []reviewpkg.ReviewResult{ok}
+
+	assert.Equal(OutcomeDeferTransient, classifyPanelOutcome(members, &quota, 0).Kind,
+		"synthesis quota failure defers instead of posting the raw fallback")
+	assert.Equal(reviewpkg.QuotaErrorPrefix+"quota exhausted",
+		classifyPanelOutcome(members, &quota, 0).LastErrorExcerpt,
+		"defer carries the synthesis error excerpt")
+	assert.Equal(OutcomeDeferTransient, classifyPanelOutcome(members, &transient, 0).Kind,
+		"synthesis transient outage defers")
+	assert.Equal(OutcomePost, classifyPanelOutcome(members, &genuine, 0).Kind,
+		"genuine synthesis failure still posts (raw fallback); retrying would not help")
+	assert.Equal(OutcomePost, classifyPanelOutcome(members, nil, 0).Kind,
+		"a healthy synthesis leaves member classification unchanged")
 }
 
 // TestClassifyPanelOutcomeExcerpt verifies the representative error excerpt is
@@ -33,17 +60,17 @@ func TestClassifyPanelOutcomeExcerpt(t *testing.T) {
 	genuineB := reviewpkg.ReviewResult{Status: reviewpkg.ResultFailed, Error: "second genuine"}
 
 	assert.Equal(reviewpkg.OutageErrorPrefix+"first outage",
-		classifyPanelOutcome([]reviewpkg.ReviewResult{transientA, transientB}, 0).LastErrorExcerpt)
+		classifyPanelOutcome([]reviewpkg.ReviewResult{transientA, transientB}, nil, 0).LastErrorExcerpt)
 	assert.Equal("first genuine",
-		classifyPanelOutcome([]reviewpkg.ReviewResult{genuineA, genuineB}, 0).LastErrorExcerpt)
+		classifyPanelOutcome([]reviewpkg.ReviewResult{genuineA, genuineB}, nil, 0).LastErrorExcerpt)
 	assert.Equal("first genuine",
-		classifyPanelOutcome([]reviewpkg.ReviewResult{genuineA, genuineB}, 3).LastErrorExcerpt)
+		classifyPanelOutcome([]reviewpkg.ReviewResult{genuineA, genuineB}, nil, 3).LastErrorExcerpt)
 }
 
 // TestClassifyPanelOutcomeEmptyIsAllSkip verifies an empty member set classifies
 // as OutcomeAllSkip (rule 4 fall-through), never a post or defer.
 func TestClassifyPanelOutcomeEmptyIsAllSkip(t *testing.T) {
-	assert.Equal(t, OutcomeAllSkip, classifyPanelOutcome(nil, 0).Kind)
+	assert.Equal(t, OutcomeAllSkip, classifyPanelOutcome(nil, nil, 0).Kind)
 }
 
 // TestClassifyPanelOutcomeDoneEmptyOutputIsNotPost verifies a done member with no
@@ -54,6 +81,6 @@ func TestClassifyPanelOutcomeDoneEmptyOutputIsNotPost(t *testing.T) {
 	doneEmpty := reviewpkg.ReviewResult{Status: reviewpkg.ResultDone, Output: "   "}
 	transient := reviewpkg.ReviewResult{Status: reviewpkg.ResultFailed, Error: reviewpkg.OutageErrorPrefix + "429"}
 
-	assert.Equal(OutcomeDeferTransient, classifyPanelOutcome([]reviewpkg.ReviewResult{doneEmpty, transient}, 0).Kind)
-	assert.Equal(OutcomeAllSkip, classifyPanelOutcome([]reviewpkg.ReviewResult{doneEmpty}, 0).Kind)
+	assert.Equal(OutcomeDeferTransient, classifyPanelOutcome([]reviewpkg.ReviewResult{doneEmpty, transient}, nil, 0).Kind)
+	assert.Equal(OutcomeAllSkip, classifyPanelOutcome([]reviewpkg.ReviewResult{doneEmpty}, nil, 0).Kind)
 }

--- a/internal/daemon/panel_posting_test.go
+++ b/internal/daemon/panel_posting_test.go
@@ -209,6 +209,43 @@ func TestSynthesisFailedPostsRawFallback(t *testing.T) {
 	assert.NotEmpty(*statuses, "commit status set")
 }
 
+// TestSynthesisQuotaFailureDefersInsteadOfRawFallback covers the quota-exhausted
+// synthesis case: the members produced real review output but the consolidation
+// step failed on quota exhaustion. Rather than posting the degraded "Synthesis
+// unavailable" raw fallback, the run defers for a later retry (when quota
+// resets) — no comment, a pending status, a deferred attempt, and a retired
+// panel — so the PR eventually gets a properly synthesized comment.
+func TestSynthesisQuotaFailureDefersInsteadOfRawFallback(t *testing.T) {
+	assert := assert.New(t)
+	h := newCIPollerHarness(t, "https://github.com/acme/api.git")
+	comments := h.CaptureComments()
+	statuses := h.CaptureCommitStatuses()
+
+	const headSHA = "synthquota123456"
+	created, err := h.DB.ReserveReviewAttempt("acme/api", 90, headSHA, time.Now())
+	require.NoError(t, err)
+	require.True(t, created, "attempt row reserved")
+
+	panel, synth, _ := h.seedCIPanelRun(t, "acme/api", 90, headSHA, "base.."+headSHA,
+		[]jobSpec{{Agent: "test", ReviewType: "review", Status: "done", Output: "Member finding X"}})
+	h.markJobFailed(t, synth.ID, reviewpkg.QuotaErrorPrefix+"agent test quota exhausted")
+
+	h.Poller.handleReviewFailed(ciEvent(synth.ID, "review.failed"))
+
+	assert.Empty(*comments, "synthesis quota failure must not post the degraded raw fallback")
+	require.Len(t, *statuses, 1, "synthesis quota defer sets exactly one status")
+	assert.Equal("pending", (*statuses)[0].State, "synthesis quota defer status is pending, never failure")
+	assert.False(h.panelPostedAt(t, panel.ID), "deferred panel is not marked posted")
+	assert.True(h.panelRetiredAt(t, panel.ID), "deferred panel is retired (removed from active set)")
+
+	attempt, err := h.DB.GetReviewAttempt("acme/api", 90, headSHA)
+	require.NoError(t, err)
+	require.NotNil(t, attempt)
+	assert.Equal("deferred", attempt.State, "attempt deferred for retry")
+	assert.Equal("transient", attempt.LastErrorClass, "quota defer records the retryable class")
+	assert.NotNil(attempt.NextAttemptAt, "quota defer schedules a next attempt")
+}
+
 func TestSynthesisCanceledDoesNotPostRawFallback(t *testing.T) {
 	assert := assert.New(t)
 	h := newCIPollerHarness(t, "https://github.com/acme/api.git")


### PR DESCRIPTION
## Summary

- When a CI panel's members produced review output but the synthesis (consolidation) job failed on quota exhaustion or a transient provider outage, the poller posted the degraded "Synthesis unavailable. Showing individual review outputs." raw fallback. The panel retry machinery never saw the synthesis failure because `classifyPanelOutcome` keyed only on member outcomes.
- `classifyPanelOutcome` now also inspects the synthesis job's outcome. A synthesis that failed on quota or a transient outage returns `OutcomeDeferTransient`, so the run defers and the existing retry sweep re-enqueues it when quota resets or the provider recovers — no comment, a `pending` status, a deferred attempt, and a retired panel.
- A genuine (deterministic) synthesis failure still falls through to the raw-member fallback, since retrying would not help.
- `finalizePanelRun` threads the synthesis outcome in via a new `synthesisFailureResult` helper, which returns nil for a done/missing/unreadable synthesis so posting is never blocked on a transient DB read.
- Idempotency on duplicate `review.failed` delivery is preserved by the existing `retired_at IS NULL` guard in `ClaimPanelForPosting`: once deferred, the retired panel cannot be re-claimed or re-posted.
- Adds a unit case (`TestClassifyPanelOutcomeSynthesisFailure`) and an integration test (`TestSynthesisQuotaFailureDefersInsteadOfRawFallback`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)