### PR TITLE
Support binary override for agent hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ git commit -m "..."   # Reviews happen automatically
 roborev tui           # View reviews in interactive UI
 ```
 
-If roborev is managed by a version manager, `roborev init` tries to
-install hooks with the stable shim/symlink. You can also choose the exact
-binary path with `roborev init --binary ~/.local/share/mise/shims/roborev`.
+If roborev is managed by a version manager, `roborev init` and
+`roborev agent-hook install` try to install hooks with the stable shim/symlink.
+You can also choose the exact binary path with
+`roborev init --binary ~/.local/share/mise/shims/roborev` or
+`roborev agent-hook install --binary ~/.local/share/mise/shims/roborev`.
 
 ![roborev review](https://raw.githubusercontent.com/roborev-dev/roborev-docs/main/public/tui-review.svg)
 

--- a/cmd/roborev/agent_hook_cmd.go
+++ b/cmd/roborev/agent_hook_cmd.go
@@ -112,6 +112,7 @@ func agentHookDaemonRunCmd() *cobra.Command {
 }
 
 func agentHookInstallCmd() *cobra.Command {
+	hookBinary := ""
 	opts := agenthook.InstallOptions{
 		Agent:            "all",
 		CodexConfigPath:  agenthook.DefaultCodexHooksPath(),
@@ -124,7 +125,7 @@ func agentHookInstallCmd() *cobra.Command {
 		Args:                  cobra.NoArgs,
 		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			command, notice, err := agenthook.ResolveHookCommand(opts.Command)
+			command, notice, err := agenthook.ResolveHookCommandWithBinary(opts.Command, hookBinary)
 			if err != nil {
 				return err
 			}
@@ -137,6 +138,7 @@ func agentHookInstallCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&opts.Agent, "agent", opts.Agent, "agent config to update: codex, claude, or all")
 	cmd.Flags().StringVar(&opts.Command, "command", opts.Command, "hook command to install; defaults to this binary plus 'agent-hook run'")
+	cmd.Flags().StringVar(&hookBinary, "binary", "", "roborev binary path to bake into agent hooks (for version-manager shims)")
 	cmd.Flags().StringVar(&opts.CodexConfigPath, "codex-config", opts.CodexConfigPath, "Codex hooks.json path")
 	cmd.Flags().StringVar(&opts.ClaudeConfigPath, "claude-config", opts.ClaudeConfigPath, "Claude settings.json path")
 	cmd.Flags().Var(&agentHookSecondsOrDuration{d: &opts.Timeout}, "timeout", "Codex hook timeout (e.g. 10s, 1m, or bare integer seconds)")

--- a/cmd/roborev/agent_hook_test.go
+++ b/cmd/roborev/agent_hook_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -40,6 +42,33 @@ func TestAgentHookDumpCodexCreatesHookConfig(t *testing.T) {
 	assert.Equal("^Bash$", firstAgentHookMatcher(t, root, "PreToolUse"))
 	assert.Equal("^Bash$", firstAgentHookMatcher(t, root, "PostToolUse"))
 	assert.InDelta(10, firstAgentHookCommandTimeout(t, root, "Stop", command), 0)
+}
+
+func TestAgentHookInstallSupportsBinaryOverride(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.json")
+	binPath := filepath.Join(dir, "roborev")
+	require.NoError(t, os.WriteFile(binPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	command := binPath + " agent-hook run"
+
+	cmd := agentHookCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetArgs([]string{
+		"install",
+		"--agent", "codex",
+		"--binary", binPath,
+		"--codex-config", path,
+	})
+
+	require.NoError(t, cmd.Execute())
+
+	var root map[string]any
+	body, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(body, &root))
+	assertAgentHookCommandCount(t, root, "PreToolUse", command, 1)
+	assertAgentHookCommandCount(t, root, "PostToolUse", command, 1)
+	assertAgentHookCommandCount(t, root, "Stop", command, 1)
 }
 
 func TestAgentHookDaemonHasLifecycleSubcommands(t *testing.T) {

--- a/cmd/roborev/agent_hook_test.go
+++ b/cmd/roborev/agent_hook_test.go
@@ -49,7 +49,6 @@ func TestAgentHookInstallSupportsBinaryOverride(t *testing.T) {
 	path := filepath.Join(dir, "hooks.json")
 	binPath := filepath.Join(dir, "roborev")
 	require.NoError(t, os.WriteFile(binPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
-	command := binPath + " agent-hook run"
 
 	cmd := agentHookCmd()
 	cmd.SetOut(io.Discard)
@@ -66,9 +65,9 @@ func TestAgentHookInstallSupportsBinaryOverride(t *testing.T) {
 	body, err := os.ReadFile(path)
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(body, &root))
-	assertAgentHookCommandCount(t, root, "PreToolUse", command, 1)
-	assertAgentHookCommandCount(t, root, "PostToolUse", command, 1)
-	assertAgentHookCommandCount(t, root, "Stop", command, 1)
+	assertAgentHookCommandContains(t, root, "PreToolUse", binPath, 1)
+	assertAgentHookCommandContains(t, root, "PostToolUse", binPath, 1)
+	assertAgentHookCommandContains(t, root, "Stop", binPath, 1)
 }
 
 func TestAgentHookDaemonHasLifecycleSubcommands(t *testing.T) {
@@ -116,6 +115,26 @@ func assertAgentHookCommandCount(t *testing.T, root map[string]any, event, comma
 			hookObj, ok := raw.(map[string]any)
 			require.True(t, ok)
 			if hookObj["type"] == "command" && hookObj["command"] == command {
+				count++
+			}
+		}
+	}
+	assert.Equal(t, want, count)
+}
+
+func assertAgentHookCommandContains(t *testing.T, root map[string]any, event, binaryPath string, want int) {
+	t.Helper()
+	count := 0
+	for _, hook := range agentHookEventEntriesForTest(t, root, event) {
+		entry, ok := hook.(map[string]any)
+		require.True(t, ok)
+		for _, raw := range entry["hooks"].([]any) {
+			hookObj, ok := raw.(map[string]any)
+			require.True(t, ok)
+			command, _ := hookObj["command"].(string)
+			if hookObj["type"] == "command" &&
+				strings.Contains(command, binaryPath) &&
+				strings.HasSuffix(command, " agent-hook run") {
 				count++
 			}
 		}

--- a/docs/agent-hook.md
+++ b/docs/agent-hook.md
@@ -14,6 +14,15 @@ By default this installs hook entries for both Codex and Claude Code. Use
 `--agent codex` or `--agent claude` to update only one harness. Existing hook
 entries are preserved, and repeated installs are idempotent.
 
+When roborev is installed through a version manager such as mise,
+`agent-hook install` resolves the same stable `roborev` shim used by
+`roborev init`. Use `--binary` to pin the binary baked into the agent hook
+command:
+
+```bash
+roborev agent-hook install --binary ~/.local/share/mise/shims/roborev
+```
+
 For declarative setups, print the JSON to manage yourself:
 
 ```bash

--- a/internal/agenthook/install.go
+++ b/internal/agenthook/install.go
@@ -453,17 +453,40 @@ func ResolveHookCommand(override string) (command, notice string, err error) {
 	if override = strings.TrimSpace(override); override != "" {
 		return override, "", nil
 	}
-	res, err := githook.ResolveRoborevPath("")
+	command, notice, err = resolveHookCommandFromBinary("")
+	if err != nil {
+		return "", "", err
+	}
+	return command, agentHookNotice(notice), nil
+}
+
+// ResolveHookCommandWithBinary returns the command to install for agent hooks.
+// commandOverride is used verbatim when set. binaryOverride is resolved and
+// quoted before appending the agent-hook runner subcommand.
+func ResolveHookCommandWithBinary(commandOverride, binaryOverride string) (command, notice string, err error) {
+	commandOverride = strings.TrimSpace(commandOverride)
+	binaryOverride = strings.TrimSpace(binaryOverride)
+	if commandOverride != "" && binaryOverride != "" {
+		return "", "", fmt.Errorf("--command and --binary cannot be used together")
+	}
+	if commandOverride != "" {
+		return commandOverride, "", nil
+	}
+	return resolveHookCommandFromBinary(binaryOverride)
+}
+
+func resolveHookCommandFromBinary(binaryOverride string) (command, notice string, err error) {
+	res, err := githook.ResolveRoborevPath(binaryOverride)
 	if err != nil {
 		return "", "", fmt.Errorf("resolve roborev binary: %w", err)
 	}
-	return shellQuote(res.Path) + " agent-hook run", agentHookNotice(res.Notice), nil
+	return shellQuote(res.Path) + " agent-hook run", res.Notice, nil
 }
 
-// agentHookNotice adapts a binary-resolution notice for agent-hook commands. The
-// shared resolver phrases its stable-binary guidance for the git hooks' --binary
-// flag; agent-hook install and dump expose --command instead, so the flag name is
-// translated to avoid pointing users at a flag these commands do not have.
+// agentHookNotice adapts a binary-resolution notice for command-only agent-hook
+// commands. The shared resolver phrases its stable-binary guidance for --binary;
+// dump exposes --command instead, so the flag name is translated to avoid
+// pointing users at a flag that command does not have.
 func agentHookNotice(notice string) string {
 	return strings.ReplaceAll(notice, "--binary", "--command")
 }

--- a/internal/agenthook/install_test.go
+++ b/internal/agenthook/install_test.go
@@ -122,13 +122,13 @@ func TestUpsertCommandHookCollapsesDuplicatesAndKeepsOthers(t *testing.T) {
 	assert.Equal([]string{spec.Command, "/usr/bin/other-tool run"}, commands)
 }
 
-func TestAgentHookNoticeTranslatesBinaryFlag(t *testing.T) {
+func TestAgentHookNoticeTranslatesBinaryFlagForCommandOnlyFlows(t *testing.T) {
 	assert := assert.New(t)
 	notice := "Warning: roborev appears to be running from a versioned mise install (/x); " +
 		"use --binary to install hooks with a stable shim if available"
 
 	got := agentHookNotice(notice)
-	assert.NotContains(got, "--binary", "agent-hook commands have no --binary flag")
+	assert.NotContains(got, "--binary", "command-only flows do not expose --binary")
 	assert.Contains(got, "--command", "the override flag is translated to --command")
 	assert.Empty(agentHookNotice(""), "an empty notice stays empty")
 }
@@ -140,6 +140,23 @@ func TestResolveHookCommandOverrideIsVerbatim(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal("/custom/roborev agent-hook run", command, "an override is used verbatim")
 	assert.Empty(notice, "an override yields no advisory notice")
+}
+
+func TestResolveHookCommandWithBinaryUsesBinaryOverride(t *testing.T) {
+	assert := assert.New(t)
+	binPath := filepath.Join(t.TempDir(), "roborev")
+	require.NoError(t, os.WriteFile(binPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+
+	command, notice, err := ResolveHookCommandWithBinary("", binPath)
+	require.NoError(t, err)
+	assert.Equal(shellQuote(binPath)+" agent-hook run", command)
+	assert.Empty(notice)
+}
+
+func TestResolveHookCommandWithBinaryRejectsCommandAndBinary(t *testing.T) {
+	_, _, err := ResolveHookCommandWithBinary("/custom/roborev agent-hook run", "/other/roborev")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--command and --binary cannot be used together")
 }
 
 func TestResolveHookCommandBlankOverrideResolvesBinary(t *testing.T) {


### PR DESCRIPTION
Agent hook installs should behave like git hook installs when roborev is managed by a version manager. Without a binary override, users can end up baking a versioned or transient roborev path into Codex or Claude hook configuration, even though the existing git-hook installer already knows how to prefer stable shims such as mise.

This change routes agent-hook install through the same binary resolver used by roborev init, adds an explicit --binary flag for pinning the roborev executable, and keeps --command available for callers that need to install an exact command line. Using both flags is rejected so the installed command is unambiguous.

Docs now call out the shared version-manager behavior, and local validation covered the focused agent-hook tests plus go vet ./... and go test ./....