### PR TITLE
Use per-checkout golangci-lint cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ __pycache__/
 .roborev.toml
 
 .gocache
+.golangci-lint-cache/
 .cache
 .gomodcache/
 .gopath/

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,15 @@ ACP_TEST_MODEL ?=
 # A mismatched version can silently apply different formatting/fixes.
 GOLANGCI_LINT_VERSION := 2.12.2
 
+# Keep the golangci-lint cache per-checkout. The default user-global cache
+# stores raw linter findings keyed by package content with absolute file
+# paths from whichever checkout computed them. Post-processors (nolint,
+# generated-file exclusion) re-read files at those paths on every run; if
+# another worktree with identical content populated the cache and was later
+# deleted, those reads fail and suppressed findings leak through as errors
+# (golangci-lint #3502). A per-checkout cache dies with its checkout.
+export GOLANGCI_LINT_CACHE := $(CURDIR)/.golangci-lint-cache
+
 .PHONY: build install clean test test-git-isolation test-integration test-acp-integration test-acp-integration-codex test-acp-integration-claude test-acp-integration-gemini test-postgres test-all postgres-up postgres-down test-postgres-ci api-generate lint lint-ci check-golangci-lint print-golangci-lint-version check-renovate-config install-hooks
 
 build:

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         packages = {
           default = pkgs.buildGoModule {
             pname = "roborev";
-            version = "0.57.1";
+            version = "0.58.0";
             go = pkgs.go_1_26;
 
             src = ./.;

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         packages = {
           default = pkgs.buildGoModule {
             pname = "roborev";
-            version = "0.58.0";
+            version = "0.57.1";
             go = pkgs.go_1_26;
 
             src = ./.;


### PR DESCRIPTION
## Summary
- Set `GOLANGCI_LINT_CACHE` in the Makefile to a repo-local `.golangci-lint-cache/` directory (gitignored) so every checkout/worktree gets its own lint cache.

## Root cause this fixes

The v0.58.0 release run aborted on phantom lint failures. golangci-lint's default cache is user-global and stores raw linter findings keyed by package content, with absolute file paths from whichever checkout computed them. Post-processors that suppress findings — `//nolint` filtering and the generated-file exclusion — re-read source files at those stored paths on every invocation.

A (since-deleted) git worktree of this repo at `~/.superset/worktrees/roborev/kata-integration` had linted identical package content and populated the shared cache. Linting `main` then returned cache hits whose paths pointed into the dead worktree; the filters could not read those files and failed open, so 35 suppressed findings (one `//nolint:errcheck`'d `tx.Rollback`, 34 in generated client files) surfaced as errors and failed `make lint`.

This is a known upstream bug (golangci/golangci-lint#3502). Scoping the cache per checkout makes the failure impossible by construction: cached paths always match the directory being linted, and a worktree's cache is deleted with the worktree.

CI is unaffected — it invokes golangci-lint via `golangci-lint-action` on fresh checkouts with its own cache, not via `make lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)