### PR TITLE
Update flake.nix for v0.58.0

### DIFF
--- a/cmd/roborev/tui/control_test.go
+++ b/cmd/roborev/tui/control_test.go
@@ -1016,15 +1016,16 @@ func TestControlSocketRoundtrip(t *testing.T) {
 	runDone := make(chan struct{})
 	go func() { _, _ = p.Run(); close(runDone) }()
 	t.Cleanup(func() {
-		// Close the write end first so bubbletea's readLoop
-		// sees EOF and exits before Kill's shutdown closes the
-		// cancel reader, avoiding a data race on the fd.
+		// Close the write end first so bubbletea's readLoop sees EOF,
+		// then Kill and wait for Run to return.
 		w.Close()
 		p.Kill()
 		<-runDone
-		// Bubbletea does not close custom readers passed via
-		// WithInput, so close the read end after Run exits.
-		r.Close()
+		// Deliberately do not close the read end. Bubbletea's input
+		// read goroutine (via cancelreader) may still call os.File.Fd()
+		// on r after Run returns, and on macOS the kqueue cancelreader
+		// races with os.File.Close(). The OS reclaims the fd at process
+		// exit; leaking it for this short-lived test is harmless.
 	})
 
 	// Give the program time to complete Init() and reach its

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         packages = {
           default = pkgs.buildGoModule {
             pname = "roborev";
-            version = "0.57.1";
+            version = "0.58.0";
             go = pkgs.go_1_26;
 
             src = ./.;


### PR DESCRIPTION
Updates flake.nix version to 0.58.0 for the v0.58.0 release.