### PR TITLE
Make update check survive GitHub API rate limits

### DIFF
--- a/cmd/roborev/update.go
+++ b/cmd/roborev/update.go
@@ -365,9 +365,10 @@ launchd or systemd).`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Println("Checking for updates...")
 
+			// kit already wraps check errors with "check for updates:".
 			info, err := update.CheckForUpdate(true) // Force check, ignore cache
 			if err != nil {
-				return fmt.Errorf("check for updates: %w", err)
+				return err
 			}
 
 			if info == nil {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"go.kenn.io/kit/selfupdate"
@@ -17,11 +19,15 @@ import (
 )
 
 const (
-	releaseOwner  = "roborev-dev"
-	releaseRepo   = "roborev"
-	binaryName    = "roborev"
-	cacheFileName = "update_check.json"
-	cacheDuration = time.Hour
+	releaseOwner         = "roborev-dev"
+	releaseRepo          = "roborev"
+	binaryName           = "roborev"
+	cacheFileName        = "update_check.json"
+	cacheDuration        = time.Hour
+	checksumsAssetName   = "SHA256SUMS"
+	defaultGitHubBaseURL = "https://github.com"
+	defaultGitHubAPIHost = "api.github.com"
+	maxChecksumsBytes    = 1 << 20
 )
 
 type UpdateInfo = selfupdate.Info
@@ -40,6 +46,7 @@ type Deps struct {
 	CacheDir         func() string
 	Executable       func() (string, error)
 	GitHubAPIBaseURL string
+	GitHubBaseURL    string
 }
 
 type Updater struct {
@@ -94,7 +101,63 @@ func NewUpdater(deps Deps) *Updater {
 	if deps.Executable == nil {
 		deps.Executable = os.Executable
 	}
+	if deps.GitHubBaseURL == "" {
+		deps.GitHubBaseURL = defaultGitHubBaseURL
+	}
+	if token := githubToken(); token != "" {
+		deps.Client = clientWithAPIAuth(deps.Client, token, apiHost(deps.GitHubAPIBaseURL))
+	}
 	return &Updater{deps: deps}
+}
+
+// githubToken returns an optional GitHub API token from the environment,
+// using the same precedence as the gh CLI.
+func githubToken() string {
+	for _, key := range []string{"GH_TOKEN", "GITHUB_TOKEN"} {
+		if token := os.Getenv(key); token != "" {
+			return token
+		}
+	}
+	return ""
+}
+
+func apiHost(apiBaseURL string) string {
+	if apiBaseURL == "" {
+		return defaultGitHubAPIHost
+	}
+	u, err := url.Parse(apiBaseURL)
+	if err != nil || u.Host == "" {
+		return defaultGitHubAPIHost
+	}
+	return u.Host
+}
+
+// clientWithAPIAuth returns a copy of base whose transport attaches the
+// token to requests for the GitHub API host. Release asset downloads go to
+// other hosts and must stay unauthenticated: GitHub redirects them to
+// pre-signed storage URLs that reject Authorization headers.
+func clientWithAPIAuth(base *http.Client, token, host string) *http.Client {
+	client := *base
+	transport := client.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	client.Transport = &apiAuthTransport{base: transport, token: token, host: host}
+	return &client
+}
+
+type apiAuthTransport struct {
+	base  http.RoundTripper
+	token string
+	host  string
+}
+
+func (t *apiAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.EqualFold(req.URL.Host, t.host) && req.Header.Get("Authorization") == "" {
+		req = req.Clone(req.Context())
+		req.Header.Set("Authorization", "Bearer "+t.token)
+	}
+	return t.base.RoundTrip(req)
 }
 
 func defaultUpdater() *Updater {
@@ -105,11 +168,186 @@ func (u *Updater) CheckForUpdate(forceCheck bool) (*UpdateInfo, error) {
 	if selfupdate.IsDevBuildVersion(u.deps.Version) && !forceCheck {
 		return nil, nil
 	}
-	return u.client().Check(context.Background(), selfupdate.CheckOptions{
+	info, err := u.client().Check(context.Background(), selfupdate.CheckOptions{
 		Force:  forceCheck,
 		GOOS:   u.deps.GOOS,
 		GOARCH: u.deps.GOARCH,
 	})
+	if err == nil {
+		return info, nil
+	}
+	// The GitHub API check is unauthenticated, and shared egress IPs (CI
+	// runners, corporate NAT) routinely exhaust the per-IP rate limit with
+	// a 403. Resolve the release through github.com instead, which is not
+	// subject to API rate limits.
+	info, fallbackErr := u.fallbackCheck(context.Background())
+	if fallbackErr != nil {
+		return nil, fmt.Errorf("%w (github.com fallback also failed: %w)", err, fallbackErr)
+	}
+	return info, nil
+}
+
+// fallbackCheck resolves the latest release without the GitHub API: the
+// /releases/latest web URL redirects to the tag, and SHA256SUMS provides the
+// asset checksum. Asset names follow the kit release naming convention.
+func (u *Updater) fallbackCheck(ctx context.Context) (*UpdateInfo, error) {
+	tag, err := u.latestReleaseTag(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	current := strings.TrimPrefix(u.deps.Version, "v")
+	latest := strings.TrimPrefix(tag, "v")
+	isDev := selfupdate.IsDevBuildVersion(current)
+	// Mirrors kit's offer rule: release builds update only to newer
+	// versions; dev builds without a parseable base version always see the
+	// latest release.
+	offer := selfupdate.IsNewer(latest, current)
+	if !offer && isDev && semverBase(current) == "" {
+		offer = true
+	}
+	if !offer {
+		return nil, nil
+	}
+
+	extension := ".tar.gz"
+	if u.deps.GOOS == "windows" {
+		extension = ".zip"
+	}
+	assetName := selfupdate.DefaultAssetName(selfupdate.AssetRequest{
+		BinaryName: binaryName,
+		Version:    latest,
+		GOOS:       u.deps.GOOS,
+		GOARCH:     u.deps.GOARCH,
+		Extension:  extension,
+	})
+
+	downloadBase := fmt.Sprintf("%s/%s/%s/releases/download/%s",
+		u.deps.GitHubBaseURL, releaseOwner, releaseRepo, tag)
+	checksum, err := u.fetchChecksum(ctx, downloadBase+"/"+checksumsAssetName, assetName)
+	if err != nil {
+		return nil, err
+	}
+	downloadURL := downloadBase + "/" + assetName
+
+	return &UpdateInfo{
+		Owner:          releaseOwner,
+		Repo:           releaseRepo,
+		CurrentVersion: u.deps.Version,
+		LatestVersion:  tag,
+		DownloadURL:    downloadURL,
+		AssetName:      assetName,
+		GOOS:           u.deps.GOOS,
+		GOARCH:         u.deps.GOARCH,
+		Size:           u.assetSize(ctx, downloadURL),
+		Checksum:       checksum,
+		IsDevBuild:     isDev,
+	}, nil
+}
+
+// latestReleaseTag follows the github.com /releases/latest redirect chain
+// (including repo renames) and extracts the tag from the final URL.
+func (u *Updater) latestReleaseTag(ctx context.Context) (string, error) {
+	pageURL := fmt.Sprintf("%s/%s/%s/releases/latest",
+		u.deps.GitHubBaseURL, releaseOwner, releaseRepo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", "roborev/"+u.deps.Version)
+
+	// Response.Request is only populated by http.Transport, so track the
+	// final URL through the client's redirect hook instead.
+	finalURL := req.URL
+	client := *u.deps.Client
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
+		}
+		finalURL = req.URL
+		return nil
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetch latest release page: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("latest release page returned %s", resp.Status)
+	}
+	const marker = "/releases/tag/"
+	idx := strings.Index(finalURL.Path, marker)
+	if idx < 0 {
+		return "", fmt.Errorf("latest release did not redirect to a tag (got %s)", finalURL)
+	}
+	tag := finalURL.Path[idx+len(marker):]
+	if tag == "" {
+		return "", fmt.Errorf("empty release tag in %s", finalURL)
+	}
+	return tag, nil
+}
+
+func (u *Updater) fetchChecksum(ctx context.Context, checksumsURL, assetName string) (string, error) {
+	resp, err := u.get(ctx, checksumsURL)
+	if err != nil {
+		return "", fmt.Errorf("fetch %s: %w", checksumsAssetName, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("fetch %s: %s", checksumsAssetName, resp.Status)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxChecksumsBytes))
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", checksumsAssetName, err)
+	}
+	checksum := selfupdate.ExtractChecksum(string(body), assetName)
+	if checksum == "" {
+		return "", fmt.Errorf("no checksum for %s in %s", assetName, checksumsURL)
+	}
+	return checksum, nil
+}
+
+// assetSize fetches the asset Content-Length for progress display. Size is
+// informational; checksum verification covers integrity, so failures
+// degrade to an unknown size.
+func (u *Updater) assetSize(ctx context.Context, downloadURL string) int64 {
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, downloadURL, nil)
+	if err != nil {
+		return 0
+	}
+	req.Header.Set("User-Agent", "roborev/"+u.deps.Version)
+	resp, err := u.deps.Client.Do(req)
+	if err != nil {
+		return 0
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || resp.ContentLength < 0 {
+		return 0
+	}
+	return resp.ContentLength
+}
+
+func (u *Updater) get(ctx context.Context, rawURL string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "roborev/"+u.deps.Version)
+	return u.deps.Client.Do(req)
+}
+
+// semverBase mirrors kit's unexported base-version extraction used by its
+// update-offer rule.
+func semverBase(v string) string {
+	v = strings.TrimPrefix(v, "v")
+	if len(v) == 0 || v[0] < '0' || v[0] > '9' || !strings.Contains(v, ".") {
+		return ""
+	}
+	if idx := strings.Index(v, "-"); idx > 0 {
+		v = v[:idx]
+	}
+	return v
 }
 
 func (u *Updater) PerformUpdate(info *UpdateInfo, reporter Reporter) error {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -139,6 +139,191 @@ func TestUpdaterCheckForUpdateUsesKitGitHubAPIReleaseDiscovery(t *testing.T) {
 	assert.False(t, info.IsDevBuild)
 }
 
+func TestUpdaterCheckForUpdateFallsBackToReleasePageOnAPIError(t *testing.T) {
+	const checksum = "abc123def456789012345678901234567890123456789012345678901234abcd"
+	const assetName = "roborev_1.3.0_darwin_arm64.tar.gz"
+
+	apiBaseURL := "https://api.example.test"
+	ghBaseURL := "https://github.example.test"
+	releaseAPIURL := apiBaseURL + "/repos/roborev-dev/roborev/releases/latest"
+	latestPageURL := ghBaseURL + "/roborev-dev/roborev/releases/latest"
+	renamedPageURL := ghBaseURL + "/kenn-io/roborev/releases/latest"
+	tagPageURL := ghBaseURL + "/kenn-io/roborev/releases/tag/v1.3.0"
+	downloadBase := ghBaseURL + "/roborev-dev/roborev/releases/download/v1.3.0"
+	seen := []string{}
+
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+	updater := NewUpdater(Deps{
+		Client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				seen = append(seen, req.Method+" "+req.URL.String())
+				switch req.Method + " " + req.URL.String() {
+				case "GET " + releaseAPIURL:
+					return newHTTPResponse(http.StatusForbidden, `{"message":"API rate limit exceeded"}`), nil
+				case "GET " + latestPageURL:
+					return newRedirectResponse(http.StatusMovedPermanently, renamedPageURL), nil
+				case "GET " + renamedPageURL:
+					return newRedirectResponse(http.StatusFound, tagPageURL), nil
+				case "GET " + tagPageURL:
+					return newHTTPResponse(http.StatusOK, "release page"), nil
+				case "GET " + downloadBase + "/SHA256SUMS":
+					return newHTTPResponse(http.StatusOK, fmt.Sprintf("%s  %s\n", checksum, assetName)), nil
+				case "HEAD " + downloadBase + "/" + assetName:
+					resp := newHTTPResponse(http.StatusOK, "")
+					resp.ContentLength = 42
+					return resp, nil
+				default:
+					return nil, fmt.Errorf("unexpected request to %s", req.URL.String())
+				}
+			}),
+		},
+		Now:              func() time.Time { return time.Unix(0, 0) },
+		Version:          "v1.2.0",
+		GOOS:             "darwin",
+		GOARCH:           "arm64",
+		CacheDir:         t.TempDir,
+		GitHubAPIBaseURL: apiBaseURL,
+		GitHubBaseURL:    ghBaseURL,
+	})
+
+	info, err := updater.CheckForUpdate(true)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Equal(t, "v1.3.0", info.LatestVersion)
+	assert.Equal(t, "v1.2.0", info.CurrentVersion)
+	assert.Equal(t, assetName, info.AssetName)
+	assert.Equal(t, downloadBase+"/"+assetName, info.DownloadURL)
+	assert.Equal(t, checksum, info.Checksum)
+	assert.Equal(t, int64(42), info.Size)
+	assert.Equal(t, "roborev-dev", info.Owner)
+	assert.Equal(t, "roborev", info.Repo)
+	assert.False(t, info.IsDevBuild)
+	assert.Contains(t, seen, "GET "+releaseAPIURL)
+}
+
+func TestUpdaterCheckForUpdateFallbackReturnsNilWhenUpToDate(t *testing.T) {
+	apiBaseURL := "https://api.example.test"
+	ghBaseURL := "https://github.example.test"
+	tagPageURL := ghBaseURL + "/roborev-dev/roborev/releases/tag/v1.2.0"
+
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+	updater := NewUpdater(Deps{
+		Client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch req.URL.String() {
+				case apiBaseURL + "/repos/roborev-dev/roborev/releases/latest":
+					return newHTTPResponse(http.StatusForbidden, "rate limited"), nil
+				case ghBaseURL + "/roborev-dev/roborev/releases/latest":
+					return newRedirectResponse(http.StatusFound, tagPageURL), nil
+				case tagPageURL:
+					return newHTTPResponse(http.StatusOK, "release page"), nil
+				default:
+					return nil, fmt.Errorf("unexpected request to %s", req.URL.String())
+				}
+			}),
+		},
+		Now:              func() time.Time { return time.Unix(0, 0) },
+		Version:          "v1.2.0",
+		GOOS:             "darwin",
+		GOARCH:           "arm64",
+		CacheDir:         t.TempDir,
+		GitHubAPIBaseURL: apiBaseURL,
+		GitHubBaseURL:    ghBaseURL,
+	})
+
+	info, err := updater.CheckForUpdate(true)
+	require.NoError(t, err)
+	assert.Nil(t, info)
+}
+
+func TestUpdaterCheckForUpdateReturnsBothErrorsWhenFallbackFails(t *testing.T) {
+	apiBaseURL := "https://api.example.test"
+	ghBaseURL := "https://github.example.test"
+
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+	updater := NewUpdater(Deps{
+		Client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch req.URL.String() {
+				case apiBaseURL + "/repos/roborev-dev/roborev/releases/latest":
+					return newHTTPResponse(http.StatusForbidden, "rate limited"), nil
+				case ghBaseURL + "/roborev-dev/roborev/releases/latest":
+					return newHTTPResponse(http.StatusNotFound, "not found"), nil
+				default:
+					return nil, fmt.Errorf("unexpected request to %s", req.URL.String())
+				}
+			}),
+		},
+		Now:              func() time.Time { return time.Unix(0, 0) },
+		Version:          "v1.2.0",
+		GOOS:             "darwin",
+		GOARCH:           "arm64",
+		CacheDir:         t.TempDir,
+		GitHubAPIBaseURL: apiBaseURL,
+		GitHubBaseURL:    ghBaseURL,
+	})
+
+	info, err := updater.CheckForUpdate(true)
+	require.Error(t, err)
+	assert.Nil(t, info)
+	assert.Contains(t, err.Error(), "403")
+	assert.Contains(t, err.Error(), "github.com fallback also failed")
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestUpdaterCheckForUpdateSendsTokenToAPIHostOnly(t *testing.T) {
+	const releaseTag = "v1.3.0"
+	const assetName = "roborev_1.3.0_darwin_arm64.tar.gz"
+	const checksum = "abc123def456789012345678901234567890123456789012345678901234abcd"
+
+	apiBaseURL := "https://api.example.test"
+	releaseURL := apiBaseURL + "/repos/roborev-dev/roborev/releases/latest"
+	checksumsURL := "https://downloads.example.test/SHA256SUMS"
+	downloadURL := "https://downloads.example.test/" + assetName
+
+	t.Setenv("GITHUB_TOKEN", "fallback-token")
+	t.Setenv("GH_TOKEN", "primary-token")
+	updater := NewUpdater(Deps{
+		Client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch req.URL.String() {
+				case releaseURL:
+					assert.Equal(t, "Bearer primary-token", req.Header.Get("Authorization"))
+					body := fmt.Sprintf(`{
+						"tag_name": %q,
+						"body": "",
+						"assets": [
+							{"name": %q, "size": 42, "browser_download_url": %q},
+							{"name": "SHA256SUMS", "size": 128, "browser_download_url": %q}
+						]
+					}`, releaseTag, assetName, downloadURL, checksumsURL)
+					return newHTTPResponse(http.StatusOK, body), nil
+				case checksumsURL:
+					assert.Empty(t, req.Header.Get("Authorization"))
+					return newHTTPResponse(http.StatusOK, fmt.Sprintf("%s  %s\n", checksum, assetName)), nil
+				default:
+					return nil, fmt.Errorf("unexpected request to %s", req.URL.String())
+				}
+			}),
+		},
+		Now:              func() time.Time { return time.Unix(0, 0) },
+		Version:          "v1.2.0",
+		GOOS:             "darwin",
+		GOARCH:           "arm64",
+		CacheDir:         t.TempDir,
+		GitHubAPIBaseURL: apiBaseURL,
+	})
+
+	info, err := updater.CheckForUpdate(true)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Equal(t, releaseTag, info.LatestVersion)
+	assert.Equal(t, checksum, info.Checksum)
+}
+
 func TestUpdaterPerformUpdateInstallsBinary(t *testing.T) {
 	binaryName := "roborev"
 	if runtime.GOOS == "windows" {
@@ -320,6 +505,12 @@ func newHTTPResponse(statusCode int, body string) *http.Response {
 		Body:       io.NopCloser(strings.NewReader(body)),
 		Header:     make(http.Header),
 	}
+}
+
+func newRedirectResponse(statusCode int, location string) *http.Response {
+	resp := newHTTPResponse(statusCode, "")
+	resp.Header.Set("Location", location)
+	return resp
 }
 
 func newBinaryResponse(statusCode int, body []byte) *http.Response {


### PR DESCRIPTION
## Summary

- The watchdog caught `roborev update` failing on GitHub-hosted runners: the release check calls `api.github.com` unauthenticated, and shared runner egress IPs routinely exhaust the per-IP rate limit, returning 403.
- When the API check fails, fall back to resolving the latest release through github.com: follow the `/releases/latest` redirect to the tag (handles repo renames) and read the asset checksum from `SHA256SUMS`. Web and download endpoints are not subject to API rate limits and need no token. If both paths fail, the error reports both causes.
- Honor `GH_TOKEN`/`GITHUB_TOKEN` for the API check when set, scoped to the API host only — asset downloads redirect to pre-signed storage URLs that reject `Authorization` headers.
- Drop the duplicate "check for updates:" error wrap in the CLI; kit already prefixes it (the watchdog log showed `check for updates: check for updates: GitHub API returned 403 Forbidden`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)