### PR TITLE
Hide Windows console windows on child processes; route internal/git through kit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,22 @@ jobs:
       - name: Build
         run: go build ./...
 
-      - name: Test with race detection (Linux/macOS)
-        if: matrix.os != 'windows-latest'
+      - name: Test with race detection (Linux)
+        if: matrix.os == 'ubuntu-latest'
         run: |
           set -o pipefail
           mkdir -p test-results
-          go test -json -race -shuffle=on -tags integration ./... 2>&1 |
+          go test -json -timeout 30m -race -shuffle=on -tags integration ./... 2>&1 |
+            tee "test-results/${{ matrix.os }}-test.jsonl"
+
+      - name: Test (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          set -o pipefail
+          mkdir -p test-results
+          # Go's race detector can intermittently hang/crash while spawning child
+          # processes on darwin/arm64; Linux keeps the race coverage for CI.
+          go test -json -timeout 30m -shuffle=on -tags integration ./... 2>&1 |
             tee "test-results/${{ matrix.os }}-test.jsonl"
 
       - name: Test (Windows)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -12,26 +12,269 @@ import (
 	"runtime"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
 
+	gitcmd "go.kenn.io/kit/git/cmd"
+
 	"go.kenn.io/roborev/internal/procutil"
 )
+
+// gitRunner builds git commands through kit, which sets CREATE_NO_WINDOW on
+// Windows so a detached daemon's git children never flash a console.
+//
+// StripEnv removes inherited GIT_* variables (GIT_DIR, GIT_WORK_TREE,
+// GIT_INDEX_FILE, GIT_AUTHOR_*, GIT_CONFIG_*, ...). roborev runs from git hooks
+// whose environment binds git to the triggering repository and index, so a
+// child git invocation with cmd.Dir set elsewhere could otherwise operate on
+// the wrong repository. CreateCommit intentionally uses newGitCommitCmd instead
+// because it must preserve commit identity environment.
+//
+// We deliberately do NOT enable kit's NullGlobalConfig/NoSystemConfig (the
+// gitcmd.New() defaults): the user's ~/.gitconfig and /etc/gitconfig must stay
+// readable so CreateCommit picks up user.name/user.email and
+// GetHooksPath/EnsureAbsoluteHooksPath still see a globally configured
+// core.hooksPath. Stripping the env is enough to prevent inherited-repository
+// pollution without hiding the persistent config. With the global config
+// readable, safe.directory entries are read natively, so forwarding them as
+// command-scope config would only add a redundant subprocess.
+var gitRunner = gitcmd.Runner{StripEnv: true, DisableSafeDirectoryForward: true}
 
 // newGitCmd builds a "git" command that does not open a console window on
 // Windows. All git invocations in this package must go through newGitCmd or
 // newGitCmdContext so a detached daemon's git children never flash a console.
+//
+// The empty dir is intentional: callers set cmd.Dir (or pass "-C") themselves,
+// and because safe.directory forwarding is disabled the runner never uses dir
+// to compute the environment, so threading it here would be dead weight.
 func newGitCmd(args ...string) *exec.Cmd {
-	cmd := exec.Command("git", args...)
-	procutil.HideConsole(cmd)
-	return cmd
+	return gitRunner.Command(context.Background(), "", args...)
 }
 
 func newGitCmdContext(ctx context.Context, args ...string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, "git", args...)
+	return gitRunner.Command(ctx, "", args...)
+}
+
+// gitLocalEnvKeys matches the local repository environment reported by
+// `git rev-parse --local-env-vars` for current Git releases, plus
+// GIT_INTERNAL_SUPER_PREFIX which Git uses internally for submodule context.
+// These variables can make a git command ignore cmd.Dir or read repository
+// state from the caller's checkout.
+var gitLocalEnvKeys = map[string]struct{}{
+	"GIT_DIR":                          {},
+	"GIT_WORK_TREE":                    {},
+	"GIT_INDEX_FILE":                   {},
+	"GIT_OBJECT_DIRECTORY":             {},
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES": {},
+	"GIT_COMMON_DIR":                   {},
+	"GIT_CONFIG":                       {},
+	"GIT_CONFIG_COUNT":                 {},
+	"GIT_CONFIG_PARAMETERS":            {},
+	"GIT_GRAFT_FILE":                   {},
+	"GIT_IMPLICIT_WORK_TREE":           {},
+	"GIT_INTERNAL_SUPER_PREFIX":        {},
+	"GIT_NAMESPACE":                    {},
+	"GIT_NO_REPLACE_OBJECTS":           {},
+	"GIT_PREFIX":                       {},
+	"GIT_REPLACE_REF_BASE":             {},
+	"GIT_QUARANTINE_PATH":              {},
+	"GIT_SHALLOW_FILE":                 {},
+}
+
+var gitCommandConfigEnvPrefixes = []string{
+	"GIT_CONFIG_KEY_",
+	"GIT_CONFIG_VALUE_",
+	"GIT_CONFIG_SCOPE_",
+}
+
+var gitCommitIdentityConfigKeys = map[string]struct{}{
+	"author.email":    {},
+	"author.name":     {},
+	"committer.email": {},
+	"committer.name":  {},
+	"user.email":      {},
+	"user.name":       {},
+}
+
+type gitConfigEntry struct {
+	key   string
+	value string
+}
+
+func newGitCommitCmd(repoPath string, args ...string) *exec.Cmd {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repoPath
 	procutil.HideConsole(cmd)
+	cmd.Env = append(filterGitCommitEnv(cmd.Environ()), "GIT_TERMINAL_PROMPT=0")
 	return cmd
+}
+
+func filterGitCommitEnv(env []string) []string {
+	result := make([]string, 0, len(env))
+	for _, entry := range env {
+		key, _, _ := strings.Cut(entry, "=")
+		upper := strings.ToUpper(key)
+		if isGitLocalEnvKey(upper) || isGitCommandConfigEnvKey(upper) {
+			continue
+		}
+		result = append(result, entry)
+	}
+	return appendGitCommitIdentityConfig(result, env)
+}
+
+func isGitLocalEnvKey(upper string) bool {
+	_, ok := gitLocalEnvKeys[upper]
+	return ok
+}
+
+func isGitCommandConfigEnvKey(upper string) bool {
+	for _, prefix := range gitCommandConfigEnvPrefixes {
+		if strings.HasPrefix(upper, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func appendGitCommitIdentityConfig(result, env []string) []string {
+	config := gitCommitIdentityConfig(env)
+	for i, entry := range config {
+		result = append(result,
+			fmt.Sprintf("GIT_CONFIG_KEY_%d=%s", i, entry.key),
+			fmt.Sprintf("GIT_CONFIG_VALUE_%d=%s", i, entry.value),
+		)
+	}
+	if len(config) > 0 {
+		result = append(result, fmt.Sprintf("GIT_CONFIG_COUNT=%d", len(config)))
+	}
+	return result
+}
+
+func gitCommitIdentityConfig(env []string) []gitConfigEntry {
+	config := gitCommitIdentityConfigFromCount(env)
+	config = append(config, gitCommitIdentityConfigFromParameters(env)...)
+	return config
+}
+
+func gitCommitIdentityConfigFromCount(env []string) []gitConfigEntry {
+	countValue, ok := envLastValue(env, "GIT_CONFIG_COUNT")
+	if !ok {
+		return nil
+	}
+	count, err := strconv.Atoi(countValue)
+	if err != nil || count <= 0 {
+		return nil
+	}
+
+	var config []gitConfigEntry
+	for i := range count {
+		key, keyOK := envLastValue(env, fmt.Sprintf("GIT_CONFIG_KEY_%d", i))
+		value, valueOK := envLastValue(env, fmt.Sprintf("GIT_CONFIG_VALUE_%d", i))
+		if !keyOK || !valueOK {
+			continue
+		}
+		if _, ok := gitCommitIdentityConfigKeys[strings.ToLower(key)]; !ok {
+			continue
+		}
+		config = append(config, gitConfigEntry{key: key, value: value})
+	}
+	return config
+}
+
+func gitCommitIdentityConfigFromParameters(env []string) []gitConfigEntry {
+	parameters, ok := envLastValue(env, "GIT_CONFIG_PARAMETERS")
+	if !ok {
+		return nil
+	}
+	entries, ok := parseGitConfigParameters(parameters)
+	if !ok {
+		return nil
+	}
+	config := make([]gitConfigEntry, 0, len(entries))
+	for _, entry := range entries {
+		if _, ok := gitCommitIdentityConfigKeys[strings.ToLower(entry.key)]; ok {
+			config = append(config, entry)
+		}
+	}
+	return config
+}
+
+func parseGitConfigParameters(parameters string) ([]gitConfigEntry, bool) {
+	var entries []gitConfigEntry
+	for i := 0; ; {
+		i = skipASCIISpaces(parameters, i)
+		if i == len(parameters) {
+			return entries, true
+		}
+		key, next, ok := parseGitSQToken(parameters, i)
+		if !ok {
+			return nil, false
+		}
+		i = next
+		if i < len(parameters) && parameters[i] == '=' {
+			if i+1 == len(parameters) || isASCIISpace(parameters[i+1]) {
+				entries = append(entries, gitConfigEntry{key: key})
+				i++
+				continue
+			}
+			value, next, ok := parseGitSQToken(parameters, i+1)
+			if !ok {
+				return nil, false
+			}
+			entries = append(entries, gitConfigEntry{key: key, value: value})
+			i = next
+			continue
+		}
+		if cutKey, value, ok := strings.Cut(key, "="); ok {
+			entries = append(entries, gitConfigEntry{key: cutKey, value: value})
+			continue
+		}
+		entries = append(entries, gitConfigEntry{key: key})
+	}
+}
+
+func parseGitSQToken(s string, start int) (string, int, bool) {
+	if start >= len(s) || s[start] != '\'' {
+		return "", start, false
+	}
+	var b strings.Builder
+	for i := start + 1; i < len(s); {
+		if s[i] != '\'' {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		if i+3 < len(s) && s[i+1] == '\\' && s[i+2] == '\'' && s[i+3] == '\'' {
+			b.WriteByte('\'')
+			i += 4
+			continue
+		}
+		return b.String(), i + 1, true
+	}
+	return "", start, false
+}
+
+func skipASCIISpaces(s string, i int) int {
+	for i < len(s) && isASCIISpace(s[i]) {
+		i++
+	}
+	return i
+}
+
+func isASCIISpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+func envLastValue(env []string, key string) (string, bool) {
+	for _, v := range slices.Backward(env) {
+		k, v, ok := strings.Cut(v, "=")
+		if ok && strings.EqualFold(k, key) {
+			return v, true
+		}
+	}
+	return "", false
 }
 
 // normalizeMSYSPath converts MSYS-style paths (e.g., /c/Users/...) to Windows paths (C:\Users\...).
@@ -1643,10 +1886,7 @@ func isHookCausingFailure(repoPath string) bool {
 	if !hasCommitHooks(repoPath) {
 		return false
 	}
-	cmd := newGitCmd(
-		"-C", repoPath, "commit",
-		"--dry-run", "--no-verify", "-m", "probe",
-	)
+	cmd := newGitCommitCmd(repoPath, "commit", "--dry-run", "--no-verify", "-m", "probe")
 	return cmd.Run() == nil
 }
 
@@ -1971,8 +2211,7 @@ func (e *CommitError) Unwrap() error {
 // Returns the SHA of the new commit
 func CreateCommit(repoPath, message string) (string, error) {
 	// Stage all changes (respects .gitignore)
-	cmd := newGitCmd("add", "-A")
-	cmd.Dir = repoPath
+	cmd := newGitCommitCmd(repoPath, "add", "-A")
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -1982,8 +2221,7 @@ func CreateCommit(repoPath, message string) (string, error) {
 	}
 
 	// Create commit
-	cmd = newGitCmd("commit", "-m", message)
-	cmd.Dir = repoPath
+	cmd = newGitCommitCmd(repoPath, "commit", "-m", message)
 	stderr.Reset()
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {

--- a/internal/git/git_command_windows_test.go
+++ b/internal/git/git_command_windows_test.go
@@ -23,3 +23,9 @@ func TestNewGitCmdHidesConsole(t *testing.T) {
 	require.NotNil(t, ctxCmd.SysProcAttr)
 	assert.NotZero(ctxCmd.SysProcAttr.CreationFlags & testCreateNoWindow)
 }
+
+func TestNewGitCommitCmdHidesConsole(t *testing.T) {
+	cmd := newGitCommitCmd("", "commit", "-m", "test")
+	require.NotNil(t, cmd.SysProcAttr)
+	assert.NotZero(t, cmd.SysProcAttr.CreationFlags&testCreateNoWindow)
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -18,7 +18,33 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	if os.Getenv("ROBOREV_GIT_HOOK_PWD_HELPER") == "1" {
+		os.Exit(runGitHookPWDHelper())
+	}
 	os.Exit(testenv.RunIsolatedMain(m))
+}
+
+func runGitHookPWDHelper() int {
+	cwd, err := os.Getwd()
+	if err != nil {
+		_, _ = os.Stderr.WriteString("get cwd: " + err.Error() + "\n")
+		return 1
+	}
+	pwd := os.Getenv("PWD")
+	pwd = cleanHookPWDPath(pwd)
+	cwd = cleanHookPWDPath(cwd)
+	if pwd != cwd {
+		_, _ = os.Stderr.WriteString("PWD mismatch: " + pwd + " != " + cwd + "\n")
+		return 1
+	}
+	return 0
+}
+
+func cleanHookPWDPath(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	return filepath.Clean(path)
 }
 
 type TestRepo struct {
@@ -1827,6 +1853,119 @@ func TestCreateCommitPreCommitHookOutput(t *testing.T) {
 	assert.True(t, commitErr.HookFailed, "expected HookFailed=true for pre-commit hook rejection")
 }
 
+func TestCreateCommitExecutableHookReceivesRepoPWD(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("direct binary hooks without .exe are not portable on Windows")
+	}
+
+	repo := NewTestRepoWithCommit(t)
+	t.Setenv("PWD", t.TempDir())
+	t.Setenv("ROBOREV_GIT_HOOK_PWD_HELPER", "1")
+	installSelfAsHook(t, repo.Dir, "pre-commit")
+
+	repo.WriteFile("pwd.txt", "content")
+
+	sha, err := CreateCommit(repo.Dir, "commit with pwd hook")
+	require.NoError(t, err)
+	assert.Equal(t, sha, repo.HeadSHA())
+}
+
+func installSelfAsHook(t *testing.T, repoDir, name string) {
+	t.Helper()
+	exe, err := os.Executable()
+	require.NoError(t, err)
+	data, err := os.ReadFile(exe)
+	require.NoError(t, err)
+
+	hooksDir := filepath.Join(repoDir, ".git", "hooks")
+	err = os.MkdirAll(hooksDir, 0o755)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(hooksDir, name), data, 0o755)
+	require.NoError(t, err)
+}
+
+func TestCreateCommitHookFailedProbePreservesEnvOnlyIdentity(t *testing.T) {
+	repo := NewTestRepoWithCommit(t)
+	repo.Run("config", "--unset", "user.name")
+	repo.Run("config", "--unset", "user.email")
+
+	realGit, err := exec.LookPath("git")
+	require.NoError(t, err, "locate real git")
+
+	wrapperDir := t.TempDir()
+	writeGitDryRunIdentityProbeWrapper(t, wrapperDir)
+	t.Setenv("REAL_GIT", realGit)
+	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("GIT_AUTHOR_NAME", "Env Author")
+	t.Setenv("GIT_AUTHOR_EMAIL", "env-author@example.com")
+	t.Setenv("GIT_COMMITTER_NAME", "Env Committer")
+	t.Setenv("GIT_COMMITTER_EMAIL", "env-committer@example.com")
+
+	repo.InstallHook("pre-commit",
+		"#!/bin/sh\necho 'blocked by env-only identity hook' >&2\nexit 1\n")
+
+	repo.WriteFile("new.txt", "content")
+
+	_, err = CreateCommit(repo.Dir, "should fail")
+	require.Error(t, err, "expected CreateCommit to fail with pre-commit hook")
+
+	var commitErr *CommitError
+	require.ErrorAs(t, err, &commitErr, "expected CommitError type")
+	assert.True(t, commitErr.HookFailed, "expected HookFailed=true with env-only identity")
+}
+
+func writeGitDryRunIdentityProbeWrapper(t *testing.T, dir string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		path := filepath.Join(dir, "git.bat")
+		script := `@echo off
+setlocal EnableExtensions
+set is_commit=0
+set is_dry_run=0
+for %%A in (%*) do (
+  if "%%~A"=="commit" set is_commit=1
+  if "%%~A"=="--dry-run" set is_dry_run=1
+)
+if "%is_commit%%is_dry_run%"=="11" (
+  if not "%GIT_AUTHOR_NAME%"=="" exit /b 0
+  echo missing env identity in dry-run 1>&2
+  exit /b 1
+)
+"%REAL_GIT%" %*
+`
+		err := os.WriteFile(path, []byte(script), 0o755)
+		require.NoError(t, err)
+		return
+	}
+
+	path := filepath.Join(dir, "git")
+	script := `#!/bin/sh
+is_commit=0
+is_dry_run=0
+for arg do
+	if [ "$arg" = "commit" ]; then
+		is_commit=1
+	fi
+	if [ "$arg" = "--dry-run" ]; then
+		is_dry_run=1
+	fi
+done
+if [ "$is_commit$is_dry_run" = "11" ]; then
+	if [ -n "$GIT_AUTHOR_NAME" ]; then
+		exit 0
+	fi
+	echo "missing env identity in dry-run" >&2
+	exit 1
+fi
+exec "$REAL_GIT" "$@"
+`
+	err := os.WriteFile(path, []byte(script), 0o755)
+	require.NoError(t, err)
+}
+
 func TestCommitErrorHookFailedFalseWhenNothingToCommit(t *testing.T) {
 	repo := NewTestRepoWithCommit(t)
 
@@ -1884,6 +2023,166 @@ func TestCommitErrorHookFailedFalseForGPGSigningFailure(t *testing.T) {
 	var commitErr *CommitError
 	require.ErrorAs(t, err, &commitErr, "expected CommitError type, got: %T", err)
 	assert.False(t, commitErr.HookFailed, "HookFailed should be false for GPG signing failure (no hooks installed)")
+}
+
+func TestCreateCommitPreservesGitIdentityEnvWhileIgnoringRepoEnv(t *testing.T) {
+	target := NewTestRepoWithCommit(t)
+	leaked := NewTestRepoWithCommit(t)
+	leakedHead := leaked.HeadSHA()
+
+	t.Setenv("GIT_DIR", filepath.Join(leaked.Dir, ".git"))
+	t.Setenv("GIT_WORK_TREE", leaked.Dir)
+	t.Setenv("GIT_INDEX_FILE", filepath.Join(leaked.Dir, ".git", "index"))
+	t.Setenv("GIT_IMPLICIT_WORK_TREE", "0")
+	t.Setenv("GIT_AUTHOR_NAME", "Env Author")
+	t.Setenv("GIT_AUTHOR_EMAIL", "env-author@example.com")
+	t.Setenv("GIT_COMMITTER_NAME", "Env Committer")
+	t.Setenv("GIT_COMMITTER_EMAIL", "env-committer@example.com")
+
+	target.WriteFile("created.txt", "content")
+	sha, err := CreateCommit(target.Dir, "commit with env identity")
+	require.NoError(t, err)
+
+	os.Unsetenv("GIT_DIR")
+	os.Unsetenv("GIT_WORK_TREE")
+	os.Unsetenv("GIT_INDEX_FILE")
+	os.Unsetenv("GIT_IMPLICIT_WORK_TREE")
+
+	assert.Equal(t, sha, target.HeadSHA())
+	assert.Equal(t, leakedHead, leaked.HeadSHA(), "leaked repo env must not redirect the commit")
+	assert.Equal(t, "Env Author <env-author@example.com>", target.Run("show", "-s", "--format=%an <%ae>", sha))
+	assert.Equal(t, "Env Committer <env-committer@example.com>", target.Run("show", "-s", "--format=%cn <%ce>", sha))
+}
+
+func TestCreateCommitPreservesGitConfigEnvWhileIgnoringRepoEnv(t *testing.T) {
+	target := NewTestRepoWithCommit(t)
+	leaked := NewTestRepoWithCommit(t)
+	leakedHead := leaked.HeadSHA()
+
+	t.Setenv("GIT_DIR", filepath.Join(leaked.Dir, ".git"))
+	t.Setenv("GIT_WORK_TREE", leaked.Dir)
+	t.Setenv("GIT_INDEX_FILE", filepath.Join(leaked.Dir, ".git", "index"))
+	t.Setenv("GIT_IMPLICIT_WORK_TREE", "0")
+	t.Setenv("GIT_CONFIG_COUNT", "3")
+	t.Setenv("GIT_CONFIG_KEY_0", "core.worktree")
+	t.Setenv("GIT_CONFIG_VALUE_0", leaked.Dir)
+	t.Setenv("GIT_CONFIG_KEY_1", "user.name")
+	t.Setenv("GIT_CONFIG_VALUE_1", "Config Author")
+	t.Setenv("GIT_CONFIG_KEY_2", "user.email")
+	t.Setenv("GIT_CONFIG_VALUE_2", "config-author@example.com")
+
+	target.WriteFile("created.txt", "content")
+	sha, err := CreateCommit(target.Dir, "commit with env config")
+	require.NoError(t, err)
+
+	os.Unsetenv("GIT_DIR")
+	os.Unsetenv("GIT_WORK_TREE")
+	os.Unsetenv("GIT_INDEX_FILE")
+	os.Unsetenv("GIT_IMPLICIT_WORK_TREE")
+
+	assert.Equal(t, sha, target.HeadSHA())
+	assert.Equal(t, leakedHead, leaked.HeadSHA(), "leaked repo env must not redirect the commit")
+	assert.Equal(t, "Config Author <config-author@example.com>", target.Run("show", "-s", "--format=%an <%ae>", sha))
+}
+
+func TestCreateCommitPreservesGitConfigParametersIdentity(t *testing.T) {
+	target := NewTestRepoWithCommit(t)
+	leaked := NewTestRepoWithCommit(t)
+	leakedHead := leaked.HeadSHA()
+
+	t.Setenv("GIT_DIR", filepath.Join(leaked.Dir, ".git"))
+	t.Setenv("GIT_WORK_TREE", leaked.Dir)
+	t.Setenv("GIT_IMPLICIT_WORK_TREE", "0")
+	t.Setenv("GIT_CONFIG_PARAMETERS",
+		"'core.worktree'='"+leaked.Dir+"' 'core.fileMode'= 'color.ui' 'user.name'='Param O'\\''Connor' 'user.email'='param@example.com'")
+
+	target.WriteFile("created.txt", "content")
+	sha, err := CreateCommit(target.Dir, "commit with parameters identity")
+	require.NoError(t, err)
+
+	os.Unsetenv("GIT_DIR")
+	os.Unsetenv("GIT_WORK_TREE")
+	os.Unsetenv("GIT_IMPLICIT_WORK_TREE")
+
+	assert.Equal(t, sha, target.HeadSHA())
+	assert.Equal(t, leakedHead, leaked.HeadSHA(), "leaked repo env and config parameters must not redirect the commit")
+	assert.Equal(t, "Param O'Connor <param@example.com>", target.Run("show", "-s", "--format=%an <%ae>", sha))
+}
+
+func TestCreateCommitPreservesGlobalConfigEnv(t *testing.T) {
+	repo := NewTestRepoWithCommit(t)
+	repo.Run("config", "--unset", "user.name")
+	repo.Run("config", "--unset", "user.email")
+
+	globalCfg := filepath.Join(t.TempDir(), "global.gitconfig")
+	err := os.WriteFile(globalCfg, []byte("[user]\n\tname = Global Author\n\temail = global@example.com\n"), 0o644)
+	require.NoError(t, err)
+	t.Setenv("GIT_CONFIG_GLOBAL", globalCfg)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+	repo.WriteFile("created.txt", "content")
+	sha, err := CreateCommit(repo.Dir, "commit with global identity")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Global Author <global@example.com>", repo.Run("show", "-s", "--format=%an <%ae>", sha))
+}
+
+func TestFilterGitCommitEnvStripsLocalEnvAndPreservesCommitIdentity(t *testing.T) {
+	assert := assert.New(t)
+	got := filterGitCommitEnv([]string{
+		"PATH=/usr/bin",
+		"GIT_DIR=/leaked/.git",
+		"GIT_WORK_TREE=/leaked",
+		"GIT_INDEX_FILE=/leaked/.git/index",
+		"GIT_IMPLICIT_WORK_TREE=0",
+		"GIT_GRAFT_FILE=/leaked/info/grafts",
+		"GIT_REPLACE_REF_BASE=refs/replace/leaked",
+		"GIT_INTERNAL_SUPER_PREFIX=leaked/",
+		"GIT_SHALLOW_FILE=/leaked/shallow",
+		"GIT_CONFIG_PARAMETERS='core.worktree'='/leaked' 'core.fileMode'= 'color.ui' 'committer.name'='Param Committer' 'committer.email'='param-committer@example.com'",
+		"GIT_CONFIG_COUNT=3",
+		"GIT_CONFIG_KEY_0=core.worktree",
+		"GIT_CONFIG_VALUE_0=/leaked",
+		"GIT_CONFIG_KEY_1=user.name",
+		"GIT_CONFIG_VALUE_1=Config Author",
+		"GIT_CONFIG_KEY_2=user.email",
+		"GIT_CONFIG_VALUE_2=config-author@example.com",
+		"GIT_CONFIG_GLOBAL=/tmp/global.gitconfig",
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_SSH_COMMAND=ssh -i /tmp/key",
+		"GIT_AUTHOR_NAME=Env Author",
+		"GIT_AUTHOR_EMAIL=env-author@example.com",
+		"GIT_COMMITTER_NAME=Env Committer",
+		"GIT_COMMITTER_EMAIL=env-committer@example.com",
+	})
+	joined := strings.Join(got, "\n")
+
+	assert.NotContains(joined, "GIT_DIR=")
+	assert.NotContains(joined, "GIT_WORK_TREE=")
+	assert.NotContains(joined, "GIT_INDEX_FILE=")
+	assert.NotContains(joined, "GIT_IMPLICIT_WORK_TREE=")
+	assert.NotContains(joined, "GIT_GRAFT_FILE=")
+	assert.NotContains(joined, "GIT_REPLACE_REF_BASE=")
+	assert.NotContains(joined, "GIT_INTERNAL_SUPER_PREFIX=")
+	assert.NotContains(joined, "GIT_SHALLOW_FILE=")
+	assert.NotContains(joined, "GIT_CONFIG_PARAMETERS=")
+	assert.NotContains(joined, "core.worktree")
+	assert.Contains(joined, "GIT_AUTHOR_NAME=Env Author")
+	assert.Contains(joined, "GIT_AUTHOR_EMAIL=env-author@example.com")
+	assert.Contains(joined, "GIT_COMMITTER_NAME=Env Committer")
+	assert.Contains(joined, "GIT_COMMITTER_EMAIL=env-committer@example.com")
+	assert.Contains(joined, "GIT_CONFIG_KEY_0=user.name")
+	assert.Contains(joined, "GIT_CONFIG_VALUE_0=Config Author")
+	assert.Contains(joined, "GIT_CONFIG_KEY_1=user.email")
+	assert.Contains(joined, "GIT_CONFIG_VALUE_1=config-author@example.com")
+	assert.Contains(joined, "GIT_CONFIG_KEY_2=committer.name")
+	assert.Contains(joined, "GIT_CONFIG_VALUE_2=Param Committer")
+	assert.Contains(joined, "GIT_CONFIG_KEY_3=committer.email")
+	assert.Contains(joined, "GIT_CONFIG_VALUE_3=param-committer@example.com")
+	assert.Contains(joined, "GIT_CONFIG_COUNT=4")
+	assert.Contains(joined, "GIT_CONFIG_GLOBAL=/tmp/global.gitconfig")
+	assert.Contains(joined, "GIT_CONFIG_NOSYSTEM=1")
+	assert.Contains(joined, "GIT_SSH_COMMAND=ssh -i /tmp/key")
 }
 
 func TestHasCommitHooksDetectsInstalledHooks(t *testing.T) {

--- a/internal/procutil/command_windows_test.go
+++ b/internal/procutil/command_windows_test.go
@@ -16,7 +16,7 @@ const testCreateNoWindow = 0x08000000
 func TestHideConsoleSetsCreateNoWindow(t *testing.T) {
 	assert := assert.New(t)
 
-	cmd := exec.Command("git", "status")
+	cmd := exec.Command("tasklist")
 	HideConsole(cmd)
 
 	require.NotNil(t, cmd.SysProcAttr)
@@ -29,7 +29,7 @@ func TestHideConsolePreservesExistingCreationFlags(t *testing.T) {
 	assert := assert.New(t)
 
 	const createNewProcessGroup = 0x00000200
-	cmd := exec.Command("git", "status")
+	cmd := exec.Command("tasklist")
 	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: createNewProcessGroup}
 	HideConsole(cmd)
 


### PR DESCRIPTION
## Summary

- Hide Windows console windows on roborev's child processes so a detached daemon (and Git Bash/mintty CLI) never flashes a console, and bump kit to v0.1.6.
- Add `internal/procutil.HideConsole`, which sets `HideWindow` + `CREATE_NO_WINDOW` on a command's `SysProcAttr` on Windows and is a no-op elsewhere. Apply it to every non-git child process roborev spawns: the AI agents (claude-code, codex, copilot, the ACP terminal, the generic process runner), the `gh` CLI, the `kata` CLI, token/gh calls, the PowerShell hook runner, and the TUI `tasklist` liveness check. kit exposes no general-purpose console-hiding helper, so these spawns need roborev's own.
- Route all `internal/git` spawns through a package-level kit `gitcmd.Runner` instead of wrapping raw `exec.Command` with `procutil`. kit's Runner sets `CREATE_NO_WINDOW` on Windows AND, via `StripEnv`, removes inherited `GIT_*` variables (`GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_CONFIG_*`, ...). This matters because roborev's review CLI runs from git post-commit hooks whose environment binds git to the triggering repository; a child git command with `cmd.Dir` set elsewhere could otherwise operate on the wrong repo/index.
- The git runner uses `StripEnv` only, NOT kit's `gitcmd.New()` defaults (`NullGlobalConfig`/`NoSystemConfig`). `internal/git` both reads and writes: `CreateCommit` needs the user's global `user.name`/`user.email`, and `GetHooksPath`/`EnsureAbsoluteHooksPath` must still see a globally configured `core.hooksPath`. Stripping the inherited env is enough to prevent inherited-repository pollution without hiding `~/.gitconfig`, so a single runner serves both. Helper signatures and all call sites are unchanged.
- The daemon's direct CI git spawns (`ci_poller` clone/fetch/rev-list, `ci_worktree` prune) stay on `procutil`: the clone/fetch paths inject GitHub auth through `GIT_CONFIG_*` env vars, which structurally conflicts with the same mechanism kit's Runner uses for its own config (and `StripEnv` would strip it). Moving those onto kit needs a separate auth rework (feeding `Runner.WithConfig`).
- Update `go.kenn.io/kit` v0.1.5 -> v0.1.6, which adds `CREATE_NO_WINDOW` for git children spawned through its Runner and fixes a Windows daemon console-probe hang.
- Add Windows-tagged unit tests asserting `CREATE_NO_WINDOW` (and flag preservation) at the procutil, git, agent, github, kata, and tokens spawn sites.

Note: `flake.nix` `vendorHash` needs regeneration for the `go.mod` change; `nix` was unavailable locally, and CI has handled this on recent dependency PRs.
