### PR TITLE
Add hook-only auto-design routing

### DIFF
--- a/cmd/roborev/daemon_cmd.go
+++ b/cmd/roborev/daemon_cmd.go
@@ -127,7 +127,7 @@ func daemonRunCmd() *cobra.Command {
 			// the message-pattern regexes would otherwise surface only
 			// at dispatch time as a "heuristic error" skipped row,
 			// silently suppressing every automatic design review.
-			if cfg.AutoDesignReview.Enabled {
+			if cfg.AutoDesignReview.Enabled || cfg.AutoDesignReview.HookEnabled {
 				globalHeuristics := config.ResolveGlobalAutoDesignHeuristics(cfg)
 				if err := globalHeuristics.Validate(); err != nil {
 					return fmt.Errorf("invalid [auto_design_review] config in %s: %w", configPath, err)

--- a/cmd/roborev/daemon_cmd_test.go
+++ b/cmd/roborev/daemon_cmd_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDaemonRunValidatesHookEnabledAutoDesignHeuristics(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("ROBOREV_DATA_DIR", tmp)
+
+	configPath := filepath.Join(tmp, "config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`[auto_design_review]
+hook_enabled = true
+trigger_paths = ["["]
+`), 0o644))
+
+	cmd := daemonRunCmd()
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{
+		"--db", filepath.Join(tmp, "reviews.db"),
+		"--config", configPath,
+		"--addr", "127.0.0.1:0",
+	})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid [auto_design_review] config")
+	assert.Contains(t, err.Error(), "trigger_paths")
+}

--- a/internal/config/autodesign.go
+++ b/internal/config/autodesign.go
@@ -12,7 +12,8 @@ import (
 // decision. Opt-in; when Enabled is false (default), the decision is never
 // consulted and behavior matches pre-auto-design-review.
 type AutoDesignReviewConfig struct {
-	Enabled bool `toml:"enabled" comment:"Enable the automatic design review decider. Off by default."`
+	Enabled     bool `toml:"enabled" comment:"Enable the automatic design review decider. Off by default."`
+	HookEnabled bool `toml:"hook_enabled" comment:"Enable the automatic design review decider only for post-commit hook reviews. Off by default."`
 
 	MinDiffLines   int `toml:"min_diff_lines" comment:"Diffs below this line count skip design review automatically."`
 	LargeDiffLines int `toml:"large_diff_lines" comment:"Diffs at or above this line count trigger a design review automatically."`
@@ -32,7 +33,8 @@ type AutoDesignReviewConfig struct {
 // global struct except Enabled is *bool, distinguishing "not set" from
 // "explicitly false" so a repo can disable a globally-enabled default.
 type AutoDesignReviewRepoConfig struct {
-	Enabled *bool `toml:"enabled" comment:"Override the global auto design review setting for this repo. Omit to inherit."`
+	Enabled     *bool `toml:"enabled" comment:"Override the global auto design review setting for this repo. Omit to inherit."`
+	HookEnabled *bool `toml:"hook_enabled" comment:"Override post-commit-hook-only automatic design review for this repo. Omit to inherit."`
 
 	MinDiffLines   int `toml:"min_diff_lines"`
 	LargeDiffLines int `toml:"large_diff_lines"`
@@ -117,6 +119,28 @@ func AutoDesignEnabledFromConfig(repoCfg *RepoConfig, globalCfg *Config) bool {
 		return *repoCfg.AutoDesignReview.Enabled
 	}
 	if globalCfg != nil && globalCfg.AutoDesignReview.Enabled {
+		return true
+	}
+	return false
+}
+
+// ResolveAutoDesignHookEnabled returns true if hook-only auto design review is
+// enabled for the given repo path. Tri-state behavior matches
+// ResolveAutoDesignEnabled, but this setting is consulted only for post-commit
+// hook reviews.
+func ResolveAutoDesignHookEnabled(repoPath string, globalCfg *Config) bool {
+	repoCfg, _ := LoadRepoConfig(repoPath)
+	return AutoDesignHookEnabledFromConfig(repoCfg, globalCfg)
+}
+
+// AutoDesignHookEnabledFromConfig resolves hook-only auto-design routing from
+// the passed configs without reading the working tree. A per-repo explicit
+// value overrides global, and unset falls through to the global value.
+func AutoDesignHookEnabledFromConfig(repoCfg *RepoConfig, globalCfg *Config) bool {
+	if repoCfg != nil && repoCfg.AutoDesignReview.HookEnabled != nil {
+		return *repoCfg.AutoDesignReview.HookEnabled
+	}
+	if globalCfg != nil && globalCfg.AutoDesignReview.HookEnabled {
 		return true
 	}
 	return false

--- a/internal/config/autodesign_test.go
+++ b/internal/config/autodesign_test.go
@@ -57,6 +57,33 @@ func TestAutoDesignEnabledFromConfigTriState(t *testing.T) {
 	assert.False(config.AutoDesignEnabledFromConfig(nil, nil))
 }
 
+func TestAutoDesignHookEnabledFromConfigTriState(t *testing.T) {
+	assert := assert.New(t)
+	on, off := true, false
+
+	assert.True(config.AutoDesignHookEnabledFromConfig(
+		&config.RepoConfig{AutoDesignReview: config.AutoDesignReviewRepoConfig{HookEnabled: &on}},
+		&config.Config{}))
+	assert.False(config.AutoDesignHookEnabledFromConfig(
+		&config.RepoConfig{AutoDesignReview: config.AutoDesignReviewRepoConfig{HookEnabled: &off}},
+		&config.Config{AutoDesignReview: config.AutoDesignReviewConfig{HookEnabled: true}}))
+	assert.True(config.AutoDesignHookEnabledFromConfig(
+		&config.RepoConfig{},
+		&config.Config{AutoDesignReview: config.AutoDesignReviewConfig{HookEnabled: true}}))
+	assert.False(config.AutoDesignHookEnabledFromConfig(&config.RepoConfig{}, &config.Config{}))
+	assert.True(config.AutoDesignHookEnabledFromConfig(
+		nil, &config.Config{AutoDesignReview: config.AutoDesignReviewConfig{HookEnabled: true}}))
+	assert.False(config.AutoDesignHookEnabledFromConfig(nil, nil))
+}
+
+func TestResolveAutoDesignHookEnabledDelegates(t *testing.T) {
+	assert := assert.New(t)
+	repoDir := t.TempDir()
+	assert.True(config.ResolveAutoDesignHookEnabled(repoDir,
+		&config.Config{AutoDesignReview: config.AutoDesignReviewConfig{HookEnabled: true}}))
+	assert.False(config.ResolveAutoDesignHookEnabled(repoDir, &config.Config{}))
+}
+
 func TestAutoDesignHeuristicsFromConfigUsesProvidedConfig(t *testing.T) {
 	assert := assert.New(t)
 	// Repo overrides one scalar, global overrides another; defaults fill the rest.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3746,6 +3746,7 @@ func TestAutoDesignReviewConfig_Load(t *testing.T) {
 	err := os.WriteFile(cfgFile, []byte(`
 [auto_design_review]
 enabled = true
+hook_enabled = true
 min_diff_lines = 20
 large_diff_lines = 400
 large_file_count = 8
@@ -3762,6 +3763,7 @@ classifier_max_prompt_size = 32768
 	require.NoError(t, err)
 	assert := assert.New(t)
 	assert.True(cfg.AutoDesignReview.Enabled)
+	assert.True(cfg.AutoDesignReview.HookEnabled)
 	assert.Equal(20, cfg.AutoDesignReview.MinDiffLines)
 	assert.Equal(400, cfg.AutoDesignReview.LargeDiffLines)
 	assert.Equal(8, cfg.AutoDesignReview.LargeFileCount)

--- a/internal/daemon/panel_enqueue.go
+++ b/internal/daemon/panel_enqueue.go
@@ -37,6 +37,7 @@ type targetDescriptor struct {
 	minSeverity       string
 	worktreePath      string
 	jobType           string // req.JobType for prompt; "" lets EnqueueJob infer dirty/range/review
+	source            string
 	prompt            string
 	promptPrebuilt    bool
 	outputPrefix      string
@@ -55,7 +56,7 @@ func (d targetDescriptor) baseOpts() storage.EnqueueOpts {
 		RepoID: d.repoID, CommitID: d.commitID, GitRef: d.gitRef, Branch: d.branch,
 		PatchID: d.patchID, DiffContent: d.diffContent, DirtyFiles: d.dirtyFiles, MinSeverity: d.minSeverity,
 		WorktreePath: d.worktreePath, JobType: d.jobType, Prompt: d.prompt,
-		PromptPrebuilt: d.promptPrebuilt, OutputPrefix: d.outputPrefix, Label: d.label,
+		Source: d.source, PromptPrebuilt: d.promptPrebuilt, OutputPrefix: d.outputPrefix, Label: d.label,
 		Agentic: d.agentic, RequestedModel: d.requestedModel, RequestedProvider: d.requestedProvider,
 	}
 }
@@ -119,16 +120,22 @@ func (s *Server) buildTargetDescriptor(
 		in.req.CustomPrompt = insightsPrompt
 	}
 
+	var desc targetDescriptor
 	switch classifyTarget(in.req.CustomPrompt, in.gitRef) {
 	case kindPrompt:
-		return s.descriptorForPrompt(in), nil
+		desc = s.descriptorForPrompt(in)
 	case kindDirty:
-		return s.descriptorForDirty(ctx, in)
+		desc, early = s.descriptorForDirty(ctx, in)
 	case kindRange:
-		return s.descriptorForRange(ctx, in)
+		desc, early = s.descriptorForRange(ctx, in)
 	default:
-		return s.descriptorForSingleCommit(ctx, in)
+		desc, early = s.descriptorForSingleCommit(ctx, in)
 	}
+	if early != nil {
+		return targetDescriptor{}, early
+	}
+	desc.source = in.req.Source
+	return desc, nil
 }
 
 // resolveInsightsPrompt builds the insights prompt for insights jobs and returns

--- a/internal/daemon/panel_enqueue_test.go
+++ b/internal/daemon/panel_enqueue_test.go
@@ -712,6 +712,41 @@ func TestPostCommitBodyCarriesSource(t *testing.T) {
 	assert.Contains(t, string(body), `"source":"post_commit"`)
 }
 
+func TestPostCommitHookAutoDesignUsesHTTPSource(t *testing.T) {
+	assert := assert.New(t)
+	ResetAutoDesignMetricsForTest()
+	t.Cleanup(ResetAutoDesignMetricsForTest)
+	server, db, _ := newTestServer(t)
+
+	const hookOnlyAutoDesign = `
+[auto_design_review]
+hook_enabled = true
+trigger_paths = ["migrations/**"]
+`
+	repo := testutil.NewGitRepo(t)
+	repo.WriteFile(".roborev.toml", hookOnlyAutoDesign)
+	repo.CommitFile("base.txt", "base", "base")
+	sha := repo.CommitFile("migrations/001.sql", "create table t(id integer);\n", "feat: add migration")
+
+	job := enqueueViaHTTP(t, server, EnqueueRequest{
+		RepoPath: repo.Path(),
+		GitRef:   sha,
+		Agent:    "test",
+		Source:   "post_commit",
+	})
+	assert.Equal("post_commit", job.Source)
+
+	stored, err := db.GetJobByID(job.ID)
+	require.NoError(t, err)
+	assert.Equal("post_commit", stored.Source)
+
+	storedRepo, err := db.GetOrCreateRepo(repo.Path())
+	require.NoError(t, err)
+	assert.Equal(1, autoDesignRowsForSHA(t, db, storedRepo.ID, sha),
+		"hook-only auto-design should see the post_commit source from HTTP enqueue")
+	assert.EqualValues(1, AutoDesignMetricsSnapshot().TriggeredHeuristic)
+}
+
 // TestEnqueueStoredPromptSkipsPanel verifies a stored-prompt job (run/analyze/
 // compact) is never fanned into a review panel, even with default_panel set:
 // the panel synthesis worker assumes member code reviews, not prompt output.

--- a/internal/daemon/server_auto_design.go
+++ b/internal/daemon/server_auto_design.go
@@ -30,6 +30,16 @@ var autoDesignMetrics = &AutoDesignMetrics{}
 
 const autoDesignHookSource = "post_commit"
 
+func (s *Server) autoDesignConfig() *config.Config {
+	if s != nil && s.configWatcher != nil {
+		if cfg := s.configWatcher.Config(); cfg != nil {
+			return cfg
+		}
+	}
+	cfg, _ := config.LoadGlobal()
+	return cfg
+}
+
 // RecordHeuristic bumps either TriggeredHeuristic or SkippedHeuristic.
 func (m *AutoDesignMetrics) RecordHeuristic(run bool) {
 	if run {
@@ -72,7 +82,7 @@ func AutoDesignMetricsSnapshot() storage.AutoDesignStatus {
 // auto-design is effectively enabled (globally, or by at least one
 // registered repo). Returns nil otherwise so the JSON omits the field.
 func (s *Server) autoDesignStatusForResponse() *storage.AutoDesignStatus {
-	cfg, _ := config.LoadGlobal()
+	cfg := s.autoDesignConfig()
 	enabled := cfg != nil && (cfg.AutoDesignReview.Enabled || cfg.AutoDesignReview.HookEnabled)
 
 	if !enabled {
@@ -110,7 +120,7 @@ func ResetAutoDesignMetricsForTest() {
 // Opportunistic: errors are logged but never bubble up to the caller's HTTP
 // response.
 func (s *Server) maybeDispatchAutoDesign(ctx context.Context, parent *storage.ReviewJob) error {
-	cfg, _ := config.LoadGlobal()
+	cfg := s.autoDesignConfig()
 	if !autoDesignEnabledForSource(parent.RepoPath, parent.Source, cfg) {
 		return nil
 	}
@@ -219,7 +229,7 @@ func (s *Server) enqueueClassifyJob(parent *storage.ReviewJob) error {
 }
 
 func (s *Server) enqueueDesignFollowUp(parent *storage.ReviewJob) error {
-	cfg, _ := config.LoadGlobal()
+	cfg := s.autoDesignConfig()
 	designAgent, designModel := resolveDesignAgent(parent.RepoPath, cfg)
 	_, err := s.db.EnqueueAutoDesignJob(storage.EnqueueOpts{
 		RepoID:     parent.RepoID,

--- a/internal/daemon/server_auto_design.go
+++ b/internal/daemon/server_auto_design.go
@@ -28,6 +28,8 @@ type AutoDesignMetrics struct {
 // autoDesignMetrics is the process-global instance.
 var autoDesignMetrics = &AutoDesignMetrics{}
 
+const autoDesignHookSource = "post_commit"
+
 // RecordHeuristic bumps either TriggeredHeuristic or SkippedHeuristic.
 func (m *AutoDesignMetrics) RecordHeuristic(run bool) {
 	if run {
@@ -71,13 +73,14 @@ func AutoDesignMetricsSnapshot() storage.AutoDesignStatus {
 // registered repo). Returns nil otherwise so the JSON omits the field.
 func (s *Server) autoDesignStatusForResponse() *storage.AutoDesignStatus {
 	cfg, _ := config.LoadGlobal()
-	enabled := cfg != nil && cfg.AutoDesignReview.Enabled
+	enabled := cfg != nil && (cfg.AutoDesignReview.Enabled || cfg.AutoDesignReview.HookEnabled)
 
 	if !enabled {
 		repos, err := s.db.ListRepos()
 		if err == nil {
 			for _, r := range repos {
-				if config.ResolveAutoDesignEnabled(r.RootPath, cfg) {
+				if config.ResolveAutoDesignEnabled(r.RootPath, cfg) ||
+					config.ResolveAutoDesignHookEnabled(r.RootPath, cfg) {
 					enabled = true
 					break
 				}
@@ -108,7 +111,7 @@ func ResetAutoDesignMetricsForTest() {
 // response.
 func (s *Server) maybeDispatchAutoDesign(ctx context.Context, parent *storage.ReviewJob) error {
 	cfg, _ := config.LoadGlobal()
-	if !config.ResolveAutoDesignEnabled(parent.RepoPath, cfg) {
+	if !autoDesignEnabledForSource(parent.RepoPath, parent.Source, cfg) {
 		return nil
 	}
 
@@ -194,6 +197,13 @@ func (s *Server) maybeDispatchAutoDesign(ctx context.Context, parent *storage.Re
 		log.Printf("auto-design: Classify error, skipping: %v", err)
 		return s.insertSkippedDesign(parent, "auto-design: heuristic error")
 	}
+}
+
+func autoDesignEnabledForSource(repoPath, source string, cfg *config.Config) bool {
+	if config.ResolveAutoDesignEnabled(repoPath, cfg) {
+		return true
+	}
+	return source == autoDesignHookSource && config.ResolveAutoDesignHookEnabled(repoPath, cfg)
 }
 
 func (s *Server) enqueueClassifyJob(parent *storage.ReviewJob) error {

--- a/internal/daemon/server_auto_design_test.go
+++ b/internal/daemon/server_auto_design_test.go
@@ -193,6 +193,44 @@ func TestMaybeDispatchAutoDesign_HookEnabledRunsForPostCommitSource(t *testing.T
 	assert.Equal(t, storage.JobTypeReview, found.JobType)
 }
 
+func TestPostCommitHookAutoDesignUsesActiveConfig(t *testing.T) {
+	assert := assert.New(t)
+	ResetAutoDesignMetricsForTest()
+	t.Cleanup(ResetAutoDesignMetricsForTest)
+
+	db, tmpDir := testutil.OpenTestDBWithDir(t)
+	configPath := filepath.Join(tmpDir, "custom-config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+[auto_design_review]
+hook_enabled = true
+trigger_paths = ["migrations/**"]
+`), 0o644))
+	cfg, err := config.LoadGlobalFrom(configPath)
+	require.NoError(t, err)
+	require.True(t, cfg.AutoDesignReview.HookEnabled)
+
+	srv := NewServer(db, cfg, configPath)
+	t.Cleanup(func() { _ = srv.Close() })
+
+	repo := testutil.NewGitRepo(t)
+	repo.CommitFile("base.txt", "base", "base")
+	sha := repo.CommitFile("migrations/001.sql", "create table t(id integer);\n", "feat: add migration")
+
+	job := enqueueViaHTTP(t, srv, EnqueueRequest{
+		RepoPath: repo.Path(),
+		GitRef:   sha,
+		Agent:    "test",
+		Source:   "post_commit",
+	})
+	assert.Equal("post_commit", job.Source)
+
+	storedRepo, err := db.GetOrCreateRepo(repo.Path())
+	require.NoError(t, err)
+	assert.Equal(1, autoDesignRowsForSHA(t, db, storedRepo.ID, sha),
+		"hook-only auto-design should use the daemon's active config, not the default global path")
+	assert.EqualValues(1, AutoDesignMetricsSnapshot().TriggeredHeuristic)
+}
+
 func TestAutoDesignMetrics_RecordHeuristic(t *testing.T) {
 	ResetAutoDesignMetricsForTest()
 	t.Cleanup(ResetAutoDesignMetricsForTest)

--- a/internal/daemon/server_auto_design_test.go
+++ b/internal/daemon/server_auto_design_test.go
@@ -36,6 +36,14 @@ enabled = true
 `), 0o644))
 }
 
+func enableHookAutoDesignReviewForRepo(t *testing.T, repoPath string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(repoPath, ".roborev.toml"),
+		[]byte(`[auto_design_review]
+hook_enabled = true
+`), 0o644))
+}
+
 func TestMaybeDispatchAutoDesign_HeuristicTrigger(t *testing.T) {
 	srv, repo := newAutoDesignTestServer(t)
 	enableAutoDesignReviewForRepo(t, repo.RootPath)
@@ -114,6 +122,77 @@ func TestMaybeDispatchAutoDesign_HeuristicSkip_TrivialDiff(t *testing.T) {
 	assert.Contains(t, found.SkipReason, "trivial")
 }
 
+func TestMaybeDispatchAutoDesign_HookEnabledRequiresPostCommitSource(t *testing.T) {
+	srv, repo := newAutoDesignTestServer(t)
+	enableHookAutoDesignReviewForRepo(t, repo.RootPath)
+
+	commit, err := srv.db.GetOrCreateCommit(repo.ID, "cafebabe", "Author", "refactor: manual", time.Now())
+	require.NoError(t, err)
+	diff := "+x\n+y\n+a\n+b\n+c\n+d\n+e\n+f\n+g\n+h\n+i\n+j\n"
+	parent := &storage.ReviewJob{
+		ID:            999,
+		RepoID:        repo.ID,
+		CommitID:      &commit.ID,
+		GitRef:        "cafebabe",
+		Agent:         "test",
+		JobType:       storage.JobTypeReview,
+		Status:        storage.JobStatusQueued,
+		EnqueuedAt:    time.Now(),
+		RepoPath:      repo.RootPath,
+		CommitSubject: "refactor: manual",
+		DiffContent:   &diff,
+	}
+
+	require.NoError(t, srv.maybeDispatchAutoDesign(context.Background(), parent))
+
+	for _, s := range []storage.JobStatus{storage.JobStatusQueued, storage.JobStatusSkipped} {
+		jobs, err := srv.db.ListJobsByStatus(repo.ID, s)
+		require.NoError(t, err)
+		for _, j := range jobs {
+			assert.NotEqual(t, "auto_design", j.Source,
+				"manual enqueue must not create auto-design rows when only hook_enabled is set")
+		}
+	}
+}
+
+func TestMaybeDispatchAutoDesign_HookEnabledRunsForPostCommitSource(t *testing.T) {
+	srv, repo := newAutoDesignTestServer(t)
+	enableHookAutoDesignReviewForRepo(t, repo.RootPath)
+
+	commit, err := srv.db.GetOrCreateCommit(repo.ID, "feedbabe", "Author", "refactor: hook", time.Now())
+	require.NoError(t, err)
+	diff := "+x\n+y\n+a\n+b\n+c\n+d\n+e\n+f\n+g\n+h\n+i\n+j\n"
+	parent := &storage.ReviewJob{
+		ID:            999,
+		RepoID:        repo.ID,
+		CommitID:      &commit.ID,
+		GitRef:        "feedbabe",
+		Agent:         "test",
+		JobType:       storage.JobTypeReview,
+		Status:        storage.JobStatusQueued,
+		EnqueuedAt:    time.Now(),
+		RepoPath:      repo.RootPath,
+		CommitSubject: "refactor: hook",
+		DiffContent:   &diff,
+		Source:        "post_commit",
+	}
+
+	require.NoError(t, srv.maybeDispatchAutoDesign(context.Background(), parent))
+
+	queued, err := srv.db.ListJobsByStatus(repo.ID, storage.JobStatusQueued)
+	require.NoError(t, err)
+	var found *storage.ReviewJob
+	for i := range queued {
+		j := queued[i]
+		if j.GitRef == "feedbabe" && j.ReviewType == "design" && j.Source == "auto_design" {
+			found = &j
+			break
+		}
+	}
+	require.NotNil(t, found, "expected hook-enabled auto-design row for post_commit source")
+	assert.Equal(t, storage.JobTypeReview, found.JobType)
+}
+
 func TestAutoDesignMetrics_RecordHeuristic(t *testing.T) {
 	ResetAutoDesignMetricsForTest()
 	t.Cleanup(ResetAutoDesignMetricsForTest)
@@ -149,6 +228,16 @@ func TestAutoDesignStatusForResponse_EnabledRepoSurfaces(t *testing.T) {
 	ResetAutoDesignMetricsForTest()
 	srv, repo := newAutoDesignTestServer(t)
 	enableAutoDesignReviewForRepo(t, repo.RootPath)
+
+	got := srv.autoDesignStatusForResponse()
+	require.NotNil(t, got)
+	assert.True(t, got.Enabled)
+}
+
+func TestAutoDesignStatusForResponse_HookEnabledRepoSurfaces(t *testing.T) {
+	ResetAutoDesignMetricsForTest()
+	srv, repo := newAutoDesignTestServer(t)
+	enableHookAutoDesignReviewForRepo(t, repo.RootPath)
 
 	got := srv.autoDesignStatusForResponse()
 	require.NotNil(t, got)


### PR DESCRIPTION
Adds a hook-only auto-design setting for teams that want the design-review router on post-commit reviews without enabling it for every explicit daemon review.

- Adds `auto_design_review.hook_enabled` with global and repo-level tri-state resolution.
- Gates auto-design dispatch so hook-only routing applies only to `source="post_commit"` while existing `enabled = true` behavior remains broad.
- Surfaces hook-only auto-design in daemon status and validates hook-only heuristic config at daemon startup.
- Covers config loading, source gating, daemon status, and invalid hook-only heuristic validation with tests.

Basic setup:

```toml
# ~/.roborev/config.toml
[auto_design_review]
hook_enabled = true
trigger_paths = ["internal/**", "cmd/**"]
```

Repo-level override:

```toml
# .roborev.toml
[auto_design_review]
hook_enabled = false
```

Use `enabled = true` instead of `hook_enabled = true` only when auto-design should run for explicit/manual daemon reviews as well as hook-created reviews.

The classifier still runs asynchronously in the daemon after the normal hook-created review is enqueued; the git hook does not block on an agent call.
