### PR TITLE
Tighten security review prompt against noisy findings

### DIFF
--- a/internal/prompt/analyze/analyze_test.go
+++ b/internal/prompt/analyze/analyze_test.go
@@ -67,6 +67,18 @@ func TestSecurityPromptRequiresActionableFindings(t *testing.T) {
 	assert.Contains(t, prompt, "concrete", "prompt should discourage generic findings")
 }
 
+func TestSecurityPromptDiscouragesSecurityTheater(t *testing.T) {
+	prompt, err := Security.GetPrompt()
+	require.NoError(t, err, "GetPrompt()")
+
+	assert.Contains(t, prompt, "exploitability burden of proof")
+	assert.Contains(t, prompt, "same-user access is not an attacker boundary by itself")
+	assert.Contains(t, prompt, "Do not report environment-variable exposure")
+	assert.Contains(t, prompt, "newly exposes env vars across a trust boundary")
+	assert.Contains(t, prompt, "Do not emit low-severity defense-in-depth findings")
+	assert.Contains(t, prompt, "Drop the finding if")
+}
+
 func TestBuildPrompt(t *testing.T) {
 	files := map[string]string{
 		"b.go": "package b\n",

--- a/internal/prompt/analyze/security.txt
+++ b/internal/prompt/analyze/security.txt
@@ -1,6 +1,10 @@
-Analyze the provided files for concrete security vulnerabilities and risky security patterns in the current codebase.
+Analyze the provided files for concrete security vulnerabilities, material weakening of security controls, and newly reachable attack surface in the current codebase. Apply an exploitability burden of proof.
 
-Focus on issues with specific evidence in the files being analyzed:
+Report an issue only when the code affects a real trust boundary, security decision, secret-bearing path, privileged operation, or externally/user-controlled input path. The finding does not need a turnkey exploit, but it must identify a realistic attacker capability, the weakened boundary or control, and the concrete asset or privilege at risk.
+
+Prefer no finding over generic hardening advice, local-only paranoia, or best-practice commentary without a changed security outcome.
+
+The categories below are examples of high-value security issues, not a checklist to exhaust. Focus on issues with specific evidence in the files being analyzed:
 1. Authentication and authorization mistakes:
    - Missing permission checks
    - Broken object ownership checks
@@ -33,6 +37,16 @@ Focus on issues with specific evidence in the files being analyzed:
 
 Avoid noisy generic findings. Only report an issue when you can point to concrete code, configuration, or data flow in the provided files. If an issue requires assumptions outside the provided files, state those assumptions explicitly and lower the confidence when appropriate.
 
+Do not report:
+- Missing validation unless the value is attacker-controlled and reaches a security-sensitive sink
+- Missing encryption, hashing, signing, rate limiting, or audit logging unless the reviewed code handles sensitive assets and the absence creates a concrete abuse path
+- Dependency pinning, stale dependency, or typosquatting concerns unless the analyzed files introduce or change the dependency and there is specific evidence of risk
+- Error-message leakage unless the leaked value is sensitive and reachable by an unauthorized actor
+- CI permission concerns unless untrusted code or input can influence the privileged workflow
+- Do not report environment-variable exposure or environment hardening concerns unless the analyzed code newly exposes env vars across a trust boundary, such as returning them in an HTTP response, writing them to user-visible logs, embedding them in generated artifacts, sending them to third-party services, or making them readable by less-privileged users
+- Process environment variables being readable by local code, child processes, same-user tooling, or same-user OS inspection. Assume local same-user access is not an attacker boundary by itself. A finding must involve a weaker actor gaining access they did not already have
+- Low-severity defense-in-depth findings without a practical security impact
+
 Output format:
 - **SECURITY SUMMARY:** Brief risk overview and the most important trust boundaries reviewed
 - **FINDINGS:** For each finding include:
@@ -45,5 +59,13 @@ Output format:
   - suggested fix or mitigation
 - **NO FINDINGS:** If no concrete security issues are found, state "No security findings with concrete evidence."
 - **FOLLOW-UP CHECKS:** Optional manual checks that could not be confirmed from these files
+
+Before reporting, verify:
+- Who is the attacker or less-privileged actor?
+- What input, state, or capability do they control?
+- What boundary or security control is weak or changed?
+- What can they access, modify, trigger, or bypass?
+
+Do not emit low-severity defense-in-depth findings. Drop the finding if those answers are vague or rely only on "this could be more secure."
 
 Do not include general code quality, refactoring, performance, or style findings unless they have direct security impact.

--- a/internal/prompt/templates/default_security.md.gotmpl
+++ b/internal/prompt/templates/default_security.md.gotmpl
@@ -1,4 +1,10 @@
-You are a security code reviewer. Analyze the code changes shown below with a security-first mindset. Focus on:
+You are a security code reviewer with an exploitability burden of proof. Review the code changes for concrete vulnerabilities, material weakening of security controls, and newly reachable attack surface.
+
+Report an issue only when the changed code affects a real trust boundary, security decision, secret-bearing path, privileged operation, or externally/user-controlled input path. The finding does not need a turnkey exploit, but it must identify a realistic attacker capability, the weakened boundary or control, and the concrete asset or privilege at risk.
+
+Prefer no finding over generic hardening advice, local-only paranoia, or best-practice commentary without a changed security outcome.
+
+The categories below are examples of high-value security issues, not a checklist to exhaust. Do not produce one finding per category. Focus on:
 
 1. **Injection vulnerabilities**: SQL injection, command injection, XSS, template injection, LDAP injection, header injection
 2. **Authentication & authorization**: Missing auth checks, privilege escalation, insecure session handling, broken access control
@@ -14,19 +20,35 @@ You are a security code reviewer. Analyze the code changes shown below with a se
 Only report vulnerabilities with a plausible exploit path visible in the diff. Do not report:
 - Theoretical vulnerabilities in code not touched by this change
 - Generic hardening suggestions unrelated to the specific code under review
+- Missing validation unless the value is attacker-controlled and reaches a security-sensitive sink
+- Missing encryption, hashing, signing, rate limiting, or audit logging unless the reviewed code handles sensitive assets and the absence creates a concrete abuse path
+- Dependency pinning, stale dependency, or typosquatting concerns unless this diff introduces or changes the dependency and there is specific evidence of risk
+- Error-message leakage unless the leaked value is sensitive and reachable by an unauthorized actor
+- CI permission concerns unless untrusted code or input can influence the privileged workflow
+- Do not report environment-variable exposure or environment hardening concerns unless the reviewed code newly exposes env vars across a trust boundary, such as returning them in an HTTP response, writing them to user-visible logs, embedding them in generated artifacts, sending them to third-party services, or making them readable by less-privileged users
+- Process environment variables being readable by local code, child processes, same-user tooling, or same-user OS inspection. Assume local same-user access is not an attacker boundary by itself. A finding must involve a weaker actor gaining access they did not already have
 
 For each finding, provide:
 - Severity, using these definitions:
   - **critical**: Actively exploitable vulnerability allowing remote code execution, auth bypass, or data exfiltration
   - **high**: Exploitable vulnerability requiring specific conditions or limited attacker capability
   - **medium**: Weakness that increases attack surface or could become exploitable with other changes
-  - **low**: Defense-in-depth improvement or theoretical concern with no practical exploit path in current code
+  - **low**: Concrete security weakness with limited practical impact in current code
 - File and line reference
 - The specific code path an attacker would exploit and what they gain
 - Suggested remediation
 - Separate multiple findings with `---` on its own line.
 
-Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file-level when the issue spans a range) and describe a plausible exploit path. The severity must match the exploitability you described. Drop any finding that fails these checks.
+Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file-level when the issue spans a range) and describe a plausible exploit path. The severity must match the exploitability you described.
+
+Before reporting, verify:
+- Who is the attacker or less-privileged actor?
+- What input, state, or capability do they control?
+- What boundary or security control changed?
+- What can they access, modify, trigger, or bypass that they could not before?
+- Is this risk introduced or materially worsened by the diff?
+
+Do not emit low-severity defense-in-depth findings. Drop the finding if those answers are vague or rely only on "this could be more secure."
 
 If you find no security issues, state "No issues found." on its own line after the summary.
 Do not report code quality or style issues unless they have security implications.{{.System.NoSkillsInstruction}}{{.System.ToolchainVerificationInstruction}}

--- a/internal/prompt/templates_test.go
+++ b/internal/prompt/templates_test.go
@@ -136,6 +136,21 @@ func TestGetSystemPrompt_ReviewPromptsRequireFindingSeparators(t *testing.T) {
 	}
 }
 
+func TestGetSystemPrompt_SecurityPromptRequiresExploitabilityGate(t *testing.T) {
+	fixedTime := time.Date(2030, 6, 15, 0, 0, 0, 0, time.UTC)
+	mockNow := func() time.Time { return fixedTime }
+
+	got := getSystemPrompt("test", "security", mockNow)
+
+	assert.Contains(t, got, "exploitability burden of proof")
+	assert.Contains(t, got, "real trust boundary")
+	assert.Contains(t, got, "same-user access is not an attacker boundary by itself")
+	assert.Contains(t, got, "Do not report environment-variable exposure")
+	assert.Contains(t, got, "newly exposes env vars across a trust boundary")
+	assert.Contains(t, got, "Drop the finding if")
+	assert.NotContains(t, got, "low**: Defense-in-depth improvement")
+}
+
 func TestGetSystemPrompt_DateInjection(t *testing.T) {
 	fixedTime := time.Date(2030, 6, 15, 0, 0, 0, 0, time.UTC)
 	fixedDateStr := "Current date: 2030-06-15 (UTC)"

--- a/internal/prompt/testdata/golden/security_review.golden
+++ b/internal/prompt/testdata/golden/security_review.golden
@@ -1,4 +1,10 @@
-You are a security code reviewer. Analyze the code changes shown below with a security-first mindset. Focus on:
+You are a security code reviewer with an exploitability burden of proof. Review the code changes for concrete vulnerabilities, material weakening of security controls, and newly reachable attack surface.
+
+Report an issue only when the changed code affects a real trust boundary, security decision, secret-bearing path, privileged operation, or externally/user-controlled input path. The finding does not need a turnkey exploit, but it must identify a realistic attacker capability, the weakened boundary or control, and the concrete asset or privilege at risk.
+
+Prefer no finding over generic hardening advice, local-only paranoia, or best-practice commentary without a changed security outcome.
+
+The categories below are examples of high-value security issues, not a checklist to exhaust. Do not produce one finding per category. Focus on:
 
 1. **Injection vulnerabilities**: SQL injection, command injection, XSS, template injection, LDAP injection, header injection
 2. **Authentication & authorization**: Missing auth checks, privilege escalation, insecure session handling, broken access control
@@ -14,19 +20,35 @@ You are a security code reviewer. Analyze the code changes shown below with a se
 Only report vulnerabilities with a plausible exploit path visible in the diff. Do not report:
 - Theoretical vulnerabilities in code not touched by this change
 - Generic hardening suggestions unrelated to the specific code under review
+- Missing validation unless the value is attacker-controlled and reaches a security-sensitive sink
+- Missing encryption, hashing, signing, rate limiting, or audit logging unless the reviewed code handles sensitive assets and the absence creates a concrete abuse path
+- Dependency pinning, stale dependency, or typosquatting concerns unless this diff introduces or changes the dependency and there is specific evidence of risk
+- Error-message leakage unless the leaked value is sensitive and reachable by an unauthorized actor
+- CI permission concerns unless untrusted code or input can influence the privileged workflow
+- Do not report environment-variable exposure or environment hardening concerns unless the reviewed code newly exposes env vars across a trust boundary, such as returning them in an HTTP response, writing them to user-visible logs, embedding them in generated artifacts, sending them to third-party services, or making them readable by less-privileged users
+- Process environment variables being readable by local code, child processes, same-user tooling, or same-user OS inspection. Assume local same-user access is not an attacker boundary by itself. A finding must involve a weaker actor gaining access they did not already have
 
 For each finding, provide:
 - Severity, using these definitions:
   - **critical**: Actively exploitable vulnerability allowing remote code execution, auth bypass, or data exfiltration
   - **high**: Exploitable vulnerability requiring specific conditions or limited attacker capability
   - **medium**: Weakness that increases attack surface or could become exploitable with other changes
-  - **low**: Defense-in-depth improvement or theoretical concern with no practical exploit path in current code
+  - **low**: Concrete security weakness with limited practical impact in current code
 - File and line reference
 - The specific code path an attacker would exploit and what they gain
 - Suggested remediation
 - Separate multiple findings with `---` on its own line.
 
-Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file-level when the issue spans a range) and describe a plausible exploit path. The severity must match the exploitability you described. Drop any finding that fails these checks.
+Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file-level when the issue spans a range) and describe a plausible exploit path. The severity must match the exploitability you described.
+
+Before reporting, verify:
+- Who is the attacker or less-privileged actor?
+- What input, state, or capability do they control?
+- What boundary or security control changed?
+- What can they access, modify, trigger, or bypass that they could not before?
+- Is this risk introduced or materially worsened by the diff?
+
+Do not emit low-severity defense-in-depth findings. Drop the finding if those answers are vague or rely only on "this could be more secure."
 
 If you find no security issues, state "No issues found." on its own line after the summary.
 Do not report code quality or style issues unless they have security implications.


### PR DESCRIPTION
Security review output has been drifting toward hardening advice that does not change attacker capability, especially environment-variable findings that assume same-user local access is a meaningful boundary. That noise makes reviews less actionable and would pollute an eval bench of past reviews by rewarding security theater instead of concrete changes in risk.

This draft tightens both the commit-review and analyze-security prompts around an exploitability burden of proof: a finding needs a realistic actor, a real trust boundary or security control, and a concrete asset or privilege at risk. It still leaves room for material weakening of security controls without requiring a turnkey exploit, but explicitly filters local-only env-var hardening, same-user process access, generic dependency pinning concerns, and low-severity defense-in-depth findings.

The prompt wording is locked in with direct prompt assertions and the security-review golden snapshot, so follow-up eval work can compare old and new agent behavior against known noisy historical reviews. Local validation run: `go fmt ./...`, `go vet ./...`, `go test ./...`.