### PR TITLE
Fix check-agents command to use resolved command for available agents

### DIFF
--- a/cmd/roborev/check_agents.go
+++ b/cmd/roborev/check_agents.go
@@ -61,7 +61,20 @@ Examples:
 					continue
 				}
 
-				a, _ := agent.Get(name)
+				if !agent.IsAvailable(name) {
+					a, _ := agent.Get(name)
+					cmdName := ""
+					if a != nil {
+						if ca, ok := a.(agent.CommandAgent); ok {
+							cmdName = ca.CommandName()
+						}
+					}
+					fmt.Printf("  - %-14s %s (not found in PATH)\n", name, cmdName)
+					skipped++
+					continue
+				}
+
+				a, _ := agent.GetAvailable(name)
 				if a == nil {
 					continue
 				}
@@ -69,12 +82,6 @@ Examples:
 				cmdName := ""
 				if ca, ok := a.(agent.CommandAgent); ok {
 					cmdName = ca.CommandName()
-				}
-
-				if !agent.IsAvailable(name) {
-					fmt.Printf("  - %-14s %s (not found in PATH)\n", name, cmdName)
-					skipped++
-					continue
 				}
 
 				path, _ := exec.LookPath(cmdName)


### PR DESCRIPTION
This PR fixes a bug in the `check-agents` health command where it checks agent availability using `agent.IsAvailable(name)` (which successfully resolves command candidates like `agy` for `gemini`), but then executes the smoke-test review by retrieving the unmodified default agent using `agent.Get(name)` (which still uses `gemini`). This causes `check-agents` to fail on systems where only `agy` is installed on the `PATH`.

With this change, `check-agents` retrieves the resolved agent via `agent.GetAvailable(name)`, which applies the resolved command candidate at runtime, ensuring health checks for `gemini` succeed when `agy` is available on the `PATH`.

Co-Authored-By: Oz <oz-agent@warp.dev>