### PR TITLE
Restrict roborev fix discovery to failing reviews

### DIFF
--- a/cmd/roborev/fix.go
+++ b/cmd/roborev/fix.go
@@ -770,12 +770,23 @@ func queryOpenJobs(
 			return nil, fmt.Errorf("decode response: %w", err)
 		}
 
-		return jobsResp.Jobs, nil
+		return filterFixCandidateJobs(jobsResp.Jobs), nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("query jobs: %w", err)
 	}
 	return jobs, nil
+}
+
+func filterFixCandidateJobs(jobs []storage.ReviewJob) []storage.ReviewJob {
+	filtered := make([]storage.ReviewJob, 0, len(jobs))
+	for _, job := range jobs {
+		if job.Verdict != nil && strings.EqualFold(strings.TrimSpace(*job.Verdict), "P") {
+			continue
+		}
+		filtered = append(filtered, job)
+	}
+	return filtered
 }
 
 func queryOpenJobIDs(

--- a/cmd/roborev/fix.go
+++ b/cmd/roborev/fix.go
@@ -781,12 +781,21 @@ func queryOpenJobs(
 func filterFixCandidateJobs(jobs []storage.ReviewJob) []storage.ReviewJob {
 	filtered := make([]storage.ReviewJob, 0, len(jobs))
 	for _, job := range jobs {
-		if job.Verdict != nil && strings.EqualFold(strings.TrimSpace(*job.Verdict), "P") {
+		if !isFixCandidateJob(job) {
 			continue
 		}
 		filtered = append(filtered, job)
 	}
 	return filtered
+}
+
+func isFixCandidateJob(job storage.ReviewJob) bool {
+	if job.Verdict == nil || !strings.EqualFold(strings.TrimSpace(*job.Verdict), "F") {
+		return false
+	}
+	return job.IsReviewJob() ||
+		job.JobType == storage.JobTypeCompact ||
+		job.IsSynthesisJob()
 }
 
 func queryOpenJobIDs(

--- a/cmd/roborev/fix_test.go
+++ b/cmd/roborev/fix_test.go
@@ -853,6 +853,7 @@ func TestFixAllBranchesDiscovery(t *testing.T) {
 func TestRunFixOpen(t *testing.T) {
 	repo := createTestRepo(t, map[string]string{"f.txt": "x"})
 	repoBranch := strings.TrimSpace(repo.Run("rev-parse", "--abbrev-ref", "HEAD"))
+	failVerdict := "F"
 
 	t.Run("no open jobs", func(t *testing.T) {
 		_ = newMockDaemonBuilder(t).
@@ -880,9 +881,9 @@ func TestRunFixOpen(t *testing.T) {
 		var openQueryCalls atomic.Int32
 		passVerdict := "P"
 		jobsByID := map[int64]storage.ReviewJob{
-			10: {ID: 10, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch},
-			20: {ID: 20, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch},
-			30: {ID: 30, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch, Verdict: &passVerdict},
+			10: {ID: 10, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch, JobType: storage.JobTypeReview, Verdict: &failVerdict},
+			20: {ID: 20, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch, JobType: storage.JobTypeReview, Verdict: &failVerdict},
+			30: {ID: 30, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch, JobType: storage.JobTypeReview, Verdict: &passVerdict},
 		}
 
 		_ = newMockDaemonBuilder(t).
@@ -995,18 +996,22 @@ func TestRunFixOpen(t *testing.T) {
 						writeJSON(w, map[string]any{
 							"jobs": []storage.ReviewJob{
 								{
-									ID:     30,
-									Status: storage.JobStatusDone,
-									Agent:  "test",
-									Branch: "other-branch",
-									GitRef: "dirty",
+									ID:      30,
+									Status:  storage.JobStatusDone,
+									Agent:   "test",
+									Branch:  "other-branch",
+									GitRef:  "dirty",
+									JobType: storage.JobTypeDirty,
+									Verdict: &failVerdict,
 								},
 								{
-									ID:     31,
-									Status: storage.JobStatusDone,
-									Agent:  "test",
-									Branch: "yet-another",
-									GitRef: "dirty",
+									ID:      31,
+									Status:  storage.JobStatusDone,
+									Agent:   "test",
+									Branch:  "yet-another",
+									GitRef:  "dirty",
+									JobType: storage.JobTypeDirty,
+									Verdict: &failVerdict,
 								},
 							},
 							"has_more": false,
@@ -1066,18 +1071,22 @@ func TestRunFixOpen(t *testing.T) {
 						writeJSON(w, map[string]any{
 							"jobs": []storage.ReviewJob{
 								{
-									ID:     40,
-									Status: storage.JobStatusDone,
-									Agent:  "test",
-									Branch: "target-branch",
-									GitRef: "dirty",
+									ID:      40,
+									Status:  storage.JobStatusDone,
+									Agent:   "test",
+									Branch:  "target-branch",
+									GitRef:  "dirty",
+									JobType: storage.JobTypeDirty,
+									Verdict: &failVerdict,
 								},
 								{
-									ID:     41,
-									Status: storage.JobStatusDone,
-									Agent:  "test",
-									Branch: "wrong-branch",
-									GitRef: "dirty",
+									ID:      41,
+									Status:  storage.JobStatusDone,
+									Agent:   "test",
+									Branch:  "wrong-branch",
+									GitRef:  "dirty",
+									JobType: storage.JobTypeDirty,
+									Verdict: &failVerdict,
 								},
 							},
 							"has_more": false,
@@ -1123,9 +1132,42 @@ func TestRunFixOpen(t *testing.T) {
 	})
 }
 
+func TestFilterFixCandidateJobsRequiresFailedActionableReviews(t *testing.T) {
+	failed := "F"
+	failedSpaced := " f "
+	passed := "P"
+	empty := ""
+	commitID := int64(42)
+
+	jobs := []storage.ReviewJob{
+		{ID: 10, JobType: storage.JobTypeReview, Verdict: &failed},
+		{ID: 11, JobType: storage.JobTypeRange, Verdict: &failed},
+		{ID: 12, JobType: storage.JobTypeDirty, Verdict: &failed},
+		{ID: 13, JobType: storage.JobTypeCompact, Verdict: &failed},
+		{ID: 14, JobType: storage.JobTypeSynthesis, Verdict: &failed},
+		{ID: 15, JobType: "", CommitID: &commitID, Verdict: &failedSpaced},
+		{ID: 20, JobType: storage.JobTypeReview, Verdict: &passed},
+		{ID: 21, JobType: storage.JobTypeReview, Verdict: nil},
+		{ID: 22, JobType: storage.JobTypeReview, Verdict: &empty},
+		{ID: 23, JobType: storage.JobTypeFix, Verdict: &failed},
+		{ID: 24, JobType: storage.JobTypeTask, Verdict: &failed},
+		{ID: 25, JobType: storage.JobTypeInsights, Verdict: &failed},
+		{ID: 26, JobType: storage.JobTypeClassify, Verdict: &failed},
+	}
+
+	filtered := filterFixCandidateJobs(jobs)
+	gotIDs := make([]int64, 0, len(filtered))
+	for _, job := range filtered {
+		gotIDs = append(gotIDs, job.ID)
+	}
+
+	assert.Equal(t, []int64{10, 11, 12, 13, 14, 15}, gotIDs)
+}
+
 func TestRunFixOpenOrdering(t *testing.T) {
 	repo := createTestRepo(t, map[string]string{"f.txt": "x"})
 	repoBranch := strings.TrimSpace(repo.Run("rev-parse", "--abbrev-ref", "HEAD"))
+	failVerdict := "F"
 
 	makeBuilder := func() (*MockDaemonBuilder, *atomic.Int32) {
 		var openQueryCalls atomic.Int32
@@ -1137,9 +1179,9 @@ func TestRunFixOpenOrdering(t *testing.T) {
 						// Return newest first (as the API does)
 						writeJSON(w, map[string]any{
 							"jobs": []storage.ReviewJob{
-								{ID: 30, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch},
-								{ID: 20, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch},
-								{ID: 10, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch},
+								{ID: 30, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch, JobType: storage.JobTypeReview, Verdict: &failVerdict},
+								{ID: 20, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch, JobType: storage.JobTypeReview, Verdict: &failVerdict},
+								{ID: 10, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch, JobType: storage.JobTypeReview, Verdict: &failVerdict},
 							},
 							"has_more": false,
 						})
@@ -1203,6 +1245,7 @@ func TestRunFixOpenOrdering(t *testing.T) {
 func TestRunFixOpenRequery(t *testing.T) {
 	repo := createTestRepo(t, map[string]string{"f.txt": "x"})
 	repoBranch := strings.TrimSpace(repo.Run("rev-parse", "--abbrev-ref", "HEAD"))
+	failVerdict := "F"
 
 	var queryCount atomic.Int32
 	_ = newMockDaemonBuilder(t).
@@ -1215,7 +1258,7 @@ func TestRunFixOpenRequery(t *testing.T) {
 					// First query: return batch 1
 					writeJSON(w, map[string]any{
 						"jobs": []storage.ReviewJob{
-							{ID: 10, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch},
+							{ID: 10, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch, JobType: storage.JobTypeReview, Verdict: &failVerdict},
 						},
 						"has_more": false,
 					})
@@ -1223,8 +1266,8 @@ func TestRunFixOpenRequery(t *testing.T) {
 					// Second query: new job appeared
 					writeJSON(w, map[string]any{
 						"jobs": []storage.ReviewJob{
-							{ID: 20, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch},
-							{ID: 10, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch},
+							{ID: 20, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch, JobType: storage.JobTypeReview, Verdict: &failVerdict},
+							{ID: 10, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch, JobType: storage.JobTypeReview, Verdict: &failVerdict},
 						},
 						"has_more": false,
 					})
@@ -1273,6 +1316,7 @@ func TestRunFixOpenRequery(t *testing.T) {
 func TestRunFixOpenRecoversFromDaemonRestartOnRequery(t *testing.T) {
 	repo := createTestRepo(t, map[string]string{"f.txt": "x"})
 	repoBranch := strings.TrimSpace(repo.Run("rev-parse", "--abbrev-ref", "HEAD"))
+	failVerdict := "F"
 
 	deadURL := "http://127.0.0.1:1"
 	var recoveryQueryCount atomic.Int32
@@ -1284,8 +1328,8 @@ func TestRunFixOpenRecoversFromDaemonRestartOnRequery(t *testing.T) {
 				if recoveryQueryCount.Add(1) == 1 {
 					writeJSON(w, map[string]any{
 						"jobs": []storage.ReviewJob{
-							{ID: 20, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch},
-							{ID: 10, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch},
+							{ID: 20, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch, JobType: storage.JobTypeReview, Verdict: &failVerdict},
+							{ID: 10, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch, JobType: storage.JobTypeReview, Verdict: &failVerdict},
 						},
 						"has_more": false,
 					})
@@ -1332,7 +1376,7 @@ func TestRunFixOpenRecoversFromDaemonRestartOnRequery(t *testing.T) {
 				openQueryCount.Add(1)
 				writeJSON(w, map[string]any{
 					"jobs": []storage.ReviewJob{
-						{ID: 10, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch},
+						{ID: 10, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch, JobType: storage.JobTypeReview, Verdict: &failVerdict},
 					},
 					"has_more": false,
 				})
@@ -2028,7 +2072,7 @@ func TestRunFixList(t *testing.T) {
 
 	t.Run("lists open jobs with details", func(t *testing.T) {
 		finishedAt := time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC)
-		verdict := "FAIL"
+		verdict := "F"
 
 		_ = newMockDaemonBuilder(t).
 			WithJobs([]storage.ReviewJob{{
@@ -2039,6 +2083,7 @@ func TestRunFixList(t *testing.T) {
 				Agent:         "claude-code",
 				Model:         "claude-3-opus",
 				Status:        storage.JobStatusDone,
+				JobType:       storage.JobTypeReview,
 				FinishedAt:    &finishedAt,
 				Verdict:       &verdict,
 			}}).
@@ -2061,7 +2106,7 @@ func TestRunFixList(t *testing.T) {
 		assert.Contains(t, out, "Subject:  Fix the widget")
 		assert.Contains(t, out, "Agent:    claude-code")
 		assert.Contains(t, out, "Model:    claude-3-opus")
-		assert.Contains(t, out, "Verdict:  FAIL")
+		assert.Contains(t, out, "Verdict:  F")
 		assert.Contains(t, out, "Summary:  Found 3 issues:")
 
 		// Check usage hints
@@ -2083,6 +2128,7 @@ func TestRunFixList(t *testing.T) {
 	})
 
 	t.Run("respects newest-first flag", func(t *testing.T) {
+		failVerdict := "F"
 		var gotIDs []int64
 		_ = newMockDaemonBuilder(t).
 			WithHandler("/api/jobs", func(w http.ResponseWriter, r *http.Request) {
@@ -2091,9 +2137,9 @@ func TestRunFixList(t *testing.T) {
 					// API returns newest first
 					writeJSON(w, map[string]any{
 						"jobs": []storage.ReviewJob{
-							{ID: 30, Status: storage.JobStatusDone, Agent: "test"},
-							{ID: 20, Status: storage.JobStatusDone, Agent: "test"},
-							{ID: 10, Status: storage.JobStatusDone, Agent: "test"},
+							{ID: 30, Status: storage.JobStatusDone, Agent: "test", JobType: storage.JobTypeReview, Verdict: &failVerdict},
+							{ID: 20, Status: storage.JobStatusDone, Agent: "test", JobType: storage.JobTypeReview, Verdict: &failVerdict},
+							{ID: 10, Status: storage.JobStatusDone, Agent: "test", JobType: storage.JobTypeReview, Verdict: &failVerdict},
 						},
 						"has_more": false,
 					})
@@ -2121,7 +2167,7 @@ func TestRunFixList(t *testing.T) {
 		require.NoError(t, err, "runFixList: %v")
 
 		assert.Len(t, gotIDs, 3)
-		assert.False(t, gotIDs[0] != 30 || gotIDs[1] != 20 || gotIDs[2] != 10)
+		assert.Equal(t, []int64{30, 20, 10}, gotIDs)
 	})
 }
 
@@ -2486,6 +2532,7 @@ func TestFixBatchSkipsPassVerdict(t *testing.T) {
 func TestRunFixBatchRequery(t *testing.T) {
 	repo := createTestRepo(t, map[string]string{"f.txt": "x"})
 	repoBranch := strings.TrimSpace(repo.Run("rev-parse", "--abbrev-ref", "HEAD"))
+	failVerdict := "F"
 
 	var queryCount atomic.Int32
 	_ = newMockDaemonBuilder(t).
@@ -2497,15 +2544,15 @@ func TestRunFixBatchRequery(t *testing.T) {
 				case 1:
 					writeJSON(w, map[string]any{
 						"jobs": []storage.ReviewJob{
-							{ID: 10, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch},
+							{ID: 10, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch, JobType: storage.JobTypeReview, Verdict: &failVerdict},
 						},
 						"has_more": false,
 					})
 				case 2:
 					writeJSON(w, map[string]any{
 						"jobs": []storage.ReviewJob{
-							{ID: 20, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch},
-							{ID: 10, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch},
+							{ID: 20, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch, JobType: storage.JobTypeReview, Verdict: &failVerdict},
+							{ID: 10, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch, JobType: storage.JobTypeReview, Verdict: &failVerdict},
 						},
 						"has_more": false,
 					})
@@ -3408,6 +3455,7 @@ func TestRunFixOpenFiltersUnreachableJobs(t *testing.T) {
 	var reviewCalls, closeCalls atomic.Int32
 	var processedJobIDs []int64
 	var mu sync.Mutex
+	failVerdict := "F"
 
 	_ = newMockDaemonBuilder(t).
 		WithHandler("/api/jobs", func(w http.ResponseWriter, r *http.Request) {
@@ -3417,18 +3465,22 @@ func TestRunFixOpenFiltersUnreachableJobs(t *testing.T) {
 				writeJSON(w, map[string]any{
 					"jobs": []storage.ReviewJob{
 						{
-							ID:     100,
-							Status: storage.JobStatusDone,
-							Agent:  "test",
-							GitRef: mainOnlySHA,
-							Branch: "main",
+							ID:      100,
+							Status:  storage.JobStatusDone,
+							Agent:   "test",
+							GitRef:  mainOnlySHA,
+							Branch:  "main",
+							JobType: storage.JobTypeReview,
+							Verdict: &failVerdict,
 						},
 						{
-							ID:     200,
-							Status: storage.JobStatusDone,
-							Agent:  "test",
-							GitRef: wtSHA,
-							Branch: "wt-branch",
+							ID:      200,
+							Status:  storage.JobStatusDone,
+							Agent:   "test",
+							GitRef:  wtSHA,
+							Branch:  "wt-branch",
+							JobType: storage.JobTypeReview,
+							Verdict: &failVerdict,
 						},
 					},
 					"has_more": false,

--- a/cmd/roborev/fix_test.go
+++ b/cmd/roborev/fix_test.go
@@ -878,6 +878,12 @@ func TestRunFixOpen(t *testing.T) {
 	t.Run("finds and processes open jobs", func(t *testing.T) {
 		var reviewCalls, closeCalls atomic.Int32
 		var openQueryCalls atomic.Int32
+		passVerdict := "P"
+		jobsByID := map[int64]storage.ReviewJob{
+			10: {ID: 10, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch},
+			20: {ID: 20, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch},
+			30: {ID: 30, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch, Verdict: &passVerdict},
+		}
 
 		_ = newMockDaemonBuilder(t).
 			WithHandler("/api/jobs", func(w http.ResponseWriter, r *http.Request) {
@@ -886,8 +892,9 @@ func TestRunFixOpen(t *testing.T) {
 					if openQueryCalls.Add(1) == 1 {
 						writeJSON(w, map[string]any{
 							"jobs": []storage.ReviewJob{
-								{ID: 10, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch},
-								{ID: 20, Status: storage.JobStatusDone, Agent: "test", Branch: repoBranch},
+								jobsByID[10],
+								jobsByID[20],
+								jobsByID[30],
 							},
 							"has_more": false,
 						})
@@ -898,9 +905,12 @@ func TestRunFixOpen(t *testing.T) {
 						})
 					}
 				} else {
+					var id int64
+					_, _ = fmt.Sscanf(q.Get("id"), "%d", &id)
+					assert.NotEqual(t, int64(30), id, "passed review should not be fetched for fixing")
 					writeJSON(w, map[string]any{
 						"jobs": []storage.ReviewJob{
-							{ID: 10, Status: storage.JobStatusDone, Agent: "test"},
+							jobsByID[id],
 						},
 						"has_more": false,
 					})

--- a/internal/agenthook/state_test.go
+++ b/internal/agenthook/state_test.go
@@ -145,23 +145,25 @@ func TestCountOpenFailedReviewsExcludesNonReviewJobTypes(t *testing.T) {
 	head := repo.CommitFile("base.txt", "base\n", "base")
 
 	closed := false
-	verdict := "F"
+	failVerdict := "F"
+	passVerdict := "P"
 	// All jobs are on the queried branch, so the reachability gate passes for
-	// each; only the job-type filter decides what counts.
-	job := func(jobType string) storage.ReviewJob {
+	// each; only the job-type and verdict filters decide what counts.
+	job := func(jobType, verdict string) storage.ReviewJob {
 		return storage.ReviewJob{
 			Status: storage.JobStatusDone, Closed: &closed, Verdict: &verdict, Branch: "main", JobType: jobType,
 		}
 	}
-	// Every job is done, open and carries an F verdict; only the review-like job
-	// types should count. A completed fix job stores a parsed verdict, so without
-	// the filter it would keep the hook prompting $roborev-fix for itself.
+	// Every job is done and open; only review-like jobs with an F verdict should
+	// count. A completed fix job stores a parsed verdict, so without the filter
+	// it would keep the hook prompting $roborev-fix for itself.
 	jobs := []storage.ReviewJob{
-		job(storage.JobTypeReview),
-		job(storage.JobTypeFix),
-		job(storage.JobTypeTask),
-		job(storage.JobTypeInsights),
-		job(storage.JobTypeClassify),
+		job(storage.JobTypeReview, failVerdict),
+		job(storage.JobTypeReview, passVerdict),
+		job(storage.JobTypeFix, failVerdict),
+		job(storage.JobTypeTask, failVerdict),
+		job(storage.JobTypeInsights, failVerdict),
+		job(storage.JobTypeClassify, failVerdict),
 	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		assert.NoError(json.NewEncoder(w).Encode(jobsResponse{Jobs: jobs}))
@@ -171,7 +173,7 @@ func TestCountOpenFailedReviewsExcludesNonReviewJobTypes(t *testing.T) {
 	count, ok := countOpenFailedReviews(context.Background(), repo.Path(), "main", head, server.URL)
 
 	assert.True(ok)
-	assert.Equal(1, count, "only the review job counts; fix/task/insights/classify verdicts are not reviews")
+	assert.Equal(1, count, "only failed review jobs count; passed reviews and non-review job types are not actionable")
 }
 
 func TestBuildHookReasonsAreCompactOneLine(t *testing.T) {

--- a/internal/skills/claude/roborev-fix/SKILL.md
+++ b/internal/skills/claude/roborev-fix/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: roborev-fix
-description: Use when the user asks to fix open reviews, invokes /roborev-fix, or provides job IDs; do not use when the user only pastes review findings with no request to discover or close reviews
+description: Use when the user asks to fix open failing reviews, invokes /roborev-fix, or provides job IDs; do not use when the user only pastes review findings with no request to discover or close reviews
 ---
 
 # roborev-fix
 
-Fix all open review findings in one pass.
+Fix all open failing review findings in one pass.
 
 ## Usage
 
@@ -24,7 +24,7 @@ file paths, suggested fixes, or copied review summaries is not by itself a
 request to run `/roborev-fix`.
 
 Use this skill when the user explicitly invokes `/roborev-fix`, asks to fix
-open/unaddressed reviews (in any phrasing), provides job IDs that need
+open failing/unaddressed reviews (in any phrasing), provides job IDs that need
 fetching, or gives a mix of job IDs and pasted findings.
 
 ## IMPORTANT
@@ -56,19 +56,19 @@ roborev show --job <job_id> --json
 ```
 
 If no job IDs are provided and no findings are in the conversation, discover
-open reviews:
+open failing reviews:
 
 ```bash
 roborev fix --list
 ```
 
-This lists each open job with its ID, commit SHA/ref, agent, and summary (a panel review shows as its synthesis parent).
+This lists each actionable open failing job with its ID, commit SHA/ref, agent, and summary (a panel review shows as its synthesis parent).
 Collect the job IDs from the output.
 
 If the command fails, report the error to the user. Common causes: the daemon
 is not running, or the repo is not initialized (suggest `roborev init`).
 
-If no open reviews are found, inform the user there is nothing to fix.
+If no open failing reviews are found, inform the user there is nothing to fix.
 
 ### 2. Fetch reviews (if needed)
 
@@ -93,7 +93,7 @@ The JSON output has this structure:
   - Comments from `roborev-fix` or `roborev-refine` are automated tool records
   - All other comments are from the developer (user feedback)
 
-A discovered open job may be a **synthesis (panel) parent**. Its `output` and
+A discovered actionable open failing job may be a **synthesis (panel) parent**. Its `output` and
 `job.verdict` are the synthesized result across the panel's reviewers, so fix
 from the parent exactly as you would a single review. When the job is a panel,
 `show --json` also includes an additive top-level `panel` block:
@@ -110,7 +110,7 @@ Skip any reviews where `job.verdict` is `"P"` (passing reviews have no findings 
 Skip any reviews where `job.verdict` is empty or missing (the review may have errored and is not actionable).
 Skip any reviews where `closed` is `true`, unless the user explicitly provided that job ID (in which case, warn them and ask to confirm).
 
-If all reviews are skipped, inform the user there is nothing to fix.
+If all discovered reviews are passed, closed, or otherwise skipped, inform the user there is nothing to fix.
 
 If the review has `comments`, respect any developer feedback (false positives, preferred approaches).
 
@@ -196,7 +196,7 @@ Agent:
 User: `/roborev-fix`
 
 Agent:
-1. Runs `roborev fix --list` and finds 2 open reviews: job 1019 and job 1021
+1. Runs `roborev fix --list` and finds 2 open failing reviews: job 1019 and job 1021
 2. Fetches both reviews with `roborev show --job 1019 --json` and `roborev show --job 1021 --json`
 3. Runs `git show <git_ref>` for one review where the finding lacked enough context
 4. Fixes all 3 findings across both reviews, sorted by severity, grouped by file

--- a/internal/skills/codex/roborev-fix/SKILL.md
+++ b/internal/skills/codex/roborev-fix/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: roborev-fix
-description: Use when the user asks to fix open reviews, invokes $roborev-fix, or provides job IDs; do not use when the user only pastes review findings with no request to discover or close reviews
+description: Use when the user asks to fix open failing reviews, invokes $roborev-fix, or provides job IDs; do not use when the user only pastes review findings with no request to discover or close reviews
 ---
 
 # roborev-fix
 
-Fix all open review findings in one pass.
+Fix all open failing review findings in one pass.
 
 ## Usage
 
@@ -24,7 +24,7 @@ file paths, suggested fixes, or copied review summaries is not by itself a
 request to run `$roborev-fix`.
 
 Use this skill when the user explicitly invokes `$roborev-fix`, asks to fix
-open/unaddressed reviews (in any phrasing), provides job IDs that need
+open failing/unaddressed reviews (in any phrasing), provides job IDs that need
 fetching, or gives a mix of job IDs and pasted findings.
 
 ## IMPORTANT
@@ -56,19 +56,19 @@ roborev show --job <job_id> --json
 ```
 
 If no job IDs are provided and no findings are in the conversation, discover
-open reviews:
+open failing reviews:
 
 ```bash
 roborev fix --list
 ```
 
-This lists each open job with its ID, commit SHA/ref, agent, and summary (a panel review shows as its synthesis parent).
+This lists each actionable open failing job with its ID, commit SHA/ref, agent, and summary (a panel review shows as its synthesis parent).
 Collect the job IDs from the output.
 
 If the command fails, report the error to the user. Common causes: the daemon
 is not running, or the repo is not initialized (suggest `roborev init`).
 
-If no open reviews are found, inform the user there is nothing to fix.
+If no open failing reviews are found, inform the user there is nothing to fix.
 
 ### 2. Fetch reviews (if needed)
 
@@ -93,7 +93,7 @@ The JSON output has this structure:
   - Comments from `roborev-fix` or `roborev-refine` are automated tool records
   - All other comments are from the developer (user feedback)
 
-A discovered open job may be a **synthesis (panel) parent**. Its `output` and
+A discovered actionable open failing job may be a **synthesis (panel) parent**. Its `output` and
 `job.verdict` are the synthesized result across the panel's reviewers, so fix
 from the parent exactly as you would a single review. When the job is a panel,
 `show --json` also includes an additive top-level `panel` block:
@@ -110,7 +110,7 @@ Skip any reviews where `job.verdict` is `"P"` (passing reviews have no findings 
 Skip any reviews where `job.verdict` is empty or missing (the review may have errored and is not actionable).
 Skip any reviews where `closed` is `true`, unless the user explicitly provided that job ID (in which case, warn them and ask to confirm).
 
-If all reviews are skipped, inform the user there is nothing to fix.
+If all discovered reviews are passed, closed, or otherwise skipped, inform the user there is nothing to fix.
 
 If the review has `comments`, respect any developer feedback (false positives, preferred approaches).
 
@@ -196,7 +196,7 @@ Agent:
 User: `$roborev-fix`
 
 Agent:
-1. Runs `roborev fix --list` and finds 2 open reviews: job 1019 and job 1021
+1. Runs `roborev fix --list` and finds 2 open failing reviews: job 1019 and job 1021
 2. Fetches both reviews with `roborev show --job 1019 --json` and `roborev show --job 1021 --json`
 3. Runs `git show <git_ref>` for one review where the finding lacked enough context
 4. Fixes all 3 findings across both reviews, sorted by severity, grouped by file

--- a/skills/roborev-fix.md
+++ b/skills/roborev-fix.md
@@ -1,6 +1,6 @@
 # /roborev-fix
 
-Fix all open review findings in one pass.
+Fix all open failing review findings in one pass.
 
 ## Usage
 
@@ -10,7 +10,7 @@ Fix all open review findings in one pass.
 
 ## Description
 
-Discovers open code reviews and fixes all their findings in a single pass. This skill batches all outstanding findings together, groups them by file, and fixes them by severity priority. It also handles single reviews when given a specific job ID.
+Discovers open failing code reviews and fixes all their findings in a single pass. This skill batches all actionable outstanding findings together, groups them by file, and fixes them by severity priority. It also handles single reviews when given a specific job ID.
 
 If job IDs are provided, only those reviews are fixed. Otherwise, the skill checks recent commits (HEAD, HEAD~1) for failed reviews that have not been closed.
 
@@ -20,7 +20,7 @@ When the user invokes `/roborev-fix [job_id...]`:
 
 1. **Discover reviews** to address:
    - If job IDs given, use those
-   - Otherwise, run `roborev show HEAD` and `roborev show HEAD~1` to find failed, open reviews
+   - Otherwise, run `roborev show HEAD` and `roborev show HEAD~1` to find open failing reviews
    - If no failed reviews found, inform the user
 
 2. **Fetch all reviews** using `roborev show --job <id>` for each job.


### PR DESCRIPTION
Passed reviews can remain open long enough for the agent hook to prompt the bundled fix workflow, but they are not actionable work. When discovery treats every open row as fixable, the hook appears to be asking agents to fix clean reviews and the skill wastes a cycle fetching and skipping no-op jobs.

This changes discovery to exclude known pass verdicts while leaving legacy or empty-verdict rows available for the existing fetch-time fallback. It also updates the bundled fix-skill instructions so agents look for open failing reviews, not generic open review rows.

Validated with `go vet ./...`, `go test ./cmd/roborev ./internal/agenthook -count=1`, and `go test ./...`.