### PR TITLE
Group CI review worktrees under a repo-named parent

### DIFF
--- a/internal/daemon/ci_worktree.go
+++ b/internal/daemon/ci_worktree.go
@@ -131,6 +131,14 @@ func cleanupStaleCIWorktrees(ctx context.Context) error {
 // (<parent>/<repo>/roborev-ci-*) and the legacy flat layout
 // (<parent>/roborev-ci-*) that older daemons produced, so a transition
 // across the layout change still cleans up pre-existing worktrees.
+//
+// A top-level roborev-ci-* entry is only treated as a legacy flat worktree
+// when it is an actual linked worktree. A repository whose own basename
+// starts with the worktree prefix produces a repo-named parent that also
+// matches the prefix; classifying that parent as a flat worktree would
+// delete it (and the worktrees nested inside it) wholesale without first
+// closing or pruning them. Such a parent is recursed into like any other
+// repo directory instead.
 func staleCIWorktreeDirs(parentDir string) ([]string, error) {
 	entries, err := os.ReadDir(parentDir)
 	if err != nil {
@@ -141,22 +149,49 @@ func staleCIWorktreeDirs(parentDir string) ([]string, error) {
 		if !entry.IsDir() {
 			continue
 		}
-		if strings.HasPrefix(entry.Name(), ciWorktreePrefix) {
-			dirs = append(dirs, filepath.Join(parentDir, entry.Name()))
+		dirPath := filepath.Join(parentDir, entry.Name())
+		hasPrefix := strings.HasPrefix(entry.Name(), ciWorktreePrefix)
+		// Legacy flat worktree: a real linked worktree directly under parent.
+		if hasPrefix && isLinkedWorktree(dirPath) {
+			dirs = append(dirs, dirPath)
 			continue
 		}
-		repoDir := filepath.Join(parentDir, entry.Name())
-		nested, err := os.ReadDir(repoDir)
-		if err != nil {
+		// Repo-named parent (current layout): collect nested worktrees so each
+		// is closed and pruned individually rather than removed wholesale.
+		if nested := nestedCIWorktreeDirs(dirPath); len(nested) > 0 {
+			dirs = append(dirs, nested...)
 			continue
 		}
-		for _, sub := range nested {
-			if sub.IsDir() && strings.HasPrefix(sub.Name(), ciWorktreePrefix) {
-				dirs = append(dirs, filepath.Join(repoDir, sub.Name()))
-			}
+		// Orphaned flat dir left by an older daemon: remove directly.
+		if hasPrefix {
+			dirs = append(dirs, dirPath)
 		}
 	}
 	return dirs, nil
+}
+
+// nestedCIWorktreeDirs returns the roborev-ci-* worktree directories nested
+// directly beneath repoDir, or nil if repoDir cannot be read or holds none.
+func nestedCIWorktreeDirs(repoDir string) []string {
+	entries, err := os.ReadDir(repoDir)
+	if err != nil {
+		return nil
+	}
+	var dirs []string
+	for _, entry := range entries {
+		if entry.IsDir() && strings.HasPrefix(entry.Name(), ciWorktreePrefix) {
+			dirs = append(dirs, filepath.Join(repoDir, entry.Name()))
+		}
+	}
+	return dirs
+}
+
+// isLinkedWorktree reports whether dir is a git linked worktree, i.e. it
+// contains a .git file pointing at a gitdir rather than being a plain
+// directory such as a repo-named worktree parent.
+func isLinkedWorktree(dir string) bool {
+	_, err := linkedWorktreeGitDir(dir)
+	return err == nil
 }
 
 func removeStaleCIWorktree(ctx context.Context, worktreeDir string) error {

--- a/internal/daemon/ci_worktree.go
+++ b/internal/daemon/ci_worktree.go
@@ -25,6 +25,21 @@ func ciWorktreeParentDir() string {
 	return filepath.Join(config.DataDir(), ciWorktreeDirName)
 }
 
+// ciWorktreeRepoDir returns the parent directory for a CI worktree, grouped
+// by the owning repository (<dataDir>/ci-worktrees/<repo>). Nesting the
+// generated worktree under a repo-named component lets downstream tooling
+// attribute the review session to the repository instead of the worktree's
+// generated leaf name. Falls back to the flat parent when repoPath has no
+// usable basename.
+func ciWorktreeRepoDir(repoPath string) string {
+	parent := ciWorktreeParentDir()
+	slug := filepath.Base(strings.TrimSpace(repoPath))
+	if slug == "" || slug == "." || slug == string(filepath.Separator) {
+		return parent
+	}
+	return filepath.Join(parent, slug)
+}
+
 func writeCIWorktreeMarker(worktreeDir, repoPath string) error {
 	repoPath = strings.TrimSpace(repoPath)
 	if repoPath == "" {
@@ -94,8 +109,7 @@ func repoPathFromLinkedWorktree(worktreeDir string) (string, error) {
 }
 
 func cleanupStaleCIWorktrees(ctx context.Context) error {
-	parentDir := ciWorktreeParentDir()
-	entries, err := os.ReadDir(parentDir)
+	dirs, err := staleCIWorktreeDirs(ciWorktreeParentDir())
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
@@ -104,16 +118,45 @@ func cleanupStaleCIWorktrees(ctx context.Context) error {
 	}
 
 	var errs []error
-	for _, entry := range entries {
-		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), ciWorktreePrefix) {
-			continue
-		}
-		dir := filepath.Join(parentDir, entry.Name())
+	for _, dir := range dirs {
 		if err := removeStaleCIWorktree(ctx, dir); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// staleCIWorktreeDirs returns candidate CI worktree directories under
+// parentDir. It handles the current repo-nested layout
+// (<parent>/<repo>/roborev-ci-*) and the legacy flat layout
+// (<parent>/roborev-ci-*) that older daemons produced, so a transition
+// across the layout change still cleans up pre-existing worktrees.
+func staleCIWorktreeDirs(parentDir string) ([]string, error) {
+	entries, err := os.ReadDir(parentDir)
+	if err != nil {
+		return nil, err
+	}
+	var dirs []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if strings.HasPrefix(entry.Name(), ciWorktreePrefix) {
+			dirs = append(dirs, filepath.Join(parentDir, entry.Name()))
+			continue
+		}
+		repoDir := filepath.Join(parentDir, entry.Name())
+		nested, err := os.ReadDir(repoDir)
+		if err != nil {
+			continue
+		}
+		for _, sub := range nested {
+			if sub.IsDir() && strings.HasPrefix(sub.Name(), ciWorktreePrefix) {
+				dirs = append(dirs, filepath.Join(repoDir, sub.Name()))
+			}
+		}
+	}
+	return dirs, nil
 }
 
 func removeStaleCIWorktree(ctx context.Context, worktreeDir string) error {

--- a/internal/daemon/ci_worktree_test.go
+++ b/internal/daemon/ci_worktree_test.go
@@ -1,0 +1,45 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCIWorktreeRepoDir_NestsByRepoBasename(t *testing.T) {
+	got := ciWorktreeRepoDir("/srv/clones/acme/widget")
+	assert.Equal(t, "widget", filepath.Base(got))
+	assert.Equal(t, ciWorktreeParentDir(), filepath.Dir(got))
+}
+
+func TestCIWorktreeRepoDir_FlatFallbackForEmptyRepo(t *testing.T) {
+	assert.Equal(t, ciWorktreeParentDir(), ciWorktreeRepoDir(""))
+	assert.Equal(t, ciWorktreeParentDir(), ciWorktreeRepoDir("/"))
+	assert.Equal(t, ciWorktreeParentDir(), ciWorktreeRepoDir("   "))
+}
+
+func TestStaleCIWorktreeDirs_HandlesNestedAndLegacyLayouts(t *testing.T) {
+	parent := t.TempDir()
+	// Legacy flat layout left by older daemons.
+	legacy := filepath.Join(parent, ciWorktreePrefix+"1-aaa")
+	require.NoError(t, os.MkdirAll(legacy, 0o755))
+	// Current repo-nested layout.
+	nested := filepath.Join(parent, "widget", ciWorktreePrefix+"2-bbb")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+	// Dirs that must be ignored: a non-worktree child of a repo dir, and a
+	// repo dir holding no CI worktrees.
+	require.NoError(t, os.MkdirAll(filepath.Join(parent, "widget", "not-a-worktree"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(parent, "empty-repo"), 0o755))
+
+	dirs, err := staleCIWorktreeDirs(parent)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{legacy, nested}, dirs)
+}
+
+func TestStaleCIWorktreeDirs_MissingParentReturnsNotExist(t *testing.T) {
+	_, err := staleCIWorktreeDirs(filepath.Join(t.TempDir(), "does-not-exist"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}

--- a/internal/daemon/ci_worktree_test.go
+++ b/internal/daemon/ci_worktree_test.go
@@ -39,6 +39,40 @@ func TestStaleCIWorktreeDirs_HandlesNestedAndLegacyLayouts(t *testing.T) {
 	assert.ElementsMatch(t, []string{legacy, nested}, dirs)
 }
 
+func TestStaleCIWorktreeDirs_RepoNamedLikeWorktreePrefix(t *testing.T) {
+	parent := t.TempDir()
+	// A repository whose basename starts with the CI worktree prefix produces
+	// a repo-named parent that also matches the prefix. Its nested worktrees
+	// must be collected individually, never the parent itself, which would be
+	// deleted wholesale without closing the worktrees underneath it.
+	repoParent := filepath.Join(parent, ciWorktreePrefix+"tools")
+	nested := filepath.Join(repoParent, ciWorktreePrefix+"3-ccc")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+
+	dirs, err := staleCIWorktreeDirs(parent)
+	require.NoError(t, err)
+	assert.Equal(t, []string{nested}, dirs)
+	assert.NotContains(t, dirs, repoParent)
+}
+
+func TestStaleCIWorktreeDirs_LinkedWorktreeNotRecursed(t *testing.T) {
+	parent := t.TempDir()
+	// A real legacy flat worktree (a .git link file) whose checkout happens to
+	// contain a directory matching the worktree prefix. The worktree itself
+	// must be returned for cleanup, not the inner directory.
+	worktree := filepath.Join(parent, ciWorktreePrefix+"4-ddd")
+	require.NoError(t, os.MkdirAll(filepath.Join(worktree, ciWorktreePrefix+"inner"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(worktree, ".git"),
+		[]byte("gitdir: /some/repo/.git/worktrees/x\n"),
+		0o600,
+	))
+
+	dirs, err := staleCIWorktreeDirs(parent)
+	require.NoError(t, err)
+	assert.Equal(t, []string{worktree}, dirs)
+}
+
 func TestStaleCIWorktreeDirs_MissingParentReturnsNotExist(t *testing.T) {
 	_, err := staleCIWorktreeDirs(filepath.Join(t.TempDir(), "does-not-exist"))
 	assert.ErrorIs(t, err, os.ErrNotExist)

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -381,7 +381,7 @@ func (wp *WorkerPool) createCIExactCheckout(
 	if headRef == "" {
 		return "", nil, fmt.Errorf("CI job %d has empty checkout ref", job.ID)
 	}
-	parentDir := ciWorktreeParentDir()
+	parentDir := ciWorktreeRepoDir(job.RepoPath)
 	if err := os.MkdirAll(parentDir, 0o755); err != nil {
 		return "", nil, fmt.Errorf("create CI worktree parent: %w", err)
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
@@ -60,6 +61,35 @@ func (r *TestRepo) Run(args ...string) string {
 	return runGit(r.T, r.Dir, args...)
 }
 
+func TestIsTransientGitError(t *testing.T) {
+	assert := assert.New(t)
+	// The exact MSYS sh.exe fork failure observed on Windows CI.
+	winFork := "0 [main] sh (4236) C:\\Program Files\\Git\\usr\\bin\\sh.exe: " +
+		"*** fatal error - add_item (\"\\??\\C:\\Program Files\\Git\", \"/\", ...) " +
+		"failed, errno 1\nfatal: Could not read from remote repository."
+	transient := []string{
+		winFork,
+		"git: fork: retry: Resource temporarily unavailable",
+		"error: cannot fork() for fetch-pack",
+		"DLL initialization failed",
+	}
+	for _, out := range transient {
+		assert.True(isTransientGitError([]byte(out)), "should retry: %q", out)
+	}
+	durable := []string{
+		"",
+		"CONFLICT (content): Merge conflict in file.txt",
+		"nothing to commit, working tree clean",
+		"fatal: not a git repository",
+		// A generic remote-read failure without the MSYS fork signature must
+		// not be retried -- it is a real, durable error.
+		"fatal: Could not read from remote repository.",
+	}
+	for _, out := range durable {
+		assert.False(isTransientGitError([]byte(out)), "should not retry: %q", out)
+	}
+}
+
 func (r *TestRepo) CommitFile(filename, content, msg string) {
 	r.T.Helper()
 	r.WriteFile(filename, content)
@@ -109,13 +139,49 @@ func (r *TestRepo) InstallHook(name, script string) {
 	require.NoError(r.T, err)
 }
 
+const (
+	gitTransientRetries   = 4
+	gitTransientRetryWait = 250 * time.Millisecond
+)
+
 func runGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	out, err := cmd.CombinedOutput()
+	var out []byte
+	var err error
+	for attempt := 0; ; attempt++ {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err = cmd.CombinedOutput()
+		if err == nil || attempt >= gitTransientRetries || !isTransientGitError(out) {
+			break
+		}
+		time.Sleep(gitTransientRetryWait)
+	}
 	require.NoError(t, err, "git %v failed: %v\n%s", args, err, out)
 	return strings.TrimSpace(string(out))
+}
+
+// isTransientGitError reports whether git output matches the intermittent
+// MSYS2/Cygwin process-spawn failures seen on Windows CI runners. git's
+// local transport (clone/fetch/push to a filesystem path) forks sh.exe, and
+// that fork sporadically aborts before doing any work -- e.g. "fatal error -
+// add_item ... failed" or "Resource temporarily unavailable". The command
+// performed no partial work, so retrying it is safe.
+func isTransientGitError(out []byte) bool {
+	s := string(out)
+	for _, sig := range []string{
+		"fatal error - add_item",
+		"Resource temporarily unavailable",
+		"fork: retry",
+		"cannot fork",
+		"unable to fork",
+		"DLL initialization failed",
+	} {
+		if strings.Contains(s, sig) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestIsUnbornHead(t *testing.T) {


### PR DESCRIPTION
## Summary

CI reviews run in an ephemeral git worktree named
`ci-worktrees/roborev-ci-<jobID>-<id>`. Tooling that derives a "project" from
the review agent's working directory therefore attributes each CI review to
the generated worktree name instead of the repository under review.

This nests each CI worktree under a repo-named parent:

```
<dataDir>/ci-worktrees/<repo>/roborev-ci-<jobID>-<id>
```

so the owning repository is recoverable from the worktree path. The change is
agent-agnostic: anything that attributes a session by its working directory
now resolves to the repository rather than the scratch worktree name.

Stale-worktree cleanup scans both the new nested layout and the legacy flat
layout, so worktrees created before this change are still removed during the
transition.

## Where to look

- `internal/daemon/worker.go` — `createCIExactCheckout` derives the worktree
  parent via `ciWorktreeRepoDir(job.RepoPath)`.
- `internal/daemon/ci_worktree.go` — `ciWorktreeRepoDir` (repo grouping with a
  flat fallback) and `staleCIWorktreeDirs` (dual-layout cleanup scan).
