### PR TITLE
Align branchless fix discovery with hook lineage

### DIFF
--- a/cmd/roborev/fix.go
+++ b/cmd/roborev/fix.go
@@ -668,6 +668,15 @@ func filterReachableJobs(
 		matchBranch = gitrepo.CurrentBranch(ctx, worktreeRoot)
 	}
 	allowBranchlessLineage := branchOverride == "" && matchBranch != ""
+	var lineageMatcher *git.BranchLineageMatcher
+	lineageMatcherLoaded := false
+	lineageMatches := func(ref string) bool {
+		if !lineageMatcherLoaded {
+			lineageMatcherLoaded = true
+			lineageMatcher, _ = git.NewBranchLineageMatcherCtx(ctx, worktreeRoot, matchBranch, "HEAD")
+		}
+		return lineageMatcher != nil && lineageMatcher.Matches(ref)
+	}
 	var detachedRefs map[string]struct{}
 	if matchBranch == "" {
 		detachedRefs = detachedHeadReviewRefs(ctx, worktreeRoot)
@@ -678,7 +687,7 @@ func filterReachableJobs(
 			filtered = append(filtered, j)
 			continue
 		}
-		if allowBranchlessLineage && branchlessJobMatchesCurrentLineage(worktreeRoot, matchBranch, j) {
+		if allowBranchlessLineage && branchlessJobMatchesCurrentLineage(j, lineageMatches) {
 			filtered = append(filtered, j)
 			continue
 		}
@@ -699,7 +708,7 @@ func branchMatch(matchBranch, jobBranch string) bool {
 	return jobBranch == matchBranch
 }
 
-func branchlessJobMatchesCurrentLineage(worktreeRoot, currentBranch string, job storage.ReviewJob) bool {
+func branchlessJobMatchesCurrentLineage(job storage.ReviewJob, lineageMatches func(string) bool) bool {
 	if strings.TrimSpace(job.Branch) != "" {
 		return false
 	}
@@ -713,7 +722,7 @@ func branchlessJobMatchesCurrentLineage(worktreeRoot, currentBranch string, job 
 	if ref == "" {
 		return false
 	}
-	return git.RefMatchesBranchLineage(worktreeRoot, currentBranch, "HEAD", ref)
+	return lineageMatches != nil && lineageMatches(ref)
 }
 
 func detachedHeadReviewRefs(ctx context.Context, worktreeRoot string) map[string]struct{} {

--- a/cmd/roborev/fix.go
+++ b/cmd/roborev/fix.go
@@ -649,13 +649,15 @@ func runFixOpen(cmd *cobra.Command, branch string, allBranches, explicitBranch, 
 	}
 }
 
-// filterReachableJobs returns only those jobs relevant to the
-// current worktree by matching the job's stored Branch field
-// against the current (or overridden) branch. branchOverride is
-// the explicit --branch value for non-mutating flows (e.g. --list).
-// Mutating flows (fix, --batch) pass "" so that the current branch
-// is auto-detected. Callers that want all branches (--all-branches)
-// skip this function entirely.
+// filterReachableJobs returns only those jobs relevant to the current worktree
+// by matching the job's stored Branch field against the current (or overridden)
+// branch. In the default current-branch path, branchless jobs are also included
+// when they are repo-scoped/dirty or their reviewed ref belongs to the current
+// branch lineage, matching the agent hook's actionable-review check.
+// branchOverride is the explicit --branch value for non-mutating flows (e.g.
+// --list). Mutating flows (fix, --batch) pass "" so that the current branch is
+// auto-detected. Callers that want all branches (--all-branches) skip this
+// function entirely.
 func filterReachableJobs(
 	ctx context.Context,
 	worktreeRoot, branchOverride string,
@@ -665,6 +667,7 @@ func filterReachableJobs(
 	if matchBranch == "" {
 		matchBranch = gitrepo.CurrentBranch(ctx, worktreeRoot)
 	}
+	allowBranchlessLineage := branchOverride == "" && matchBranch != ""
 	var detachedRefs map[string]struct{}
 	if matchBranch == "" {
 		detachedRefs = detachedHeadReviewRefs(ctx, worktreeRoot)
@@ -672,6 +675,10 @@ func filterReachableJobs(
 	var filtered []storage.ReviewJob
 	for _, j := range jobs {
 		if branchMatch(matchBranch, j.Branch) {
+			filtered = append(filtered, j)
+			continue
+		}
+		if allowBranchlessLineage && branchlessJobMatchesCurrentLineage(worktreeRoot, matchBranch, j) {
 			filtered = append(filtered, j)
 			continue
 		}
@@ -683,13 +690,30 @@ func filterReachableJobs(
 }
 
 // branchMatch returns true when a job's branch matches the target.
-// Both must be known and equal. Jobs with no branch are excluded
-// (use --all-branches to include them).
+// Both must be known and equal. Branchless lineage matching is handled
+// separately for the default current-branch path.
 func branchMatch(matchBranch, jobBranch string) bool {
 	if matchBranch == "" || jobBranch == "" {
 		return false
 	}
 	return jobBranch == matchBranch
+}
+
+func branchlessJobMatchesCurrentLineage(worktreeRoot, currentBranch string, job storage.ReviewJob) bool {
+	if strings.TrimSpace(job.Branch) != "" {
+		return false
+	}
+	ref := strings.TrimSpace(job.GitRef)
+	if ref == "" || ref == "dirty" {
+		return true
+	}
+	if _, end, ok := git.ParseRange(ref); ok {
+		ref = strings.TrimSpace(end)
+	}
+	if ref == "" {
+		return false
+	}
+	return git.RefMatchesBranchLineage(worktreeRoot, currentBranch, "HEAD", ref)
 }
 
 func detachedHeadReviewRefs(ctx context.Context, worktreeRoot string) map[string]struct{} {

--- a/cmd/roborev/fix_test.go
+++ b/cmd/roborev/fix_test.go
@@ -3664,7 +3664,8 @@ func TestRunFixOpenExcludesMergedBranchJobs(t *testing.T) {
 
 // TestFilterReachableJobsFeatureBranch verifies that on a feature
 // branch, jobs from other branches are excluded even though their
-// SHAs are reachable from HEAD. Jobs with no branch fail open.
+// SHAs are reachable from HEAD. Branchless concrete refs are included only
+// when they are outside trunk history.
 func TestFilterReachableJobsFeatureBranch(t *testing.T) {
 	repo := newTestGitRepo(t)
 	baseSHA := repo.CommitFile("base.txt", "base", "base commit")

--- a/cmd/roborev/fix_test.go
+++ b/cmd/roborev/fix_test.go
@@ -3147,6 +3147,13 @@ func TestFilterReachableJobs(t *testing.T) {
 			wantIDs: []int64{2},
 		},
 		{
+			name: "reachable SHA no branch included",
+			jobs: []storage.ReviewJob{
+				{ID: 14, GitRef: mainSHA},
+			},
+			wantIDs: []int64{14},
+		},
+		{
 			name: "unreachable SHA no branch excluded",
 			jobs: []storage.ReviewJob{
 				{ID: 2, GitRef: otherSHA},
@@ -3176,11 +3183,11 @@ func TestFilterReachableJobs(t *testing.T) {
 			wantIDs: nil,
 		},
 		{
-			name: "empty GitRef no branch excluded",
+			name: "empty GitRef no branch included",
 			jobs: []storage.ReviewJob{
 				{ID: 3, GitRef: ""},
 			},
-			wantIDs: nil,
+			wantIDs: []int64{3},
 		},
 		{
 			name: "dirty ref matching branch included",
@@ -3197,11 +3204,11 @@ func TestFilterReachableJobs(t *testing.T) {
 			wantIDs: nil,
 		},
 		{
-			name: "dirty ref no branch excluded",
+			name: "dirty ref no branch included",
 			jobs: []storage.ReviewJob{
 				{ID: 4, GitRef: "dirty"},
 			},
-			wantIDs: nil,
+			wantIDs: []int64{4},
 		},
 		{
 			name: "range ref matching branch included",
@@ -3237,7 +3244,14 @@ func TestFilterReachableJobs(t *testing.T) {
 			wantIDs: []int64{5},
 		},
 		{
-			name: "range ref no branch excluded",
+			name: "range ref reachable end no branch included",
+			jobs: []storage.ReviewJob{
+				{ID: 15, GitRef: otherSHA + ".." + mainSHA},
+			},
+			wantIDs: []int64{15},
+		},
+		{
+			name: "range ref unreachable end no branch excluded",
 			jobs: []storage.ReviewJob{
 				{ID: 5, GitRef: "abc123..def456"},
 			},
@@ -3312,6 +3326,14 @@ func TestFilterReachableJobs(t *testing.T) {
 			branchOverride: "other-branch",
 			jobs: []storage.ReviewJob{
 				{ID: 13, GitRef: mainSHA, Branch: defaultBranch},
+			},
+			wantIDs: nil,
+		},
+		{
+			name:           "branch override excludes branchless current lineage ref",
+			branchOverride: "other-branch",
+			jobs: []storage.ReviewJob{
+				{ID: 16, GitRef: mainSHA},
 			},
 			wantIDs: nil,
 		},
@@ -3688,6 +3710,13 @@ func TestFilterReachableJobsFeatureBranch(t *testing.T) {
 				{ID: 3, GitRef: baseSHA},
 			},
 			wantIDs: nil,
+		},
+		{
+			name: "feature branch commit with no branch included",
+			jobs: []storage.ReviewJob{
+				{ID: 5, GitRef: featureSHA},
+			},
+			wantIDs: []int64{5},
 		},
 		{
 			name: "base branch commit matching branch included",

--- a/internal/agenthook/state.go
+++ b/internal/agenthook/state.go
@@ -1136,9 +1136,9 @@ func countOpenFailedReviews(ctx context.Context, repoRoot, branch, head, configu
 //     carry a branch label created after the worktree started detached.
 //   - A job carrying a branch belongs to the queried branch (the daemon already
 //     scoped the attached-branch query to it).
-//   - On a branch, a branchless review counts unless it pins a concrete ref that
-//     is unreachable from HEAD; reviews with no ref (repo-level or dirty) still
-//     count, matching the long-standing reminder behavior.
+//   - On a branch, branchless repo-level or dirty reviews still count, matching
+//     the long-standing reminder behavior. Branchless concrete refs count only
+//     when they belong to the current branch lineage and are not trunk history.
 func failedReviewCountsForHead(repoRoot, branch, head string, job storage.ReviewJob) bool {
 	if branch == "" {
 		return head != "" && detachedReviewMatches(repoRoot, head, job)

--- a/internal/agenthook/state.go
+++ b/internal/agenthook/state.go
@@ -1105,6 +1105,15 @@ func countOpenFailedReviews(ctx context.Context, repoRoot, branch, head, configu
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return 0, false
 	}
+	var lineageMatcher *roborevgit.BranchLineageMatcher
+	lineageMatcherLoaded := false
+	lineageMatches := func(ref string) bool {
+		if !lineageMatcherLoaded {
+			lineageMatcherLoaded = true
+			lineageMatcher, _ = roborevgit.NewBranchLineageMatcherCtx(ctx, repoRoot, branch, head)
+		}
+		return lineageMatcher != nil && lineageMatcher.Matches(ref)
+	}
 	count := 0
 	for _, job := range out.Jobs {
 		if job.Status != "" && job.Status != storage.JobStatusDone {
@@ -1116,7 +1125,7 @@ func countOpenFailedReviews(ctx context.Context, repoRoot, branch, head, configu
 		if !countsAsFailedReview(job) {
 			continue
 		}
-		if !failedReviewCountsForHead(repoRoot, branch, head, job) {
+		if !failedReviewCountsForHead(repoRoot, branch, head, job, lineageMatches) {
 			continue
 		}
 		if job.Verdict != nil && strings.EqualFold(*job.Verdict, "F") {
@@ -1139,7 +1148,7 @@ func countOpenFailedReviews(ctx context.Context, repoRoot, branch, head, configu
 //   - On a branch, branchless repo-level or dirty reviews still count, matching
 //     the long-standing reminder behavior. Branchless concrete refs count only
 //     when they belong to the current branch lineage and are not trunk history.
-func failedReviewCountsForHead(repoRoot, branch, head string, job storage.ReviewJob) bool {
+func failedReviewCountsForHead(repoRoot, branch, head string, job storage.ReviewJob, lineageMatches func(string) bool) bool {
 	if branch == "" {
 		return head != "" && detachedReviewMatches(repoRoot, head, job)
 	}
@@ -1150,7 +1159,7 @@ func failedReviewCountsForHead(repoRoot, branch, head string, job storage.Review
 	if ref == "" || ref == "dirty" || head == "" {
 		return true
 	}
-	return roborevgit.RefMatchesBranchLineage(repoRoot, branch, head, ref)
+	return lineageMatches != nil && lineageMatches(ref)
 }
 
 func detachedReviewMatches(repoRoot, head string, job storage.ReviewJob) bool {

--- a/internal/agenthook/state.go
+++ b/internal/agenthook/state.go
@@ -1150,7 +1150,7 @@ func failedReviewCountsForHead(repoRoot, branch, head string, job storage.Review
 	if ref == "" || ref == "dirty" || head == "" {
 		return true
 	}
-	return detachedReviewMatches(repoRoot, head, job)
+	return roborevgit.RefMatchesBranchLineage(repoRoot, branch, head, ref)
 }
 
 func detachedReviewMatches(repoRoot, head string, job storage.ReviewJob) bool {

--- a/internal/agenthook/state_test.go
+++ b/internal/agenthook/state_test.go
@@ -3,9 +3,11 @@ package agenthook
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -163,6 +165,48 @@ func TestCountOpenFailedReviewsExcludesBaseBranchBranchlessReviews(t *testing.T)
 
 	assert.True(ok)
 	assert.Equal(1, count, "only the branchless review outside trunk history should count")
+}
+
+func TestCountOpenFailedReviewsCachesBranchlessLineageContext(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	repo := testutil.NewGitRepo(t)
+	repo.CommitFile("base.txt", "base\n", "base")
+	repo.RunGit("checkout", "-b", "feature/lineage")
+
+	closed := false
+	verdict := "F"
+	jobs := make([]storage.ReviewJob, 0, 25)
+	for i := range 25 {
+		ref := repo.CommitFile(
+			filepath.Join("feature", fmt.Sprintf("file-%02d.txt", i)),
+			"feature\n",
+			"feature commit",
+		)
+		jobs = append(jobs, storage.ReviewJob{Status: storage.JobStatusDone, Closed: &closed, Verdict: &verdict, GitRef: ref})
+	}
+	featureHead := repo.HeadSHA()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		assert.NoError(json.NewEncoder(w).Encode(jobsResponse{Jobs: jobs}))
+	}))
+	t.Cleanup(server.Close)
+
+	gitPath, err := exec.LookPath("git")
+	require.NoError(err)
+	countPath := filepath.Join(t.TempDir(), "git-count")
+	wrapperDir := t.TempDir()
+	wrapperPath := filepath.Join(wrapperDir, "git")
+	wrapper := "#!/bin/sh\nprintf x >> " + countPath + "\nexec " + gitPath + " \"$@\"\n"
+	require.NoError(os.WriteFile(wrapperPath, []byte(wrapper), 0o755))
+	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	count, ok := countOpenFailedReviews(context.Background(), repo.Path(), "feature/lineage", featureHead, server.URL)
+
+	assert.True(ok)
+	assert.Equal(len(jobs), count)
+	gitCalls, err := os.ReadFile(countPath)
+	require.NoError(err)
+	assert.LessOrEqual(len(gitCalls), 5, "lineage context should be built once instead of spawning git per branchless job")
 }
 
 func TestCountOpenFailedReviewsExcludesNonReviewJobTypes(t *testing.T) {

--- a/internal/agenthook/state_test.go
+++ b/internal/agenthook/state_test.go
@@ -139,6 +139,32 @@ func TestCountOpenFailedReviewsExcludesUnreachableBranchlessReviews(t *testing.T
 	assert.Equal(4, count, "only the unreachable branchless review must be excluded on a branch query")
 }
 
+func TestCountOpenFailedReviewsExcludesBaseBranchBranchlessReviews(t *testing.T) {
+	assert := assert.New(t)
+	repo := testutil.NewGitRepo(t)
+	base := repo.CommitFile("base.txt", "base\n", "base")
+	mainOnly := repo.CommitFile("main.txt", "main\n", "main only")
+	repo.RunGit("checkout", "-b", "feature/lineage")
+	featureHead := repo.CommitFile("feature.txt", "feature\n", "feature")
+
+	closed := false
+	verdict := "F"
+	jobs := []storage.ReviewJob{
+		{Status: storage.JobStatusDone, Closed: &closed, Verdict: &verdict, GitRef: base},
+		{Status: storage.JobStatusDone, Closed: &closed, Verdict: &verdict, GitRef: mainOnly},
+		{Status: storage.JobStatusDone, Closed: &closed, Verdict: &verdict, GitRef: featureHead},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		assert.NoError(json.NewEncoder(w).Encode(jobsResponse{Jobs: jobs}))
+	}))
+	t.Cleanup(server.Close)
+
+	count, ok := countOpenFailedReviews(context.Background(), repo.Path(), "feature/lineage", featureHead, server.URL)
+
+	assert.True(ok)
+	assert.Equal(1, count, "only the branchless review outside trunk history should count")
+}
+
 func TestCountOpenFailedReviewsExcludesNonReviewJobTypes(t *testing.T) {
 	assert := assert.New(t)
 	repo := testutil.NewGitRepo(t)

--- a/internal/agenthook/state_test.go
+++ b/internal/agenthook/state_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -196,7 +197,17 @@ func TestCountOpenFailedReviewsCachesBranchlessLineageContext(t *testing.T) {
 	countPath := filepath.Join(t.TempDir(), "git-count")
 	wrapperDir := t.TempDir()
 	wrapperPath := filepath.Join(wrapperDir, "git")
-	wrapper := "#!/bin/sh\nprintf x >> " + countPath + "\nexec " + gitPath + " \"$@\"\n"
+	shellQuote := func(path string) string {
+		return "'" + strings.ReplaceAll(path, "'", "'\\''") + "'"
+	}
+	cmdQuote := func(path string) string {
+		return `"` + strings.ReplaceAll(path, `"`, `""`) + `"`
+	}
+	wrapper := fmt.Sprintf("#!/bin/sh\nprintf x >> %s\nexec %s \"$@\"\n", shellQuote(countPath), shellQuote(gitPath))
+	if runtime.GOOS == "windows" {
+		wrapperPath += ".cmd"
+		wrapper = fmt.Sprintf("@echo off\r\n<nul set /p dummy=x>>%s\r\n%s %%*\r\nexit /b %%ERRORLEVEL%%\r\n", cmdQuote(countPath), cmdQuote(gitPath))
+	}
 	require.NoError(os.WriteFile(wrapperPath, []byte(wrapper), 0o755))
 	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
@@ -206,7 +217,7 @@ func TestCountOpenFailedReviewsCachesBranchlessLineageContext(t *testing.T) {
 	assert.Equal(len(jobs), count)
 	gitCalls, err := os.ReadFile(countPath)
 	require.NoError(err)
-	assert.LessOrEqual(len(gitCalls), 5, "lineage context should be built once instead of spawning git per branchless job")
+	assert.LessOrEqual(strings.Count(string(gitCalls), "x"), 5, "lineage context should be built once instead of spawning git per branchless job")
 }
 
 func TestCountOpenFailedReviewsExcludesNonReviewJobTypes(t *testing.T) {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -558,6 +558,8 @@ func IsAncestor(repoPath, ancestor, descendant string) (bool, error) {
 // current lineage. The ref must be reachable from head. For non-default
 // branches, refs already reachable from the default branch are excluded so
 // branchless reviews from trunk history do not follow every feature branch.
+// If the default branch cannot be identified, concrete branchless refs fail
+// closed because there is no trunk boundary to compare against.
 func RefMatchesBranchLineage(repoPath, currentBranch, head, ref string) bool {
 	ref = strings.TrimSpace(ref)
 	if _, end, ok := ParseRange(ref); ok {
@@ -571,11 +573,14 @@ func RefMatchesBranchLineage(repoPath, currentBranch, head, ref string) bool {
 		return false
 	}
 	defaultBranch, err := GetDefaultBranch(repoPath)
-	if err != nil || IsOnBaseBranch(repoPath, currentBranch, defaultBranch) {
+	if err != nil {
+		return false
+	}
+	if IsOnBaseBranch(repoPath, currentBranch, defaultBranch) {
 		return true
 	}
 	onDefault, err := IsAncestor(repoPath, ref, defaultBranch)
-	return err != nil || !onDefault
+	return err == nil && !onDefault
 }
 
 // GetRepoRoot returns the root directory of the git repository

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -561,26 +561,70 @@ func IsAncestor(repoPath, ancestor, descendant string) (bool, error) {
 // If the default branch cannot be identified, concrete branchless refs fail
 // closed because there is no trunk boundary to compare against.
 func RefMatchesBranchLineage(repoPath, currentBranch, head, ref string) bool {
+	matcher, err := NewBranchLineageMatcher(repoPath, currentBranch, head)
+	return err == nil && matcher.Matches(ref)
+}
+
+// BranchLineageMatcher caches the current branch lineage as a commit set so a
+// batch of branchless concrete review refs can be checked without repeatedly
+// spawning git processes. For non-default branches, the set contains commits
+// reachable from head and not reachable from the repository default branch. For
+// the default branch itself, the set contains commits reachable from head.
+type BranchLineageMatcher struct {
+	commits map[string]struct{}
+}
+
+// NewBranchLineageMatcher builds a reusable matcher for currentBranch's current
+// lineage. Callers that need to test more than one ref should create one matcher
+// and reuse Matches instead of calling RefMatchesBranchLineage repeatedly.
+func NewBranchLineageMatcher(repoPath, currentBranch, head string) (*BranchLineageMatcher, error) {
+	return NewBranchLineageMatcherCtx(context.Background(), repoPath, currentBranch, head)
+}
+
+// NewBranchLineageMatcherCtx is NewBranchLineageMatcher with a cancellable
+// context.
+func NewBranchLineageMatcherCtx(ctx context.Context, repoPath, currentBranch, head string) (*BranchLineageMatcher, error) {
+	currentBranch = strings.TrimSpace(currentBranch)
+	head = strings.TrimSpace(head)
+	if repoPath == "" || currentBranch == "" || head == "" {
+		return nil, fmt.Errorf("repo path, current branch, and head are required")
+	}
+	defaultBranch, err := GetDefaultBranch(repoPath)
+	if err != nil {
+		return nil, err
+	}
+	args := []string{"rev-list", head}
+	if !IsOnBaseBranch(repoPath, currentBranch, defaultBranch) {
+		args = append(args, "--not", defaultBranch)
+	}
+	cmd := newGitCmdContext(ctx, args...)
+	cmd.Dir = repoPath
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git rev-list branch lineage: %w", err)
+	}
+	commits := make(map[string]struct{})
+	for commit := range strings.FieldsSeq(string(out)) {
+		commits[commit] = struct{}{}
+	}
+	return &BranchLineageMatcher{commits: commits}, nil
+}
+
+// Matches reports whether ref belongs to the cached branch lineage. Range refs
+// are matched by their end ref, preserving RefMatchesBranchLineage behavior.
+func (m *BranchLineageMatcher) Matches(ref string) bool {
+	if m == nil {
+		return false
+	}
 	ref = strings.TrimSpace(ref)
 	if _, end, ok := ParseRange(ref); ok {
 		ref = strings.TrimSpace(end)
 	}
-	if ref == "" || currentBranch == "" || head == "" {
+	if ref == "" {
 		return false
 	}
-	onCurrent, err := IsAncestor(repoPath, ref, head)
-	if err != nil || !onCurrent {
-		return false
-	}
-	defaultBranch, err := GetDefaultBranch(repoPath)
-	if err != nil {
-		return false
-	}
-	if IsOnBaseBranch(repoPath, currentBranch, defaultBranch) {
-		return true
-	}
-	onDefault, err := IsAncestor(repoPath, ref, defaultBranch)
-	return err == nil && !onDefault
+	_, ok := m.commits[ref]
+	return ok
 }
 
 // GetRepoRoot returns the root directory of the git repository

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -571,7 +571,9 @@ func RefMatchesBranchLineage(repoPath, currentBranch, head, ref string) bool {
 // reachable from head and not reachable from the repository default branch. For
 // the default branch itself, the set contains commits reachable from head.
 type BranchLineageMatcher struct {
-	commits map[string]struct{}
+	repoPath       string
+	commits        map[string]struct{}
+	resolvedCommit map[string]string
 }
 
 // NewBranchLineageMatcher builds a reusable matcher for currentBranch's current
@@ -607,7 +609,11 @@ func NewBranchLineageMatcherCtx(ctx context.Context, repoPath, currentBranch, he
 	for commit := range strings.FieldsSeq(string(out)) {
 		commits[commit] = struct{}{}
 	}
-	return &BranchLineageMatcher{commits: commits}, nil
+	return &BranchLineageMatcher{
+		repoPath:       repoPath,
+		commits:        commits,
+		resolvedCommit: make(map[string]string),
+	}, nil
 }
 
 // Matches reports whether ref belongs to the cached branch lineage. Range refs
@@ -623,8 +629,40 @@ func (m *BranchLineageMatcher) Matches(ref string) bool {
 	if ref == "" {
 		return false
 	}
-	_, ok := m.commits[ref]
+	if _, ok := m.commits[ref]; ok {
+		return true
+	}
+	if isFullObjectID(ref) {
+		return false
+	}
+	commit, ok := m.resolvedCommit[ref]
+	if !ok {
+		var err error
+		commit, err = ResolveSHA(m.repoPath, ref)
+		if err != nil {
+			m.resolvedCommit[ref] = ""
+			return false
+		}
+		m.resolvedCommit[ref] = commit
+	}
+	if commit == "" {
+		return false
+	}
+	_, ok = m.commits[commit]
 	return ok
+}
+
+func isFullObjectID(ref string) bool {
+	if len(ref) != 40 && len(ref) != 64 {
+		return false
+	}
+	for _, r := range ref {
+		if (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F') {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // GetRepoRoot returns the root directory of the git repository

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -554,6 +554,30 @@ func IsAncestor(repoPath, ancestor, descendant string) (bool, error) {
 	return false, fmt.Errorf("git merge-base --is-ancestor: %w", err)
 }
 
+// RefMatchesBranchLineage reports whether ref belongs to currentBranch's
+// current lineage. The ref must be reachable from head. For non-default
+// branches, refs already reachable from the default branch are excluded so
+// branchless reviews from trunk history do not follow every feature branch.
+func RefMatchesBranchLineage(repoPath, currentBranch, head, ref string) bool {
+	ref = strings.TrimSpace(ref)
+	if _, end, ok := ParseRange(ref); ok {
+		ref = strings.TrimSpace(end)
+	}
+	if ref == "" || currentBranch == "" || head == "" {
+		return false
+	}
+	onCurrent, err := IsAncestor(repoPath, ref, head)
+	if err != nil || !onCurrent {
+		return false
+	}
+	defaultBranch, err := GetDefaultBranch(repoPath)
+	if err != nil || IsOnBaseBranch(repoPath, currentBranch, defaultBranch) {
+		return true
+	}
+	onDefault, err := IsAncestor(repoPath, ref, defaultBranch)
+	return err != nil || !onDefault
+}
+
 // GetRepoRoot returns the root directory of the git repository
 func GetRepoRoot(path string) (string, error) {
 	cmd := newGitCmd("rev-parse", "--show-toplevel")

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1981,6 +1981,25 @@ func TestRefMatchesBranchLineage(t *testing.T) {
 		assert.True(t, RefMatchesBranchLineage(repo.Dir, "main", "main", trunkSHA))
 	})
 
+	t.Run("resolves symbolic and abbreviated refs before cached lookup", func(t *testing.T) {
+		repo := NewTestRepo(t)
+		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.CommitFile("trunk.txt", "trunk", "trunk commit")
+		repo.Run("checkout", "-b", "feature/lineage")
+		repo.CommitFile("feature-1.txt", "feature", "feature commit 1")
+		previousFeatureSHA := repo.HeadSHA()
+		repo.CommitFile("feature-2.txt", "feature", "feature commit 2")
+		featureSHA := repo.HeadSHA()
+
+		matcher, err := NewBranchLineageMatcher(repo.Dir, "feature/lineage", "HEAD")
+		require.NoError(t, err)
+		assert.True(t, matcher.Matches("HEAD"))
+		assert.True(t, matcher.Matches("HEAD~1"))
+		assert.True(t, matcher.Matches("feature/lineage"))
+		assert.True(t, matcher.Matches(featureSHA[:12]))
+		assert.True(t, matcher.Matches(previousFeatureSHA[:12]+"..HEAD"))
+	})
+
 	t.Run("missing default branch fails closed", func(t *testing.T) {
 		repo := NewTestRepo(t)
 		repo.Run("symbolic-ref", "HEAD", "refs/heads/trunk")

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1966,6 +1966,33 @@ func TestIsAncestor(t *testing.T) {
 	})
 }
 
+func TestRefMatchesBranchLineage(t *testing.T) {
+	t.Run("feature branch excludes trunk refs and includes feature refs", func(t *testing.T) {
+		repo := NewTestRepo(t)
+		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.CommitFile("trunk.txt", "trunk", "trunk commit")
+		trunkSHA := repo.HeadSHA()
+		repo.Run("checkout", "-b", "feature/lineage")
+		repo.CommitFile("feature.txt", "feature", "feature commit")
+		featureSHA := repo.HeadSHA()
+
+		assert.False(t, RefMatchesBranchLineage(repo.Dir, "feature/lineage", "HEAD", trunkSHA))
+		assert.True(t, RefMatchesBranchLineage(repo.Dir, "feature/lineage", "HEAD", featureSHA))
+		assert.True(t, RefMatchesBranchLineage(repo.Dir, "main", "main", trunkSHA))
+	})
+
+	t.Run("missing default branch fails closed", func(t *testing.T) {
+		repo := NewTestRepo(t)
+		repo.Run("symbolic-ref", "HEAD", "refs/heads/trunk")
+		repo.CommitFile("trunk.txt", "trunk", "trunk commit")
+		repo.Run("checkout", "-b", "feature/no-default")
+		repo.CommitFile("feature.txt", "feature", "feature commit")
+		featureSHA := repo.HeadSHA()
+
+		assert.False(t, RefMatchesBranchLineage(repo.Dir, "feature/no-default", "HEAD", featureSHA))
+	})
+}
+
 func TestGetPatchID(t *testing.T) {
 	t.Run("stable across rebase", func(t *testing.T) {
 		repo := NewTestRepo(t)


### PR DESCRIPTION
The stop hook can correctly decide that branchless failed review rows are actionable for the current checkout, especially when reviews were created before a branch label existed or while work was detached. After #856, `roborev fix --list` only shows failed actionable review jobs, but its branch filter still hid branchless rows that the hook was asking the agent to fix. That made the prompt look stale even when legitimate fixable review work existed.

This keeps explicit `--branch` filtering exact, while the default current-checkout path now includes branchless repo-scoped/dirty rows and concrete branchless refs that belong to the current branch lineage. Concrete refs already reachable from trunk are excluded on feature branches, so old base-branch reviews do not follow every descendant branch.

```mermaid
gitGraph LR:
  commit id: "trunk base"
  commit id: "trunk-only review excluded"
  branch feature
  checkout feature
  commit id: "A branchless review included"
  commit id: "B branchless review included"
  commit id: "C branchless review included"
  commit id: "D branch created here"
```

In the default `roborev fix` path, branchless reviews for A, B, C, and D are included because they are reachable from the current feature `HEAD` and are not already reachable from trunk. The trunk-only row is excluded on the feature branch. Passing `--branch` still requires the stored job branch to match exactly, and detached HEAD keeps using the detached-ref matching path.

Checked locally with `go test ./...` and `go vet ./...`.
