### PR TITLE
Add global review guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,13 @@ snapshot_dir = ".roborev"
 review_guidelines = """
 Project-specific review instructions here.
 """
+# Optional: use repo guidelines instead of appending global review_guidelines.
+review_guidelines_supersede_global = false
 ```
+
+You can also set `review_guidelines` in `~/.roborev/config.toml`. Global
+guidelines apply to every repo and are appended before repo guidelines by
+default.
 
 `snapshot_dir` must be repo-relative. `roborev init` ensures it is ignored in `.gitignore`; snapshot creation also adds a local `.git/info/exclude` fallback for existing checkouts whose ignore setup is stale.
 

--- a/cmd/roborev/compact.go
+++ b/cmd/roborev/compact.go
@@ -236,7 +236,7 @@ func enqueueConsolidation(ctx context.Context, cmd *cobra.Command, repoRoot stri
 	)
 	// Build verification prompt after agent resolution so compact can reuse
 	// the selected agent's regular review output contract.
-	compactPrompt := buildCompactPrompt(jobReviews, branchFilter, repoRoot, agentName)
+	compactPrompt := buildCompactPrompt(ctx, jobReviews, branchFilter, repoRoot, agentName)
 	// Resolve model locally for display; the daemon re-resolves with
 	// its own canonical-agent comparison to skip generic default_model
 	// when the agent was overridden on CLI.
@@ -462,7 +462,7 @@ func runCompact(cmd *cobra.Command, opts compactOptions) error {
 	return nil
 }
 
-func buildCompactPrompt(jobReviews []jobReview, branch, repoRoot, agentName string) string {
+func buildCompactPrompt(ctx context.Context, jobReviews []jobReview, branch, repoRoot, agentName string) string {
 	var sb strings.Builder
 
 	if reviewPrompt := strings.TrimSpace(prompt.GetSystemPrompt(agentName, "review")); reviewPrompt != "" {
@@ -475,9 +475,11 @@ func buildCompactPrompt(jobReviews []jobReview, branch, repoRoot, agentName stri
 
 	// Include project review guidelines so the compact agent
 	// respects the same rules as regular reviews.
-	if repoCfg, err := config.LoadRepoConfig(repoRoot); err == nil && repoCfg != nil && repoCfg.ReviewGuidelines != "" {
+	globalCfg, _ := config.LoadGlobal()
+	guidelines := prompt.LoadGuidelinesWithConfig(ctx, repoRoot, globalCfg)
+	if guidelines != "" {
 		sb.WriteString("## Project Guidelines\n\n")
-		sb.WriteString(strings.TrimSpace(repoCfg.ReviewGuidelines))
+		sb.WriteString(strings.TrimSpace(guidelines))
 		sb.WriteString("\n\n")
 	}
 

--- a/cmd/roborev/compact_test.go
+++ b/cmd/roborev/compact_test.go
@@ -311,7 +311,7 @@ func TestBuildCompactPrompt(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildCompactPrompt(tt.jobReviews, tt.branch, "", "codex")
+			got := buildCompactPrompt(t.Context(), tt.jobReviews, tt.branch, "", "codex")
 
 			for _, want := range tt.wantContains {
 				assert.Contains(t, got, want, "buildCompactPrompt() missing")

--- a/cmd/roborev/run.go
+++ b/cmd/roborev/run.go
@@ -18,6 +18,7 @@ import (
 
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/daemon"
+	"go.kenn.io/roborev/internal/prompt"
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -306,12 +307,13 @@ func buildPromptWithContext(repoPath, userPrompt string) string {
 	sb.WriteString("## Context\n\n")
 	fmt.Fprintf(&sb, "You are working in the repository \"%s\" at %s.\n", repoName, repoPath)
 
-	// Load project guidelines if available
-	repoCfg, err := config.LoadRepoConfig(repoPath)
-	if err == nil && repoCfg != nil && repoCfg.ReviewGuidelines != "" {
+	// Load project guidelines if available.
+	globalCfg, _ := config.LoadGlobal()
+	guidelines := prompt.LoadGuidelinesLocal(repoPath, globalCfg)
+	if guidelines != "" {
 		sb.WriteString("\n## Project Guidelines\n\n")
 		sb.WriteString("The following are project-specific guidelines for this repository:\n\n")
-		sb.WriteString(strings.TrimSpace(repoCfg.ReviewGuidelines))
+		sb.WriteString(strings.TrimSpace(guidelines))
 		sb.WriteString("\n")
 	}
 

--- a/cmd/roborev/run_test.go
+++ b/cmd/roborev/run_test.go
@@ -125,6 +125,21 @@ func TestBuildPromptWithContext(t *testing.T) {
 		assert.Contains(t, result, "Always use tabs for indentation")
 	})
 
+	t.Run("appends global and project guidelines", func(t *testing.T) {
+		dataDir := t.TempDir()
+		t.Setenv("ROBOREV_DATA_DIR", dataDir)
+		require.NoError(t, os.MkdirAll(dataDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dataDir, "config.toml"),
+			[]byte(`review_guidelines = "Global rule"`+"\n"), 0o644))
+		repoPath := createRepoWithConfig(t, `review_guidelines = "Project rule"`)
+
+		result := buildPromptWithContext(repoPath, "test prompt")
+
+		assert.Contains(t, result, "Global rule")
+		assert.Contains(t, result, "Project rule")
+		assert.Less(t, strings.Index(result, "Global rule"), strings.Index(result, "Project rule"))
+	})
+
 	t.Run("omits guidelines section when not configured", func(t *testing.T) {
 		repoPath := createRepoWithConfig(t, "")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -104,6 +104,7 @@ type Config struct {
 	MaxWorkers                 int    `toml:"max_workers"`
 	ReviewContextCount         int    `toml:"review_context_count"`
 	ReuseReviewSessionLookback int    `toml:"reuse_review_session_lookback"` // 0 means no candidate cap
+	ReviewGuidelines           string `toml:"review_guidelines" comment:"Extra review instructions added to prompts globally."`
 	DefaultAgent               string `toml:"default_agent" comment:"Default agent when no workflow-specific agent is set."`
 	DefaultModel               string `toml:"default_model"` // Default model for agents (format varies by agent)
 	DefaultBackupAgent         string `toml:"default_backup_agent"`
@@ -289,27 +290,28 @@ type ACPAgentConfig struct {
 
 // RepoConfig holds per-repo overrides
 type RepoConfig struct {
-	Agent                      string   `toml:"agent" comment:"Default agent for this repo when no workflow-specific agent is set."`
-	Model                      string   `toml:"model" comment:"Default model for this repo when no workflow-specific model is set."` // Model for agents (format varies by agent)
-	BackupAgent                string   `toml:"backup_agent" comment:"Backup agent for this repo if the primary agent fails."`
-	BackupModel                string   `toml:"backup_model" comment:"Backup model for this repo if the primary model fails."`
-	ReviewContextCount         int      `toml:"review_context_count" comment:"Number of related reviews to include as context for this repo."`
-	ReviewGuidelines           string   `toml:"review_guidelines" comment:"Extra review instructions added to prompts for this repo."`
-	JobTimeoutMinutes          int      `toml:"job_timeout_minutes" comment:"Override the review job timeout in minutes for this repo."`
-	ExcludedBranches           []string `toml:"excluded_branches" comment:"Branches that should be skipped for automatic review in this repo."`
-	ExcludedCommitPatterns     []string `toml:"excluded_commit_patterns" comment:"Commit message substrings that should skip review for this repo."`
-	DisplayName                string   `toml:"display_name" comment:"Display name shown for this repo in the TUI and output."`
-	ReviewReasoning            string   `toml:"review_reasoning" comment:"Reasoning level for reviews in this repo: fast, standard, medium, thorough, or maximum."`
-	RefineReasoning            string   `toml:"refine_reasoning" comment:"Reasoning level for refine in this repo: fast, standard, medium, thorough, or maximum."`
-	FixReasoning               string   `toml:"fix_reasoning" comment:"Reasoning level for fix in this repo: fast, standard, medium, thorough, or maximum."`
-	FixMinSeverity             string   `toml:"fix_min_severity" comment:"Minimum severity for fix in this repo: critical, high, medium, or low."`     // Minimum severity for fix: critical, high, medium, low
-	RefineMinSeverity          string   `toml:"refine_min_severity" comment:"Minimum severity for refine in this repo: critical, high, medium, low."`  // Minimum severity for refine: critical, high, medium, low
-	ReviewMinSeverity          string   `toml:"review_min_severity" comment:"Minimum severity for reviews in this repo: critical, high, medium, low."` // Minimum severity for review: critical, high, medium, low
-	ExcludePatterns            []string `toml:"exclude_patterns" comment:"Filenames or glob patterns to exclude from review diffs for this repo."`
-	SnapshotDir                string   `toml:"snapshot_dir" comment:"Repo-local directory for temporary oversized diff snapshots."`
-	PostCommitReview           string   `toml:"post_commit_review" comment:"Automatic post-commit review mode for this repo: commit or branch."` // "commit" (default) or "branch"
-	ReuseReviewSession         *bool    `toml:"reuse_review_session"`
-	ReuseReviewSessionLookback int      `toml:"reuse_review_session_lookback"` // 0 means no candidate cap
+	Agent                           string   `toml:"agent" comment:"Default agent for this repo when no workflow-specific agent is set."`
+	Model                           string   `toml:"model" comment:"Default model for this repo when no workflow-specific model is set."` // Model for agents (format varies by agent)
+	BackupAgent                     string   `toml:"backup_agent" comment:"Backup agent for this repo if the primary agent fails."`
+	BackupModel                     string   `toml:"backup_model" comment:"Backup model for this repo if the primary model fails."`
+	ReviewContextCount              int      `toml:"review_context_count" comment:"Number of related reviews to include as context for this repo."`
+	ReviewGuidelines                string   `toml:"review_guidelines" comment:"Extra review instructions added to prompts for this repo."`
+	ReviewGuidelinesSupersedeGlobal bool     `toml:"review_guidelines_supersede_global" comment:"Use repo review_guidelines instead of appending global review_guidelines."`
+	JobTimeoutMinutes               int      `toml:"job_timeout_minutes" comment:"Override the review job timeout in minutes for this repo."`
+	ExcludedBranches                []string `toml:"excluded_branches" comment:"Branches that should be skipped for automatic review in this repo."`
+	ExcludedCommitPatterns          []string `toml:"excluded_commit_patterns" comment:"Commit message substrings that should skip review for this repo."`
+	DisplayName                     string   `toml:"display_name" comment:"Display name shown for this repo in the TUI and output."`
+	ReviewReasoning                 string   `toml:"review_reasoning" comment:"Reasoning level for reviews in this repo: fast, standard, medium, thorough, or maximum."`
+	RefineReasoning                 string   `toml:"refine_reasoning" comment:"Reasoning level for refine in this repo: fast, standard, medium, thorough, or maximum."`
+	FixReasoning                    string   `toml:"fix_reasoning" comment:"Reasoning level for fix in this repo: fast, standard, medium, thorough, or maximum."`
+	FixMinSeverity                  string   `toml:"fix_min_severity" comment:"Minimum severity for fix in this repo: critical, high, medium, or low."`     // Minimum severity for fix: critical, high, medium, low
+	RefineMinSeverity               string   `toml:"refine_min_severity" comment:"Minimum severity for refine in this repo: critical, high, medium, low."`  // Minimum severity for refine: critical, high, medium, low
+	ReviewMinSeverity               string   `toml:"review_min_severity" comment:"Minimum severity for reviews in this repo: critical, high, medium, low."` // Minimum severity for review: critical, high, medium, low
+	ExcludePatterns                 []string `toml:"exclude_patterns" comment:"Filenames or glob patterns to exclude from review diffs for this repo."`
+	SnapshotDir                     string   `toml:"snapshot_dir" comment:"Repo-local directory for temporary oversized diff snapshots."`
+	PostCommitReview                string   `toml:"post_commit_review" comment:"Automatic post-commit review mode for this repo: commit or branch."` // "commit" (default) or "branch"
+	ReuseReviewSession              *bool    `toml:"reuse_review_session"`
+	ReuseReviewSessionLookback      int      `toml:"reuse_review_session_lookback"` // 0 means no candidate cap
 
 	// CI-specific overrides (used by CI poller for this repo)
 	CI RepoCIConfig `toml:"ci"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -269,6 +269,17 @@ func TestLoadGlobalMouseEnabledFromTOML(t *testing.T) {
 	}, "MouseEnabled should be false when loaded from TOML")
 }
 
+func TestLoadGlobalConfigWithReviewGuidelines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	err := os.WriteFile(path, []byte(`review_guidelines = "Prefer small, focused changes."`+"\n"), 0o644)
+	require.NoError(t, err)
+
+	cfg, err := LoadGlobalFrom(path)
+	require.NoError(t, err)
+	assert.Equal(t, "Prefer small, focused changes.", cfg.ReviewGuidelines)
+}
+
 func TestLoadRepoConfigWithGuidelines(t *testing.T) {
 	tmpDir := newTempRepo(t, `
 agent = "claude-code"
@@ -295,6 +306,19 @@ All public APIs must have documentation comments.
 	assert.Condition(t, func() bool {
 		return strings.Contains(cfg.ReviewGuidelines, "composition over inheritance")
 	}, "Expected guidelines to contain 'composition over inheritance'")
+}
+
+func TestLoadRepoConfigWithGuidelinesSupersedeGlobal(t *testing.T) {
+	tmpDir := newTempRepo(t, `
+review_guidelines = "Repo-only rule."
+review_guidelines_supersede_global = true
+`)
+
+	cfg, err := LoadRepoConfig(tmpDir)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "Repo-only rule.", cfg.ReviewGuidelines)
+	assert.Equal(t, true, cfg.ReviewGuidelinesSupersedeGlobal)
 }
 
 func TestLoadRepoConfigNoGuidelines(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -318,7 +318,7 @@ review_guidelines_supersede_global = true
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	assert.Equal(t, "Repo-only rule.", cfg.ReviewGuidelines)
-	assert.Equal(t, true, cfg.ReviewGuidelinesSupersedeGlobal)
+	assert.True(t, cfg.ReviewGuidelinesSupersedeGlobal)
 }
 
 func TestLoadRepoConfigNoGuidelines(t *testing.T) {

--- a/internal/config/keyval_test.go
+++ b/internal/config/keyval_test.go
@@ -595,7 +595,7 @@ func TestIsGlobalKey(t *testing.T) {
 		{"hooks", true},
 		{"agent", false},
 		{"sync", false},
-		{"review_guidelines", false},
+		{"review_guidelines", true},
 		{"nonexistent", false},
 	}
 
@@ -606,6 +606,13 @@ func TestIsGlobalKey(t *testing.T) {
 			assert.Equal(tt.want, got)
 		})
 	}
+}
+
+func TestReviewGuidelinesValidInGlobalAndRepoConfig(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(SetConfigValue(&Config{}, "review_guidelines", "Global rule"))
+	assert.NoError(SetConfigValue(&RepoConfig{}, "review_guidelines", "Repo rule"))
+	assert.NoError(SetConfigValue(&RepoConfig{}, "review_guidelines_supersede_global", "true"))
 }
 
 func TestListExplicitKeys(t *testing.T) {

--- a/internal/daemon/insights.go
+++ b/internal/daemon/insights.go
@@ -28,7 +28,7 @@ func (s *Server) buildInsightsPrompt(
 
 	cfg := s.configWatcher.Config()
 	maxPromptSize := config.ResolveMaxPromptSize(repoRoot, cfg)
-	guidelines := prompt.LoadGuidelines(ctx, repoRoot)
+	guidelines := prompt.LoadGuidelinesWithConfig(ctx, repoRoot, cfg)
 
 	promptText := prompt.BuildInsightsPrompt(prompt.InsightsData{
 		Reviews:       reviews,

--- a/internal/daemon/insights_test.go
+++ b/internal/daemon/insights_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -71,6 +72,50 @@ func TestHandleEnqueueInsightsBuildsPromptServerSide(t *testing.T) {
 	assert.NotContains(t, stored.Prompt, "Compact finding")
 	assert.NotContains(t, stored.Prompt, "Feature finding")
 	assert.NotContains(t, stored.Prompt, "Old finding")
+}
+
+func TestHandleEnqueueInsightsIncludesGlobalAndRepoGuidelines(t *testing.T) {
+	server, db, _ := newTestServer(t)
+	server.configWatcher.Config().ReviewGuidelines = "Global rule."
+
+	repo := testutil.InitTestRepo(t)
+	repoDir := repo.Path()
+	repo.CommitFile(".roborev.toml", "review_guidelines = \"Repo rule.\"\n", "add repo guidelines")
+
+	mainRoot, err := gitpkg.GetMainRepoRoot(repoDir)
+	require.NoError(t, err)
+
+	storedRepo, err := db.GetOrCreateRepo(mainRoot)
+	require.NoError(t, err)
+
+	enqueueCompletedInsightsReviewJob(
+		t, db, storedRepo.ID, "aaa111", "main",
+		storage.JobTypeReview, failingInsightsOutput("Included finding"),
+	)
+
+	since := time.Now().Add(-24 * time.Hour)
+	req := testutil.MakeJSONRequest(t, http.MethodPost, "/api/enqueue", EnqueueRequest{
+		RepoPath: repoDir,
+		GitRef:   "insights",
+		Agent:    "test",
+		JobType:  storage.JobTypeInsights,
+		Since:    since.Format(time.RFC3339),
+	})
+	w := httptest.NewRecorder()
+
+	server.httpServer.Handler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+
+	var job storage.ReviewJob
+	testutil.DecodeJSON(t, w, &job)
+
+	stored, err := db.GetJobByID(job.ID)
+	require.NoError(t, err)
+
+	require.Contains(t, stored.Prompt, "Global rule.")
+	require.Contains(t, stored.Prompt, "Repo rule.")
+	assert.Less(t, strings.Index(stored.Prompt, "Global rule."), strings.Index(stored.Prompt, "Repo rule."))
 }
 
 func TestHandleEnqueueInsightsSkipsWhenNoFailingReviewsMatch(t *testing.T) {

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -544,10 +544,9 @@ func (b *Builder) BuildDirtyWithFiles(diff string, changedFiles []string, contex
 	ctx := b.newPromptBuildContext(agentName, reviewType, minSeverity, "dirty", optionalSectionsView{})
 	ctx.optional.DependencyMetadata = buildDependencyMetadataSection(changedFiles)
 
-	// Add project-specific guidelines if configured
-	if repoCfg, err := config.LoadRepoConfig(b.repoPath); err == nil && repoCfg != nil {
-		ctx.optional.ProjectGuidelines = buildProjectGuidelinesSectionView(repoCfg.ReviewGuidelines)
-	}
+	ctx.optional.ProjectGuidelines = buildProjectGuidelinesSectionView(
+		LoadGuidelinesLocal(b.repoPath, b.globalCfg),
+	)
 
 	// Uncommitted changes have no commit messages, so "current" mode has no
 	// refs to resolve; "open" mode still lists open katas.
@@ -781,9 +780,9 @@ func (b *Builder) newPromptBuildContext(agentName, reviewType, minSeverity, defa
 	}
 }
 
-func defaultOptionalSections(ctx context.Context, repoPath, additionalContext string) optionalSectionsView {
+func defaultOptionalSections(ctx context.Context, repoPath string, globalCfg *config.Config, additionalContext string) optionalSectionsView {
 	return optionalSectionsView{
-		ProjectGuidelines: buildProjectGuidelinesSectionView(LoadGuidelines(ctx, repoPath)),
+		ProjectGuidelines: buildProjectGuidelinesSectionView(LoadGuidelinesWithConfig(ctx, repoPath, globalCfg)),
 		AdditionalContext: buildAdditionalContextSection(additionalContext),
 	}
 }
@@ -1092,7 +1091,7 @@ func selectRichestRangePromptView(limit int, view TemplateContext, variants []di
 
 // buildSinglePrompt constructs a prompt for a single commit
 func (b *Builder) buildSinglePrompt(sha string, contextCount int, agentName, reviewType string, opts buildOpts) (string, error) {
-	ctx := b.newPromptBuildContext(agentName, reviewType, opts.minSeverity, "review", defaultOptionalSections(b.context(), b.repoPath, opts.additionalContext))
+	ctx := b.newPromptBuildContext(agentName, reviewType, opts.minSeverity, "review", defaultOptionalSections(b.context(), b.repoPath, b.globalCfg, opts.additionalContext))
 
 	// Get previous reviews if requested
 	if contextCount > 0 && b.db != nil {
@@ -1216,7 +1215,7 @@ func (b *Builder) buildSinglePrompt(sha string, contextCount int, agentName, rev
 
 // buildRangePrompt constructs a prompt for a commit range
 func (b *Builder) buildRangePrompt(rangeRef string, contextCount int, agentName, reviewType string, opts buildOpts) (string, error) {
-	ctx := b.newPromptBuildContext(agentName, reviewType, opts.minSeverity, "range", defaultOptionalSections(b.context(), b.repoPath, opts.additionalContext))
+	ctx := b.newPromptBuildContext(agentName, reviewType, opts.minSeverity, "range", defaultOptionalSections(b.context(), b.repoPath, b.globalCfg, opts.additionalContext))
 
 	// Get previous reviews from before the range start
 	if contextCount > 0 && b.db != nil {
@@ -1452,10 +1451,65 @@ func orderedPreviousReviewViews(contexts []HistoricalReviewContext) []previousRe
 	return previousReviewViews(ordered)
 }
 
-// LoadGuidelines loads review guidelines from the repo's default
+type loadedGuidelines struct {
+	text            string
+	supersedeGlobal bool
+}
+
+// LoadGuidelines loads repo review guidelines from the repo's default
 // branch, falling back to filesystem config when the default branch
 // has no .roborev.toml.
 func LoadGuidelines(ctx context.Context, repoPath string) string {
+	return loadRepoGuidelines(ctx, repoPath).text
+}
+
+// LoadGuidelinesWithConfig merges global review guidelines with repo
+// guidelines. Repo guidelines append to global guidelines by default;
+// review_guidelines_supersede_global in repo config disables the global
+// guidelines for that repo.
+func LoadGuidelinesWithConfig(ctx context.Context, repoPath string, globalCfg *config.Config) string {
+	repo := loadRepoGuidelines(ctx, repoPath)
+	return mergeGuidelines(globalGuidelines(globalCfg), repo.text, repo.supersedeGlobal)
+}
+
+// LoadGuidelinesLocal is like LoadGuidelinesWithConfig, but reads repo
+// guidelines from the working tree. Use it for dirty/local agent prompts
+// where the user's current local config is expected to apply.
+func LoadGuidelinesLocal(repoPath string, globalCfg *config.Config) string {
+	var repo loadedGuidelines
+	if fsCfg, err := config.LoadRepoConfig(repoPath); err == nil && fsCfg != nil {
+		repo = loadedGuidelines{
+			text:            fsCfg.ReviewGuidelines,
+			supersedeGlobal: fsCfg.ReviewGuidelinesSupersedeGlobal,
+		}
+	}
+	return mergeGuidelines(globalGuidelines(globalCfg), repo.text, repo.supersedeGlobal)
+}
+
+func globalGuidelines(globalCfg *config.Config) string {
+	if globalCfg == nil {
+		return ""
+	}
+	return globalCfg.ReviewGuidelines
+}
+
+func mergeGuidelines(global, repo string, repoSupersedesGlobal bool) string {
+	global = strings.TrimSpace(global)
+	repo = strings.TrimSpace(repo)
+	if repoSupersedesGlobal {
+		return repo
+	}
+	switch {
+	case global == "":
+		return repo
+	case repo == "":
+		return global
+	default:
+		return global + "\n\n" + repo
+	}
+}
+
+func loadRepoGuidelines(ctx context.Context, repoPath string) loadedGuidelines {
 	// Load review guidelines from the default branch (origin/main,
 	// origin/master, etc.). Branch-specific guidelines are intentionally
 	// ignored to prevent prompt injection from untrusted PR authors.
@@ -1465,21 +1519,27 @@ func LoadGuidelines(ctx context.Context, repoPath string) string {
 			if config.IsConfigParseError(err) {
 				log.Printf("prompt: invalid .roborev.toml on %s: %v",
 					defaultBranch, err)
-				return ""
+				return loadedGuidelines{}
 			}
 			log.Printf("prompt: failed to read .roborev.toml from %s: %v"+
 				" (will try filesystem)", defaultBranch, err)
 		} else if cfg != nil {
-			return cfg.ReviewGuidelines
+			return loadedGuidelines{
+				text:            cfg.ReviewGuidelines,
+				supersedeGlobal: cfg.ReviewGuidelinesSupersedeGlobal,
+			}
 		}
 	}
 
 	// Fall back to filesystem config when default branch has no config
 	// (e.g., no remote, or .roborev.toml not yet committed).
 	if fsCfg, err := config.LoadRepoConfig(repoPath); err == nil && fsCfg != nil {
-		return fsCfg.ReviewGuidelines
+		return loadedGuidelines{
+			text:            fsCfg.ReviewGuidelines,
+			supersedeGlobal: fsCfg.ReviewGuidelinesSupersedeGlobal,
+		}
 	}
-	return ""
+	return loadedGuidelines{}
 }
 
 func (b *Builder) previousAttemptContexts(gitRef string) []reviewAttemptContext {
@@ -1619,9 +1679,9 @@ func (b *Builder) BuildAddressPrompt(review *storage.Review, previousAttempts []
 		JobID:          review.JobID,
 	}
 
-	if repoCfg, err := config.LoadRepoConfig(b.repoPath); err == nil && repoCfg != nil {
-		view.ProjectGuidelines = buildProjectGuidelinesSectionView(repoCfg.ReviewGuidelines)
-	}
+	view.ProjectGuidelines = buildProjectGuidelinesSectionView(
+		LoadGuidelinesLocal(b.repoPath, b.globalCfg),
+	)
 
 	if len(previousAttempts) > 0 {
 		toolAttempts, userComments := SplitResponses(previousAttempts)

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -1810,6 +1810,54 @@ func TestBuildRangePrompt_WithGuidelines(t *testing.T) {
 	assertNotContains(t, section, "Branch-only rule.", "branch guidelines should not appear in guidelines section")
 }
 
+func TestBuildSinglePrompt_WithGlobalGuidelines(t *testing.T) {
+	ctx := setupGuidelinesRepo(t, "main", "", "", nil)
+	cfg := &config.Config{ReviewGuidelines: "Global rule."}
+
+	b := NewBuilderWithConfig(nil, cfg)
+	prompt, err := b.ForRepo(ctx.Dir, 0).Build(ctx.BaseSHA, 0, "test", "review", "")
+	require.NoError(t, err, "Build: %v", err)
+
+	section := extractGuidelinesSection(prompt)
+	assertContains(t, section, "Global rule.", "expected global guidelines in prompt")
+}
+
+func TestBuildSinglePrompt_AppendsGlobalAndRepoGuidelines(t *testing.T) {
+	ctx := setupGuidelinesRepo(t, "main", "Repo rule.", "", nil)
+	cfg := &config.Config{ReviewGuidelines: "Global rule."}
+
+	b := NewBuilderWithConfig(nil, cfg)
+	prompt, err := b.ForRepo(ctx.Dir, 0).Build(ctx.BaseSHA, 0, "test", "review", "")
+	require.NoError(t, err, "Build: %v", err)
+
+	section := extractGuidelinesSection(prompt)
+	assertContains(t, section, "Global rule.", "expected global guidelines in prompt")
+	assertContains(t, section, "Repo rule.", "expected repo guidelines in prompt")
+	assert.Less(t, strings.Index(section, "Global rule."), strings.Index(section, "Repo rule."))
+}
+
+func TestBuildSinglePrompt_RepoGuidelinesSupersedeGlobalWhenConfigured(t *testing.T) {
+	ctx := setupGuidelinesRepo(t, "main", "", "", func(t *testing.T, r *testRepo) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(filepath.Join(r.dir, ".roborev.toml"),
+			[]byte("review_guidelines = \"Repo rule.\"\nreview_guidelines_supersede_global = true\n"), 0o644))
+		r.git("add", "-A")
+		r.git("commit", "-m", "add guidelines")
+		r.git("remote", "add", "origin", r.dir)
+		r.git("fetch", "origin")
+		r.git("symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+	})
+	cfg := &config.Config{ReviewGuidelines: "Global rule."}
+
+	b := NewBuilderWithConfig(nil, cfg)
+	prompt, err := b.ForRepo(ctx.Dir, 0).Build(ctx.BaseSHA, 0, "test", "review", "")
+	require.NoError(t, err, "Build: %v", err)
+
+	section := extractGuidelinesSection(prompt)
+	assertContains(t, section, "Repo rule.", "expected repo guidelines in prompt")
+	assertNotContains(t, section, "Global rule.", "global guidelines should be superseded")
+}
+
 // setupExcludePatternRepo creates a repo with a "custom.dat" file
 // (to be excluded) and a "keep.go" file (to be retained). Returns
 // the repo directory and the commit SHA containing both files.


### PR DESCRIPTION
Users who review many repositories need personal review guidance without committing `.roborev.toml` into every codebase they touch. This adds global `review_guidelines` support in `~/.roborev/config.toml` and keeps repo-level guidelines available for project-specific rules.

By default, global guidelines are appended before repo guidelines so personal standards and project standards both reach review prompts. Repos can set `review_guidelines_supersede_global = true` when their local rules should replace personal guidance instead. Committed and range reviews continue to read repo guidance from the trusted default branch, while dirty/local flows read the working-tree config.

Addresses #859. Validated locally with `go test ./...` and `go vet ./...`.