### PR TITLE
Clarify agent hook continuation prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,6 @@ CLI (roborev) -> HTTP API -> Daemon -> Worker Pool -> Agent adapters
 
 Use `testify` (`github.com/stretchr/testify`) for all test assertions. Use `require.*` for fatal preconditions and `assert.*` for non-fatal checks. Do not use raw `if`/`t.Errorf`/`t.Fatalf` patterns.
 
-- After any Go code changes, run `go fmt ./...` and `go vet ./...` before committing.
 - Fast test pass: `go test ./...`
 - Integration tests: `go test -tags=integration ./...`
 - PostgreSQL tests: `go test -tags=postgres -v ./internal/storage/... -run Integration`

--- a/docs/agent-hook.md
+++ b/docs/agent-hook.md
@@ -88,6 +88,11 @@ it. Commit baselines are tracked by branch and by worktree, so detached
 worktrees keep their own commit sequence and attaching a branch later does not
 drop the detached history.
 
+When a `PostToolUse` prompt fires, roborev appends context telling the agent to
+fix any Roborev issues it finds and then continue the task that the hook
+interrupted. `Stop` prompts do not include that continuation framing because
+they fire when the agent has already reached the end of its turn.
+
 Command flags override environment variables, which override TOML config:
 
 ```text

--- a/internal/agenthook/output.go
+++ b/internal/agenthook/output.go
@@ -1,5 +1,10 @@
 package agenthook
 
+import "strings"
+
+const postToolUseContinuationInstruction = "If Roborev issues are found, fix them, " +
+	"then continue the task you were doing before this hook interrupted you."
+
 func BuildOutput(input Input, resp Response) map[string]any {
 	if !resp.Triggered {
 		return map[string]any{}
@@ -8,7 +13,7 @@ func BuildOutput(input Input, resp Response) map[string]any {
 		return map[string]any{
 			"hookSpecificOutput": map[string]any{
 				"hookEventName":     "PostToolUse",
-				"additionalContext": resp.Reason,
+				"additionalContext": postToolUseAdditionalContext(resp.Reason),
 			},
 		}
 	}
@@ -16,4 +21,12 @@ func BuildOutput(input Input, resp Response) map[string]any {
 		"decision": "block",
 		"reason":   resp.Reason,
 	}
+}
+
+func postToolUseAdditionalContext(reason string) string {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return postToolUseContinuationInstruction
+	}
+	return reason + " " + postToolUseContinuationInstruction
 }

--- a/internal/agenthook/output_test.go
+++ b/internal/agenthook/output_test.go
@@ -15,6 +15,7 @@ func TestBuildOutputForStopBlocks(t *testing.T) {
 
 	assert.Equal(t, "block", output["decision"])
 	assert.Equal(t, "Invoke $roborev-fix.", output["reason"])
+	assert.NotContains(t, output["reason"], "continue the task")
 }
 
 func TestBuildOutputForPostToolUseAddsContext(t *testing.T) {
@@ -27,7 +28,12 @@ func TestBuildOutputForPostToolUseAddsContext(t *testing.T) {
 	specific, ok := output["hookSpecificOutput"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "PostToolUse", specific["hookEventName"])
-	assert.Equal(t, "Invoke $roborev-fix.", specific["additionalContext"])
+	assert.Equal(
+		t,
+		"Invoke $roborev-fix. If Roborev issues are found, fix them, "+
+			"then continue the task you were doing before this hook interrupted you.",
+		specific["additionalContext"],
+	)
 }
 
 func TestBuildOutputWhenNotTriggeredIsEmpty(t *testing.T) {

--- a/internal/agenthook/state_test.go
+++ b/internal/agenthook/state_test.go
@@ -260,7 +260,7 @@ func TestCountOpenFailedReviewsExcludesNonReviewJobTypes(t *testing.T) {
 func TestBuildHookReasonsAreCompactOneLine(t *testing.T) {
 	assert := assert.New(t)
 	req := Request{
-		Instruction: "Invoke the $roborev-fix skill now.",
+		Instruction: DefaultInstruction,
 		Event: Input{
 			SessionID: "019e94d7-4320-73a3-8833-e697eb1ea5cb",
 			CWD:       "/Users/wesm/.superset/worktrees/roborev/agent-hook-integration",
@@ -280,12 +280,14 @@ func TestBuildHookReasonsAreCompactOneLine(t *testing.T) {
 	assert.NotContains(failed, "\n")
 	assert.NotContains(failed, req.Event.SessionID)
 	assert.NotContains(failed, "/Users/wesm")
+	assert.NotContains(failed, "continue the task")
 
 	stop := buildStopReason(req, st)
 	assert.Equal("Invoke the $roborev-fix skill now. 4 Stop hooks reached.", stop)
 	assert.NotContains(stop, "\n")
 	assert.NotContains(stop, req.Event.SessionID)
 	assert.NotContains(stop, "/Users/wesm")
+	assert.NotContains(stop, "continue the task")
 
 	commit := buildCommitReason(req, st.CommitCount, st.LastCommitRepo)
 	assert.Equal(`Invoke the $roborev-fix skill now. 2 commits reached in "agent-hook-integration".`, commit)


### PR DESCRIPTION
PostToolUse agent hooks can fire while the agent is still in the middle of another task. Without explicit continuation framing, the hook can steer the session into fixing Roborev feedback and leave the original task abandoned. This PR appends PostToolUse-only context telling the agent to fix any Roborev issues it finds and then continue the interrupted work.

Stop hooks have different semantics: they fire after the agent has reached the end of its turn and already believes it is done. Adding the same continuation language there would be misleading, so the default Stop/blocking reason remains the plain Roborev-fix instruction. The tests now assert that Stop output does not include resume wording while PostToolUse additional context does.

The AGENTS.md cleanup removes redundant manual fmt/vet guidance now that the commit hook routes through prek and golangci-lint for vet and formatting enforcement.

<sup>generated by a clanker</sup>