### PR TITLE
Keep CI retries on configured agents during cooldowns

### DIFF
--- a/internal/agent/limit.go
+++ b/internal/agent/limit.go
@@ -13,12 +13,6 @@ const (
 	LimitKindTransient                  // 429-style; retry locally, no cooldown
 	LimitKindQuota                      // hard quota exhaustion (Gemini/Codex today)
 	// LimitKindSession is a session-level cap (e.g. Claude 5-hour).
-	// Plumbing is in place — daemon cooldown/abort and CLI strict abort
-	// both handle it — but defaultLimitRules does not yet produce it for
-	// any real agent. ClassifyLimit can return LimitKindSession only via
-	// an injected classifier (tests). Production support is pending a
-	// captured Claude session-cap message; see the TODO at
-	// defaultLimitRules.
 	LimitKindSession
 )
 
@@ -55,16 +49,6 @@ type limitRule struct {
 // config-validation errors. A transient classification only triggers a
 // local retry with backoff (no cooldown), so the bar is deliberately
 // kept high to avoid retrying deterministic failures forever.
-//
-// TODO: add a LimitKindSession rule for Claude's 5-hour cap once the
-// exact error wording is captured from a real session-cap failure.
-// Speculative substrings ("usage limit", "limit reached", etc.) are
-// not added on purpose — they would also match policy errors,
-// transient 429s, and config-validation messages, and a false positive
-// would abort roborev fix and cool down the agent when retrying might
-// have worked. Until that pattern lands, ClassifyLimit returns
-// LimitKindSession only when an injected classifier produces it
-// (i.e., in tests).
 var defaultLimitRules = []limitRule{
 	{Agents: []string{"*"}, Substring: "resource exhausted", Kind: LimitKindQuota},
 	{Agents: []string{"*"}, Substring: "quota exceeded", Kind: LimitKindQuota},
@@ -79,6 +63,8 @@ var defaultLimitRules = []limitRule{
 	// specific intent wins under first-match-wins (classifyLimitWithRules).
 	// Codex ChatGPT-account usage cap — a quota skip, not a hard failure.
 	{Agents: []string{"codex"}, Substring: "you've hit your usage limit", Kind: LimitKindQuota},
+	// Claude Code five-hour session cap, captured from real daemon logs.
+	{Agents: []string{"claude-code"}, Substring: "you've hit your session limit", Kind: LimitKindSession},
 	// Transient/outage — observed provider wording only (no speculative
 	// substrings; see the no-speculative note above). Retried with backoff.
 	{Agents: []string{"*"}, Substring: "too many requests", Kind: LimitKindTransient},

--- a/internal/agent/limit_parse.go
+++ b/internal/agent/limit_parse.go
@@ -47,7 +47,7 @@ func ParseResetDuration(errMsg string) time.Duration {
 }
 
 // ParseResetTime extracts an absolute reset time from messages like
-// "resets at 5:42 PM" or "try again at 17:42". Interprets the parsed
+// "resets at 5:42 PM", "resets 5:42pm", or "try again at 17:42". Interprets the parsed
 // clock time in the local timezone. Returns the zero time.Time if no
 // recognized phrase is present or the time is unparseable.
 //
@@ -68,6 +68,8 @@ func parseResetTimeAt(errMsg string, now time.Time) time.Time {
 	switch {
 	case strings.Contains(lower, "resets at "):
 		idx = strings.Index(lower, "resets at ") + len("resets at ")
+	case strings.Contains(lower, "resets "):
+		idx = strings.Index(lower, "resets ") + len("resets ")
 	case strings.Contains(lower, "try again at "):
 		idx = strings.Index(lower, "try again at ") + len("try again at ")
 	default:
@@ -80,7 +82,7 @@ func parseResetTimeAt(errMsg string, now time.Time) time.Time {
 	end := len(rest)
 	for i, r := range rest {
 		// Stop at sentence-ending punctuation or newline.
-		if r == '.' || r == ',' || r == ';' || r == '\n' || r == ')' {
+		if r == '.' || r == ',' || r == ';' || r == '\n' || r == '(' || r == ')' {
 			end = i
 			break
 		}

--- a/internal/agent/limit_parse_test.go
+++ b/internal/agent/limit_parse_test.go
@@ -52,6 +52,11 @@ func TestParseResetTime(t *testing.T) {
 			want: time.Date(2026, 5, 5, 17, 42, 0, 0, loc),
 		},
 		{
+			name: "resets without at and utc suffix",
+			msg:  "You've hit your session limit · resets 5:50am (UTC)",
+			want: time.Date(2026, 5, 6, 5, 50, 0, 0, loc),
+		},
+		{
 			name: "resets at earlier today rolls to next day",
 			msg:  "limit resets at 9:00 AM",
 			want: time.Date(2026, 5, 6, 9, 0, 0, 0, loc),

--- a/internal/agent/limit_test.go
+++ b/internal/agent/limit_test.go
@@ -99,6 +99,12 @@ func TestClassifyLimitTransientAndUsage(t *testing.T) {
 			LimitKindQuota,
 		},
 		{
+			"claude session limit -> session", "claude-code",
+			`agent: claude-code failed
+stream: stream errors: You've hit your session limit · resets 5:50am (UTC): exit status 1`,
+			LimitKindSession,
+		},
+		{
 			// Usage-cap text wrapped in a 429/Too Many Requests envelope must
 			// still classify as quota: the codex usage-limit rule precedes the
 			// generic transient rules, so first-match-wins keeps it quota. This

--- a/internal/daemon/panel_outcome.go
+++ b/internal/daemon/panel_outcome.go
@@ -17,8 +17,9 @@ const (
 	// member produced real review output.
 	OutcomePost OutcomeKind = iota
 	// OutcomeDeferTransient defers the run for a later retry: no member
-	// succeeded and at least one failed on a transient provider outage. The
-	// finalize path posts nothing unless the transient retry wall is exhausted.
+	// succeeded and at least one failed on a provider outage or agent
+	// availability limit. The finalize path posts nothing unless the transient
+	// retry wall is exhausted.
 	OutcomeDeferTransient
 	// OutcomeDeferGenuine defers the run for a later retry: no member succeeded,
 	// none failed transiently, and at least one failed genuinely, but the
@@ -27,8 +28,8 @@ const (
 	// OutcomeGenuineGiveUp posts a genuine-failure soft note with a blocking
 	// commit status: a genuine failure recurred up to the give-up cap.
 	OutcomeGenuineGiveUp
-	// OutcomeAllSkip posts the all-skipped summary: every member was a
-	// quota/timeout skip (or the member set was empty), with no real result.
+	// OutcomeAllSkip posts the all-skipped summary: every member was a timeout
+	// skip (or the member set was empty), with no real result.
 	OutcomeAllSkip
 )
 
@@ -59,11 +60,12 @@ type PanelOutcome struct {
 //     help).
 //  1. any done member with non-empty output -> OutcomePost (a partial review is
 //     better than nothing once any reviewer landed real output).
-//  2. else any transient-outage failure -> OutcomeDeferTransient (wait for the
-//     real review rather than post a failed/partial result).
+//  2. else any transient-outage or quota/session failure ->
+//     OutcomeDeferTransient (wait for the real review rather than post a
+//     failed/partial result).
 //  3. else any genuine failure -> OutcomeGenuineGiveUp when this attempt would
 //     hit the give-up cap (consecutiveGenuine+1), otherwise OutcomeDeferGenuine.
-//  4. else (all quota/timeout skips, or empty) -> OutcomeAllSkip.
+//  4. else (all timeout skips, or empty) -> OutcomeAllSkip.
 func classifyPanelOutcome(
 	results []reviewpkg.ReviewResult, synthesis *reviewpkg.ReviewResult, consecutiveGenuine int,
 ) PanelOutcome {
@@ -75,6 +77,9 @@ func classifyPanelOutcome(
 		return PanelOutcome{Kind: OutcomePost}
 	}
 	if r := firstMatch(results, reviewpkg.IsTransientFailure); r != nil {
+		return PanelOutcome{Kind: OutcomeDeferTransient, LastErrorExcerpt: r.Error}
+	}
+	if r := firstMatch(results, reviewpkg.IsQuotaFailure); r != nil {
 		return PanelOutcome{Kind: OutcomeDeferTransient, LastErrorExcerpt: r.Error}
 	}
 	if r := firstMatch(results, reviewpkg.IsGenuineFailure); r != nil {

--- a/internal/daemon/panel_outcome_test.go
+++ b/internal/daemon/panel_outcome_test.go
@@ -17,9 +17,9 @@ func TestClassifyPanelOutcome(t *testing.T) {
 
 	assert.Equal(OutcomePost, classifyPanelOutcome([]reviewpkg.ReviewResult{ok, transient}, nil, 0).Kind)
 	assert.Equal(OutcomeDeferTransient, classifyPanelOutcome([]reviewpkg.ReviewResult{transient}, nil, 0).Kind)
+	assert.Equal(OutcomeDeferTransient, classifyPanelOutcome([]reviewpkg.ReviewResult{quota}, nil, 0).Kind)
 	assert.Equal(OutcomeDeferGenuine, classifyPanelOutcome([]reviewpkg.ReviewResult{genuine}, nil, 1).Kind)
 	assert.Equal(OutcomeGenuineGiveUp, classifyPanelOutcome([]reviewpkg.ReviewResult{genuine}, nil, 3).Kind)
-	assert.Equal(OutcomeAllSkip, classifyPanelOutcome([]reviewpkg.ReviewResult{quota}, nil, 0).Kind)
 }
 
 // TestClassifyPanelOutcomeSynthesisFailure verifies the synthesis-failure

--- a/internal/daemon/panel_posting_test.go
+++ b/internal/daemon/panel_posting_test.go
@@ -756,6 +756,43 @@ func TestPostPanelRunDefersTransient(t *testing.T) {
 	assert.NotNil(attempt.NextAttemptAt, "transient defer schedules a next attempt")
 }
 
+// TestPostPanelRunDefersQuotaOnly covers the agent-unavailable policy: when
+// every member is skipped because the configured agent is quota/session limited,
+// the panel is deferred for the retry sweep instead of posting an all-skipped
+// result and marking the HEAD terminal.
+func TestPostPanelRunDefersQuotaOnly(t *testing.T) {
+	assert := assert.New(t)
+	h := newCIPollerHarness(t, "https://github.com/acme/api.git")
+	comments := h.CaptureComments()
+	statuses := h.CaptureCommitStatuses()
+
+	const headSHA = "quotaonly123456"
+	created, err := h.DB.ReserveReviewAttempt("acme/api", 86, headSHA, time.Now())
+	require.NoError(t, err)
+	require.True(t, created, "attempt row reserved")
+
+	quota := reviewpkg.QuotaErrorPrefix + "agent codex quota cooldown active"
+	panel, synth, _ := h.seedCIPanelRun(t, "acme/api", 86, headSHA, "base.."+headSHA,
+		[]jobSpec{{Agent: "codex", ReviewType: "review", Status: "failed", Error: quota}})
+	h.markJobFailed(t, synth.ID, "synthesis released after all members failed")
+
+	h.Poller.handleReviewFailed(ciEvent(synth.ID, "review.failed"))
+
+	assert.Empty(*comments, "quota-only defer must not post a comment")
+	require.Len(t, *statuses, 1, "quota-only defer sets exactly one status")
+	assert.Equal("pending", (*statuses)[0].State, "quota-only defer status is pending")
+	assert.False(h.panelPostedAt(t, panel.ID), "deferred panel is not marked posted")
+	assert.True(h.panelRetiredAt(t, panel.ID), "deferred panel is retired for retry")
+
+	attempt, err := h.DB.GetReviewAttempt("acme/api", 86, headSHA)
+	require.NoError(t, err)
+	require.NotNil(t, attempt)
+	assert.Equal("deferred", attempt.State)
+	assert.Equal("transient", attempt.LastErrorClass)
+	assert.Equal(0, attempt.ConsecutiveGenuineAttempts)
+	assert.NotNil(attempt.NextAttemptAt, "quota-only defer schedules a next attempt")
+}
+
 // TestPostPanelRunDefersGenuine covers the genuine-failure defer: a genuine
 // failure below the give-up cap posts nothing, sets pending, bumps the
 // consecutive-genuine streak, and retires the run.

--- a/internal/daemon/synthesis_worker.go
+++ b/internal/daemon/synthesis_worker.go
@@ -91,7 +91,7 @@ func (wp *WorkerPool) synthesizeSucceededResults(
 	// branches skip this check because they never invoke an agent.
 	canonicalAgent := agent.CanonicalName(job.Agent)
 	if wp.isAgentCoolingDown(canonicalAgent) {
-		wp.failoverOrFail(workerID, job, canonicalAgent,
+		wp.failCooldownOrFailover(workerID, job, canonicalAgent,
 			fmt.Sprintf("agent %s quota cooldown active", canonicalAgent))
 		return
 	}

--- a/internal/daemon/synthesis_worker_test.go
+++ b/internal/daemon/synthesis_worker_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
+	reviewpkg "go.kenn.io/roborev/internal/review"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testutil"
 	"go.kenn.io/roborev/internal/tokens"
@@ -859,6 +861,43 @@ func TestSynthesisMultiSuccessRespectsCooldown(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, storage.JobStatusDone, got.Status,
 		"cooldown must divert before completing the synthesis")
+}
+
+func TestSynthesisCIReviewCooldownDoesNotFailOverToBackup(t *testing.T) {
+	tc := newWorkerTestContext(t, 1)
+
+	const memberAgent = "panel-ci-cd-member"
+	registerPassingAgent(t, memberAgent)
+
+	var called bool
+	const synthAgent = "synth-ci-cd"
+	registerNeverCalledAgent(t, synthAgent, &called)
+
+	tc.Pool.cooldownAgent(synthAgent, time.Now().Add(time.Hour))
+
+	runUUID, members, _ := enqueuePanelRun(t, tc, "ci-cd-panel", []memberSpec{
+		{name: "m0", agent: memberAgent},
+		{name: "m1", agent: memberAgent},
+	})
+	setSynthesisAgent(t, tc, runUUID, synthAgent)
+	_, err := tc.DB.Exec(
+		`UPDATE review_jobs
+		 SET source = ?, ci_base_branch = ?, backup_agent = ?
+		 WHERE panel_run_uuid = ? AND panel_role = 'synthesis'`,
+		storage.JobSourceCI, "main", "test", runUUID,
+	)
+	require.NoError(t, err)
+	completeMember(t, tc, members[0].ID, memberAgent, "Finding A")
+	completeMember(t, tc, members[1].ID, memberAgent, "Finding B")
+
+	synth := releaseAndClaimSynthesis(t, tc, runUUID)
+	tc.Pool.processSynthesisJob(context.Background(), testWorkerID, synth)
+
+	assert.False(t, called, "CI synthesis must not invoke an agent in cooldown")
+	got := tc.assertJobStatus(t, synth.ID, storage.JobStatusFailed)
+	assert.Equal(t, synthAgent, got.Agent, "CI synthesis cooldown must not fail over to backup")
+	assert.True(t, strings.HasPrefix(got.Error, reviewpkg.QuotaErrorPrefix),
+		"cooldown failure should be a retryable quota skip, got %q", got.Error)
 }
 
 // TestSynthesisRunsAgainstWorktree verifies the synthesis agent runs against the

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -551,7 +551,7 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 	if wp.isAgentCoolingDown(canonicalAgent) {
 		log.Printf("[%s] Agent %s in cooldown, skipping job %d",
 			workerID, canonicalAgent, job.ID)
-		wp.failoverOrFail(workerID, job, canonicalAgent,
+		wp.failCooldownOrFailover(workerID, job, canonicalAgent,
 			fmt.Sprintf("agent %s quota cooldown active", canonicalAgent))
 		return
 	}
@@ -1026,18 +1026,19 @@ func (wp *WorkerPool) failOrRetryAgent(workerID string, job *storage.ReviewJob, 
 }
 
 // finalErrorMsg tags the stored error with review.OutageErrorPrefix when an
-// agent failure classifies as a transient provider outage (429 /
-// stream-disconnect / 5xx) so the CI batch layer can treat it as retryable
-// rather than a genuine failure. Non-agent and non-transient errors are
-// returned unchanged.
+// agent failure classifies as a transient provider outage or session cap so the
+// CI batch layer can treat it as retryable rather than a genuine failure.
+// Non-agent and non-transient errors are returned unchanged.
 func (wp *WorkerPool) finalErrorMsg(agentName, errorMsg string, agentError bool) string {
 	if !agentError {
 		return errorMsg
 	}
-	if wp.classify(agent.CanonicalName(agentName), errorMsg).Kind == agent.LimitKindTransient {
+	switch wp.classify(agent.CanonicalName(agentName), errorMsg).Kind {
+	case agent.LimitKindTransient, agent.LimitKindSession:
 		return review.OutageError(errorMsg)
+	default:
+		return errorMsg
 	}
-	return errorMsg
 }
 
 func (wp *WorkerPool) failOrRetryInner(workerID string, job *storage.ReviewJob, agentName string, errorMsg string, agentError bool) {
@@ -1059,9 +1060,15 @@ func (wp *WorkerPool) failOrRetryInner(workerID string, job *storage.ReviewJob, 
 				}
 			}
 			wp.cooldownAgent(agentName, time.Now().Add(dur))
-			log.Printf("[%s] Agent %s quota exhausted, cooldown %v",
+			log.Printf("[%s] Agent %s limit exhausted, cooldown %v",
 				workerID, agentName, dur)
-			wp.failoverOrFail(workerID, job, agentName, errorMsg)
+			prefix := review.QuotaErrorPrefix
+			label := "quota"
+			if cls.Kind == agent.LimitKindSession {
+				prefix = review.OutageErrorPrefix
+				label = "session limit"
+			}
+			wp.failoverOrFailWithPrefix(workerID, job, agentName, errorMsg, prefix, label)
 			return
 		case agent.LimitKindNone:
 			if errorMsg != "" {
@@ -1407,13 +1414,31 @@ func (wp *WorkerPool) isAgentCoolingDown(name string) bool {
 	return true
 }
 
-// failoverOrFail attempts failover to a backup agent for the job.
-// If no backup is available, fails the job with a quota-prefixed error.
+func (wp *WorkerPool) failCooldownOrFailover(
+	workerID string, job *storage.ReviewJob,
+	agentName, errorMsg string,
+) {
+	wp.failoverOrFailWithPrefix(workerID, job, agentName, errorMsg, review.QuotaErrorPrefix, "quota")
+}
+
+// failoverOrFail attempts failover to a backup agent for non-CI jobs. CI
+// reviews must preserve their configured panel member and let the CI retry
+// schedule handle quota/session availability failures.
 func (wp *WorkerPool) failoverOrFail(
 	workerID string, job *storage.ReviewJob,
 	agentName, errorMsg string,
 ) {
-	backupAgent := wp.resolveBackupAgent(job)
+	wp.failoverOrFailWithPrefix(workerID, job, agentName, errorMsg, review.QuotaErrorPrefix, "quota")
+}
+
+func (wp *WorkerPool) failoverOrFailWithPrefix(
+	workerID string, job *storage.ReviewJob,
+	agentName, errorMsg, prefix, label string,
+) {
+	backupAgent := ""
+	if !job.IsCIReview() {
+		backupAgent = wp.resolveBackupAgent(job)
+	}
 	if backupAgent != "" && !wp.isAgentCoolingDown(backupAgent) {
 		backupModel := wp.resolveBackupModel(job)
 		failedOver, err := wp.db.FailoverJob(
@@ -1424,27 +1449,43 @@ func (wp *WorkerPool) failoverOrFail(
 				workerID, job.ID, err)
 		}
 		if failedOver {
-			log.Printf("[%s] Job %d failing over from %s to %s (quota): %s",
-				workerID, job.ID, agentName, backupAgent, errorMsg)
+			log.Printf("[%s] Job %d failing over from %s to %s (%s): %s",
+				workerID, job.ID, agentName, backupAgent, label, errorMsg)
 			return
 		}
 	}
 
-	// No backup or failover failed — fail with quota prefix
-	quotaMsg := review.QuotaErrorPrefix + errorMsg
-	if updated, err := wp.db.FailJob(job.ID, workerID, quotaMsg); err != nil {
+	wp.failJobWithPrefix(workerID, job, agentName, errorMsg, prefix, label)
+}
+
+func (wp *WorkerPool) failJobWithPrefix(
+	workerID string, job *storage.ReviewJob,
+	agentName, errorMsg, prefix, label string,
+) {
+	storedMsg := prefixedFailure(prefix, errorMsg)
+	if updated, err := wp.db.FailJob(job.ID, workerID, storedMsg); err != nil {
 		log.Printf("[%s] Error failing job %d: %v", workerID, job.ID, err)
 	} else if updated {
-		log.Printf("[%s] Job %d skipped (agent %s quota exhausted)",
-			workerID, job.ID, agentName)
-		wp.broadcastFailed(job, agentName, quotaMsg)
+		log.Printf("[%s] Job %d skipped (agent %s %s)",
+			workerID, job.ID, agentName, label)
+		wp.broadcastFailed(job, agentName, storedMsg)
 		if wp.errorLog != nil {
 			wp.errorLog.LogError("worker",
-				fmt.Sprintf("job %d skipped (quota): %s", job.ID, errorMsg),
+				fmt.Sprintf("job %d skipped (%s): %s", job.ID, label, errorMsg),
 				job.ID)
 		}
-		wp.logJobFailed(job.ID, workerID, agentName, quotaMsg)
+		wp.logJobFailed(job.ID, workerID, agentName, storedMsg)
 	}
+}
+
+func prefixedFailure(prefix, msg string) string {
+	if prefix == "" || strings.HasPrefix(msg, prefix) {
+		return msg
+	}
+	if prefix == review.OutageErrorPrefix {
+		return review.OutageError(msg)
+	}
+	return prefix + msg
 }
 
 func preparePrebuiltPrompt(

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -1818,6 +1818,50 @@ func TestProcessJob_CooldownResolvesAlias(t *testing.T) {
 	tc.assertJobStatus(t, job.ID, storage.JobStatusFailed)
 }
 
+func TestProcessJob_CIReviewCooldownDoesNotFailOverToBackup(t *testing.T) {
+	tc := newWorkerTestContext(t, 1)
+	sha := testutil.GetHeadSHA(t, tc.TmpDir)
+
+	cfg := config.DefaultConfig()
+	cfg.DefaultBackupAgent = "test"
+	tc.reconfigurePool(cfg)
+
+	claimed := tc.createAndClaimJobWithAgent(t, sha, testWorkerID, "codex")
+	claimed.Source = storage.JobSourceCI
+	claimed.CIBaseBranch = "main"
+	tc.Pool.cooldownAgent("codex", time.Now().Add(time.Hour))
+
+	tc.Pool.processJob(testWorkerID, claimed)
+
+	updated := tc.assertJobStatus(t, claimed.ID, storage.JobStatusFailed)
+	assert := assert.New(t)
+	assert.Equal("codex", updated.Agent, "CI cooldown must not fail over to backup")
+	assert.True(strings.HasPrefix(updated.Error, review.QuotaErrorPrefix),
+		"cooldown failure should be a retryable quota skip, got %q", updated.Error)
+}
+
+func TestFailOrRetryInner_CIQuotaDoesNotFailOverToBackup(t *testing.T) {
+	tc := newWorkerTestContext(t, 1)
+	sha := testutil.GetHeadSHA(t, tc.TmpDir)
+
+	cfg := config.DefaultConfig()
+	cfg.DefaultBackupAgent = "test"
+	tc.reconfigurePool(cfg)
+
+	job := tc.createAndClaimJobWithAgent(t, sha, testWorkerID, "codex")
+	job.Source = storage.JobSourceCI
+	job.CIBaseBranch = "main"
+
+	tc.Pool.failOrRetryAgent(testWorkerID, job, "codex", "resource exhausted: reset after 1h")
+
+	updated := tc.assertJobStatus(t, job.ID, storage.JobStatusFailed)
+	assert := assert.New(t)
+	assert.Equal("codex", updated.Agent, "CI quota must not fail over to backup")
+	assert.True(strings.HasPrefix(updated.Error, review.QuotaErrorPrefix),
+		"quota failure should be a retryable quota skip, got %q", updated.Error)
+	assert.True(tc.Pool.isAgentCoolingDown("codex"), "quota should cool down the configured agent")
+}
+
 func TestResolveBackupAgent_AliasMatchesPrimary(t *testing.T) {
 	// "claude" is an alias for "claude-code". If job.Agent is "claude"
 	// and backup resolves to "claude-code", they are the same agent.
@@ -2068,6 +2112,23 @@ func TestFailOrRetryInner_SessionLimitCoolsDownAndSkipsRetries(t *testing.T) {
 	got, err := tc.DB.GetJobRetryCount(job.ID)
 	require.NoError(t, err)
 	assert.Equal(0, got, "session-limit error must not consume a retry slot")
+}
+
+func TestFailOrRetryInner_SessionLimitFinalFailureIsRetryableOutage(t *testing.T) {
+	tc := newWorkerTestContext(t, 1)
+	job := tc.createAndClaimJobWithAgent(t, "session-limit-outage-test", testWorkerID, "claude-code")
+	job = tc.exhaustRetries(t, job, testWorkerID, "claude-code")
+
+	errText := "agent: claude-code failed\nstream: stream errors: You've hit your session limit · resets 5:50am (UTC): exit status 1"
+	tc.Pool.failOrRetryAgent(testWorkerID, job, "claude-code", errText)
+
+	updated := tc.assertJobStatus(t, job.ID, storage.JobStatusFailed)
+	assert := assert.New(t)
+	assert.True(tc.Pool.isAgentCoolingDown("claude-code"), "agent should be in cooldown")
+	assert.True(strings.HasPrefix(updated.Error, review.OutageErrorPrefix),
+		"session-limit failure should be retryable outage, got %q", updated.Error)
+	assert.False(strings.HasPrefix(updated.Error, review.QuotaErrorPrefix),
+		"session-limit failure should not be stored as quota skip")
 }
 
 func TestFailOrRetryInner_UnmatchedAgentErrorLogsWarn(t *testing.T) {


### PR DESCRIPTION
CI panel retries must remain attached to the PR head and the configured panel agents. The previous behavior let a Codex quota/cooldown event silently fail over CI member jobs to the global backup agent, so a Codex outage could spill into Claude. Because Claude's captured session-limit wording was not classified, those provider-capacity failures were then counted as genuine agent failures and could produce the wrong terminal Review Unavailable comment before the intended retry window elapsed.

This preserves backup failover for non-CI work, but treats CI quota/session/provider availability failures as retryable panel outcomes. Quota-only or outage-only CI panels now defer the attempt, leave the commit status pending, and re-enter the existing retry sweep instead of posting a terminal comment or marking the head done. Claude's five-hour session-limit wording is also classified as a session limit so it is stored as an outage rather than a genuine/config failure.

The key operator consequence is that a rate-limited Codex reviewer should not cause Claude to burn capacity or cause the CI poller to capitulate with the genuine-failure note. It should keep retrying the same PR head under the 72-hour transient retry wall, unless the PR advances or closes.

Validated with `go test ./...`; the commit hook also passed git test isolation and golangci-lint.