### PR TITLE
Add Renovate pep621 coverage for docs Python deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "dependencyDashboard": true,
-  "enabledManagers": ["github-actions", "gomod"],
+  "enabledManagers": ["github-actions", "gomod", "pep621"],
   "osvVulnerabilityAlerts": true,
   "minimumReleaseAge": "7 days",
   "minimumReleaseAgeBehaviour": "timestamp-required",
@@ -18,6 +18,11 @@
       "groupName": "Go dependencies",
       "groupSlug": "go-dependencies",
       "postUpdateOptions": ["gomodUpdateImportPaths", "gomodTidy"]
+    },
+    {
+      "matchManagers": ["pep621"],
+      "groupName": "Docs dependencies",
+      "groupSlug": "docs-dependencies"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Enable Renovate's `pep621` manager so the docs Python toolchain (`docs/pyproject.toml` / `docs/uv.lock`, currently `zensical`) receives dependency and security updates. After the docs migration into this repo, `enabledManagers` was limited to `github-actions` and `gomod`, leaving these deps with no update coverage — coverage the standalone roborev-docs repo previously had via Renovate's default managers.
- Group the docs dependency PRs as "Docs dependencies", mirroring the existing "Go dependencies" group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
