### PR TITLE
Stabilize post-commit timeout test

### DIFF
--- a/cmd/roborev/postcommit_test.go
+++ b/cmd/roborev/postcommit_test.go
@@ -243,18 +243,24 @@ func TestPostCommitLogsCreatesParentDir(t *testing.T) {
 // that accepts connections but never responds, without needing
 // a real httptest server or a long sleep.
 type stallingRoundTripper struct {
-	hit chan struct{}
+	hit       chan struct{}
+	cancelled chan time.Duration
 }
 
 func (s *stallingRoundTripper) RoundTrip(
 	req *http.Request,
 ) (*http.Response, error) {
+	start := time.Now()
 	select {
 	case s.hit <- struct{}{}:
 	default:
 	}
 	select {
 	case <-req.Context().Done():
+		select {
+		case s.cancelled <- time.Since(start):
+		default:
+		}
 	case <-time.After(5 * time.Second):
 		return nil, fmt.Errorf("stallingRoundTripper: context was never cancelled")
 	}
@@ -274,7 +280,10 @@ func TestPostCommitTimesOutOnSlowDaemon(t *testing.T) {
 
 	repo.CommitFile("file.txt", "content", "initial")
 
-	rt := &stallingRoundTripper{hit: make(chan struct{}, 1)}
+	rt := &stallingRoundTripper{
+		hit:       make(chan struct{}, 1),
+		cancelled: make(chan time.Duration, 1),
+	}
 	orig := hookHTTPClient
 	hookHTTPClient = func() *http.Client {
 		return &http.Client{
@@ -284,9 +293,7 @@ func TestPostCommitTimesOutOnSlowDaemon(t *testing.T) {
 	}
 	t.Cleanup(func() { hookHTTPClient = orig })
 
-	start := time.Now()
 	_, _, err := executePostCommitCmd("--repo", repo.Dir)
-	elapsed := time.Since(start)
 
 	require.NoError(t, err)
 
@@ -297,10 +304,15 @@ func TestPostCommitTimesOutOnSlowDaemon(t *testing.T) {
 		require.NoError(t, err, "RoundTrip was never called; timeout not exercised")
 	}
 	assert.False(t, realHandlerCalled, "real handler should not be reached")
-	assert.LessOrEqual(t, elapsed, time.Second,
 
-		"command took %v; should return promptly via timeout",
-		elapsed)
+	select {
+	case elapsed := <-rt.cancelled:
+		assert.LessOrEqual(t, elapsed, time.Second,
+			"request took %v; should return promptly via timeout",
+			elapsed)
+	default:
+		require.FailNow(t, "request context was not cancelled by timeout")
+	}
 }
 
 func TestEnqueueAliasIsHidden(t *testing.T) {


### PR DESCRIPTION
Windows CI failed because `TestPostCommitTimesOutOnSlowDaemon` measured the full hook command wall-clock time and tripped at `1.0057231s` against a `1s` threshold. The behavior the test owns is narrower: the stalled `/api/enqueue` request should have its context canceled by the hook HTTP client timeout.

This PR moves the timing assertion into the fake transport, starting when the enqueue POST is actually attempted. That keeps coverage for the timeout path while avoiding unrelated git setup, daemon probing, and Windows scheduler overhead in the assertion budget.

I validated the focused timeout test over 20 local runs, the post-commit/enqueue alias group, and the full `cmd/roborev` integration package with `go test -tags integration ./cmd/roborev -count=1`.