### PR TITLE
Cap agent quota cooldowns by config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,14 @@ Test conventions:
 - Keep changes simple; avoid over-engineering.
 - Prefer Go stdlib over new dependencies.
 - No emojis in code or output (commit messages are fine).
+- Do not include private review data or infrastructure details in tests,
+  fixtures, commit messages, PR descriptions, PR comments, issue comments, or
+  public docs unless the user explicitly asks for that disclosure. This includes
+  real hostnames, usernames, local paths, daemon/service names, job IDs, review
+  IDs, PR numbers from private queues, database rows, log excerpts, timestamps
+  tied to incidents, config contents, auth state, and machine-specific behavior.
+  Use synthetic identifiers, generic provider messages, and behavior-focused
+  descriptions instead.
 - Never amend commits; fixes should be new commits.
 - Never push/pull unless explicitly asked.
 - NEVER merge pull requests.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,6 +110,7 @@ type Config struct {
 	DefaultBackupAgent         string `toml:"default_backup_agent"`
 	DefaultBackupModel         string `toml:"default_backup_model"`
 	JobTimeoutMinutes          int    `toml:"job_timeout_minutes"`
+	AgentQuotaCooldown         string `toml:"agent_quota_cooldown" comment:"Maximum daemon-wide cooldown after an agent quota error, as a Go duration such as 30m."`
 	ReviewReasoning            string `toml:"review_reasoning" comment:"Default reasoning level for reviews: fast, standard, medium, thorough, or maximum."`
 	RefineReasoning            string `toml:"refine_reasoning" comment:"Default reasoning level for refine: fast, standard, medium, thorough, or maximum."`
 	FixReasoning               string `toml:"fix_reasoning" comment:"Default reasoning level for fix: fast, standard, medium, thorough, or maximum."`
@@ -424,6 +425,7 @@ type RepoConfig struct {
 
 const (
 	DefaultPiJSONSchemaExtension = "npm:@nqbao/pi-json-schema@0.1.1"
+	DefaultAgentQuotaCooldown    = 30 * time.Minute
 )
 
 // DefaultConfig returns the default configuration
@@ -434,6 +436,7 @@ func DefaultConfig() *Config {
 		ReviewContextCount: 3,
 		DefaultAgent:       "codex",
 		JobTimeoutMinutes:  30,
+		AgentQuotaCooldown: DefaultAgentQuotaCooldown.String(),
 		CodexCmd:           "codex",
 		ClaudeCodeCmd:      "claude",
 		CursorCmd:          "agent",
@@ -829,6 +832,20 @@ func ResolveJobTimeout(repoPath string, globalCfg *Config) int {
 		globalVal = clampPositive(globalCfg.JobTimeoutMinutes)
 	}
 	return resolve(30, repoVal, globalVal)
+}
+
+// ResolveAgentQuotaCooldown returns the maximum daemon-wide agent cooldown
+// after a quota/session-limit error. Provider reset hints may shorten this
+// value, but daemon scheduling must not lengthen beyond operator config.
+func ResolveAgentQuotaCooldown(globalCfg *Config) time.Duration {
+	if globalCfg == nil || strings.TrimSpace(globalCfg.AgentQuotaCooldown) == "" {
+		return DefaultAgentQuotaCooldown
+	}
+	d, err := time.ParseDuration(globalCfg.AgentQuotaCooldown)
+	if err != nil || d <= 0 {
+		return DefaultAgentQuotaCooldown
+	}
+	return d
 }
 
 // ResolveAutoClosePassingReviews returns whether passing reviews should

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -41,6 +41,8 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Empty(t, cfg.Cost.Endpoint)
 	assert.Equal(t, "10s", cfg.Cost.Timeout)
 	assert.Equal(t, 10*time.Second, cfg.Cost.ResolvedTimeout())
+	assert.Equal(t, "30m0s", cfg.AgentQuotaCooldown)
+	assert.Equal(t, 30*time.Minute, ResolveAgentQuotaCooldown(cfg))
 }
 
 func TestDataDir(t *testing.T) {
@@ -546,6 +548,46 @@ func TestResolveJobTimeout(t *testing.T) {
 					return false
 				}, "ResolveJobTimeout() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestResolveAgentQuotaCooldown(t *testing.T) {
+	tests := []struct {
+		name         string
+		globalConfig *Config
+		want         time.Duration
+	}{
+		{
+			name: "default when no config",
+			want: 30 * time.Minute,
+		},
+		{
+			name:         "default when global config has empty value",
+			globalConfig: &Config{AgentQuotaCooldown: ""},
+			want:         30 * time.Minute,
+		},
+		{
+			name:         "default when global config is invalid",
+			globalConfig: &Config{AgentQuotaCooldown: "soon"},
+			want:         30 * time.Minute,
+		},
+		{
+			name:         "default when global config is non-positive",
+			globalConfig: &Config{AgentQuotaCooldown: "-1m"},
+			want:         30 * time.Minute,
+		},
+		{
+			name:         "global config takes precedence over default",
+			globalConfig: &Config{AgentQuotaCooldown: "5m"},
+			want:         5 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveAgentQuotaCooldown(tt.globalConfig)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -1982,8 +1982,9 @@ func (p *CIPoller) recordDeferral(
 	if err := p.db.MarkPanelRetired(row.ID); err != nil {
 		log.Printf("CI poller: error retiring deferred panel %d: %v", row.ID, err)
 	}
-	log.Printf("CI poller: deferred %s panel run for %s#%d (panel %d, retrying)",
-		errClass, row.GithubRepo, row.PRNumber, row.ID)
+	log.Printf("CI poller: deferred %s panel run for %s#%d@%s (panel %d, run %s, attempt %d, next_attempt_at %s, last_error=%q)",
+		errClass, row.GithubRepo, row.PRNumber, gitpkg.ShortSHA(row.HeadSHA), row.ID, row.PanelRunUUID,
+		attempt.Attempt, nextAt.Format(time.RFC3339), logExcerpt(excerpt))
 }
 
 // markAttemptDone marks the HEAD's attempt terminal. finalizePanelRun guarantees
@@ -2344,7 +2345,7 @@ func (p *CIPoller) retryDueReviewAttempt(
 		}
 		return false // PR advanced; the new HEAD already has its own attempt
 	}
-	claimed, _, _, err := p.db.ClaimDueReviewAttempt(ghRepo, attempt.PRNumber, attempt.HeadSHA, now)
+	claimed, attemptNumber, firstAttemptAt, err := p.db.ClaimDueReviewAttempt(ghRepo, attempt.PRNumber, attempt.HeadSHA, now)
 	if err != nil {
 		log.Printf("CI poller: error claiming due review attempt for %s#%d@%s: %v",
 			ghRepo, attempt.PRNumber, gitpkg.ShortSHA(attempt.HeadSHA), err)
@@ -2362,7 +2363,21 @@ func (p *CIPoller) retryDueReviewAttempt(
 			ghRepo, attempt.PRNumber, gitpkg.ShortSHA(attempt.HeadSHA), err)
 		return false
 	}
+	nextAttemptAt := "<nil>"
+	if attempt.NextAttemptAt != nil {
+		nextAttemptAt = attempt.NextAttemptAt.Format(time.RFC3339)
+	}
+	log.Printf("CI poller: re-enqueued deferred review attempt for %s#%d@%s (attempt %d, first_attempt_at %s, previous_next_attempt_at %s, last_error_class %q, last_error=%q)",
+		ghRepo, attempt.PRNumber, gitpkg.ShortSHA(attempt.HeadSHA), attemptNumber,
+		firstAttemptAt.Format(time.RFC3339), nextAttemptAt, attempt.LastErrorClass,
+		logExcerpt(attempt.LastErrorExcerpt))
 	return true
+}
+
+func logExcerpt(excerpt string) string {
+	preview := strings.ReplaceAll(excerpt, "\n", " ")
+	preview = strings.ReplaceAll(preview, "\r", "")
+	return truncateRunes(preview, 200)
 }
 
 func (p *CIPoller) retryAttemptPR(

--- a/internal/daemon/config_watcher.go
+++ b/internal/daemon/config_watcher.go
@@ -37,7 +37,8 @@ func (sc *StaticConfig) Config() *config.Config {
 // ConfigWatcher watches config.toml for changes and reloads configuration.
 //
 // Hot-reloadable settings take effect immediately: default_agent, job_timeout,
-// allow_unsafe_agents, anthropic_api_key, review_context_count.
+// agent_quota_cooldown, allow_unsafe_agents, anthropic_api_key,
+// review_context_count.
 //
 // Settings requiring restart: server_addr, max_workers, [sync] section.
 // These are read at startup and the running values are preserved even if the
@@ -243,6 +244,9 @@ func logConfigChanges(old, new *config.Config) {
 	}
 	if old.JobTimeoutMinutes != new.JobTimeoutMinutes {
 		log.Printf("Config change: job_timeout_minutes %d -> %d", old.JobTimeoutMinutes, new.JobTimeoutMinutes)
+	}
+	if old.AgentQuotaCooldown != new.AgentQuotaCooldown {
+		log.Printf("Config change: agent_quota_cooldown %q -> %q", old.AgentQuotaCooldown, new.AgentQuotaCooldown)
 	}
 	oldUnsafe := old.AllowUnsafeAgents != nil && *old.AllowUnsafeAgents
 	newUnsafe := new.AllowUnsafeAgents != nil && *new.AllowUnsafeAgents

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -1372,15 +1372,14 @@ func isContextWindowError(errMsg string) bool {
 	return false
 }
 
-// cooldownAgent sets or extends the cooldown expiry for an agent.
-// Only extends — never shortens an existing cooldown.
+// cooldownAgent records the cooldown expiry for an agent, bounded by the
+// current configured maximum. Later provider hints may shorten an existing
+// cooldown; a subsequent quota error can extend it again, but never past config.
 func (wp *WorkerPool) cooldownAgent(name string, until time.Time) {
 	name = agent.CanonicalName(name)
+	until = wp.clampAgentCooldownExpiry(until, time.Now())
 	wp.agentCooldownsMu.Lock()
 	defer wp.agentCooldownsMu.Unlock()
-	if existing, ok := wp.agentCooldowns[name]; ok && existing.After(until) {
-		return
-	}
 	wp.agentCooldowns[name] = until
 }
 
@@ -1388,31 +1387,60 @@ func (wp *WorkerPool) cooldownAgent(name string, until time.Time) {
 // quota cooldown period. Expired entries are cleaned up eagerly.
 func (wp *WorkerPool) isAgentCoolingDown(name string) bool {
 	name = agent.CanonicalName(name)
+	now := time.Now()
 	wp.agentCooldownsMu.RLock()
 	expiry, ok := wp.agentCooldowns[name]
 	if !ok {
 		wp.agentCooldownsMu.RUnlock()
 		return false
 	}
-	if time.Now().After(expiry) {
+	if now.After(expiry) {
 		wp.agentCooldownsMu.RUnlock()
 		if wp.testHookCooldownLockUpgrade != nil {
 			wp.testHookCooldownLockUpgrade()
 		}
-		// Upgrade to write lock and delete expired entry
 		wp.agentCooldownsMu.Lock()
-		// Re-check under write lock (may have been refreshed)
-		exp, stillExists := wp.agentCooldowns[name]
-		if stillExists && time.Now().After(exp) {
-			delete(wp.agentCooldowns, name)
-			wp.agentCooldownsMu.Unlock()
-			return false
-		}
+		cooling := wp.clampActiveCooldownLocked(name)
 		wp.agentCooldownsMu.Unlock()
-		return stillExists
+		return cooling
+	}
+	clampedExpiry := wp.clampAgentCooldownExpiry(expiry, now)
+	if clampedExpiry.Before(expiry) {
+		wp.agentCooldownsMu.RUnlock()
+		wp.agentCooldownsMu.Lock()
+		cooling := wp.clampActiveCooldownLocked(name)
+		wp.agentCooldownsMu.Unlock()
+		return cooling
 	}
 	wp.agentCooldownsMu.RUnlock()
 	return true
+}
+
+// clampActiveCooldownLocked rechecks and clamps a cooldown under the write lock.
+// The caller must hold agentCooldownsMu for writing.
+func (wp *WorkerPool) clampActiveCooldownLocked(name string) bool {
+	expiry, ok := wp.agentCooldowns[name]
+	if !ok {
+		return false
+	}
+	now := time.Now()
+	if now.After(expiry) {
+		delete(wp.agentCooldowns, name)
+		return false
+	}
+	clampedExpiry := wp.clampAgentCooldownExpiry(expiry, now)
+	if clampedExpiry.Before(expiry) {
+		wp.agentCooldowns[name] = clampedExpiry
+	}
+	return true
+}
+
+func (wp *WorkerPool) clampAgentCooldownExpiry(expiry, now time.Time) time.Time {
+	maxExpiry := now.Add(wp.agentQuotaCooldown())
+	if expiry.After(maxExpiry) {
+		return maxExpiry
+	}
+	return expiry
 }
 
 func (wp *WorkerPool) failCooldownOrFailover(

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -1050,12 +1050,12 @@ func (wp *WorkerPool) failOrRetryInner(workerID string, job *storage.ReviewJob, 
 		cls := wp.classify(agent.CanonicalName(agentName), errorMsg)
 		switch cls.Kind {
 		case agent.LimitKindQuota, agent.LimitKindSession:
-			dur := defaultCooldown
-			if cls.CooldownFor > 0 {
+			dur := wp.agentQuotaCooldown()
+			if cls.CooldownFor > 0 && cls.CooldownFor < dur {
 				dur = cls.CooldownFor
 			}
 			if !cls.ResetAt.IsZero() {
-				if until := time.Until(cls.ResetAt); until > 0 {
+				if until := time.Until(cls.ResetAt); until > 0 && until < dur {
 					dur = until
 				}
 			}
@@ -1072,10 +1072,8 @@ func (wp *WorkerPool) failOrRetryInner(workerID string, job *storage.ReviewJob, 
 			return
 		case agent.LimitKindNone:
 			if errorMsg != "" {
-				preview := strings.ReplaceAll(errorMsg, "\n", " ")
-				preview = strings.ReplaceAll(preview, "\r", "")
 				log.Printf("[%s] unclassified agent error from %s: %s",
-					workerID, agentName, truncateRunes(preview, 200))
+					workerID, agentName, logExcerpt(errorMsg))
 			}
 			// fall through to context-window / retry handling
 		case agent.LimitKindTransient:
@@ -1349,9 +1347,12 @@ func (wp *WorkerPool) captureTokenUsageForSession(
 	}
 }
 
-// defaultCooldown is the fallback duration when the error message doesn't
-// contain a parseable "reset after" token.
-const defaultCooldown = 30 * time.Minute
+func (wp *WorkerPool) agentQuotaCooldown() time.Duration {
+	if wp == nil || wp.cfgGetter == nil {
+		return config.DefaultAgentQuotaCooldown
+	}
+	return config.ResolveAgentQuotaCooldown(wp.cfgGetter.Config())
+}
 
 func isContextWindowError(errMsg string) bool {
 	lower := strings.ToLower(errMsg)

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -1737,13 +1737,48 @@ func TestAgentCooldown(t *testing.T) {
 		}, "expected expired cooldown to return false")
 	}
 
-	// cooldownAgent never shortens
+	// A later shorter cooldown still leaves the agent cooling down.
+	// Duration-specific shortening behavior is covered below.
 	pool.cooldownAgent("gemini", time.Now().Add(1*time.Minute))
 	if !pool.isAgentCoolingDown("gemini") {
 		assert.Condition(t, func() bool {
 			return false
-		}, "cooldown should not have been shortened")
+		}, "expected gemini to remain in cooldown")
 	}
+}
+
+func TestAgentCooldown_ShorterCooldownReplacesExisting(t *testing.T) {
+	cfg := config.DefaultConfig()
+	pool := NewWorkerPool(nil, NewStaticConfig(cfg), 1, NewBroadcaster(), nil, nil)
+
+	start := time.Now()
+	pool.cooldownAgent("codex", start.Add(30*time.Minute))
+	pool.cooldownAgent("codex", start.Add(2*time.Minute))
+
+	pool.agentCooldownsMu.RLock()
+	expiry, ok := pool.agentCooldowns["codex"]
+	pool.agentCooldownsMu.RUnlock()
+	require.True(t, ok, "expected codex cooldown entry")
+	assert.WithinDuration(t, start.Add(2*time.Minute), expiry, time.Minute)
+}
+
+func TestAgentCooldown_CheckClampsExistingCooldownToConfiguredCap(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.AgentQuotaCooldown = "5m"
+	pool := NewWorkerPool(nil, NewStaticConfig(cfg), 1, NewBroadcaster(), nil, nil)
+
+	start := time.Now()
+	pool.agentCooldownsMu.Lock()
+	pool.agentCooldowns["codex"] = start.Add(time.Hour)
+	pool.agentCooldownsMu.Unlock()
+
+	require.True(t, pool.isAgentCoolingDown("codex"))
+
+	pool.agentCooldownsMu.RLock()
+	expiry, ok := pool.agentCooldowns["codex"]
+	pool.agentCooldownsMu.RUnlock()
+	require.True(t, ok, "expected codex cooldown entry")
+	assert.WithinDuration(t, start.Add(5*time.Minute), expiry, time.Minute)
 }
 
 func TestAgentCooldown_ExpiredEntryDeleted(t *testing.T) {

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -2030,35 +2030,55 @@ func TestFailOrRetryInner_QuotaSkipsRetries(t *testing.T) {
 }
 
 func TestFailOrRetryInner_QuotaResetAtDoesNotExceedConfiguredCooldown(t *testing.T) {
-	tc := newWorkerTestContext(t, 1)
-	cfg := config.DefaultConfig()
-	cfg.AgentQuotaCooldown = "5m"
-	tc.reconfigurePool(cfg)
-
-	sha := testutil.GetHeadSHA(t, tc.TmpDir)
-	job := tc.createAndClaimJobWithAgent(t, sha, testWorkerID, "codex")
-	start := time.Now()
-	tc.Pool.classify = func(agentName, msg string) agent.LimitClassification {
-		return agent.LimitClassification{
-			Kind:    agent.LimitKindQuota,
-			Agent:   agentName,
-			ResetAt: start.Add(time.Hour),
-			Message: msg,
-		}
+	tests := []struct {
+		name      string
+		resetFrom time.Duration
+		want      time.Duration
+	}{
+		{
+			name:      "later provider reset is capped by config",
+			resetFrom: time.Hour,
+			want:      5 * time.Minute,
+		},
+		{
+			name:      "earlier provider reset is honored",
+			resetFrom: 2 * time.Minute,
+			want:      2 * time.Minute,
+		},
 	}
 
-	tc.Pool.failOrRetryInner(
-		testWorkerID, job, "codex",
-		"codex stream reported failure: You've hit your usage limit.",
-		true,
-	)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := newWorkerTestContext(t, 1)
+			cfg := config.DefaultConfig()
+			cfg.AgentQuotaCooldown = "5m"
+			tc.reconfigurePool(cfg)
 
-	tc.Pool.agentCooldownsMu.RLock()
-	expiry, ok := tc.Pool.agentCooldowns["codex"]
-	tc.Pool.agentCooldownsMu.RUnlock()
-	require.True(t, ok, "expected codex cooldown entry")
-	assert.WithinDuration(t, start.Add(5*time.Minute), expiry, time.Minute,
-		"cooldown should use configured duration, not provider reset time")
+			sha := testutil.GetHeadSHA(t, tc.TmpDir)
+			job := tc.createAndClaimJobWithAgent(t, sha, testWorkerID, "codex")
+			start := time.Now()
+			tc.Pool.classify = func(agentName, msg string) agent.LimitClassification {
+				return agent.LimitClassification{
+					Kind:    agent.LimitKindQuota,
+					Agent:   agentName,
+					ResetAt: start.Add(tt.resetFrom),
+					Message: msg,
+				}
+			}
+
+			tc.Pool.failOrRetryInner(
+				testWorkerID, job, "codex",
+				"codex stream reported failure: You've hit your usage limit.",
+				true,
+			)
+
+			tc.Pool.agentCooldownsMu.RLock()
+			expiry, ok := tc.Pool.agentCooldowns["codex"]
+			tc.Pool.agentCooldownsMu.RUnlock()
+			require.True(t, ok, "expected codex cooldown entry")
+			assert.WithinDuration(t, start.Add(tt.want), expiry, time.Minute)
+		})
+	}
 }
 
 func TestFailOrRetryInner_QuotaCooldownForHonorsConfiguredCap(t *testing.T) {

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -2029,6 +2029,100 @@ func TestFailOrRetryInner_QuotaSkipsRetries(t *testing.T) {
 	}
 }
 
+func TestFailOrRetryInner_QuotaResetAtDoesNotExceedConfiguredCooldown(t *testing.T) {
+	tc := newWorkerTestContext(t, 1)
+	cfg := config.DefaultConfig()
+	cfg.AgentQuotaCooldown = "5m"
+	tc.reconfigurePool(cfg)
+
+	sha := testutil.GetHeadSHA(t, tc.TmpDir)
+	job := tc.createAndClaimJobWithAgent(t, sha, testWorkerID, "codex")
+	start := time.Now()
+	tc.Pool.classify = func(agentName, msg string) agent.LimitClassification {
+		return agent.LimitClassification{
+			Kind:    agent.LimitKindQuota,
+			Agent:   agentName,
+			ResetAt: start.Add(time.Hour),
+			Message: msg,
+		}
+	}
+
+	tc.Pool.failOrRetryInner(
+		testWorkerID, job, "codex",
+		"codex stream reported failure: You've hit your usage limit.",
+		true,
+	)
+
+	tc.Pool.agentCooldownsMu.RLock()
+	expiry, ok := tc.Pool.agentCooldowns["codex"]
+	tc.Pool.agentCooldownsMu.RUnlock()
+	require.True(t, ok, "expected codex cooldown entry")
+	assert.WithinDuration(t, start.Add(5*time.Minute), expiry, time.Minute,
+		"cooldown should use configured duration, not provider reset time")
+}
+
+func TestFailOrRetryInner_QuotaCooldownForHonorsConfiguredCap(t *testing.T) {
+	tests := []struct {
+		name        string
+		cooldownFor time.Duration
+		want        time.Duration
+	}{
+		{
+			name:        "longer provider duration is capped by config",
+			cooldownFor: time.Hour,
+			want:        5 * time.Minute,
+		},
+		{
+			name:        "shorter provider duration is honored",
+			cooldownFor: 2 * time.Minute,
+			want:        2 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := newWorkerTestContext(t, 1)
+			cfg := config.DefaultConfig()
+			cfg.AgentQuotaCooldown = "5m"
+			tc.reconfigurePool(cfg)
+
+			sha := testutil.GetHeadSHA(t, tc.TmpDir)
+			job := tc.createAndClaimJobWithAgent(t, sha, testWorkerID, "codex")
+			tc.Pool.classify = func(agentName, msg string) agent.LimitClassification {
+				return agent.LimitClassification{
+					Kind:        agent.LimitKindQuota,
+					Agent:       agentName,
+					CooldownFor: tt.cooldownFor,
+					Message:     msg,
+				}
+			}
+
+			start := time.Now()
+			tc.Pool.failOrRetryInner(
+				testWorkerID, job, "codex",
+				"codex stream reported failure: resource exhausted: reset after 1h",
+				true,
+			)
+
+			tc.Pool.agentCooldownsMu.RLock()
+			expiry, ok := tc.Pool.agentCooldowns["codex"]
+			tc.Pool.agentCooldownsMu.RUnlock()
+			require.True(t, ok, "expected codex cooldown entry")
+			assert.WithinDuration(t, start.Add(tt.want), expiry, time.Minute)
+		})
+	}
+}
+
+func TestAgentCooldown_DaemonRestartClearsCooldown(t *testing.T) {
+	cfg := config.DefaultConfig()
+	first := NewWorkerPool(nil, NewStaticConfig(cfg), 1, NewBroadcaster(), nil, nil)
+	first.cooldownAgent("codex", time.Now().Add(time.Hour))
+	require.True(t, first.isAgentCoolingDown("codex"))
+
+	restarted := NewWorkerPool(nil, NewStaticConfig(cfg), 1, NewBroadcaster(), nil, nil)
+	assert.False(t, restarted.isAgentCoolingDown("codex"))
+}
+
 func TestFailOrRetryInner_QuotaExhaustedVariant(t *testing.T) {
 	tc := newWorkerTestContext(t, 1)
 	sha := testutil.GetHeadSHA(t, tc.TmpDir)


### PR DESCRIPTION
This fixes quota/session cooldown handling by bounding daemon-wide per-agent cooldowns with `agent_quota_cooldown` (default `30m0s`). Provider reset hints can shorten the cooldown, but they cannot extend it beyond operator config. Cooldown state remains process-local, so daemon restart clears in-memory cooldowns.

The CI poller deferral and retry logs now include generic correlators, including head SHA, attempt number, next retry time, panel run UUID, and a sanitized error excerpt. That keeps retry flow diagnosable from daemon logs without putting private review or infrastructure context into PR text.

Regression coverage now exercises reset-time hints, reset-duration hints, configured caps, shorter provider durations, and restart-local cooldown state.