### PR TITLE
Keep status off slow repo config probes

### DIFF
--- a/cmd/roborev/status.go
+++ b/cmd/roborev/status.go
@@ -20,6 +20,7 @@ type statusJSONResult struct {
 	Daemon  *storage.DaemonStatus `json:"daemon,omitempty"`
 	Health  *storage.HealthStatus `json:"health,omitempty"`
 	Jobs    []storage.ReviewJob   `json:"jobs,omitempty"`
+	Error   string                `json:"error,omitempty"`
 }
 
 func statusCmd() *cobra.Command {
@@ -33,6 +34,17 @@ func statusCmd() *cobra.Command {
 				enc := json.NewEncoder(os.Stdout)
 				enc.SetIndent("", "  ")
 				return enc.Encode(result)
+			}
+			writeStatusUnavailable := func(err error) error {
+				if jsonOutput {
+					return writeJSONResult(statusJSONResult{
+						Running: true,
+						Error:   err.Error(),
+					})
+				}
+				fmt.Println("Daemon: running")
+				fmt.Printf("Status: unavailable: %v\n", err)
+				return nil
 			}
 
 			// Ensure daemon is running (and restart if version mismatch)
@@ -51,13 +63,7 @@ func statusCmd() *cobra.Command {
 			client := ep.HTTPClient(2 * time.Second)
 			resp, err := client.Get(addr + "/api/status")
 			if err != nil {
-				if jsonOutput {
-					return writeJSONResult(statusJSONResult{Running: false})
-				}
-				fmt.Println("Daemon: not running")
-				fmt.Println()
-				fmt.Println("Start with: roborev daemon start")
-				return nil
+				return writeStatusUnavailable(err)
 			}
 			defer resp.Body.Close()
 

--- a/cmd/roborev/status_test.go
+++ b/cmd/roborev/status_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,6 +17,26 @@ type statusJSONOutput struct {
 	Running bool                 `json:"running"`
 	Daemon  storage.DaemonStatus `json:"daemon"`
 	Jobs    []storage.ReviewJob  `json:"jobs,omitempty"`
+}
+
+func TestStatusCmdDoesNotReportNotRunningWhenStatusRequestTimesOut(t *testing.T) {
+	md := NewMockDaemon(t, MockRefineHooks{
+		OnStatus: func(w http.ResponseWriter, r *http.Request, _ *mockRefineState) bool {
+			time.Sleep(3 * time.Second)
+			return true
+		},
+	})
+	defer md.Close()
+
+	output := captureStdout(t, func() {
+		cmd := statusCmd()
+		err := cmd.Execute()
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "Daemon: running")
+	assert.Contains(t, output, "Status: unavailable")
+	assert.NotContains(t, output, "Daemon: not running")
 }
 
 func TestStatusCmdJSONIncludesDaemonEndpoint(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -575,6 +575,9 @@ func RepoConfigPath(repoPath string) string {
 	if _, err := os.Stat(local); err == nil {
 		return local
 	}
+	if info, err := os.Stat(filepath.Join(repoPath, ".git")); err == nil && info.IsDir() {
+		return local
+	}
 
 	// Not present (or unreadable) at repoPath. If repoPath is a worktree, the
 	// config may live only in the main checkout. Any resolution failure (not a

--- a/internal/daemon/server_auto_design.go
+++ b/internal/daemon/server_auto_design.go
@@ -89,8 +89,9 @@ func (s *Server) autoDesignStatusForResponse() *storage.AutoDesignStatus {
 		repos, err := s.db.ListRepos()
 		if err == nil {
 			for _, r := range repos {
-				if config.ResolveAutoDesignEnabled(r.RootPath, cfg) ||
-					config.ResolveAutoDesignHookEnabled(r.RootPath, cfg) {
+				repoCfg, _ := config.LoadRepoConfig(r.RootPath)
+				if config.AutoDesignEnabledFromConfig(repoCfg, cfg) ||
+					config.AutoDesignHookEnabledFromConfig(repoCfg, cfg) {
 					enabled = true
 					break
 				}

--- a/internal/daemon/server_auto_design_test.go
+++ b/internal/daemon/server_auto_design_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -260,6 +261,30 @@ func TestAutoDesignStatusForResponse_DisabledOmitted(t *testing.T) {
 	// No repo enables auto_design_review.
 	got := srv.autoDesignStatusForResponse()
 	assert.Nil(t, got)
+}
+
+func TestAutoDesignStatusForResponse_DisabledRegularRepoDoesNotSpawnGit(t *testing.T) {
+	ResetAutoDesignMetricsForTest()
+	db := testutil.OpenTestDB(t)
+	repo := testutil.NewGitRepo(t)
+	_, err := db.GetOrCreateRepo(repo.Path())
+	require.NoError(t, err)
+
+	srv := NewServer(db, config.DefaultConfig(), "")
+	marker := filepath.Join(t.TempDir(), "git-invoked")
+	t.Setenv("ROBOREV_GIT_MARKER", marker)
+
+	fakeGit := "#!/bin/sh\n: > \"$ROBOREV_GIT_MARKER\"\nexit 1\n"
+	if runtime.GOOS == "windows" {
+		fakeGit = "@echo git > \"%ROBOREV_GIT_MARKER%\"\r\n@exit /b 1\r\n"
+	}
+	restore := testutil.MockBinaryInPath(t, "git", fakeGit)
+	defer restore()
+
+	got := srv.autoDesignStatusForResponse()
+	assert.Nil(t, got)
+	_, err = os.Stat(marker)
+	assert.True(t, os.IsNotExist(err), "disabled status path must not shell out to git for regular repos without config")
 }
 
 func TestAutoDesignStatusForResponse_EnabledRepoSurfaces(t *testing.T) {


### PR DESCRIPTION
Windows users can have a healthy daemon while `roborev status` reports it as not running because the status endpoint currently performs per-repo auto-design config discovery. In the default-off configuration, registered repos without a local `.roborev.toml` can fall into the linked-worktree config fallback and spawn `git`; with enough repos on Windows, that can exceed the CLI status deadline.

This keeps ordinary checkout config misses on a filesystem-only path while preserving the worktree fallback for actual linked worktrees, and it resolves both auto-design flags from a single loaded repo config. The CLI also now distinguishes a reachable daemon with unavailable status details from an actually missing daemon, so a slow status endpoint no longer tells users to start a daemon that is already alive.

The main reviewer consequence is that `/api/status` should stay cheap for default installations with many registered repos, while still surfacing auto-design metrics when global or per-repo config enables them. Full Go tests pass locally.

Fixes #871