### PR TITLE
Avoid terminal probe import at CLI startup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
+*.sh text eol=lf
 *.gotmpl text eol=lf
 *.golden text eol=lf

--- a/cmd/roborev/startup_imports_test.go
+++ b/cmd/roborev/startup_imports_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoborevStartupAvoidsTerminalProbeImports(t *testing.T) {
+	cmd := exec.Command("go", "list", "-deps", ".")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "go list -deps failed:\n%s", out)
+
+	deps := strings.Fields(string(out))
+	assert.NotContains(t, deps, "charm.land/lipgloss/v2/compat")
+}

--- a/cmd/roborev/tui/colors.go
+++ b/cmd/roborev/tui/colors.go
@@ -1,13 +1,11 @@
 package tui
 
 import (
-	"charm.land/lipgloss/v2"
-	"charm.land/lipgloss/v2/compat"
+	"image/color"
+
+	"go.kenn.io/roborev/internal/termstyle"
 )
 
-func adaptiveColor(light, dark string) compat.AdaptiveColor {
-	return compat.AdaptiveColor{
-		Light: lipgloss.Color(light),
-		Dark:  lipgloss.Color(dark),
-	}
+func adaptiveColor(light, dark string) color.Color {
+	return termstyle.AdaptiveColor(light, dark)
 }

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
 
             src = ./.;
 
-            vendorHash = "sha256-rrjsevN+7xIOWZOeEFchOdfoaqB3usKXCELsgC8De2s=";
+            vendorHash = "sha256-XxmzuVbNDl3ed10JCqwkJPizrf+qzjW5OK+yiDs4Bdw=";
 
             subPackages = [ "cmd/roborev" ];
 

--- a/internal/streamfmt/streamfmt.go
+++ b/internal/streamfmt/streamfmt.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"image/color"
 	"io"
 	"os"
 	"strings"
@@ -13,9 +14,10 @@ import (
 	gansi "charm.land/glamour/v2/ansi"
 	"charm.land/glamour/v2/styles"
 	"charm.land/lipgloss/v2"
-	"charm.land/lipgloss/v2/compat"
 	"github.com/muesli/termenv"
 	"golang.org/x/term"
+
+	"go.kenn.io/roborev/internal/termstyle"
 )
 
 // Styles for TTY-mode stream output.
@@ -30,11 +32,8 @@ var (
 				Foreground(adaptiveColor("242", "243")).Italic(true) // Dim italic — thinking indicator
 )
 
-func adaptiveColor(light, dark string) compat.AdaptiveColor {
-	return compat.AdaptiveColor{
-		Light: lipgloss.Color(light),
-		Dark:  lipgloss.Color(dark),
-	}
+func adaptiveColor(light, dark string) color.Color {
+	return termstyle.AdaptiveColor(light, dark)
 }
 
 // Formatter wraps an io.Writer to transform raw NDJSON stream output
@@ -107,6 +106,7 @@ func TerminalWidth(w io.Writer) int {
 func GlamourStyle() gansi.StyleConfig {
 	mode := strings.ToLower(os.Getenv("ROBOREV_COLOR_MODE"))
 	var style gansi.StyleConfig
+	isDark := true
 	switch {
 	case mode == "none" || termenv.EnvNoColor():
 		// Use dark style as base; colors will be stripped by Ascii profile.
@@ -115,12 +115,15 @@ func GlamourStyle() gansi.StyleConfig {
 		style = styles.DarkStyleConfig
 	case mode == "light":
 		style = styles.LightStyleConfig
+		isDark = false
 	default: // "auto" or ""
 		style = styles.LightStyleConfig
-		if termenv.HasDarkBackground() {
+		isDark = termenv.HasDarkBackground()
+		if isDark {
 			style = styles.DarkStyleConfig
 		}
 	}
+	termstyle.SetDarkBackground(isDark)
 	zeroMargin := uint(0)
 	style.Document.Margin = &zeroMargin
 	style.CodeBlock.Margin = &zeroMargin

--- a/internal/termstyle/adaptive.go
+++ b/internal/termstyle/adaptive.go
@@ -1,0 +1,56 @@
+package termstyle
+
+import (
+	"image/color"
+	"os"
+	"strings"
+	"sync/atomic"
+
+	"charm.land/lipgloss/v2"
+)
+
+var (
+	detectedDarkBackground    atomic.Bool
+	detectedDarkBackgroundSet atomic.Bool
+)
+
+type adaptiveColor struct {
+	light color.Color
+	dark  color.Color
+}
+
+// AdaptiveColor returns a light/dark color without performing terminal I/O.
+func AdaptiveColor(light, dark string) color.Color {
+	return adaptiveColor{
+		light: lipgloss.Color(light),
+		dark:  lipgloss.Color(dark),
+	}
+}
+
+// SetDarkBackground records terminal background detection performed by callers
+// that already have a safe point to query the terminal.
+func SetDarkBackground(isDark bool) {
+	detectedDarkBackground.Store(isDark)
+	detectedDarkBackgroundSet.Store(true)
+}
+
+// DarkBackground returns the palette choice for adaptive colors.
+func DarkBackground() bool {
+	switch strings.ToLower(os.Getenv("ROBOREV_COLOR_MODE")) {
+	case "light":
+		return false
+	case "dark", "none":
+		return true
+	}
+	if detectedDarkBackgroundSet.Load() {
+		return detectedDarkBackground.Load()
+	}
+	return true
+}
+
+func (c adaptiveColor) RGBA() (uint32, uint32, uint32, uint32) {
+	if DarkBackground() {
+		return c.dark.RGBA()
+	}
+	return c.light.RGBA()
+}

--- a/internal/termstyle/adaptive_test.go
+++ b/internal/termstyle/adaptive_test.go
@@ -1,0 +1,48 @@
+package termstyle
+
+import (
+	"image/color"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func resetAdaptiveColorState(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("ROBOREV_COLOR_MODE", "")
+	detectedDarkBackground.Store(false)
+	detectedDarkBackgroundSet.Store(false)
+}
+
+func colorTuple(c color.Color) [4]uint32 {
+	r, g, b, a := c.RGBA()
+	return [4]uint32{r, g, b, a}
+}
+
+func TestAdaptiveColorDefaultsToDarkPalette(t *testing.T) {
+	resetAdaptiveColorState(t)
+
+	got := AdaptiveColor("1", "2")
+
+	assert.Equal(t, colorTuple(lipgloss.Color("2")), colorTuple(got))
+}
+
+func TestAdaptiveColorRespectsExplicitLightMode(t *testing.T) {
+	resetAdaptiveColorState(t)
+	t.Setenv("ROBOREV_COLOR_MODE", "light")
+
+	got := AdaptiveColor("1", "2")
+
+	assert.Equal(t, colorTuple(lipgloss.Color("1")), colorTuple(got))
+}
+
+func TestAdaptiveColorUsesDetectedAutoBackground(t *testing.T) {
+	resetAdaptiveColorState(t)
+	SetDarkBackground(false)
+
+	got := AdaptiveColor("1", "2")
+
+	assert.Equal(t, colorTuple(lipgloss.Color("1")), colorTuple(got))
+}

--- a/scripts/bash_test.go
+++ b/scripts/bash_test.go
@@ -1,0 +1,59 @@
+package scripts
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func bashPath(t *testing.T, path string) string {
+	t.Helper()
+
+	if runtime.GOOS != "windows" {
+		return path
+	}
+
+	abs, err := filepath.Abs(path)
+	require.NoError(t, err)
+
+	volume := filepath.VolumeName(abs)
+	if len(volume) != 2 || volume[1] != ':' {
+		return filepath.ToSlash(abs)
+	}
+
+	drive := strings.ToLower(volume[:1])
+	rest := strings.TrimPrefix(filepath.ToSlash(strings.TrimPrefix(abs, volume)), "/")
+	candidates := []string{
+		"/mnt/" + drive + "/" + rest,
+		"/" + drive + "/" + rest,
+		filepath.ToSlash(abs),
+	}
+	for _, candidate := range candidates {
+		cmd := exec.Command("bash", "-lc", "test -e "+shellQuote(candidate))
+		if err := cmd.Run(); err == nil {
+			return candidate
+		}
+	}
+
+	t.Fatalf("could not translate Windows path %q for bash", path)
+	return ""
+}
+
+func readShellScript(t *testing.T, path string) []byte {
+	t.Helper()
+
+	script, err := os.ReadFile(path)
+	require.NoError(t, err)
+	script = bytes.ReplaceAll(script, []byte("\r\n"), []byte("\n"))
+	return script
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}

--- a/scripts/hydrate_assets_test.go
+++ b/scripts/hydrate_assets_test.go
@@ -49,12 +49,13 @@ func TestHydrateAssetsForceFetchesRemoteAssetBranches(t *testing.T) {
 	writeStaticAssets(t, filepath.Join(docsAssetsDir, "static"), "stale local static")
 	writeGeneratedAssets(t, filepath.Join(docsAssetsDir, "generated"), "stale local generated")
 
-	script, err := os.ReadFile(filepath.Join("..", "docs", "assets", "hydrate-assets.sh"))
-	require.NoError(t, err)
+	git(t, localRepo, "remote", "set-url", "origin", bashPath(t, remoteRepo))
+
+	script := readShellScript(t, filepath.Join("..", "docs", "assets", "hydrate-assets.sh"))
 	scriptPath := filepath.Join(docsAssetsDir, "hydrate-assets.sh")
 	require.NoError(t, os.WriteFile(scriptPath, script, 0o755))
 
-	cmd := exec.Command("bash", scriptPath)
+	cmd := exec.Command("bash", bashPath(t, scriptPath))
 	cmd.Dir = localRepo
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
@@ -97,7 +98,7 @@ func TestAssetPublishersRejectUnexpectedFiles(t *testing.T) {
 			require.NoError(t, os.WriteFile(filepath.Join(sourceDir, ".env.local"), []byte("TOKEN=secret\n"), 0o600))
 
 			scriptPath := installAssetScript(t, repo, tc.scriptRel)
-			cmd := exec.Command("bash", scriptPath, "--source", sourceDir)
+			cmd := exec.Command("bash", bashPath(t, scriptPath), "--source", bashPath(t, sourceDir))
 			cmd.Dir = repo
 			output, err := cmd.CombinedOutput()
 
@@ -110,8 +111,7 @@ func TestAssetPublishersRejectUnexpectedFiles(t *testing.T) {
 
 func installAssetScript(t *testing.T, repo, scriptRel string) string {
 	t.Helper()
-	script, err := os.ReadFile(filepath.Join("..", scriptRel))
-	require.NoError(t, err)
+	script := readShellScript(t, filepath.Join("..", scriptRel))
 	scriptPath := filepath.Join(repo, scriptRel)
 	require.NoError(t, os.MkdirAll(filepath.Dir(scriptPath), 0o755))
 	require.NoError(t, os.WriteFile(scriptPath, script, 0o755))

--- a/scripts/prepare_demo_db_test.go
+++ b/scripts/prepare_demo_db_test.go
@@ -386,11 +386,20 @@ func insertScreenshotJobWithoutReview(t *testing.T, db *sql.DB, repoID, jobID in
 func runPrepareDemoDB(t *testing.T, tempDir, sourceDB string) string {
 	t.Helper()
 
-	cmd := exec.Command("bash", "../docs/screenshots/prepare-demo-db.sh")
-	cmd.Env = append(os.Environ(),
-		"TMPDIR="+tempDir,
-		"ROBOREV_DOCS_SOURCE_DB="+sourceDB,
-		"HOME="+filepath.Join(tempDir, "maintainer-home"),
+	script := readShellScript(t, filepath.Join("..", "docs", "screenshots", "prepare-demo-db.sh"))
+	scriptPath := filepath.Join(tempDir, "prepare-demo-db.sh")
+	require.NoError(t, os.WriteFile(scriptPath, script, 0o755))
+
+	homeDir := filepath.Join(tempDir, "maintainer-home")
+	require.NoError(t, os.MkdirAll(homeDir, 0o755))
+
+	cmd := exec.Command(
+		"bash",
+		"-lc",
+		"export TMPDIR="+shellQuote(bashPath(t, tempDir))+
+			" ROBOREV_DOCS_SOURCE_DB="+shellQuote(bashPath(t, sourceDB))+
+			" HOME="+shellQuote(bashPath(t, homeDir))+
+			"; exec "+shellQuote(bashPath(t, scriptPath)),
 	)
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))


### PR DESCRIPTION
Fixes #872.

Windows users can hit a foreground CLI startup hang when their console exposes stdin but never answers the OSC-11 background-color query. The failure happens before command dispatch because `lipgloss/v2/compat` performs that query from package init, so even commands like `roborev version` can appear to do nothing.

This removes the impure compat package from the roborev command dependency graph and keeps adaptive colors behind a local helper that has no terminal I/O at init. Auto color selection still uses the existing stream formatter detection point once execution reaches code that is intentionally rendering terminal output.

The important review boundary is startup behavior: the binary should not regain an import-time terminal probe while registering commands. A dependency-graph regression test now guards that directly.

Windows validation also exposed script-test harness assumptions around CRLF shell scripts and raw Windows paths passed into Bash. The PR now normalizes shipped shell scripts to LF and makes the script tests hand Bash-visible paths and remotes to WSL/Git Bash.