### PR TITLE
Fix Windows summary filters and Codex token usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,9 @@ Use `testify` (`github.com/stretchr/testify`) for all test assertions. Use `requ
 - Integration tests: `go test -tags=integration ./...`
 - PostgreSQL tests: `go test -tags=postgres -v ./internal/storage/... -run Integration`
 - ACP smoke tests: use the `make test-acp-integration*` targets in `Makefile`
+- On Windows, repo-wide and daemon/CLI package tests can take several minutes.
+  Use command wrapper timeouts of at least 10 minutes for `go test ./...` and
+  at least 5 minutes for `go test ./internal/daemon` or `go test ./cmd/roborev`.
 - Pre-commit hooks in this repo are managed with `prek`; run `prek install` after cloning or `make install-hooks` as a wrapper.
 - The local pre-commit hook is a `prek` system hook that runs `make lint` with `always_run`, so it executes on every commit and may auto-fix files before the commit succeeds.
 - If the hook rewrites files, re-stage them and rerun the commit. Use `prek run --all-files` to execute the hook manually and `make lint-ci` for a non-mutating lint check.

--- a/cmd/roborev/backfill_tokens.go
+++ b/cmd/roborev/backfill_tokens.go
@@ -10,6 +10,7 @@ import (
 
 	"go.kenn.io/roborev/internal/backfill"
 	"go.kenn.io/roborev/internal/config"
+	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/tokens"
 )
@@ -19,9 +20,11 @@ func backfillTokensCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "backfill-tokens",
-		Short: "Backfill token usage for completed jobs via agentsview",
-		Long: `Scan completed jobs that have a session ID but missing token cost data,
-and attempt to fetch token consumption from agentsview.
+		Short: "Backfill token usage for completed jobs",
+		Long: `Scan completed jobs missing token usage or cost data.
+
+Codex job logs are checked first for turn.completed usage events. When
+available, agentsview is also queried to recover cost estimates.
 
 This is best-effort: jobs whose session files have been deleted
 will be skipped.`,
@@ -51,10 +54,19 @@ will be skipped.`,
 			for _, job := range candidates {
 				total++
 
+				logUsage, logErr := tokens.ParseCodexUsageFile(
+					daemon.JobLogPath(job.ID),
+				)
+				if logErr != nil {
+					log.Printf(
+						"job %d: parse job log: %v", job.ID, logErr,
+					)
+				}
+
 				ctx, cancel := context.WithTimeout(
 					context.Background(), 15*time.Second,
 				)
-				usage, fetchErr := tokens.FetchForSessionWithConfig(
+				fetchedUsage, fetchErr := tokens.FetchForSessionWithConfig(
 					ctx, job.SessionID, fetchConfig,
 				)
 				cancel()
@@ -63,9 +75,14 @@ will be skipped.`,
 					log.Printf(
 						"job %d: fetch error: %v", job.ID, fetchErr,
 					)
-					failed++
-					continue
+					if logUsage == nil {
+						failed++
+						continue
+					}
 				}
+				usage := backfill.MergeTokenUsage(
+					tokens.ToJSON(logUsage), fetchedUsage,
+				)
 				if usage == nil {
 					skipped++
 					continue
@@ -82,7 +99,7 @@ will be skipped.`,
 				}
 
 				j := tokens.ToJSON(mergedUsage)
-				if err := db.SaveJobTokenUsage(job.ID, job.SessionID, j); err != nil {
+				if err := db.BackfillJobTokenUsage(job.ID, job.SessionID, j); err != nil {
 					log.Printf(
 						"job %d: save error: %v", job.ID, err,
 					)

--- a/cmd/roborev/backfill_tokens.go
+++ b/cmd/roborev/backfill_tokens.go
@@ -48,7 +48,11 @@ will be skipped.`,
 				return fmt.Errorf("list jobs: %w", err)
 			}
 
-			candidates := backfill.TokenCandidates(jobs)
+			agentsviewCandidates := make(map[int64]bool)
+			for _, job := range backfill.TokenCandidates(jobs) {
+				agentsviewCandidates[job.ID] = true
+			}
+			candidates := backfill.LogTokenCandidates(jobs)
 
 			var total, updated, skipped, failed int
 			for _, job := range candidates {
@@ -63,13 +67,17 @@ will be skipped.`,
 					)
 				}
 
-				ctx, cancel := context.WithTimeout(
-					context.Background(), 15*time.Second,
-				)
-				fetchedUsage, fetchErr := tokens.FetchForSessionWithConfig(
-					ctx, job.SessionID, fetchConfig,
-				)
-				cancel()
+				var fetchedUsage *tokens.Usage
+				var fetchErr error
+				if agentsviewCandidates[job.ID] {
+					ctx, cancel := context.WithTimeout(
+						context.Background(), 15*time.Second,
+					)
+					fetchedUsage, fetchErr = tokens.FetchForSessionWithConfig(
+						ctx, job.SessionID, fetchConfig,
+					)
+					cancel()
+				}
 
 				if fetchErr != nil {
 					log.Printf(
@@ -99,7 +107,11 @@ will be skipped.`,
 				}
 
 				j := tokens.ToJSON(mergedUsage)
-				if err := db.BackfillJobTokenUsage(job.ID, job.SessionID, j); err != nil {
+				sessionID := job.SessionID
+				if sessionID == "" {
+					sessionID = mergedUsage.ThreadID
+				}
+				if err := db.BackfillJobTokenUsage(job.ID, sessionID, j); err != nil {
 					log.Printf(
 						"job %d: save error: %v", job.ID, err,
 					)

--- a/cmd/roborev/backfill_tokens_test.go
+++ b/cmd/roborev/backfill_tokens_test.go
@@ -1,13 +1,17 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/roborev/internal/backfill"
 	"go.kenn.io/roborev/internal/config"
+	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/tokens"
 )
@@ -208,4 +212,72 @@ func TestMergeBackfillTokenUsagePreservesExistingCountsForCostOnlyFetch(t *testi
 	assert.Equal(t, int64(118000), got.PeakContextTokens)
 	assert.True(t, got.HasCost)
 	assert.InDelta(t, 0.42, got.CostUSD, 1e-9)
+}
+
+func TestMergeBackfillTokenUsagePreservesCodexInputBucketsForCostOnlyFetch(t *testing.T) {
+	existing := `{"input_tokens":79150,"cached_input_tokens":2560,` +
+		`"total_output_tokens":3389,"usage_source":"job_log_turn_completed",` +
+		`"thread_id":"thread-123","event_offset":91}`
+	fetched := &tokens.Usage{CostUSD: 0.42, HasCost: true}
+
+	got := backfill.MergeTokenUsage(existing, fetched)
+
+	assert.Equal(t, int64(79150), got.InputTokens)
+	assert.Equal(t, int64(2560), got.CachedInputTokens)
+	assert.Equal(t, int64(3389), got.OutputTokens)
+	assert.Equal(t, "job_log_turn_completed", got.UsageSource)
+	assert.Equal(t, "thread-123", got.ThreadID)
+	assert.Equal(t, int64(91), got.EventOffset)
+	assert.True(t, got.HasCost)
+	assert.InDelta(t, 0.42, got.CostUSD, 1e-9)
+}
+
+func TestBackfillTokensUsesCodexJobLogWhenAgentsviewMissing(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("ROBOREV_DATA_DIR", dataDir)
+	t.Setenv("PATH", t.TempDir())
+
+	db, err := storage.Open(storage.DefaultDBPath())
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo, err := db.GetOrCreateRepo(filepath.Join(t.TempDir(), "repo"))
+	require.NoError(t, err)
+	commit, err := db.GetOrCreateCommit(repo.ID, "abc123", "Author", "Subject", time.Now())
+	require.NoError(t, err)
+	job, err := db.EnqueueJob(storage.EnqueueOpts{
+		RepoID:    repo.ID,
+		CommitID:  commit.ID,
+		GitRef:    "abc123",
+		Agent:     "codex",
+		SessionID: "thread-123",
+	})
+	require.NoError(t, err)
+	claimed, err := db.ClaimJob("worker-1")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	require.Equal(t, job.ID, claimed.ID)
+	require.NoError(t, db.CompleteJob(job.ID, "codex", "prompt", "No issues found."))
+
+	logPath := daemon.JobLogPath(job.ID)
+	require.NoError(t, os.MkdirAll(filepath.Dir(logPath), 0o700))
+	require.NoError(t, os.WriteFile(logPath, []byte(
+		`{"type":"thread.started","thread_id":"thread-123"}`+"\n"+
+			`{"type":"turn.completed","usage":{"input_tokens":79150,`+
+			`"cached_input_tokens":2560,"output_tokens":3389}}`+"\n",
+	), 0o600))
+
+	cmd := backfillTokensCmd()
+	cmd.SetArgs(nil)
+	require.NoError(t, cmd.Execute())
+
+	updated, err := db.GetJobByID(job.ID)
+	require.NoError(t, err)
+	usage := tokens.ParseJSON(updated.TokenUsage)
+	require.NotNil(t, usage)
+	assert.Equal(t, int64(79150), usage.InputTokens)
+	assert.Equal(t, int64(2560), usage.CachedInputTokens)
+	assert.Equal(t, int64(3389), usage.OutputTokens)
+	assert.Equal(t, "job_log_turn_completed", usage.UsageSource)
+	assert.Equal(t, "thread-123", usage.ThreadID)
 }

--- a/cmd/roborev/backfill_tokens_test.go
+++ b/cmd/roborev/backfill_tokens_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -280,4 +281,85 @@ func TestBackfillTokensUsesCodexJobLogWhenAgentsviewMissing(t *testing.T) {
 	assert.Equal(t, int64(3389), usage.OutputTokens)
 	assert.Equal(t, "job_log_turn_completed", usage.UsageSource)
 	assert.Equal(t, "thread-123", usage.ThreadID)
+}
+
+func TestBackfillTokensUsesCodexJobLogsWithoutAgentsviewEligibleSession(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("ROBOREV_DATA_DIR", dataDir)
+	t.Setenv("PATH", t.TempDir())
+
+	db, err := storage.Open(storage.DefaultDBPath())
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo, err := db.GetOrCreateRepo(filepath.Join(t.TempDir(), "repo"))
+	require.NoError(t, err)
+	commit, err := db.GetOrCreateCommit(repo.ID, "abc123", "Author", "Subject", time.Now())
+	require.NoError(t, err)
+
+	missingSession := enqueueCompleteJob(t, db, repo.ID, commit.ID, "")
+	sharedSessionA := enqueueCompleteJob(t, db, repo.ID, commit.ID, "shared-session")
+	sharedSessionB := enqueueCompleteJob(t, db, repo.ID, commit.ID, "shared-session")
+
+	writeCodexUsageLog(t, missingSession.ID, "missing-session-thread", 1000, 100, 200)
+	writeCodexUsageLog(t, sharedSessionA.ID, "shared-session", 2000, 200, 300)
+	writeCodexUsageLog(t, sharedSessionB.ID, "shared-session", 3000, 300, 400)
+
+	cmd := backfillTokensCmd()
+	cmd.SetArgs(nil)
+	require.NoError(t, cmd.Execute())
+
+	assertJobUsage := func(jobID int64, threadID string, input, cached, output int64) {
+		updated, err := db.GetJobByID(jobID)
+		require.NoError(t, err)
+		usage := tokens.ParseJSON(updated.TokenUsage)
+		require.NotNil(t, usage)
+		assert.Equal(t, input, usage.InputTokens)
+		assert.Equal(t, cached, usage.CachedInputTokens)
+		assert.Equal(t, output, usage.OutputTokens)
+		assert.Equal(t, threadID, usage.ThreadID)
+		assert.Equal(t, "job_log_turn_completed", usage.UsageSource)
+	}
+	assertJobUsage(missingSession.ID, "missing-session-thread", 1000, 100, 200)
+	assertJobUsage(sharedSessionA.ID, "shared-session", 2000, 200, 300)
+	assertJobUsage(sharedSessionB.ID, "shared-session", 3000, 300, 400)
+
+	updatedMissingSession, err := db.GetJobByID(missingSession.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "missing-session-thread", updatedMissingSession.SessionID)
+}
+
+func enqueueCompleteJob(
+	t *testing.T, db *storage.DB, repoID, commitID int64, sessionID string,
+) *storage.ReviewJob {
+	t.Helper()
+	job, err := db.EnqueueJob(storage.EnqueueOpts{
+		RepoID:    repoID,
+		CommitID:  commitID,
+		GitRef:    "abc123",
+		Agent:     "codex",
+		SessionID: sessionID,
+	})
+	require.NoError(t, err)
+	claimed, err := db.ClaimJob("worker-1")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	require.Equal(t, job.ID, claimed.ID)
+	require.NoError(t, db.CompleteJob(job.ID, "codex", "prompt", "No issues found."))
+	return job
+}
+
+func writeCodexUsageLog(
+	t *testing.T, jobID int64, threadID string, input, cached, output int64,
+) {
+	t.Helper()
+	logPath := daemon.JobLogPath(jobID)
+	require.NoError(t, os.MkdirAll(filepath.Dir(logPath), 0o700))
+	require.NoError(t, os.WriteFile(logPath, []byte(
+		`{"type":"thread.started","thread_id":"`+threadID+`"}`+"\n"+
+			`{"type":"turn.completed","usage":{"input_tokens":`+
+			fmt.Sprintf("%d", input)+`,"cached_input_tokens":`+
+			fmt.Sprintf("%d", cached)+`,"output_tokens":`+
+			fmt.Sprintf("%d", output)+`}}`+"\n",
+	), 0o600))
 }

--- a/internal/backfill/tokens.go
+++ b/internal/backfill/tokens.go
@@ -65,6 +65,23 @@ func TokenCandidates(jobs []storage.ReviewJob) []storage.ReviewJob {
 	return out
 }
 
+// LogTokenCandidates filters jobs whose per-job logs may contain recoverable
+// token usage. Unlike TokenCandidates, this does not require a session ID or a
+// unique session because the usage event came from the individual job log.
+func LogTokenCandidates(jobs []storage.ReviewJob) []storage.ReviewJob {
+	var out []storage.ReviewJob
+	for _, job := range jobs {
+		if !job.HasViewableOutput() {
+			continue
+		}
+		if !NeedsTokenUsageBackfill(job.TokenUsage) {
+			continue
+		}
+		out = append(out, job)
+	}
+	return out
+}
+
 func MergeTokenUsage(existingJSON string, fetched *tokens.Usage) *tokens.Usage {
 	if fetched == nil {
 		return tokens.ParseJSON(existingJSON)
@@ -104,6 +121,18 @@ func MergeTokenUsage(existingJSON string, fetched *tokens.Usage) *tokens.Usage {
 func NeedsTokenCostBackfill(tokenUsage string) bool {
 	usage := tokens.ParseJSON(tokenUsage)
 	return usage == nil || !usage.HasCost
+}
+
+func NeedsTokenUsageBackfill(tokenUsage string) bool {
+	usage := tokens.ParseJSON(tokenUsage)
+	if usage == nil {
+		return true
+	}
+	hasTokenCounts := usage.InputTokens != 0 ||
+		usage.CachedInputTokens != 0 ||
+		usage.OutputTokens != 0 ||
+		usage.PeakContextTokens != 0
+	return !hasTokenCounts || !usage.HasCost
 }
 
 func ApplyTokenUsage(

--- a/internal/backfill/tokens.go
+++ b/internal/backfill/tokens.go
@@ -79,6 +79,21 @@ func MergeTokenUsage(existingJSON string, fetched *tokens.Usage) *tokens.Usage {
 		merged.OutputTokens = existing.OutputTokens
 		merged.PeakContextTokens = existing.PeakContextTokens
 	}
+	if merged.InputTokens == 0 {
+		merged.InputTokens = existing.InputTokens
+	}
+	if merged.CachedInputTokens == 0 {
+		merged.CachedInputTokens = existing.CachedInputTokens
+	}
+	if merged.UsageSource == "" {
+		merged.UsageSource = existing.UsageSource
+	}
+	if merged.ThreadID == "" {
+		merged.ThreadID = existing.ThreadID
+	}
+	if merged.EventOffset == 0 {
+		merged.EventOffset = existing.EventOffset
+	}
 	if !merged.HasCost && existing.HasCost {
 		merged.CostUSD = existing.CostUSD
 		merged.HasCost = true

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -17,6 +17,7 @@ import (
 	gitworktree "go.kenn.io/kit/git/worktree"
 
 	"go.kenn.io/roborev/internal/agent"
+	"go.kenn.io/roborev/internal/backfill"
 	"go.kenn.io/roborev/internal/config"
 	gitpkg "go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/kata"
@@ -1311,37 +1312,64 @@ func (wp *WorkerPool) releaseIfPanelMember(job *storage.ReviewJob) {
 func (wp *WorkerPool) captureTokenUsageForSession(
 	ctx context.Context, workerID string, job *storage.ReviewJob, capturedSession string,
 ) {
-	// Fetch token usage from agentsview (best-effort).
-	// Only collect for fresh sessions (where we captured a new session ID).
-	// Resumed sessions report cumulative totals across all turns, which
-	// would overcount if assigned to a single job.
+	// Only fetch agentsview usage for fresh sessions (where we captured a new
+	// session ID). Resumed-session agentsview totals are cumulative across
+	// turns, but Codex job-log turn.completed usage belongs to this job's
+	// stream and is safe to parse below.
 	wasResumed := job.SessionID != "" && capturedSession == job.SessionID
-	if capturedSession == "" || wasResumed {
-		return
+
+	var usage *tokens.Usage
+	logUsage, logErr := tokens.ParseCodexUsageFile(JobLogPath(job.ID))
+	if logErr != nil {
+		log.Printf("[%s] Warning: parse token usage from job log for job %d: %v",
+			workerID, job.ID, logErr)
+	} else if logUsage != nil {
+		usage = logUsage
 	}
-	fetcher := wp.tokenUsageFetcher
-	if fetcher == nil {
-		cfg := wp.cfgGetter.Config()
-		fetcher = func(ctx context.Context, sessionID string) (*tokens.Usage, error) {
-			return tokens.FetchForSessionWithConfig(
-				ctx, sessionID,
-				tokens.FetchConfig{
-					Endpoint: cfg.Cost.Endpoint,
-					Timeout:  cfg.Cost.ResolvedTimeout(),
-				},
-			)
+
+	if capturedSession != "" && !wasResumed {
+		fetcher := wp.tokenUsageFetcher
+		if fetcher == nil {
+			cfg := wp.cfgGetter.Config()
+			fetcher = func(ctx context.Context, sessionID string) (*tokens.Usage, error) {
+				return tokens.FetchForSessionWithConfig(
+					ctx, sessionID,
+					tokens.FetchConfig{
+						Endpoint: cfg.Cost.Endpoint,
+						Timeout:  cfg.Cost.ResolvedTimeout(),
+					},
+				)
+			}
+		}
+		fetched, tokenErr := fetcher(ctx, capturedSession)
+		if tokenErr != nil {
+			log.Printf("[%s] Warning: fetch token usage for job %d: %v",
+				workerID, job.ID, tokenErr)
+		} else {
+			usage = backfill.MergeTokenUsage(tokens.ToJSON(usage), fetched)
 		}
 	}
-	usage, tokenErr := fetcher(ctx, capturedSession)
-	if tokenErr != nil {
-		log.Printf("[%s] Warning: fetch token usage for job %d: %v",
-			workerID, job.ID, tokenErr)
-		return
-	}
+
 	if usage == nil {
 		return
 	}
-	if err := wp.db.SaveJobTokenUsage(job.ID, capturedSession, tokens.ToJSON(usage)); err != nil {
+	sessionID := capturedSession
+	if sessionID == "" {
+		sessionID = usage.ThreadID
+	}
+	if sessionID == "" {
+		return
+	}
+	var err error
+	if capturedSession != "" {
+		err = wp.db.SaveJobTokenUsage(job.ID, sessionID, tokens.ToJSON(usage))
+		if err == nil {
+			err = wp.db.BackfillJobTokenUsage(job.ID, sessionID, tokens.ToJSON(usage))
+		}
+	} else {
+		err = wp.db.BackfillJobTokenUsage(job.ID, sessionID, tokens.ToJSON(usage))
+	}
+	if err != nil {
 		log.Printf("[%s] Warning: save token usage for job %d: %v",
 			workerID, job.ID, err)
 	}

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -881,6 +881,42 @@ func TestProcessJob_UsageEndpointFailureKeepsCompletedJob(t *testing.T) {
 	assert.Empty(t, updated.TokenUsage)
 }
 
+func TestCaptureTokenUsageForSessionUsesCodexJobLog(t *testing.T) {
+	t.Setenv("ROBOREV_DATA_DIR", t.TempDir())
+	tc := newWorkerTestContext(t, 1)
+	sha := testutil.GetHeadSHA(t, tc.TmpDir)
+	job := tc.createAndClaimJobWithAgent(t, sha, testWorkerID, "codex")
+	require.NoError(t, tc.DB.CompleteJob(job.ID, "codex", "prompt", "No issues found."))
+
+	logPath := JobLogPath(job.ID)
+	require.NoError(t, os.MkdirAll(filepath.Dir(logPath), 0o700))
+	require.NoError(t, os.WriteFile(logPath, []byte(
+		`{"type":"thread.started","thread_id":"thread-123"}`+"\n"+
+			`{"type":"turn.completed","usage":{"input_tokens":79150,`+
+			`"cached_input_tokens":2560,"output_tokens":3389}}`+"\n",
+	), 0o600))
+
+	tc.Pool.tokenUsageFetcher = func(context.Context, string) (*tokens.Usage, error) {
+		return &tokens.Usage{CostUSD: 0.42, HasCost: true}, nil
+	}
+
+	tc.Pool.captureTokenUsageForSession(
+		context.Background(), testWorkerID, job, "thread-123",
+	)
+
+	updated, err := tc.DB.GetJobByID(job.ID)
+	require.NoError(t, err)
+	usage := tokens.ParseJSON(updated.TokenUsage)
+	require.NotNil(t, usage)
+	assert.Equal(t, int64(79150), usage.InputTokens)
+	assert.Equal(t, int64(2560), usage.CachedInputTokens)
+	assert.Equal(t, int64(3389), usage.OutputTokens)
+	assert.True(t, usage.HasCost)
+	assert.InDelta(t, 0.42, usage.CostUSD, 1e-9)
+	assert.Equal(t, "job_log_turn_completed", usage.UsageSource)
+	assert.Equal(t, "thread-123", usage.ThreadID)
+}
+
 func TestProcessJob_UsesStoredReviewPromptOverride(t *testing.T) {
 	tc := newWorkerTestContext(t, 1)
 	sha := testutil.GetHeadSHA(t, tc.TmpDir)

--- a/internal/daemon_client/client.gen.go
+++ b/internal/daemon_client/client.gen.go
@@ -683,9 +683,11 @@ type ReviewJob struct {
 // SessionUsagePayload defines model for SessionUsagePayload.
 type SessionUsagePayload struct {
 	Agent             *string  `json:"agent,omitempty"`
+	CachedInputTokens *int64   `json:"cached_input_tokens,omitempty"`
 	CostUsd           *float64 `json:"cost_usd,omitempty"`
 	HasCost           *bool    `json:"has_cost"`
 	HasTokenData      *bool    `json:"has_token_data"`
+	InputTokens       *int64   `json:"input_tokens,omitempty"`
 	PeakContextTokens *int64   `json:"peak_context_tokens,omitempty"`
 	Project           *string  `json:"project,omitempty"`
 	SessionId         string   `json:"session_id"`

--- a/internal/daemon_client/openapi-3.0.json
+++ b/internal/daemon_client/openapi-3.0.json
@@ -1807,6 +1807,10 @@
           "agent": {
             "type": "string"
           },
+          "cached_input_tokens": {
+            "format": "int64",
+            "type": "integer"
+          },
           "cost_usd": {
             "format": "double",
             "type": "number"
@@ -1818,6 +1822,10 @@
           "has_token_data": {
             "nullable": true,
             "type": "boolean"
+          },
+          "input_tokens": {
+            "format": "int64",
+            "type": "integer"
           },
           "peak_context_tokens": {
             "format": "int64",

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -476,6 +476,32 @@ func (db *DB) SaveJobTokenUsage(jobID int64, sessionID, tokenUsageJSON string) e
 	return err
 }
 
+// BackfillJobTokenUsage stores recovered token usage for a terminal job.
+// Unlike SaveJobTokenUsage, this path runs after the producing worker is gone,
+// so it scopes the update to a terminal row and preserves any different
+// existing session_id to avoid stamping usage onto an unrelated attempt.
+func (db *DB) BackfillJobTokenUsage(jobID int64, sessionID, tokenUsageJSON string) error {
+	if tokenUsageJSON == "" {
+		return nil
+	}
+	now := time.Now().Format(time.RFC3339)
+	_, err := db.Exec(
+		`UPDATE review_jobs
+		 SET token_usage = ?,
+		     session_id = CASE
+		       WHEN ? != '' AND (session_id IS NULL OR session_id = '') THEN ?
+		       ELSE session_id
+		     END,
+		     updated_at = ?,
+		     synced_at = NULL
+		 WHERE id = ?
+		   AND status IN ('done', 'applied', 'rebased', 'failed', 'canceled', 'skipped')
+		   AND (session_id IS NULL OR session_id = '' OR session_id = ?)`,
+		tokenUsageJSON, sessionID, sessionID, now, jobID, sessionID,
+	)
+	return err
+}
+
 // CompleteFixJob atomically marks a fix job as done, stores the review,
 // and persists the patch in a single transaction. This prevents invalid
 // states where a patch is written but the job isn't done, or vice versa.

--- a/internal/storage/summary.go
+++ b/internal/storage/summary.go
@@ -116,6 +116,10 @@ type SummaryOptions struct {
 // GetSummary computes aggregate review statistics.
 // All sub-queries run inside a single read transaction for snapshot consistency.
 func (db *DB) GetSummary(opts SummaryOptions) (*Summary, error) {
+	if opts.RepoPath != "" {
+		opts.RepoPath = normalizeRepoPathBestEffort(opts.RepoPath)
+	}
+
 	tx, err := db.Begin()
 	if err != nil {
 		return nil, err

--- a/internal/storage/summary_test.go
+++ b/internal/storage/summary_test.go
@@ -222,6 +222,23 @@ func TestGetSummary_RepoFilter(t *testing.T) {
 	assert.Equal(t, 2, s.Overview.Total)
 }
 
+func TestGetSummary_RepoFilterNormalizesWindowsSeparators(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo := createRepo(t, db, `C:\Users\dev\Projects\repo`)
+	commit := createCommit(t, db, repo.ID, "aaa111")
+	enqueueJob(t, db, repo.ID, commit.ID, "aaa111")
+
+	s, err := db.GetSummary(SummaryOptions{
+		RepoPath: `C:\Users\dev\Projects\repo`,
+		Since:    time.Now().Add(-1 * time.Hour),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "C:/Users/dev/Projects/repo", s.RepoPath)
+	assert.Equal(t, 1, s.Overview.Total)
+}
+
 func TestGetSummary_BranchFilter(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()

--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -1,6 +1,8 @@
 package tokens
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -8,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -19,10 +22,15 @@ import (
 // Stored as JSON in the review_jobs.token_usage column.
 // Fields align with agentsview's session-usage output.
 type Usage struct {
+	InputTokens       int64   `json:"input_tokens,omitempty"`
+	CachedInputTokens int64   `json:"cached_input_tokens,omitempty"`
 	OutputTokens      int64   `json:"total_output_tokens,omitempty"`
 	PeakContextTokens int64   `json:"peak_context_tokens,omitempty"`
 	CostUSD           float64 `json:"cost_usd,omitempty"`
 	HasCost           bool    `json:"has_cost,omitempty"`
+	UsageSource       string  `json:"usage_source,omitempty"`
+	ThreadID          string  `json:"thread_id,omitempty"`
+	EventOffset       int64   `json:"event_offset,omitempty"`
 }
 
 // FetchConfig configures session usage lookup. When Endpoint is set,
@@ -57,6 +65,8 @@ type SessionUsagePayload struct {
 	SessionID         string   `json:"session_id"`
 	Agent             string   `json:"agent,omitempty"`
 	Project           string   `json:"project,omitempty"`
+	InputTokens       *int64   `json:"input_tokens,omitempty"`
+	CachedInputTokens *int64   `json:"cached_input_tokens,omitempty"`
 	OutputTokens      *int64   `json:"total_output_tokens,omitempty"`
 	PeakContextTokens *int64   `json:"peak_context_tokens,omitempty"`
 	HasTokenData      *bool    `json:"has_token_data"`
@@ -69,16 +79,33 @@ type SessionUsagePayload struct {
 // when a cost estimate is available. Returns empty string when there
 // is neither token nor cost data.
 func (u Usage) FormatSummary() string {
-	hasTokens := u.PeakContextTokens != 0 || u.OutputTokens != 0
+	inputTokens := u.PeakContextTokens
+	inputLabel := "ctx"
+	if inputTokens == 0 && u.InputTokens != 0 {
+		inputTokens = u.InputTokens
+		inputLabel = "in"
+	}
+	hasTokens := inputTokens != 0 || u.OutputTokens != 0 ||
+		u.CachedInputTokens != 0
 	if !hasTokens {
 		// No token counts: show the cost alone when present.
 		return u.FormatCost()
 	}
 	s := fmt.Sprintf(
-		"%s ctx · %s out",
-		formatCount(u.PeakContextTokens),
+		"%s %s · %s out",
+		formatCount(inputTokens),
+		inputLabel,
 		formatCount(u.OutputTokens),
 	)
+	if u.CachedInputTokens != 0 {
+		s = fmt.Sprintf(
+			"%s %s (%s cached) · %s out",
+			formatCount(inputTokens),
+			inputLabel,
+			formatCount(u.CachedInputTokens),
+			formatCount(u.OutputTokens),
+		)
+	}
 	if cost := u.FormatCost(); cost != "" {
 		s += " · " + cost
 	}
@@ -325,11 +352,22 @@ func UsageFromSessionPayload(resp SessionUsagePayload) (*Usage, error) {
 
 	usage := &Usage{}
 	if *resp.HasTokenData {
-		if resp.OutputTokens == nil || resp.PeakContextTokens == nil {
+		if resp.OutputTokens == nil {
 			return nil, fmt.Errorf("usage endpoint schema: missing token counts")
 		}
 		usage.OutputTokens = *resp.OutputTokens
-		usage.PeakContextTokens = *resp.PeakContextTokens
+		if resp.PeakContextTokens != nil {
+			usage.PeakContextTokens = *resp.PeakContextTokens
+		}
+		if resp.InputTokens != nil {
+			usage.InputTokens = *resp.InputTokens
+		}
+		if resp.CachedInputTokens != nil {
+			usage.CachedInputTokens = *resp.CachedInputTokens
+		}
+		if usage.PeakContextTokens == 0 && usage.InputTokens == 0 {
+			return nil, fmt.Errorf("usage endpoint schema: missing token counts")
+		}
 	}
 	if *resp.HasCost {
 		if resp.CostUSD == nil {
@@ -338,7 +376,7 @@ func UsageFromSessionPayload(resp SessionUsagePayload) (*Usage, error) {
 		usage.CostUSD = *resp.CostUSD
 		usage.HasCost = true
 	}
-	if usage.OutputTokens == 0 && usage.PeakContextTokens == 0 && !usage.HasCost {
+	if !usage.HasUsageData() {
 		return nil, nil
 	}
 	return usage, nil
@@ -354,10 +392,90 @@ func ParseJSON(data string) *Usage {
 	if err := json.Unmarshal([]byte(data), &u); err != nil {
 		return nil
 	}
-	if u.OutputTokens == 0 && u.PeakContextTokens == 0 && !u.HasCost {
+	if !u.HasUsageData() {
 		return nil
 	}
 	return &u
+}
+
+// HasUsageData reports whether the usage value carries counts or cost data.
+func (u Usage) HasUsageData() bool {
+	return u.InputTokens != 0 ||
+		u.CachedInputTokens != 0 ||
+		u.OutputTokens != 0 ||
+		u.PeakContextTokens != 0 ||
+		u.HasCost
+}
+
+// ParseCodexUsageFile extracts the final Codex turn.completed usage event
+// from a raw JSONL job log.
+func ParseCodexUsageFile(path string) (*Usage, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+	return ParseCodexUsageJSONL(f)
+}
+
+// ParseCodexUsageJSONL extracts the final Codex turn.completed usage event
+// from an event stream. Non-JSON lines and unrelated JSON events are ignored.
+func ParseCodexUsageJSONL(r io.Reader) (*Usage, error) {
+	type codexUsageEvent struct {
+		Type     string `json:"type"`
+		ThreadID string `json:"thread_id,omitempty"`
+		Usage    struct {
+			InputTokens       int64 `json:"input_tokens"`
+			CachedInputTokens int64 `json:"cached_input_tokens"`
+			OutputTokens      int64 `json:"output_tokens"`
+		} `json:"usage,omitempty"`
+	}
+
+	reader := bufio.NewReader(r)
+	var offset int64
+	var threadID string
+	var usage *Usage
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			trimmed := bytes.TrimSpace(line)
+			if len(trimmed) > 0 {
+				var ev codexUsageEvent
+				if json.Unmarshal(trimmed, &ev) == nil {
+					if ev.ThreadID != "" {
+						threadID = ev.ThreadID
+					}
+					if ev.Type == "turn.completed" {
+						u := Usage{
+							InputTokens:       ev.Usage.InputTokens,
+							CachedInputTokens: ev.Usage.CachedInputTokens,
+							OutputTokens:      ev.Usage.OutputTokens,
+							UsageSource:       "job_log_turn_completed",
+							ThreadID:          threadID,
+							EventOffset:       offset,
+						}
+						if ev.ThreadID != "" {
+							u.ThreadID = ev.ThreadID
+						}
+						if u.HasUsageData() {
+							usage = &u
+						}
+					}
+				}
+			}
+			offset += int64(len(line))
+		}
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, io.EOF) {
+			return usage, nil
+		}
+		return nil, err
+	}
 }
 
 // ToJSON serializes token usage to JSON for database storage.

--- a/internal/tokens/tokens_test.go
+++ b/internal/tokens/tokens_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -55,6 +56,14 @@ func TestFormatSummary(t *testing.T) {
 			"tokens unpriced",
 			Usage{PeakContextTokens: 1000, OutputTokens: 200},
 			"1.0k ctx · 200 out",
+		},
+		{
+			"codex input counts",
+			Usage{
+				InputTokens: 79150, CachedInputTokens: 2560,
+				OutputTokens: 3389,
+			},
+			"79.2k in (2.6k cached) · 3.4k out",
 		},
 		{
 			"cost only",
@@ -113,6 +122,17 @@ func TestParseJSON(t *testing.T) {
 		assert.InDelta(t, 0.05, u.CostUSD, 1e-9)
 	})
 
+	t.Run("codex input buckets", func(t *testing.T) {
+		u := ParseJSON(
+			`{"input_tokens":79150,"cached_input_tokens":2560,` +
+				`"total_output_tokens":3389}`,
+		)
+		require.NotNil(t, u)
+		assert.Equal(t, int64(79150), u.InputTokens)
+		assert.Equal(t, int64(2560), u.CachedInputTokens)
+		assert.Equal(t, int64(3389), u.OutputTokens)
+	})
+
 	t.Run("all zeros", func(t *testing.T) {
 		assert.Nil(t, ParseJSON(
 			`{"peak_context_tokens":0,"total_output_tokens":0}`,
@@ -122,6 +142,35 @@ func TestParseJSON(t *testing.T) {
 	t.Run("invalid json", func(t *testing.T) {
 		assert.Nil(t, ParseJSON(`{invalid`))
 	})
+}
+
+func TestParseCodexUsageJSONL(t *testing.T) {
+	log := strings.Join([]string{
+		`{"type":"thread.started","thread_id":"thread-123"}`,
+		`{"type":"turn.started"}`,
+		`{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}`,
+		`{"type":"turn.completed","usage":{"input_tokens":79150,"cached_input_tokens":2560,"output_tokens":3389}}`,
+	}, "\n") + "\n"
+
+	usage, err := ParseCodexUsageJSONL(strings.NewReader(log))
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	assert.Equal(t, int64(79150), usage.InputTokens)
+	assert.Equal(t, int64(2560), usage.CachedInputTokens)
+	assert.Equal(t, int64(3389), usage.OutputTokens)
+	assert.Equal(t, "job_log_turn_completed", usage.UsageSource)
+	assert.Equal(t, "thread-123", usage.ThreadID)
+	assert.Positive(t, usage.EventOffset)
+}
+
+func TestParseCodexUsageJSONLIgnoresMissingUsage(t *testing.T) {
+	usage, err := ParseCodexUsageJSONL(strings.NewReader(
+		"plain text\n" +
+			`{"type":"turn.completed","usage":{}}` + "\n",
+	))
+
+	require.NoError(t, err)
+	assert.Nil(t, usage)
 }
 
 // installFakeAgentsview writes an executable "agentsview" shell script

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -902,9 +902,11 @@ func (r ReviewJob) Validate() error {
 
 type SessionUsagePayload struct {
 	Agent             *string  `json:"agent,omitempty"`
+	CachedInputTokens *int64   `json:"cached_input_tokens,omitempty"`
 	CostUsd           *float64 `json:"cost_usd,omitempty"`
 	HasCost           *bool    `json:"has_cost,omitempty"`
 	HasTokenData      *bool    `json:"has_token_data,omitempty"`
+	InputTokens       *int64   `json:"input_tokens,omitempty"`
 	PeakContextTokens *int64   `json:"peak_context_tokens,omitempty"`
 	Project           *string  `json:"project,omitempty"`
 	SessionID         string   `json:"session_id" validate:"required"`

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -1383,6 +1383,9 @@ components:
       properties:
         agent:
           type: string
+        cached_input_tokens:
+          format: int64
+          type: integer
         cost_usd:
           format: double
           type: number
@@ -1394,6 +1397,9 @@ components:
           type:
             - boolean
             - "null"
+        input_tokens:
+          format: int64
+          type: integer
         peak_context_tokens:
           format: int64
           type: integer


### PR DESCRIPTION
Fixes #667.

This normalizes summary repo filters before storage lookup so Windows `C:\...` inputs match repo rows stored with forward slashes.

It also treats Codex raw job logs as a first-class token usage source by parsing `turn.completed.usage`, storing input/cached/output buckets plus source metadata in the existing `token_usage` JSON, and merging those counts with agentsview cost data when available. Backfill now checks job logs before agentsview, and the session usage API schema accepts the optional Codex input buckets.

The repo agent guide now calls out longer Windows command timeouts for daemon, CLI, and full test runs.