### PR TITLE
Document 0.59.0 release updates

### DIFF
--- a/cmd/roborev/insights.go
+++ b/cmd/roborev/insights.go
@@ -39,7 +39,7 @@ improvements to review guidelines.
 
 This is an LLM-powered command that:
 1. Queries completed reviews (focusing on failures) from the database
-2. Includes the current review_guidelines from .roborev.toml as context
+2. Includes the currently resolved review_guidelines from global and repo config
 3. Sends the batch to an agent with a structured analysis prompt
 4. Returns actionable recommendations for guideline changes
 
@@ -48,7 +48,7 @@ The agent produces:
 - Hotspot areas (files/packages that concentrate failures)
 - Noise candidates (findings consistently dismissed without code changes)
 - Guideline gaps (patterns flagged by reviews but not in guidelines)
-- Suggested guideline additions (concrete text for .roborev.toml)
+- Suggested guideline additions (concrete text for .roborev.toml or config.toml)
 
 Examples:
   roborev insights                          # Analyze last 30 days of reviews

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,44 @@ description: Release history for roborev
 
 All notable changes to roborev, grouped by minor release.
 
+## 0.59.0
+<small>2026-06-22</small>
+
+**New features**
+
+- Repository-hosted documentation. The roborev.io docs now live in this repository, with guides, command reference, integration docs, troubleshooting, and a local Zensical build/check workflow. See [Docs Maintainer Guide](/development/#documentation).
+- Global review guidelines. Set `review_guidelines` in `~/.roborev/config.toml` to apply shared reviewer instructions across repositories. Repo-level `review_guidelines` are appended after the global text by default; set `review_guidelines_supersede_global = true` in `.roborev.toml` when a repo should replace the global guidance. See [Review Guidelines](/configuration/#review-guidelines).
+- Hook-only auto-design routing. `[auto_design_review] hook_enabled = true` runs the design-review router for post-commit hook reviews without also enabling it for manual reviews or CI. See [Auto Design Review](/configuration/#auto-design-review).
+
+**Improvements**
+
+- `roborev status` is more responsive because it no longer performs slow repository config probes while rendering status.
+- CLI startup is faster because terminal capability probing is no longer imported during startup.
+- CI review retries keep using the agents configured for the PR instead of being derailed by daemon quota cooldowns.
+- Agent quota cooldowns can now be capped with `agent_quota_cooldown`, a global Go-duration config value that defaults to `30m`.
+- CI review worktrees are grouped under repo-named parent directories, making daemon clone/worktree storage easier to inspect.
+- Security review prompts are stricter about reporting only concrete, exploitable issues and avoiding generic low-signal findings.
+- Agent-hook continuation prompts now tell the agent to fix roborev issues and then continue the interrupted task, reducing session derailment.
+- Self-update and install release discovery are more resilient when GitHub API rate limits are hit.
+
+**Bug fixes**
+
+- Hidden Windows console windows for daemon, git, and agent child processes.
+- Fixed Windows summary filtering behavior.
+- Fixed Codex token usage backfill and reporting.
+- Fixed `check-agents` availability checks so configured command overrides such as `codex_cmd` and `claude_code_cmd` are honored.
+- Improved `roborev fix` discovery so it targets failing reviews and follows hook lineage correctly, including branchless and detached-head flows.
+
+**Acknowledgements**
+
+- Thanks to [Wes McKinney](https://github.com/wesm) for repository-hosted docs, faster `status`, lighter CLI startup, capped quota cooldowns, CI retry/worktree improvements, self-update resilience, Windows summary and Codex token fixes, and release/doc maintenance.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for global review guidelines, clearer agent-hook continuation prompts, tighter security review prompts, `roborev fix` discovery improvements, and Windows child-process hardening in git and agent paths.
+- Thanks to [Phillip Cloud](https://github.com/cpcloud) for hook-only auto-design routing.
+- Thanks to [Ewan Dawson](https://github.com/EwanDawson) for fixing `check-agents` availability checks with resolved agent commands.
+- Thanks to [Christophe Dervieux](https://github.com/cderv) for suppressing extra daemon child-process console windows on Windows.
+
+---
+
 ## 0.58
 <small>2026-06-11</small>
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -341,7 +341,7 @@ roborev insights --json                  # Output as JSON
 | `--wait` | Wait for completion and display result (default: true) |
 | `--json` | Output job info as JSON |
 
-Analyzes failing code reviews to identify recurring patterns and suggest improvements to review guidelines. The command queries completed reviews (focusing on failures) within the time window, includes the current `review_guidelines` from `.roborev.toml` as context, and sends the batch to an agent for structured analysis.
+Analyzes failing code reviews to identify recurring patterns and suggest improvements to review guidelines. The command queries completed reviews (focusing on failures) within the time window, includes the currently resolved `review_guidelines` from global and repo config as context, and sends the batch to an agent for structured analysis.
 
 The agent produces:
 
@@ -349,7 +349,7 @@ The agent produces:
 - Hotspot areas (files/packages with concentrated failures)
 - Noise candidates (findings consistently dismissed without code changes)
 - Guideline gaps (patterns flagged by reviews but not covered by guidelines)
-- Suggested guideline additions (concrete text for `.roborev.toml`)
+- Suggested guideline additions (concrete text for `.roborev.toml` or `~/.roborev/config.toml`)
 
 If no failing reviews match the time window and branch filter, the command exits with a message instead of queuing a job.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,6 +151,7 @@ max_chars = 50000
 | `security_backup_agent` | string | Fallback agent for security reviews |
 | `design_backup_agent` | string | Fallback agent for design reviews |
 | `review_guidelines` | string | Project-specific guidelines for the reviewer |
+| `review_guidelines_supersede_global` | bool | Use repo guidelines instead of appending global `review_guidelines` |
 | `kata_context.mode` | string | Kata task context in review prompts: `off`, `current`, or `open`. See [Kata Integration](#kata-integration) |
 | `kata_context.max_chars` | int | Maximum bytes of Kata issue context to include (default: `50000`) |
 | `max_prompt_size` | int | Maximum prompt size in bytes for this repo (default: 200000) |
@@ -158,12 +159,21 @@ max_chars = 50000
 
 ### Review Guidelines
 
-Use `review_guidelines` to give the AI reviewer project-specific
-context: suppress irrelevant warnings, enforce conventions, or
-describe trust boundaries and architecture so the reviewer doesn't
-flag non-issues:
+Use `review_guidelines` to give the AI reviewer persistent context:
+suppress irrelevant warnings, enforce conventions, or describe trust
+boundaries and architecture so the reviewer doesn't flag non-issues.
+Guidelines can be global, per-repo, or both:
 
 ```toml
+# ~/.roborev/config.toml
+review_guidelines = """
+These rules apply to every repository on this machine.
+Prefer clear error messages and avoid speculative findings.
+"""
+```
+
+```toml
+# .roborev.toml
 review_guidelines = """
 This is a local CLI tool. The daemon runs on localhost and all
 displayed data originates from the user's own filesystem and git
@@ -173,10 +183,18 @@ crosses a trust boundary.
 Performance is critical - flag any O(n^2) or worse algorithms.
 All error messages must be user-friendly.
 """
+
+# Optional: replace global review_guidelines for this repo instead of appending.
+review_guidelines_supersede_global = false
 ```
 
-Guidelines are included in the review prompt, so they shape what the
-reviewer flags and what it ignores. Common uses:
+When both scopes are configured, global guidelines are rendered first and
+repo guidelines are appended after them. Set
+`review_guidelines_supersede_global = true` in `.roborev.toml` when a repo
+needs to replace the global rules entirely.
+
+Guidelines are included in the review prompt for local and daemon review jobs,
+so they shape what the reviewer flags and what it ignores. Common uses:
 
 - **Trust boundaries**: Describe where untrusted data enters the
   system so the reviewer doesn't flag sanitization for trusted paths.
@@ -429,7 +447,9 @@ default_model = "gpt-5.5"  # Default LLM
 default_backup_model = "claude-sonnet-4-20250514"  # Fallback model for backup agent
 server_addr = "127.0.0.1:7373"
 max_workers = 4
-job_timeout = "10m"  # Per-job timeout (default: 10m)
+job_timeout_minutes = 30          # Per-job timeout in minutes
+agent_quota_cooldown = "30m"      # Maximum quota cooldown after agent limits
+review_guidelines = "Global review instructions for every repo."
 hide_closed_by_default = true     # Start TUI with closed/failed/canceled hidden
 auto_filter_repo = true           # Auto-filter TUI to current repo on startup
 auto_filter_branch = true         # Auto-filter TUI to current branch/worktree on startup
@@ -448,10 +468,12 @@ column_borders = true             # Show separators between TUI columns
 | `default_model` | string | agent default | Model to use (format varies by agent) | Yes |
 | `server_addr` | string | 127.0.0.1:7373 | Daemon listen address. Use `unix://` for Unix domain socket (see [Unix Domain Socket](#unix-domain-socket)) | No |
 | `max_workers` | int | 4 | Number of parallel review workers | No |
-| `job_timeout` | duration | 10m | Per-job timeout | Yes |
+| `job_timeout_minutes` | int | 30 | Per-job timeout in minutes | Yes |
+| `agent_quota_cooldown` | string | `30m0s` | Maximum daemon-wide cooldown after an agent quota or session-limit error, as a Go duration such as `10m`, `30m`, or `1h` | Yes |
 | `allow_unsafe_agents` | bool | false | Enable agentic mode globally | Yes |
 | `anthropic_api_key` | string | - | Anthropic API key for Claude Code | Yes |
 | `review_context_count` | int | 3 | Recent reviews to include as context | Yes |
+| `review_guidelines` | string | - | Global reviewer instructions included in review prompts for every repo | Yes |
 | `reuse_review_session` | bool | false | (Experimental) Resume prior agent sessions on the same branch. See [Session Reuse](/guides/reviewing-code/#session-reuse) | Yes |
 | `reuse_review_session_lookback` | int | 0 | Max recent session candidates to consider (0 = unlimited) | Yes |
 | `auto_close_passing_reviews` | bool | false | Automatically close reviews that pass with no findings | Yes |
@@ -806,7 +828,7 @@ Template variables: `{job_id}`, `{repo}`, `{repo_name}`, `{sha}`, `{agent}`, `{v
 
 ## Auto Design Review
 
-Off by default. When enabled, roborev decides per commit whether to dispatch a `--type design` review on top of the normal code review. The router uses cheap heuristics first (path globs, diff size, file count, commit-subject regexes) and falls back to a JSON-schema-constrained classifier for ambiguous cases. The post-commit, `roborev review`, range, and dirty paths all consult the router, as does the CI poller when `design` is not already in the configured panel or review matrix. When the router decides not to run, a skipped row is recorded with a short reason and rendered dimmed in the TUI; PR synthesis includes a one-line `Auto-design-review skipped: <reason>` section.
+Off by default. When enabled, roborev decides per commit whether to dispatch a `--type design` review on top of the normal code review. The router uses cheap heuristics first (path globs, diff size, file count, commit-subject regexes) and falls back to a JSON-schema-constrained classifier for ambiguous cases. With `enabled = true`, the post-commit, `roborev review`, range, and dirty paths all consult the router, as does the CI poller when `design` is not already in the configured panel or review matrix. When the router decides not to run, a skipped row is recorded with a short reason and rendered dimmed in the TUI; PR synthesis includes a one-line `Auto-design-review skipped: <reason>` section.
 
 By default, the TUI queue hides the auto-design-router's classifier jobs (`job_type = classify`) and skipped design rows (`status = skipped`, scoped to `source = auto_design`) so per-commit routing decisions do not crowd out review rows. Decisions are still recorded and counted on the daemon status endpoint. Press `s` in the TUI to toggle visibility for the current session, or set `show_classify_jobs = true` in `~/.roborev/config.toml` to make them visible globally; per-repo `.roborev.toml` can override with a nullable `show_classify_jobs` field (omit to inherit). When viewing a hidden classifier or skipped row, press `l` to see the classifier verdict and `skip_reason` rendered above the (typically empty) log.
 
@@ -819,12 +841,22 @@ Turn it on globally in `~/.roborev/config.toml`:
 enabled = true
 ```
 
-A per-repo `[auto_design_review]` block in `.roborev.toml` overrides the global value. The per-repo `enabled` field is tri-state: omitting it inherits the global setting, `enabled = false` explicitly opts a repo out of a globally-enabled default, and `enabled = true` opts a repo in when the global default is off.
+To run the router only for automatic post-commit hook reviews, use `hook_enabled` instead:
+
+```toml
+[auto_design_review]
+hook_enabled = true
+```
+
+`hook_enabled = true` does not affect manual `roborev review`, dirty/range reviews, or CI. Use `enabled = true` when those entry points should consult the router too.
+
+A per-repo `[auto_design_review]` block in `.roborev.toml` overrides the global values. The per-repo `enabled` and `hook_enabled` fields are tri-state: omitting a field inherits the global setting, `false` explicitly opts a repo out of a globally-enabled default, and `true` opts a repo in when the global default is off.
 
 ```toml
 # .roborev.toml
 [auto_design_review]
 enabled = false   # opt this repo out of a globally-enabled router
+hook_enabled = true  # still allow post-commit hook routing for this repo
 ```
 
 ### Heuristics
@@ -833,6 +865,8 @@ The router checks rules in fixed order: trigger paths, large diff, large file co
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
+| `enabled` | bool | false | Enable auto-design routing for post-commit hooks, manual reviews, dirty/range reviews, and CI |
+| `hook_enabled` | bool | false | Enable auto-design routing only for post-commit hook reviews |
 | `min_diff_lines` | int | 10 | Diffs below this changed-line count are skipped automatically |
 | `large_diff_lines` | int | 500 | Diffs at or above this line count trigger a design review automatically |
 | `large_file_count` | int | 10 | Commits touching at least this many files trigger automatically |

--- a/docs/guides/reviewing-code.md
+++ b/docs/guides/reviewing-code.md
@@ -168,6 +168,28 @@ review_min_severity = "medium"
 
 The cascade order is: CLI flag > per-repo config > global config. The CLI flag overrides the config value. See [Configuration](/configuration/#per-repository-options).
 
+## Review Guidelines
+
+Use `review_guidelines` to give reviewers durable context about your project or your whole machine:
+
+```toml
+# ~/.roborev/config.toml
+review_guidelines = """
+Prefer concrete, actionable findings.
+Do not flag localhost-only data paths as remote trust boundaries.
+"""
+
+# .roborev.toml
+review_guidelines = """
+This repo has no production database yet.
+Public APIs must keep backward-compatible JSON fields.
+"""
+```
+
+Global guidelines apply to every repo. Repo guidelines are appended after global guidelines by default, so a repo can add local rules without losing shared preferences. Set `review_guidelines_supersede_global = true` in `.roborev.toml` when a repo should replace the global text entirely.
+
+See [Review Guidelines](/configuration/#review-guidelines) for common patterns and precedence details.
+
 ## Specific Commit Ranges
 
 Use `--since` to review commits since a specific point:

--- a/docs/integrations/github.md
+++ b/docs/integrations/github.md
@@ -473,7 +473,7 @@ The CI poller tracks retry state per repo, PR number, and HEAD SHA. If any panel
 
 If panel members produced review output but the synthesis agent hits quota or a transient provider failure, roborev now retries the panel instead of posting the degraded raw-member fallback. Genuine synthesis failures still fall back to the available member output because retrying the same broken synthesis setup is unlikely to help.
 
-Deferred retries are rechecked before they run. roborev retries only if the PR is still open and still points at the same HEAD SHA. Closed PRs, stale heads, and repo identity mismatches are retired without posting comments. If a new push arrives while an older panel is active, the older active panel is canceled and superseded by the new HEAD.
+Deferred retries are rechecked before they run. roborev retries only if the PR is still open and still points at the same HEAD SHA. Closed PRs, stale heads, and repo identity mismatches are retired without posting comments. If a new push arrives while an older panel is active, the older active panel is canceled and superseded by the new HEAD. Retry runs preserve the PR's configured agents and review panel; daemon cooldown state can skip an agent during execution, but it does not rewrite the retry's configured review plan.
 
 ## Per-Repo Overrides
 
@@ -755,18 +755,18 @@ model = "claude-opus-4-8"
 
 When an agent hits a hard rate or quota limit, roborev puts that agent into a timed cooldown instead of failing the review immediately.
 
-| Setting | Default | Range |
-|---------|---------|-------|
-| Cooldown duration | 30 minutes | 1 minute to 24 hours |
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `agent_quota_cooldown` | `30m0s` | Maximum daemon-wide cooldown after an agent quota or session-limit error, as a Go duration such as `10m`, `30m`, or `1h` |
 
 During cooldown:
 
 - The agent is skipped for new jobs. CI comments show "skipped (quota)" for that agent instead of "failed".
 - If a backup agent is configured (see [Backup Agents](/configuration/#backup-agents)) and is not also in cooldown, the job is retried with the backup agent automatically.
 - Commit status is set to `success` when all panel members were skipped due to quota. This prevents quota exhaustion from blocking PRs.
-- The cooldown timer resets each time the agent hits a quota error, so persistent overuse keeps the agent paused.
+- The cooldown timer resets each time the agent hits a quota error, but it is capped by `agent_quota_cooldown`. Provider reset hints can shorten the cooldown, not lengthen it beyond your configured cap.
 
-No configuration is needed. Quota detection and cooldown are automatic. The daemon logs cooldown start and end events so you can monitor agent availability.
+No configuration is needed unless you want a different cap. Quota detection and cooldown are automatic. The daemon logs cooldown start and end events so you can monitor agent availability.
 
 ## CI Review (GitHub Actions)
 


### PR DESCRIPTION
The 0.59.0 release added several user-facing behaviors that need accurate docs before users rely on the hosted site as the source of truth: global review guidelines, hook-only auto-design routing, configurable quota cooldown caps, and CI retry behavior during cooldowns. This updates those references against the released code paths and adds the 0.59.0 changelog entry with contributor acknowledgements in the same style as prior releases.

The main reviewer consequence is that configuration examples and command text now point users at the actual released keys and precedence rules, including `job_timeout_minutes` rather than the stale timeout key and global-plus-repo guideline resolution rather than repo-only guidance.