### PR TITLE
Render Pi job log traces

### DIFF
--- a/internal/streamfmt/streamfmt.go
+++ b/internal/streamfmt/streamfmt.go
@@ -61,6 +61,7 @@ type Formatter struct {
 
 	// Tracks opencode tool call IDs that have already been rendered.
 	opencodeRenderedToolIDs map[string]struct{}
+	piRenderedToolIDs       map[string]struct{}
 	codexCommands           codexCommandTracker
 }
 
@@ -213,6 +214,11 @@ type streamEvent struct {
 	Item *codexItem `json:"item,omitempty"`
 	// OpenCode: nested part payload
 	Part json.RawMessage `json:"part,omitempty"`
+	// Pi: message/tool execution events
+	AssistantMessageEvent *piAssistantMessageEvent `json:"assistantMessageEvent,omitempty"`
+	ToolCallID            string                   `json:"toolCallId,omitempty"`
+	PiToolName            string                   `json:"toolName,omitempty"`
+	Args                  json.RawMessage          `json:"args,omitempty"`
 }
 
 // codexItem represents the item field in codex JSONL events.
@@ -232,6 +238,11 @@ type opencodeToolPart struct {
 		Status string                     `json:"status,omitempty"`
 		Input  map[string]json.RawMessage `json:"input,omitempty"`
 	} `json:"state"`
+}
+
+type piAssistantMessageEvent struct {
+	Type    string `json:"type"`
+	Content string `json:"content,omitempty"`
 }
 
 type contentBlock struct {
@@ -329,6 +340,13 @@ func (f *Formatter) processLine(line string) {
 	case "item.started", "item.completed", "item.updated":
 		// Codex format: item events
 		f.processCodexItem(ev.Type, ev.Item)
+	case "message_update":
+		// Pi format: render only completed assistant text.
+		f.processPiMessageUpdate(ev.AssistantMessageEvent)
+	case "tool_execution_start":
+		// Pi format: render each tool call once, at start, so
+		// running logs show progress without replaying result text.
+		f.processPiToolExecution(ev.ToolCallID, ev.PiToolName, ev.Args)
 	case "text", "reasoning", "tool", "tool_use":
 		// Both Gemini and opencode use "tool_use", and opencode
 		// 1.4+ emits "tool_use" where earlier versions used
@@ -344,7 +362,10 @@ func (f *Formatter) processLine(line string) {
 	case "step_start", "step_finish":
 		// OpenCode lifecycle events — suppress
 	case "result", "tool_result", "init",
-		"thread.started", "turn.started", "turn.completed":
+		"thread.started", "turn.started", "turn.completed",
+		"session", "agent_start", "turn_start", "turn_end",
+		"agent_end", "message_start", "message_end",
+		"tool_execution_update", "tool_execution_end":
 		// Suppress lifecycle events
 	default:
 		// Suppress system, user, and other events
@@ -434,6 +455,30 @@ func (f *Formatter) processOpenCodePart(
 	}
 }
 
+func (f *Formatter) processPiMessageUpdate(
+	ev *piAssistantMessageEvent,
+) {
+	if ev == nil || ev.Type != "text_end" {
+		return
+	}
+	f.writeText(SanitizeControlKeepNewlines(ev.Content))
+}
+
+func (f *Formatter) processPiToolExecution(
+	callID, toolName string, args json.RawMessage,
+) {
+	if callID != "" {
+		if f.piRenderedToolIDs == nil {
+			f.piRenderedToolIDs = make(map[string]struct{})
+		}
+		if _, seen := f.piRenderedToolIDs[callID]; seen {
+			return
+		}
+		f.piRenderedToolIDs[callID] = struct{}{}
+	}
+	f.formatToolUse(toolName, args)
+}
+
 // opencodeToolInput returns the raw JSON input map from an opencode
 // tool part, suitable for passing to formatToolUse.
 func (f *Formatter) opencodeToolInput(
@@ -491,7 +536,11 @@ func (f *Formatter) formatToolUse(name string, input json.RawMessage) {
 
 	switch display {
 	case "Read", "Edit", "Write":
-		f.writeTool(display, jsonString(fields["filepath"]))
+		path := jsonString(fields["filepath"])
+		if path == "" {
+			path = jsonString(fields["path"])
+		}
+		f.writeTool(display, path)
 	case "Bash":
 		cmd := jsonString(fields["command"])
 		if len(cmd) > 80 {

--- a/internal/streamfmt/streamfmt.go
+++ b/internal/streamfmt/streamfmt.go
@@ -62,6 +62,7 @@ type Formatter struct {
 	// Tracks opencode tool call IDs that have already been rendered.
 	opencodeRenderedToolIDs map[string]struct{}
 	piRenderedToolIDs       map[string]struct{}
+	piLastAssistantText     string
 	codexCommands           codexCommandTracker
 }
 
@@ -468,7 +469,7 @@ func (f *Formatter) processPiMessageUpdate(
 	if ev == nil || ev.Type != "text_end" {
 		return
 	}
-	f.writeText(SanitizeControlKeepNewlines(ev.Content))
+	f.writePiAssistantText(ev.Content)
 }
 
 func (f *Formatter) processPiMessageEnd(
@@ -487,15 +488,24 @@ func (f *Formatter) processPiMessageEnd(
 			}
 		}
 		if len(parts) > 0 {
-			f.writeText(strings.Join(parts, "\n"))
+			f.writePiAssistantText(strings.Join(parts, "\n"))
 		}
 		return
 	}
 
 	var text string
 	if err := json.Unmarshal(raw, &text); err == nil {
-		f.writeText(text)
+		f.writePiAssistantText(text)
 	}
+}
+
+func (f *Formatter) writePiAssistantText(text string) {
+	text = strings.TrimSpace(SanitizeControlKeepNewlines(text))
+	if text == "" || text == f.piLastAssistantText {
+		return
+	}
+	f.piLastAssistantText = text
+	f.writeText(text)
 }
 
 func (f *Formatter) processPiToolExecution(

--- a/internal/streamfmt/streamfmt.go
+++ b/internal/streamfmt/streamfmt.go
@@ -203,6 +203,7 @@ type streamEvent struct {
 	Type string `json:"type"`
 	// Claude: nested message with content blocks
 	Message *struct {
+		Role    string          `json:"role,omitempty"`
 		Content json.RawMessage `json:"content,omitempty"`
 	} `json:"message,omitempty"`
 	// Gemini: top-level fields
@@ -343,6 +344,12 @@ func (f *Formatter) processLine(line string) {
 	case "message_update":
 		// Pi format: render only completed assistant text.
 		f.processPiMessageUpdate(ev.AssistantMessageEvent)
+	case "message_end":
+		// Pi format: some streams only include the completed
+		// assistant content on message_end.
+		if ev.Message != nil {
+			f.processPiMessageEnd(ev.Message.Role, ev.Message.Content)
+		}
 	case "tool_execution_start":
 		// Pi format: render each tool call once, at start, so
 		// running logs show progress without replaying result text.
@@ -364,7 +371,7 @@ func (f *Formatter) processLine(line string) {
 	case "result", "tool_result", "init",
 		"thread.started", "turn.started", "turn.completed",
 		"session", "agent_start", "turn_start", "turn_end",
-		"agent_end", "message_start", "message_end",
+		"agent_end", "message_start",
 		"tool_execution_update", "tool_execution_end":
 		// Suppress lifecycle events
 	default:
@@ -462,6 +469,33 @@ func (f *Formatter) processPiMessageUpdate(
 		return
 	}
 	f.writeText(SanitizeControlKeepNewlines(ev.Content))
+}
+
+func (f *Formatter) processPiMessageEnd(
+	role string, raw json.RawMessage,
+) {
+	if role != "assistant" || raw == nil {
+		return
+	}
+
+	var blocks []contentBlock
+	if err := json.Unmarshal(raw, &blocks); err == nil {
+		var parts []string
+		for _, block := range blocks {
+			if block.Type == "text" && block.Text != "" {
+				parts = append(parts, block.Text)
+			}
+		}
+		if len(parts) > 0 {
+			f.writeText(strings.Join(parts, "\n"))
+		}
+		return
+	}
+
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		f.writeText(text)
+	}
 }
 
 func (f *Formatter) processPiToolExecution(

--- a/internal/streamfmt/streamfmt_test.go
+++ b/internal/streamfmt/streamfmt_test.go
@@ -1035,6 +1035,10 @@ func TestFormatter_PiRendering(t *testing.T) {
 				),
 				eventPiMessageUpdate("text_delta", "", "draft"),
 				eventPiMessageUpdate("text_end", "Final review.\n\nNo issues found.", ""),
+				eventPiMessageEnd("assistant", []anthropicContentBlock{{
+					Type: "text",
+					Text: "Final review.\n\nNo issues found.",
+				}}),
 				`{"type":"turn_end"}`,
 				`{"type":"agent_end"}`,
 			},
@@ -1046,6 +1050,8 @@ func TestFormatter_PiRendering(t *testing.T) {
 			},
 			counts: map[string]int{
 				"Bash   go test ./...": 1,
+				"Final review.":        1,
+				"No issues found.":     1,
 			},
 			notContains: []string{
 				"checking repo",

--- a/internal/streamfmt/streamfmt_test.go
+++ b/internal/streamfmt/streamfmt_test.go
@@ -151,7 +151,8 @@ type anthropicContentBlock struct {
 }
 
 type anthropicMessage struct {
-	Content any `json:"content"`
+	Role    string `json:"role,omitempty"`
+	Content any    `json:"content"`
 }
 
 type anthropicToolUseResult struct {
@@ -349,6 +350,7 @@ type piTestAssistantMessageEvent struct {
 type piEvent struct {
 	Type                  string                       `json:"type"`
 	AssistantMessageEvent *piTestAssistantMessageEvent `json:"assistantMessageEvent,omitempty"`
+	Message               *anthropicMessage            `json:"message,omitempty"`
 	ToolCallID            string                       `json:"toolCallId,omitempty"`
 	ToolName              string                       `json:"toolName,omitempty"`
 	Args                  any                          `json:"args,omitempty"`
@@ -364,6 +366,16 @@ func eventPiMessageUpdate(eventType, content, delta string) string {
 			Type:    eventType,
 			Content: content,
 			Delta:   delta,
+		},
+	})
+}
+
+func eventPiMessageEnd(role string, content any) string {
+	return toJSON(piEvent{
+		Type: "message_end",
+		Message: &anthropicMessage{
+			Role:    role,
+			Content: content,
 		},
 	})
 }
@@ -1053,6 +1065,25 @@ func TestFormatter_PiRendering(t *testing.T) {
 				`{"type":"agent_end"}`,
 			},
 			empty: true,
+		},
+		{
+			name: "AssistantMessageEndText",
+			events: []string{
+				eventPiMessageEnd("user", []anthropicContentBlock{{
+					Type: "text",
+					Text: "prompt echo",
+				}}),
+				eventPiMessageEnd("assistant", []anthropicContentBlock{{
+					Type: "text",
+					Text: "Final review from message_end.",
+				}}),
+			},
+			contains: []string{
+				"Final review from message_end.",
+			},
+			notContains: []string{
+				"prompt echo",
+			},
 		},
 	}
 

--- a/internal/streamfmt/streamfmt_test.go
+++ b/internal/streamfmt/streamfmt_test.go
@@ -340,6 +340,45 @@ func eventOpenCode(
 	})
 }
 
+type piTestAssistantMessageEvent struct {
+	Type    string `json:"type"`
+	Content string `json:"content,omitempty"`
+	Delta   string `json:"delta,omitempty"`
+}
+
+type piEvent struct {
+	Type                  string                       `json:"type"`
+	AssistantMessageEvent *piTestAssistantMessageEvent `json:"assistantMessageEvent,omitempty"`
+	ToolCallID            string                       `json:"toolCallId,omitempty"`
+	ToolName              string                       `json:"toolName,omitempty"`
+	Args                  any                          `json:"args,omitempty"`
+	PartialResult         string                       `json:"partialResult,omitempty"`
+	Result                string                       `json:"result,omitempty"`
+	IsError               bool                         `json:"isError,omitempty"`
+}
+
+func eventPiMessageUpdate(eventType, content, delta string) string {
+	return toJSON(piEvent{
+		Type: "message_update",
+		AssistantMessageEvent: &piTestAssistantMessageEvent{
+			Type:    eventType,
+			Content: content,
+			Delta:   delta,
+		},
+	})
+}
+
+func eventPiToolExecution(
+	eventType, callID, toolName string, args any,
+) string {
+	return toJSON(piEvent{
+		Type:       eventType,
+		ToolCallID: callID,
+		ToolName:   toolName,
+		Args:       args,
+	})
+}
+
 func TestFormatter_NonTTY(t *testing.T) {
 	fix := newFixture(false)
 	raw := `{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}`
@@ -939,6 +978,79 @@ func TestFormatter_CodexRendering(t *testing.T) {
 			events: []string{
 				`{"type":"item.started","item":{"type":"reasoning","text":"draft thinking"}}`,
 				`{"type":"item.updated","item":{"type":"reasoning","text":"still thinking"}}`,
+			},
+			empty: true,
+		},
+	}
+
+	for _, tc := range tests {
+		runStreamTestCase(t, tc)
+	}
+}
+
+func TestFormatter_PiRendering(t *testing.T) {
+	tests := []streamTestCase{
+		{
+			name: "ToolCallsAndFinalText",
+			events: []string{
+				`{"type":"session","id":"pi-session-123"}`,
+				`{"type":"agent_start"}`,
+				`{"type":"turn_start"}`,
+				eventPiMessageUpdate("thinking_delta", "", "checking repo"),
+				eventPiToolExecution(
+					"tool_execution_start",
+					"tool-1",
+					"bash",
+					map[string]string{"command": "go test ./..."},
+				),
+				eventPiToolExecution(
+					"tool_execution_update",
+					"tool-1",
+					"bash",
+					map[string]string{"command": "go test ./..."},
+				),
+				eventPiToolExecution(
+					"tool_execution_end",
+					"tool-1",
+					"bash",
+					map[string]string{"command": "go test ./..."},
+				),
+				eventPiToolExecution(
+					"tool_execution_start",
+					"tool-2",
+					"read",
+					map[string]string{"path": "internal/streamfmt/streamfmt.go"},
+				),
+				eventPiMessageUpdate("text_delta", "", "draft"),
+				eventPiMessageUpdate("text_end", "Final review.\n\nNo issues found.", ""),
+				`{"type":"turn_end"}`,
+				`{"type":"agent_end"}`,
+			},
+			contains: []string{
+				"Bash   go test ./...",
+				"Read   internal/streamfmt/streamfmt.go",
+				"Final review.",
+				"No issues found.",
+			},
+			counts: map[string]int{
+				"Bash   go test ./...": 1,
+			},
+			notContains: []string{
+				"checking repo",
+				"draft",
+				"tool_execution_update",
+				"tool_execution_end",
+				"pi-session-123",
+			},
+		},
+		{
+			name: "LifecycleSuppressed",
+			events: []string{
+				`{"type":"session","id":"pi-session-123"}`,
+				`{"type":"agent_start"}`,
+				`{"type":"turn_start"}`,
+				`{"type":"turn_end"}`,
+				`{"type":"agent_end"}`,
 			},
 			empty: true,
 		},


### PR DESCRIPTION
Pi jobs already write rich JSONL traces to disk, but roborev's formatted log view did not understand Pi's event names. That made Pi reviews look opaque compared with Codex and Claude even when the raw logs contained tool execution events and final assistant output.

This teaches the existing stream formatter to render Pi tool starts and completed assistant text while continuing to suppress prompt echo, lifecycle events, deltas, and tool result payloads. The reviewer-facing consequence is that `roborev log` and the TUI log view should now expose useful Pi progress without flooding users with raw JSON.

The change is covered by formatter and log-command tests, plus the full Go test suite.