### PR TITLE
Show partial panel costs

### DIFF
--- a/cmd/roborev/tui/queue_test.go
+++ b/cmd/roborev/tui/queue_test.go
@@ -811,6 +811,30 @@ func TestTUIQueueCollapsedPanelShowsSummaryCostBeforeExpansion(t *testing.T) {
 	assert.Contains(t, out, "~$0.40", "collapsed parent row uses panel_summary cost before member fetch")
 }
 
+func TestTUIQueueCollapsedPanelShowsPartialSummaryCostBeforeExpansion(t *testing.T) {
+	parent := makeJob(10, withRef("syn"), withStatus(storage.JobStatusDone),
+		withSynthesis("R", storage.PanelSummary{
+			MembersTotal:        2,
+			MembersTerminal:     2,
+			MembersSucceeded:    2,
+			MembersWithCost:     1,
+			MembersCostUSD:      0.35,
+			MembersCostComplete: false,
+		}))
+
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.width = 200
+	m.height = 30
+	m.jobs = []storage.ReviewJob{parent}
+	m.panelMembers = map[string][]storage.ReviewJob{}
+	m.selectedIdx = 0
+	m.selectedJobID = parent.ID
+
+	out := stripTestANSI(m.renderQueueView())
+	assert.False(t, m.expandedPanels["R"], "panel remains collapsed")
+	assert.Contains(t, out, "~$0.35", "collapsed parent row shows known member costs even when partial")
+}
+
 func TestTUIQueueCollapsedPanelUsesSummaryCostWhenMemberCacheStale(t *testing.T) {
 	parent := makeJob(10, withRef("syn"), withStatus(storage.JobStatusDone),
 		withSynthesis("R", storage.PanelSummary{
@@ -835,6 +859,27 @@ func TestTUIQueueCollapsedPanelUsesSummaryCostWhenMemberCacheStale(t *testing.T)
 	out := stripTestANSI(m.renderQueueView())
 	assert.False(t, m.expandedPanels["R"], "panel remains collapsed")
 	assert.Contains(t, out, "~$0.40", "complete panel_summary cost wins over stale cached members")
+}
+
+func TestTUIQueueCollapsedPanelShowsPartialCachedMemberCost(t *testing.T) {
+	parent := makeJob(10, withRef("syn"), withStatus(storage.JobStatusDone),
+		withSynthesis("R", storage.PanelSummary{MembersTotal: 2, MembersTerminal: 2, MembersSucceeded: 2}))
+	memberA := makeJob(11, withPanelMember("R", "default", 0), withStatus(storage.JobStatusDone))
+	memberA.TokenUsage = `{"cost_usd":0.10,"has_cost":true}`
+	memberB := makeJob(12, withPanelMember("R", "security", 1), withStatus(storage.JobStatusDone))
+	memberB.TokenUsage = `{"has_cost":false}`
+
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.width = 200
+	m.height = 30
+	m.jobs = []storage.ReviewJob{parent}
+	m.panelMembers = map[string][]storage.ReviewJob{"R": {memberA, memberB}}
+	m.selectedIdx = 0
+	m.selectedJobID = parent.ID
+
+	out := stripTestANSI(m.renderQueueView())
+	assert.False(t, m.expandedPanels["R"], "panel remains collapsed")
+	assert.Contains(t, out, "~$0.10", "collapsed parent row shows known cached member costs even when partial")
 }
 
 func TestTUIQueueTableRendersWithinWidth(t *testing.T) {

--- a/cmd/roborev/tui/render_queue.go
+++ b/cmd/roborev/tui/render_queue.go
@@ -969,8 +969,8 @@ func (m model) jobCells(job storage.ReviewJob) []string {
 }
 
 // jobCostCell renders the stored priced estimate for a row. For a panel parent,
-// it adds cached member costs only when every cached member has a priced cost,
-// avoiding a misleading partial panel total.
+// it adds known member costs as a lower-bound aggregate; unpriced members do not
+// suppress costs from members that did report pricing.
 func (m model) jobCostCell(job storage.ReviewJob) string {
 	total := 0.0
 	hasCost := false
@@ -988,7 +988,8 @@ func (m model) jobCostCell(job storage.ReviewJob) string {
 
 	members := m.panelMembers[job.PanelRunUUID]
 	if len(members) == 0 {
-		if job.PanelSummary != nil && job.PanelSummary.MembersCostComplete {
+		if job.PanelSummary != nil &&
+			(job.PanelSummary.MembersCostComplete || job.PanelSummary.MembersWithCost > 0) {
 			return tokens.Usage{CostUSD: total + job.PanelSummary.MembersCostUSD, HasCost: true}.FormatCost()
 		}
 		if !hasCost {
@@ -1004,14 +1005,15 @@ func (m model) jobCostCell(job storage.ReviewJob) string {
 			if job.PanelSummary != nil && job.PanelSummary.MembersCostComplete {
 				return tokens.Usage{CostUSD: total + job.PanelSummary.MembersCostUSD, HasCost: true}.FormatCost()
 			}
-			if !hasCost {
-				return ""
-			}
-			return tokens.Usage{CostUSD: total, HasCost: true}.FormatCost()
+			continue
 		}
 		memberTotal += tu.CostUSD
+		hasCost = true
 	}
 
+	if !hasCost {
+		return ""
+	}
 	return tokens.Usage{CostUSD: total + memberTotal, HasCost: true}.FormatCost()
 }
 

--- a/internal/daemon_client/client.gen.go
+++ b/internal/daemon_client/client.gen.go
@@ -474,6 +474,7 @@ type PanelSummary struct {
 	MembersSucceeded    int64    `json:"members_succeeded"`
 	MembersTerminal     int64    `json:"members_terminal"`
 	MembersTotal        int64    `json:"members_total"`
+	MembersWithCost     *int64   `json:"members_with_cost,omitempty"`
 	PanelRunUuid        string   `json:"panel_run_uuid"`
 }
 

--- a/internal/daemon_client/openapi-3.0.json
+++ b/internal/daemon_client/openapi-3.0.json
@@ -1133,6 +1133,10 @@
             "format": "int64",
             "type": "integer"
           },
+          "members_with_cost": {
+            "format": "int64",
+            "type": "integer"
+          },
           "panel_run_uuid": {
             "type": "string"
           }

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -1872,6 +1872,7 @@ type PanelSummary struct {
 	MembersFailed       int     `json:"members_failed"`
 	MembersCanceled     int     `json:"members_canceled"`
 	MembersSkipped      int     `json:"members_skipped"`
+	MembersWithCost     int     `json:"members_with_cost,omitempty"`
 	MembersCostUSD      float64 `json:"members_cost_usd,omitempty"`
 	MembersCostComplete bool    `json:"members_cost_complete,omitempty"`
 }
@@ -1919,6 +1920,7 @@ func (db *DB) GetPanelSummaries(runUUIDs []string) (map[string]PanelSummary, err
 			&membersWithCost, &s.MembersCostUSD); err != nil {
 			return nil, fmt.Errorf("scan panel summary: %w", err)
 		}
+		s.MembersWithCost = membersWithCost
 		s.MembersCostComplete = s.MembersTotal > 0 && membersWithCost == s.MembersTotal
 		out[s.PanelRunUUID] = s
 	}

--- a/internal/storage/panels_test.go
+++ b/internal/storage/panels_test.go
@@ -460,6 +460,7 @@ func TestGetPanelSummaries(t *testing.T) {
 	assert.Equal(1, sumA.MembersFailed)
 	assert.Equal(0, sumA.MembersCanceled)
 	assert.Equal(1, sumA.MembersSkipped)
+	assert.Equal(3, sumA.MembersWithCost)
 	assert.True(sumA.MembersCostComplete)
 	assert.InDelta(0.40, sumA.MembersCostUSD, 0.000001)
 
@@ -470,6 +471,7 @@ func TestGetPanelSummaries(t *testing.T) {
 	assert.Equal(1, sumB.MembersCanceled)
 	assert.Equal(0, sumB.MembersFailed)
 	assert.Equal(0, sumB.MembersSkipped)
+	assert.Equal(1, sumB.MembersWithCost)
 	assert.False(sumB.MembersCostComplete, "partial member cost is not complete")
 	assert.InDelta(0.20, sumB.MembersCostUSD, 0.000001)
 
@@ -480,6 +482,7 @@ func TestGetPanelSummaries(t *testing.T) {
 	assert.Equal(0, sumC.MembersFailed)
 	assert.Equal(0, sumC.MembersCanceled)
 	assert.Equal(0, sumC.MembersSkipped)
+	assert.Equal(0, sumC.MembersWithCost)
 	assert.False(sumC.MembersCostComplete)
 
 	// A run with no member rows is absent from the map (not a zero-value entry).

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -584,6 +584,7 @@ type PanelSummary struct {
 	MembersSucceeded    int64    `json:"members_succeeded"`
 	MembersTerminal     int64    `json:"members_terminal"`
 	MembersTotal        int64    `json:"members_total"`
+	MembersWithCost     *int64   `json:"members_with_cost,omitempty"`
 	PanelRunUUID        string   `json:"panel_run_uuid" validate:"required"`
 }
 

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -877,6 +877,9 @@ components:
         members_total:
           format: int64
           type: integer
+        members_with_cost:
+          format: int64
+          type: integer
         panel_run_uuid:
           type: string
       required:


### PR DESCRIPTION
Panels can include agents whose usage provider does not know pricing, but hiding the entire panel cost makes known spend disappear as soon as one member is unpriced. That is misleading for mixed panels because the aggregate row looks like there was no cost data at all.

This keeps the panel aggregate useful by rendering known member spend as a lower-bound total while still tracking whether every member reported cost. The API summary now exposes how many panel members contributed pricing so collapsed TUI rows can distinguish partial cost data from no cost data, including legitimate zero-dollar reports.