### PR TITLE
Allow flaky panel subagents

### DIFF
--- a/docs/advanced/subagent-review-panels.md
+++ b/docs/advanced/subagent-review-panels.md
@@ -25,11 +25,14 @@ instructions = "Focus on correctness, regressions, edge cases, and missing tests
 agent = "claude-code"
 review_type = "security"
 reasoning = "thorough"
+timeout = "10m"
 instructions = "Focus on authn/authz, secret handling, injection, and unsafe file access."
 
 [review.subagents.design]
 agent = "codex"
 review_type = "design"
+allow_failure = true
+timeout = "3m"
 
 [review.panels.quick]
 members = ["bug"]
@@ -107,6 +110,8 @@ provider = "anthropic"
 reasoning = "thorough"
 review_type = "security"
 instructions = "Focus on authentication and authorization."
+allow_failure = true
+timeout = "3m"
 ```
 
 | Key | Type | Description |
@@ -117,8 +122,12 @@ instructions = "Focus on authentication and authorization."
 | `reasoning` | string | Reasoning level for this member. Empty means use review reasoning. |
 | `review_type` | string | `default`, `security`, or `design`. `review` and `general` are accepted as aliases for `default`. |
 | `instructions` | string | Additional instructions appended only to this member prompt. |
+| `allow_failure` | bool | When true, a failed or canceled member does not make an otherwise successful panel fail. |
+| `timeout` | duration string | Per-member job timeout such as `90s`, `3m`, or `1h`. Empty uses repo/global `job_timeout_minutes`. |
 
 The member workflow is chosen from `review_type`: `default` uses review workflow config, `security` uses security workflow config, and `design` uses design workflow config. If a member sets `agent` but omits `model`, roborev inherits only a workflow specific model. It does not pair that explicit agent with an unrelated generic `default_model`.
+
+`allow_failure` and `timeout` are independent. Use both for a reviewer that is useful when available but should not block the panel, such as a reviewer running on flaky external infrastructure. If every required reviewer also fails and no member produces review output, the panel still records a failed/unavailable review instead of passing.
 
 ### Panels
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -255,6 +255,8 @@ instructions = "Focus on correctness, regressions, and missing tests."
 [review.subagents.security]
 agent = "claude-code"
 review_type = "security"
+allow_failure = true
+timeout = "3m"
 
 [review.panels.branch_final]
 members = ["bug", "security"]

--- a/internal/config/panels.go
+++ b/internal/config/panels.go
@@ -20,6 +20,7 @@ type SubagentSpec struct {
 	Reasoning    string `toml:"reasoning"`
 	ReviewType   string `toml:"review_type"`
 	Instructions string `toml:"instructions"`
+	AllowFailure bool   `toml:"allow_failure"`
 }
 
 // PanelSpec is a named set of subagent members plus an optional synthesis
@@ -159,6 +160,7 @@ type ResolvedMember struct {
 	Reasoning    string `json:"reasoning"`
 	ReviewType   string `json:"review_type"`
 	Instructions string `json:"instructions"`
+	AllowFailure bool   `json:"allow_failure,omitempty"`
 }
 
 // SynthesisSpec is the resolved agent/model/reasoning for a panel's synthesis
@@ -334,6 +336,7 @@ func resolveMemberFromConfig(
 		Reasoning:    reasoning,
 		ReviewType:   reviewType,
 		Instructions: spec.Instructions,
+		AllowFailure: spec.AllowFailure,
 	}, nil
 }
 

--- a/internal/config/panels.go
+++ b/internal/config/panels.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"slices"
 	"strings"
+	"time"
 )
 
 // SubagentSpec is a named reviewer spec referenced by panels. Empty scalar
@@ -21,6 +22,7 @@ type SubagentSpec struct {
 	ReviewType   string `toml:"review_type"`
 	Instructions string `toml:"instructions"`
 	AllowFailure bool   `toml:"allow_failure"`
+	Timeout      string `toml:"timeout"`
 }
 
 // PanelSpec is a named set of subagent members plus an optional synthesis
@@ -161,6 +163,7 @@ type ResolvedMember struct {
 	ReviewType   string `json:"review_type"`
 	Instructions string `json:"instructions"`
 	AllowFailure bool   `json:"allow_failure,omitempty"`
+	Timeout      string `json:"timeout,omitempty"`
 }
 
 // SynthesisSpec is the resolved agent/model/reasoning for a panel's synthesis
@@ -311,6 +314,9 @@ func resolveMemberFromConfig(
 	if err != nil {
 		return ResolvedMember{}, fmt.Errorf("subagent %q: %w", name, err)
 	}
+	if err := validateSubagentTimeout(spec.Timeout); err != nil {
+		return ResolvedMember{}, fmt.Errorf("subagent %q: %w", name, err)
+	}
 	workflow := workflowForReviewType(reviewType)
 	agent := spec.Agent
 	if agent == "" {
@@ -337,7 +343,19 @@ func resolveMemberFromConfig(
 		ReviewType:   reviewType,
 		Instructions: spec.Instructions,
 		AllowFailure: spec.AllowFailure,
+		Timeout:      spec.Timeout,
 	}, nil
+}
+
+func validateSubagentTimeout(timeout string) error {
+	if timeout == "" {
+		return nil
+	}
+	d, err := time.ParseDuration(timeout)
+	if err != nil || d <= 0 {
+		return fmt.Errorf("invalid timeout %q", timeout)
+	}
+	return nil
 }
 
 // resolveSynthesis resolves the synthesis agent/model/reasoning: the panel's

--- a/internal/config/panels_test.go
+++ b/internal/config/panels_test.go
@@ -37,6 +37,7 @@ review_type = "security"
 reasoning = "thorough"
 instructions = "Focus on authz."
 allow_failure = true
+timeout = "3m"
 
 [review.panels.quick]
 members = ["default"]
@@ -59,6 +60,7 @@ synthesis_model = "gpt-5.5"
 	assert.Equal("thorough", cfg.Review.Subagents["security"].Reasoning)
 	assert.Equal("Focus on authz.", cfg.Review.Subagents["security"].Instructions)
 	assert.True(cfg.Review.Subagents["security"].AllowFailure)
+	assert.Equal("3m", cfg.Review.Subagents["security"].Timeout)
 	assert.Equal([]string{"default", "security"}, cfg.Review.Panels["branch_final"].Members)
 	assert.Equal("codex", cfg.Review.Panels["branch_final"].SynthesisAgent)
 	assert.Equal("gpt-5.5", cfg.Review.Panels["branch_final"].SynthesisModel)
@@ -199,6 +201,7 @@ func TestResolvePanel(t *testing.T) {
 					Reasoning:    "thorough",
 					Instructions: "Focus on authz.",
 					AllowFailure: true,
+					Timeout:      "3m",
 				},
 			},
 			Panels: map[string]PanelSpec{
@@ -236,6 +239,7 @@ func TestResolvePanel(t *testing.T) {
 	assert.Equal("thorough", members[1].Reasoning)
 	assert.Equal("Focus on authz.", members[1].Instructions)
 	assert.True(members[1].AllowFailure)
+	assert.Equal("3m", members[1].Timeout)
 
 	// Synthesis from the panel's explicit fields; reasoning is the fix default.
 	assert.Equal("codex", synth.Agent)
@@ -258,6 +262,18 @@ func TestResolvePanel(t *testing.T) {
 	require.ErrorContains(t, err, `panel "empty" has no members`)
 	_, _, err = ResolvePanel("typo", "", global)
 	require.ErrorContains(t, err, `references undefined subagent "missing"`)
+}
+
+func TestResolvePanelRejectsInvalidSubagentTimeout(t *testing.T) {
+	global := &Config{Review: ReviewConfig{
+		Subagents: map[string]SubagentSpec{
+			"bad": {Agent: "codex", Timeout: "0"},
+		},
+		Panels: map[string]PanelSpec{"p": {Members: []string{"bad"}}},
+	}}
+
+	_, _, err := ResolvePanel("p", "", global)
+	require.ErrorContains(t, err, `subagent "bad": invalid timeout`)
 }
 
 // TestResolvePanelExplicitAgentSkipsGenericModel verifies A3: a member that

--- a/internal/config/panels_test.go
+++ b/internal/config/panels_test.go
@@ -36,6 +36,7 @@ agent = "codex"
 review_type = "security"
 reasoning = "thorough"
 instructions = "Focus on authz."
+allow_failure = true
 
 [review.panels.quick]
 members = ["default"]
@@ -57,6 +58,7 @@ synthesis_model = "gpt-5.5"
 	assert.Equal("security", cfg.Review.Subagents["security"].ReviewType)
 	assert.Equal("thorough", cfg.Review.Subagents["security"].Reasoning)
 	assert.Equal("Focus on authz.", cfg.Review.Subagents["security"].Instructions)
+	assert.True(cfg.Review.Subagents["security"].AllowFailure)
 	assert.Equal([]string{"default", "security"}, cfg.Review.Panels["branch_final"].Members)
 	assert.Equal("codex", cfg.Review.Panels["branch_final"].SynthesisAgent)
 	assert.Equal("gpt-5.5", cfg.Review.Panels["branch_final"].SynthesisModel)
@@ -196,6 +198,7 @@ func TestResolvePanel(t *testing.T) {
 					ReviewType:   "security",
 					Reasoning:    "thorough",
 					Instructions: "Focus on authz.",
+					AllowFailure: true,
 				},
 			},
 			Panels: map[string]PanelSpec{
@@ -232,6 +235,7 @@ func TestResolvePanel(t *testing.T) {
 	assert.Equal("security", members[1].ReviewType)
 	assert.Equal("thorough", members[1].Reasoning)
 	assert.Equal("Focus on authz.", members[1].Instructions)
+	assert.True(members[1].AllowFailure)
 
 	// Synthesis from the panel's explicit fields; reasoning is the fix default.
 	assert.Equal("codex", synth.Agent)

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -2077,17 +2077,28 @@ func panelCommitStatus(members []storage.BatchReviewResult) (state, desc string)
 	results := toReviewResults(members)
 	completed := 0
 	failedMembers := 0
-	for _, m := range members {
+	quotaSkips := 0
+	timeoutSkips := 0
+	transientSkips := 0
+	for i, m := range members {
+		r := results[i]
 		switch storage.JobStatus(m.Status) {
 		case storage.JobStatusDone:
 			completed++
 		case storage.JobStatusFailed, storage.JobStatusCanceled:
+			if r.AllowFailure {
+				continue
+			}
 			failedMembers++
+			if reviewpkg.IsQuotaFailure(r) {
+				quotaSkips++
+			} else if reviewpkg.IsTimeoutCancellation(r) {
+				timeoutSkips++
+			} else if reviewpkg.IsTransientFailure(r) {
+				transientSkips++
+			}
 		}
 	}
-	quotaSkips := reviewpkg.CountQuotaFailures(results)
-	timeoutSkips := reviewpkg.CountTimeoutCancellations(results)
-	transientSkips := reviewpkg.CountTransientFailures(results)
 	skippedTotal := quotaSkips + timeoutSkips + transientSkips
 	realFailures := max(failedMembers-quotaSkips-timeoutSkips-transientSkips, 0)
 
@@ -3054,14 +3065,21 @@ func toReviewResults(
 func toReviewResult(
 	br storage.BatchReviewResult,
 ) reviewpkg.ReviewResult {
+	var member struct {
+		AllowFailure bool `json:"allow_failure"`
+	}
+	if br.PanelMemberConfigJSON != "" {
+		_ = json.Unmarshal([]byte(br.PanelMemberConfigJSON), &member)
+	}
 	return reviewpkg.ReviewResult{
-		Agent:      br.Agent,
-		ReviewType: br.ReviewType,
-		Output:     br.Output,
-		Status:     br.Status,
-		Error:      br.Error,
-		Skipped:    br.Status == string(storage.JobStatusSkipped),
-		SkipReason: br.SkipReason,
+		Agent:        br.Agent,
+		ReviewType:   br.ReviewType,
+		Output:       br.Output,
+		Status:       br.Status,
+		Error:        br.Error,
+		Skipped:      br.Status == string(storage.JobStatusSkipped),
+		SkipReason:   br.SkipReason,
+		AllowFailure: member.AllowFailure,
 	}
 }
 

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -2223,12 +2223,13 @@ func (p *CIPoller) expireTimedOutPanels(ghRepo string, cfg *config.Config) {
 
 // panelMemberTimeoutState reports the two predicates that gate timeout expiry:
 // hasMeaningful is true when at least one member carries a REAL postable result -
-// a done member, or a failed/canceled member that is NOT a quota skip and NOT a
-// prior timeout cancellation (those are counted as skips downstream and must not
-// pass the guard). hasExpiredRunning is true when at least one running member has
-// consumed runtime beyond the timeout. Queued time never counts toward this
-// timeout. Classification reuses the review-package skip classifiers via
-// toReviewResult so it agrees with how panelCommitStatus accounts for skips.
+// a done member, or a failed/canceled member that is NOT allowed to fail, NOT a
+// quota skip, and NOT a prior timeout cancellation (those are counted as skips
+// downstream and must not pass the guard). hasExpiredRunning is true when at
+// least one running member has consumed runtime beyond the timeout. Queued time
+// never counts toward this timeout. Classification reuses the review-package
+// skip classifiers via toReviewResult so it agrees with how panelCommitStatus
+// accounts for skips.
 func panelMemberTimeoutState(members []storage.BatchReviewResult, timeout time.Duration, now time.Time) (hasMeaningful, hasExpiredRunning bool) {
 	for i := range members {
 		switch storage.JobStatus(members[i].Status) {
@@ -2236,7 +2237,7 @@ func panelMemberTimeoutState(members []storage.BatchReviewResult, timeout time.D
 			hasMeaningful = true
 		case storage.JobStatusFailed, storage.JobStatusCanceled:
 			r := toReviewResult(members[i])
-			if !reviewpkg.IsQuotaFailure(r) && !reviewpkg.IsTimeoutCancellation(r) {
+			if !r.AllowFailure && !reviewpkg.IsQuotaFailure(r) && !reviewpkg.IsTimeoutCancellation(r) {
 				hasMeaningful = true
 			}
 		case storage.JobStatusRunning:

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -196,11 +196,12 @@ func (h *ciPollerHarness) CaptureCommitStatuses() *[]capturedStatus {
 }
 
 type jobSpec struct {
-	Agent      string
-	ReviewType string
-	Status     string // "done", "failed", "canceled", "running", "queued"
-	Output     string
-	Error      string
+	Agent                 string
+	ReviewType            string
+	Status                string // "done", "failed", "canceled", "running", "queued"
+	Output                string
+	Error                 string
+	PanelMemberConfigJSON string
 }
 
 // markJobDoneWithReview sets a job to "done" and inserts a review row.

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -2500,12 +2500,13 @@ func TestToReviewResults(t *testing.T) {
 			Error:      "",
 		},
 		{
-			JobID:      2,
-			Agent:      "gemini",
-			ReviewType: "review",
-			Output:     "",
-			Status:     "failed",
-			Error:      review.QuotaErrorPrefix + "limit reached",
+			JobID:                 2,
+			Agent:                 "gemini",
+			ReviewType:            "review",
+			Output:                "",
+			Status:                "failed",
+			Error:                 review.QuotaErrorPrefix + "limit reached",
+			PanelMemberConfigJSON: `{"allow_failure":true}`,
 		},
 	}
 
@@ -2535,6 +2536,7 @@ func TestToReviewResults(t *testing.T) {
 			return false
 		}, "rrs[1].Agent=%q, want gemini", rrs[1].Agent)
 	}
+	assert.True(t, rrs[1].AllowFailure)
 }
 
 func TestCIPollerProcessPR_ThrottlesRecentPR(t *testing.T) {

--- a/internal/daemon/panel_cleanup_test.go
+++ b/internal/daemon/panel_cleanup_test.go
@@ -27,7 +27,7 @@ func (h *ciPollerHarness) seedBlockedPanelRun(
 		members = append(members, storage.EnqueueOpts{
 			RepoID: h.Repo.ID, GitRef: gitRef, Agent: s.Agent, ReviewType: s.ReviewType,
 			JobType: storage.JobTypeRange, PanelName: "ci", PanelMemberName: s.Agent,
-			PanelMemberIndex: i,
+			PanelMemberIndex: i, PanelMemberConfigJSON: s.PanelMemberConfigJSON,
 		})
 	}
 	synthesis := storage.EnqueueOpts{
@@ -339,6 +339,39 @@ func TestExpireTimedOutPanelsQuotaFailureNotMeaningful(t *testing.T) {
 	assert.Empty(canceled, "no worker killed when only skips are terminal")
 
 	// Synthesis stays gated so no fake success can be posted.
+	assert.True(h.synthBlocked(t, synth.PanelRunUUID), "synthesis stays blocked (no fake success)")
+	assert.NotEqual(storage.JobStatusCanceled, h.jobStatus(t, synth.ID), "synthesis not canceled")
+}
+
+func TestExpireTimedOutPanelsAllowedFailureNotMeaningful(t *testing.T) {
+	assert := assert.New(t)
+	h := newCIPollerHarness(t, "https://github.com/acme/api.git")
+	h.Cfg.CI.BatchTimeout = "1ms"
+
+	var canceled []int64
+	h.Poller.jobCancelFn = func(jobID int64) { canceled = append(canceled, jobID) }
+
+	panel, synth, members := h.seedBlockedPanelRun(t, "acme/api", 25, "headsha", "base..headsha",
+		[]jobSpec{
+			{
+				Agent:                 "pi",
+				ReviewType:            "review",
+				Status:                "failed",
+				Error:                 "pi host disappeared",
+				PanelMemberConfigJSON: `{"allow_failure":true}`,
+			},
+			{Agent: "codex", ReviewType: "review", Status: "running"},
+		})
+	require.Len(t, members, 2)
+	h.backdatePanelCreatedAt(t, panel.ID)
+	h.backdateJobStartedAt(t, members[1].ID)
+	require.True(t, h.synthBlocked(t, synth.PanelRunUUID), "synthesis blocked before sweep")
+
+	h.Poller.expireTimedOutPanels("acme/api", h.Cfg)
+
+	assert.Equal(storage.JobStatusFailed, h.jobStatus(t, members[0].ID), "allowed-failed member untouched")
+	assert.Equal(storage.JobStatusRunning, h.jobStatus(t, members[1].ID), "required running member left running")
+	assert.Empty(canceled, "no worker killed when only optional failures are terminal")
 	assert.True(h.synthBlocked(t, synth.PanelRunUUID), "synthesis stays blocked (no fake success)")
 	assert.NotEqual(storage.JobStatusCanceled, h.jobStatus(t, synth.ID), "synthesis not canceled")
 }

--- a/internal/daemon/panel_outcome_test.go
+++ b/internal/daemon/panel_outcome_test.go
@@ -84,3 +84,16 @@ func TestClassifyPanelOutcomeDoneEmptyOutputIsNotPost(t *testing.T) {
 	assert.Equal(OutcomeDeferTransient, classifyPanelOutcome([]reviewpkg.ReviewResult{doneEmpty, transient}, nil, 0).Kind)
 	assert.Equal(OutcomeAllSkip, classifyPanelOutcome([]reviewpkg.ReviewResult{doneEmpty}, nil, 0).Kind)
 }
+
+func TestClassifyPanelOutcomeAllowsConfiguredFailureAfterSuccessfulReview(t *testing.T) {
+	assert := assert.New(t)
+	ok := reviewpkg.ReviewResult{Status: reviewpkg.ResultDone, Output: "Findings"}
+	optionalFailure := reviewpkg.ReviewResult{
+		Status:       reviewpkg.ResultFailed,
+		Error:        "pi host disappeared",
+		AllowFailure: true,
+	}
+
+	assert.Equal(OutcomePost, classifyPanelOutcome([]reviewpkg.ReviewResult{ok, optionalFailure}, nil, 0).Kind)
+	assert.Equal(OutcomeDeferGenuine, classifyPanelOutcome([]reviewpkg.ReviewResult{optionalFailure}, nil, 0).Kind)
+}

--- a/internal/daemon/panel_posting_test.go
+++ b/internal/daemon/panel_posting_test.go
@@ -157,6 +157,21 @@ func TestPanelCommitStatus(t *testing.T) {
 			wantDesc:  "Review complete (1/3 jobs failed)",
 		},
 		{
+			name: "allowed failure with successful sibling is success",
+			members: []storage.BatchReviewResult{
+				member("codex", "review", "done", ""),
+				{
+					Agent:                 "pi",
+					ReviewType:            "security",
+					Status:                "failed",
+					Error:                 "pi host disappeared",
+					PanelMemberConfigJSON: `{"allow_failure":true}`,
+				},
+			},
+			wantState: "success",
+			wantDesc:  "Review complete",
+		},
+		{
 			name: "done plus skip is success with note",
 			members: []storage.BatchReviewResult{
 				member("codex", "review", "done", ""),

--- a/internal/daemon/synthesis_worker.go
+++ b/internal/daemon/synthesis_worker.go
@@ -133,7 +133,7 @@ func allMembersPassed(
 	results []reviewpkg.ReviewResult,
 	succeeded []reviewpkg.ReviewResult,
 ) bool {
-	if len(results) == 0 || len(results) != len(succeeded) {
+	if len(results) == 0 {
 		return false
 	}
 	for _, r := range succeeded {
@@ -141,7 +141,13 @@ func allMembersPassed(
 			return false
 		}
 	}
-	return true
+	ignored := 0
+	for _, r := range results {
+		if r.AllowFailure && (r.Status == reviewpkg.ResultFailed || r.Status == "canceled") {
+			ignored++
+		}
+	}
+	return len(results)-ignored == len(succeeded)
 }
 
 // completeSynthesis stores the synthesis review, guards against the cancel race,

--- a/internal/daemon/synthesis_worker_test.go
+++ b/internal/daemon/synthesis_worker_test.go
@@ -91,6 +91,16 @@ func registerNeverCalledAgent(t *testing.T, name string, called *bool) {
 	t.Cleanup(func() { agent.Unregister(name) })
 }
 
+func TestAllMembersPassedIgnoresAllowedFailure(t *testing.T) {
+	results := []reviewpkg.ReviewResult{
+		{Status: reviewpkg.ResultDone, Output: "No issues found."},
+		{Status: reviewpkg.ResultFailed, Error: "pi host disappeared", AllowFailure: true},
+	}
+	succeeded := filterSucceeded(results)
+
+	assert.True(t, allMembersPassed(results, succeeded))
+}
+
 // jobAgentInvoked reads the raw agent_invoked cost-eligibility marker for a job.
 func jobAgentInvoked(t *testing.T, tc *workerTestContext, jobID int64) bool {
 	t.Helper()

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -528,9 +528,11 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 	// This prevents mixed settings if config reloads mid-job.
 	cfg := wp.cfgGetter.Config()
 
-	// Get timeout from config (per-repo or global, default 30 minutes)
+	// Get timeout from config (per-repo or global, default 30 minutes), then
+	// overlay any frozen panel-member timeout captured at enqueue time.
 	timeoutMinutes := config.ResolveJobTimeout(job.RepoPath, cfg)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutMinutes)*time.Minute)
+	timeoutDuration := resolveJobTimeoutDuration(job, timeoutMinutes)
+	ctx, cancel := context.WithTimeout(context.Background(), timeoutDuration)
 	defer cancel()
 
 	// Register for cancellation tracking
@@ -861,7 +863,7 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 		if errors.Is(err, context.DeadlineExceeded) || ctx.Err() == context.DeadlineExceeded {
 			timeoutErr := fmt.Sprintf(
 				"agent timeout after %s",
-				(time.Duration(timeoutMinutes) * time.Minute).Round(time.Second),
+				timeoutDuration.Round(time.Second),
 			)
 			log.Printf("[%s] Job %d timed out: %v", workerID, job.ID, err)
 			wp.failOrRetryAgent(workerID, job, agentName, timeoutErr)
@@ -1295,6 +1297,22 @@ func memberInstructionSuffix(job *storage.ReviewJob) string {
 		"\n\n## Additional reviewer instructions (panel: %s / member: %s)\n%s\n",
 		job.PanelName, job.PanelMemberName, m.Instructions,
 	)
+}
+
+func resolveJobTimeoutDuration(job *storage.ReviewJob, defaultMinutes int) time.Duration {
+	defaultDuration := time.Duration(defaultMinutes) * time.Minute
+	if job.PanelRole != storage.PanelRoleMember || job.PanelMemberConfigJSON == "" {
+		return defaultDuration
+	}
+	var m config.ResolvedMember
+	if json.Unmarshal([]byte(job.PanelMemberConfigJSON), &m) != nil || m.Timeout == "" {
+		return defaultDuration
+	}
+	d, err := time.ParseDuration(m.Timeout)
+	if err != nil || d <= 0 {
+		return defaultDuration
+	}
+	return d
 }
 
 // releaseIfPanelMember releases a panel run's blocked synthesis job when this

--- a/internal/daemon/worker_panel_test.go
+++ b/internal/daemon/worker_panel_test.go
@@ -23,6 +23,7 @@ type memberSpec struct {
 	name         string
 	agent        string
 	instructions string
+	timeout      string
 }
 
 // enqueuePanelRun builds and enqueues a panel run (members + gated synthesis)
@@ -44,6 +45,7 @@ func enqueuePanelRun(
 			Index:        i,
 			Agent:        m.agent,
 			Instructions: m.instructions,
+			Timeout:      m.timeout,
 		})
 		require.NoError(t, err)
 		opts = append(opts, storage.EnqueueOpts{
@@ -130,6 +132,24 @@ func TestMemberInstructionsAppended(t *testing.T) {
 	assert.Contains(captured, "Focus on auth boundaries.")
 	assert.Contains(captured, "auth-reviewer")
 	assert.Contains(captured, "Additional reviewer instructions")
+}
+
+func TestPanelMemberTimeoutOverridesDefaultJobTimeout(t *testing.T) {
+	job := &storage.ReviewJob{
+		PanelRole:             storage.PanelRoleMember,
+		PanelMemberConfigJSON: `{"timeout":"90s"}`,
+	}
+
+	assert.Equal(t, 90*time.Second, resolveJobTimeoutDuration(job, 30))
+}
+
+func TestPanelMemberInvalidTimeoutFallsBackToDefaultJobTimeout(t *testing.T) {
+	job := &storage.ReviewJob{
+		PanelRole:             storage.PanelRoleMember,
+		PanelMemberConfigJSON: `{"timeout":"later"}`,
+	}
+
+	assert.Equal(t, 30*time.Minute, resolveJobTimeoutDuration(job, 30))
 }
 
 func TestMemberInstructionsNotAppendedForNonPanelJob(t *testing.T) {

--- a/internal/review/result.go
+++ b/internal/review/result.go
@@ -21,6 +21,11 @@ type ReviewResult struct {
 	// crashing on missing Output.
 	Skipped    bool
 	SkipReason string
+
+	// AllowFailure means this panel member is allowed to fail without making an
+	// otherwise successful panel fail. It is set from the resolved member config
+	// stored with the job, not from live config.
+	AllowFailure bool
 }
 
 // Result status values for ReviewResult.Status.

--- a/internal/storage/ci.go
+++ b/internal/storage/ci.go
@@ -25,17 +25,18 @@ func (db *DB) RecordCIReview(githubRepo string, prNumber int, headSHA string, jo
 
 // BatchReviewResult holds the output of a single review job within a panel run.
 type BatchReviewResult struct {
-	JobID           int64  `json:"job_id"`
-	Agent           string `json:"agent"`
-	ReviewType      string `json:"review_type"`
-	PanelMemberName string `json:"panel_member_name,omitempty"`
-	Output          string `json:"output"`
-	Status          string `json:"status"` // "done", "failed", "skipped", etc.
-	Error           string `json:"error"`
-	SkipReason      string `json:"skip_reason,omitempty"`
-	StartedAt       string `json:"started_at,omitempty"`
-	FinishedAt      string `json:"finished_at,omitempty"`
-	TokenUsage      string `json:"token_usage,omitempty"`
+	JobID                 int64  `json:"job_id"`
+	Agent                 string `json:"agent"`
+	ReviewType            string `json:"review_type"`
+	PanelMemberName       string `json:"panel_member_name,omitempty"`
+	Output                string `json:"output"`
+	Status                string `json:"status"` // "done", "failed", "skipped", etc.
+	Error                 string `json:"error"`
+	SkipReason            string `json:"skip_reason,omitempty"`
+	PanelMemberConfigJSON string `json:"panel_member_config_json,omitempty"`
+	StartedAt             string `json:"started_at,omitempty"`
+	FinishedAt            string `json:"finished_at,omitempty"`
+	TokenUsage            string `json:"token_usage,omitempty"`
 }
 
 // CancelJobWithError cancels a queued or running job and sets an error

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -1837,6 +1837,7 @@ func (db *DB) GetPanelMemberReviews(panelRunUUID string) ([]BatchReviewResult, e
 	}
 	rows, err := db.Query(`
 		SELECT j.id, j.agent, j.review_type, COALESCE(j.panel_member_name, ''), COALESCE(rv.output, ''), j.status, COALESCE(j.error, ''), COALESCE(j.skip_reason, ''),
+		       COALESCE(j.panel_member_config_json, ''),
 		       COALESCE(j.started_at, ''), COALESCE(j.finished_at, ''), COALESCE(j.token_usage, '')
 		FROM review_jobs j
 		LEFT JOIN reviews rv ON rv.job_id = j.id
@@ -1850,7 +1851,7 @@ func (db *DB) GetPanelMemberReviews(panelRunUUID string) ([]BatchReviewResult, e
 	var results []BatchReviewResult
 	for rows.Next() {
 		var r BatchReviewResult
-		if err := rows.Scan(&r.JobID, &r.Agent, &r.ReviewType, &r.PanelMemberName, &r.Output, &r.Status, &r.Error, &r.SkipReason, &r.StartedAt, &r.FinishedAt, &r.TokenUsage); err != nil {
+		if err := rows.Scan(&r.JobID, &r.Agent, &r.ReviewType, &r.PanelMemberName, &r.Output, &r.Status, &r.Error, &r.SkipReason, &r.PanelMemberConfigJSON, &r.StartedAt, &r.FinishedAt, &r.TokenUsage); err != nil {
 			return nil, fmt.Errorf("scan panel member review: %w", err)
 		}
 		results = append(results, r)


### PR DESCRIPTION
Panel reviews can include useful reviewers that run on less reliable or slower infrastructure. Before this change, one such member failure could turn an otherwise useful multi-review panel into a failed or degraded result, which makes mixed panels brittle for CI and daemon review workflows.

This adds explicit per-subagent controls for that case: `allow_failure` lets operators mark a reviewer as optional, and `timeout` lets them shorten or lengthen only that member without changing the repo-wide job timeout. Both settings are frozen into the queued member config so synthesis and CI posting use the decision that existed when the panel was enqueued.

The important safety boundary is unchanged: roborev still requires at least one member to produce real review output. Optional failures are ignored only when another reviewer succeeded; an all-failed panel still records failure or unavailable review state.