### PR TITLE
Document 0.59.1 release updates

### DIFF
--- a/docs/advanced/subagent-review-panels.md
+++ b/docs/advanced/subagent-review-panels.md
@@ -33,6 +33,7 @@ agent = "codex"
 review_type = "design"
 allow_failure = true
 timeout = "3m"
+instructions = "Helpful when available, but do not block the panel if this reviewer flakes."
 
 [review.panels.quick]
 members = ["bug"]
@@ -127,7 +128,7 @@ timeout = "3m"
 
 The member workflow is chosen from `review_type`: `default` uses review workflow config, `security` uses security workflow config, and `design` uses design workflow config. If a member sets `agent` but omits `model`, roborev inherits only a workflow specific model. It does not pair that explicit agent with an unrelated generic `default_model`.
 
-`allow_failure` and `timeout` are independent. Use both for a reviewer that is useful when available but should not block the panel, such as a reviewer running on flaky external infrastructure. If every required reviewer also fails and no member produces review output, the panel still records a failed/unavailable review instead of passing.
+`allow_failure` is how you mark a flaky or best-effort reviewer. The member still runs and its findings are included when it succeeds, but a failed or canceled run is tolerated when at least one required member produced usable output. `allow_failure` and `timeout` are independent; use both for a reviewer that is useful when available but should not block the panel, such as a reviewer running on flaky external infrastructure. If every required reviewer also fails and no member produces review output, the panel still records a failed/unavailable review instead of passing.
 
 ### Panels
 
@@ -217,7 +218,7 @@ The TUI shows a panel run as one synthesis parent row. Press `Space` or `Right` 
 }
 ```
 
-When token usage is available, panel parent cost in the TUI includes member costs plus synthesis cost after the run is complete.
+When token usage is available, panel parent cost in the TUI includes known member costs even while the panel is still running or while some members are unpriced. Once synthesis reports usage, the parent total also includes synthesis cost. Treat the displayed value as a lower bound whenever not every member has reported cost.
 
 ## Operational Notes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,22 @@ description: Release history for roborev
 
 All notable changes to roborev, grouped by minor release.
 
+## 0.59.1
+<small>2026-06-22</small>
+
+**New features**
+
+- Configurable fix commit metadata. Set `fix_commit_author` and `fix_commit_co_authored_by` globally or per repo to control author metadata for `roborev refine` commits, background fix commits applied from the TUI, and prompt instructions for foreground `roborev fix` and `roborev analyze --fix` commits. See [Fix Commit Metadata](/configuration/#fix-commit-metadata).
+- Tolerated panel member failures. Mark a panel subagent with `allow_failure = true` when that reviewer is useful but flaky, so a transient failure or cancellation does not fail an otherwise usable panel result. See [Subagents](/advanced/subagent-review-panels/#subagents).
+
+**Improvements**
+
+- Pi job logs now render trace-style message and tool output instead of exposing raw event JSON, making Pi review sessions easier to inspect in CLI and TUI logs.
+- Panel parent rows and CI comment footers now surface known member costs even when some panel work is still pending or unpriced, with partial coverage clearly marked where comments include costs.
+- Expanded documentation for configuration, GitHub integration, review workflows, auto-fix/refine workflows, and subagent review panels.
+
+---
+
 ## 0.59.0
 <small>2026-06-22</small>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -310,7 +310,7 @@ members = ["bug", "security"]
 synthesis_agent = "codex"
 ```
 
-`default_panel` applies to manual daemon reviews when `--panel` is not set. `hook_review_panel` applies to automatic post-commit reviews. CI reviews can select a named panel with `[ci] panel = "branch_final"`.
+`default_panel` applies to manual daemon reviews when `--panel` is not set. `hook_review_panel` applies to automatic post-commit reviews. CI reviews can select a named panel with `[ci] panel = "branch_final"`. Use `allow_failure = true` for flaky or best-effort subagents whose failure should not fail an otherwise successful panel.
 
 Global and repo panel maps are merged by name, with repo entries overriding global entries. See [Subagent Review Panels](/advanced/subagent-review-panels/) for the full reference.
 

--- a/docs/guides/auto-fixing.md
+++ b/docs/guides/auto-fixing.md
@@ -60,6 +60,8 @@ flowchart TD
 
 If the agent makes no changes for a review, that review is skipped and refine moves on to the next failed review.
 
+Refine creates its own commits after applying agent changes. If `fix_commit_author` or `fix_commit_co_authored_by` is configured, refine applies those values directly with Git's `--author` and `--trailer` options. See [Fix Commit Metadata](/configuration/#fix-commit-metadata).
+
 ## Refine vs Fix
 
 | | `roborev fix` | `roborev refine` |

--- a/docs/guides/reviewing-code.md
+++ b/docs/guides/reviewing-code.md
@@ -63,6 +63,8 @@ roborev review --branch --panel none
 
 See [Subagent Review Panels](/advanced/subagent-review-panels/) for panel configuration.
 
+Panel subagents can be marked `allow_failure = true` when a reviewer is useful but flaky. Those members still contribute findings when they succeed, but a transient failure or cancellation does not fail the synthesized parent if required reviewers produced usable output.
+
 ### CI Integration
 
 ```bash

--- a/docs/integrations/github.md
+++ b/docs/integrations/github.md
@@ -27,7 +27,7 @@ Before enabling the CI poller, understand the following:
 - **All open PRs are reviewed.** There is no filtering by draft status, labels, or author. Draft PRs, bot PRs, and stale PRs all get reviewed.
 - **CI settings are global by default, with per-repo overrides.** The `panel`, `agents`, `review_types`, and `model` in the global `[ci]` section apply to every repo unless overridden. Individual repos can override panels, agents, review types, and reasoning level via the `[ci]` section in their `.roborev.toml` (see [Per-Repo Overrides](#per-repo-overrides)).
 - **Reviews run with `max_workers` concurrency** (default: 4). Jobs are enqueued immediately but executed up to 4 at a time. A panel consumes normal worker capacity as its members run. A 2 type x 2 agent matrix creates 4 members plus 1 synthesis parent.
-- **PR comments include panel metadata.** Comments include a footer with the panel name, synthesis job, member reviewers, statuses, runtimes, and optional costs.
+- **PR comments include panel metadata.** Comments include a footer with the panel name, synthesis job, member reviewers, statuses, runtimes, and optional costs. When only some panel jobs have reported cost, the footer marks the total as partial.
 - **The daemon does not survive reboots.** Use `roborev daemon start` to run in the background, but you'll need a launchd agent (macOS) or systemd service (Linux) if you want it to start on boot.
 
 !!! warning "First-run with many open PRs"
@@ -352,6 +352,7 @@ instructions = "Focus on authn/authz, injection, secrets, and unsafe file access
 [review.subagents.design]
 agent = "codex"
 review_type = "design"
+allow_failure = true
 
 [review.panels.ci]
 members = ["bug", "security", "design"]
@@ -359,6 +360,8 @@ synthesis_agent = "codex"
 ```
 
 When `panel` is set, the CI poller ignores `agents`, `review_types`, and `[ci.reviews]` for that repo. The named panel is resolved from global config plus the repo's `.roborev.toml` as loaded from the repo's default branch. Repo definitions override global definitions by name.
+
+Use `allow_failure = true` on a subagent when that reviewer is best-effort or depends on flaky infrastructure. Its successful output is still included, but a failure or cancellation will not block an otherwise usable CI panel comment.
 
 See [Subagent Review Panels](/advanced/subagent-review-panels/) for the full panel configuration reference.
 

--- a/docs/integrations/tui.md
+++ b/docs/integrations/tui.md
@@ -138,9 +138,9 @@ The queue displays two separate status columns:
 - **Status**: The job's lifecycle state: Queued (yellow), Running (blue), Done (default), Error (orange), Canceled (gray).
 - **P/F**: The review verdict, shown once the review completes: Pass (green) or Fail (red). This reflects whether the code review found issues, not whether the job itself errored. A job can finish successfully (Status = Done) with a Fail verdict if the reviewer flagged problems.
 
-The default-visible "Cost" column shows the model-pricing estimate from [agentsview](/commands/#token-usage) for completed jobs. The cell stays blank for unpriced models, for jobs whose usage has not been fetched yet, and on agentsview versions older than 0.30.0.
+The default-visible "Cost" column shows the model-pricing estimate from [agentsview](/commands/#token-usage) for jobs that have reported usage. The cell stays blank for unpriced models, for jobs whose usage has not been fetched yet, and on agentsview versions older than 0.30.0.
 
-For panel parent rows, the cost column sums member costs plus synthesis cost after the panel run is complete.
+For panel parent rows, the cost column shows known member costs as soon as they are available, including while other members are still running or unpriced. After synthesis reports usage, synthesis cost is added to the parent value. Until every member reports cost, the value is a lower-bound estimate.
 
 The queue status line also shows approximate aggregate cost for the active filter scope when the scope contains jobs where an agent ran. This is the same lower-bound coverage model as `roborev cost`: if only some eligible jobs reported cost, the status line includes the priced-job coverage.
 


### PR DESCRIPTION
The 0.59.1 release included several user-facing changes that need to be discoverable from roborev.io, not just from individual implementation commits. The docs should tell users how to configure fix commit metadata, how to tolerate flaky panel reviewers, and how to interpret partial panel cost display in the TUI and GitHub comments.

This updates the release notes and the adjacent workflow docs so the new behavior is explained where users are likely to look while configuring reviews, CI panels, and auto-fix/refine runs. The generated site validation passed locally.