### PR TITLE
Open Homebrew tap updates through PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Checkout tap repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
-          repository: roborev-dev/homebrew-tap
+          repository: kenn-io/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-tap
 
@@ -245,7 +245,9 @@ jobs:
           fi
           echo "All checksums verified"
 
-      - name: Commit and push
+      - name: Commit, push, and open PR
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           cd homebrew-tap
           git config user.name "github-actions[bot]"
@@ -257,6 +259,19 @@ jobs:
             exit 0
           fi
 
+          branch="roborev-v${VERSION}"
+          git checkout -B "$branch"
           git add Formula/roborev.rb
           git commit -m "Update roborev to v${VERSION}"
-          git push
+          git push -u origin "$branch" --force-with-lease
+
+          if gh pr list --repo kenn-io/homebrew-tap --state open --head "$branch" --json number --jq '.[0].number' | grep -q .; then
+            echo "Open Homebrew tap PR for $branch already exists"
+          else
+            gh pr create \
+              --repo kenn-io/homebrew-tap \
+              --base main \
+              --head "$branch" \
+              --title "Update roborev to v${VERSION}" \
+              --body "Updates the Homebrew formula to roborev v${VERSION} using the release tarball checksums from the release workflow."
+          fi

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,13 +37,13 @@ The install script downloads the latest release binary for your platform:
 Install via Homebrew:
 
 ```bash
-brew install roborev-dev/tap/roborev
+brew install kenn-io/tap/roborev
 ```
 
 Or tap first, then install:
 
 ```bash
-brew tap roborev-dev/tap
+brew tap kenn-io/tap
 brew install roborev
 ```
 


### PR DESCRIPTION
The v0.59.1 release generated the Homebrew formula update correctly, but the release workflow still checked out the moved tap repository through the old owner alias and then tried to push directly to the tap's protected main branch. The tap now lives under kenn-io and organization rules require changes through pull requests, so the update was rejected after checksum verification.

This changes future release runs to update a versioned branch in kenn-io/homebrew-tap and create a tap PR with the release tarball checksums. It also updates the installation docs to point at the new Homebrew tap owner.