### PR TITLE
Avoid fail reviews for quota-only panels

### DIFF
--- a/internal/daemon/synthesis_worker.go
+++ b/internal/daemon/synthesis_worker.go
@@ -41,6 +41,10 @@ func (wp *WorkerPool) processSynthesisJob(
 
 	switch len(succeeded) {
 	case 0:
+		if errMsg, ok := allAvailabilitySkippedFailure(results); ok {
+			wp.failSynthesisWithoutReview(workerID, job, errMsg)
+			return
+		}
 		// Every member failed — emit a durable fail review with no agent call.
 		// The comment renders the head SHA (FormatAllFailedComment short-SHAs its
 		// arg), so pass the head side of the frozen mergeBase..headSHA range.
@@ -69,6 +73,26 @@ func (wp *WorkerPool) processSynthesisJob(
 		// Two or more succeeded — combine and deduplicate via one agent call.
 		wp.synthesizeSucceededResults(ctx, workerID, job, succeeded)
 	}
+}
+
+func allAvailabilitySkippedFailure(results []reviewpkg.ReviewResult) (string, bool) {
+	if len(results) == 0 {
+		return "", false
+	}
+	first := ""
+	for _, r := range results {
+		if reviewpkg.IsQuotaFailure(r) || reviewpkg.IsTransientFailure(r) {
+			if first == "" {
+				first = r.Error
+			}
+			continue
+		}
+		return "", false
+	}
+	if first == "" {
+		first = reviewpkg.OutageError("all review agents unavailable")
+	}
+	return first, true
 }
 
 func singleSuccessCanPassthrough(minSeverity string) bool {
@@ -148,6 +172,22 @@ func allMembersPassed(
 		}
 	}
 	return len(results)-ignored == len(succeeded)
+}
+
+func (wp *WorkerPool) failSynthesisWithoutReview(workerID string, job *storage.ReviewJob, errorMsg string) {
+	if updated, err := wp.db.FailJob(job.ID, workerID, errorMsg); err != nil {
+		log.Printf("[%s] Error failing skipped synthesis job %d: %v", workerID, job.ID, err)
+	} else if updated {
+		log.Printf("[%s] Synthesis job %d skipped because all panel members were unavailable",
+			workerID, job.ID)
+		wp.broadcastFailed(job, job.Agent, errorMsg)
+		if wp.errorLog != nil {
+			wp.errorLog.LogError("worker",
+				fmt.Sprintf("synthesis job %d skipped: %s", job.ID, errorMsg),
+				job.ID)
+		}
+		wp.logJobFailed(job.ID, workerID, job.Agent, errorMsg)
+	}
 }
 
 // completeSynthesis stores the synthesis review, guards against the cancel race,

--- a/internal/daemon/synthesis_worker_test.go
+++ b/internal/daemon/synthesis_worker_test.go
@@ -44,8 +44,13 @@ func completeMember(t *testing.T, tc *workerTestContext, jobID int64, ag, output
 // failMember drives a specific member to terminal failure.
 func failMember(t *testing.T, tc *workerTestContext, jobID int64) {
 	t.Helper()
+	failMemberWithError(t, tc, jobID, "boom")
+}
+
+func failMemberWithError(t *testing.T, tc *workerTestContext, jobID int64, errMsg string) {
+	t.Helper()
 	markMemberRunning(t, tc, jobID)
-	ok, err := tc.DB.FailJob(jobID, testWorkerID, "boom")
+	ok, err := tc.DB.FailJob(jobID, testWorkerID, errMsg)
 	require.NoError(t, err)
 	require.True(t, ok, "FailJob should mark the running member failed")
 }
@@ -431,6 +436,36 @@ func TestSynthesisAllFailed(t *testing.T) {
 	assert.Contains(review.Output, "Review Failed")
 	assert.Contains(review.Output, "All review jobs in this batch failed")
 	assert.False(synthCalled, "no agent should run when every member failed")
+}
+
+func TestSynthesisAllQuotaSkippedDoesNotStoreFailReview(t *testing.T) {
+	assert := assert.New(t)
+	tc := newWorkerTestContext(t, 1)
+
+	const memberAgent = "panel-all-quota-member"
+	registerPassingAgent(t, memberAgent)
+
+	var synthCalled bool
+	const synthAgent = "synth-all-quota"
+	registerNeverCalledAgent(t, synthAgent, &synthCalled)
+
+	runUUID, members, _ := enqueuePanelRun(t, tc, "all-quota-panel", []memberSpec{
+		{name: "m0", agent: memberAgent},
+		{name: "m1", agent: memberAgent},
+	})
+	setSynthesisAgent(t, tc, runUUID, synthAgent)
+	for _, m := range members {
+		failMemberWithError(t, tc, m.ID, reviewpkg.QuotaErrorPrefix+"agent quota exhausted")
+	}
+
+	synth := releaseAndClaimSynthesis(t, tc, runUUID)
+	tc.Pool.processSynthesisJob(context.Background(), testWorkerID, synth)
+
+	got := tc.assertJobStatus(t, synth.ID, storage.JobStatusFailed)
+	assert.Contains(got.Error, reviewpkg.QuotaErrorPrefix)
+	_, err := tc.DB.GetReviewByJobID(synth.ID)
+	require.Error(t, err, "all-quota synthesis must not store a verdict-bearing review")
+	assert.False(synthCalled, "no agent should run when every member was skipped")
 }
 
 func TestSynthesisSingleSuccessPassthrough(t *testing.T) {


### PR DESCRIPTION
When every CI panel subagent is skipped because of quota exhaustion or provider unavailability, roborev currently creates a completed synthesis review whose body says the review was skipped but whose parsed verdict is Fail. That is confusing in local review history even though the GitHub-facing CI path correctly suppresses posting and retries later.

This changes the synthesis parent for quota/provider-only panels to fail with the same retryable availability class that the CI finalizer already understands, without storing a verdict-bearing review body. Genuine all-failed panels still keep the existing durable failure review, so deterministic agent failures remain visible while availability-only runs avoid misleading UX.

The regression coverage exercises the all-quota panel path and confirms no synthesis agent is invoked and no fail review is stored.