### PR TITLE
Require explicit workflow backup agents

### DIFF
--- a/cmd/roborev/analyze.go
+++ b/cmd/roborev/analyze.go
@@ -802,7 +802,7 @@ func runFixAgent(cmd *cobra.Command, repoPath, agentName, model, reasoning, prom
 	}
 	agentName = resolution.PreferredAgent
 
-	a, err := agent.GetAvailableWithConfig(
+	a, err := agent.GetPreferredOrBackupWithConfig(
 		repoPath, agentName, cfg, resolution.BackupAgent,
 	)
 	if err != nil {

--- a/cmd/roborev/fix.go
+++ b/cmd/roborev/fix.go
@@ -481,7 +481,7 @@ func resolveFixAgent(repoPath string, opts fixOptions) (agent.Agent, error) {
 		return nil, fmt.Errorf("resolve workflow config: %w", err)
 	}
 
-	a, err := agent.GetAvailableWithConfig(
+	a, err := agent.GetPreferredOrBackupWithConfig(
 		repoPath, resolution.PreferredAgent, cfg, resolution.BackupAgent,
 	)
 	if err != nil {

--- a/cmd/roborev/fix_test.go
+++ b/cmd/roborev/fix_test.go
@@ -2953,7 +2953,7 @@ fix_agent = "claude"
 	assert.Empty(t, modelStr)
 }
 
-func TestResolveFixAgentFallbackUsesDefaultModelForActualAgent(t *testing.T) {
+func TestResolveFixAgentBackupUsesBackupModel(t *testing.T) {
 	t.Cleanup(testutil.MockExecutableIsolated(t, "codex", 0))
 
 	tmpDir := t.TempDir()
@@ -2964,6 +2964,8 @@ func TestResolveFixAgentFallbackUsesDefaultModelForActualAgent(t *testing.T) {
 default_agent = "codex"
 default_model = "gpt-5.4"
 fix_agent = "claude"
+fix_backup_agent = "codex"
+fix_backup_model = "backup-gpt"
 `), 0o644); err != nil {
 		require.NoError(t, err)
 	}
@@ -2973,7 +2975,7 @@ fix_agent = "claude"
 
 	codexAgent, ok := selected.(*agent.CodexAgent)
 	assert.True(t, ok)
-	assert.Equal(t, "gpt-5.4", codexAgent.Model)
+	assert.Equal(t, "backup-gpt", codexAgent.Model)
 }
 
 func TestResolveFixAgentUsesRepoWorkflowModel(t *testing.T) {

--- a/cmd/roborev/refine.go
+++ b/cmd/roborev/refine.go
@@ -1262,7 +1262,7 @@ func verifyRepoState(
 }
 
 func selectRefineAgent(repoPath string, cfg *config.Config, resolvedAgent string, reasoningLevel agent.ReasoningLevel, backups ...string) (agent.Agent, error) {
-	baseAgent, err := agent.GetAvailableWithConfig(repoPath, resolvedAgent, cfg, backups...)
+	baseAgent, err := agent.GetPreferredOrBackupWithConfig(repoPath, resolvedAgent, cfg, backups...)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/roborev/refine_test.go
+++ b/cmd/roborev/refine_test.go
@@ -150,12 +150,12 @@ func (m *mockDaemonClient) WithJob(id int64, gitRef string, status storage.JobSt
 
 var _ daemon.Client = (*mockDaemonClient)(nil)
 
-func TestSelectRefineAgentCodexFallback(t *testing.T) {
+func TestSelectRefineAgentUnavailableWithoutBackupFails(t *testing.T) {
 	t.Setenv("PATH", "")
 
 	_, err := selectRefineAgent("", nil, "codex", agent.ReasoningFast, "")
 	require.Error(t, err, "expected error when no agents are available")
-	if !strings.Contains(err.Error(), "no agents available") {
+	if !strings.Contains(err.Error(), "no configured agent available") {
 		require.NoError(t, err)
 	}
 }
@@ -260,10 +260,10 @@ func TestSelectRefineAgentCodexACPConfigAliasUsesACPResolution(t *testing.T) {
 	assert.Equal(t, "acp-agent", acpAgent.CommandName())
 }
 
-func TestSelectRefineAgentCodexFallbackUsesRequestedReasoning(t *testing.T) {
+func TestSelectRefineAgentBackupUsesRequestedReasoning(t *testing.T) {
 	t.Cleanup(testutil.MockExecutableIsolated(t, "codex", 0))
 
-	selected, err := selectRefineAgent("", nil, "gemini", agent.ReasoningThorough, "")
+	selected, err := selectRefineAgent("", nil, "gemini", agent.ReasoningThorough, "codex")
 	require.NoError(t, err, "selectRefineAgent failed: %v")
 
 	codexAgent, ok := selected.(*agent.CodexAgent)

--- a/cmd/roborev/review.go
+++ b/cmd/roborev/review.go
@@ -471,7 +471,7 @@ func runLocalReview(cmd *cobra.Command, repoPath, gitRef, diffContent string, di
 	}
 
 	// Get the agent (try backup before hardcoded chain)
-	a, err := agent.GetAvailableWithConfig(
+	a, err := agent.GetPreferredOrBackupWithConfig(
 		repoPath, resolution.PreferredAgent, cfg, resolution.BackupAgent,
 	)
 	if err != nil {

--- a/docs/advanced/subagent-review-panels.md
+++ b/docs/advanced/subagent-review-panels.md
@@ -146,7 +146,7 @@ synthesis_backup_model = "claude-opus-4-8"
 | `members` | array | Ordered list of subagent names. Required and must not be empty. |
 | `synthesis_agent` | string | Agent for synthesis. Empty means use fix workflow agent resolution. |
 | `synthesis_model` | string | Model for synthesis. Empty means use fix workflow model resolution. |
-| `synthesis_backup_agent` | string | Explicit backup agent for synthesis if the primary fails. |
+| `synthesis_backup_agent` | string | Explicit backup agent for synthesis if the primary is unavailable or fails. |
 | `synthesis_backup_model` | string | Explicit backup model for synthesis backup. |
 
 Panel validation fails if `default_panel` or `hook_review_panel` names an undefined panel, a panel has no members, or a panel references an undefined subagent.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,7 +146,7 @@ max_chars = 50000
 | `design_agent_<level>` | string | Agent for design reviews at specific reasoning level |
 | `design_model` | string | Model for design reviews |
 | `design_model_<level>` | string | Model for design reviews at specific reasoning level |
-| `backup_agent` | string | Fallback agent if primary fails |
+| `backup_agent` | string | Fallback agent if primary is unavailable or fails |
 | `review_backup_agent` | string | Fallback agent for reviews |
 | `refine_backup_agent` | string | Fallback agent for refine |
 | `fix_backup_agent` | string | Fallback agent for fix |
@@ -316,7 +316,7 @@ Global and repo panel maps are merged by name, with repo entries overriding glob
 
 ### Backup Agents
 
-If the primary agent fails (rate limits, network errors, crashes), roborev can automatically retry the job with a backup agent. This is useful when your primary agent has usage caps. For example, Codex plans often hit rate limits during heavy review sessions, so falling back to Claude Code keeps reviews flowing.
+If the primary agent is unavailable (for example, its command is not visible to the daemon) or fails during execution (rate limits, network errors, crashes), roborev can use a configured backup agent. This is useful when your primary agent has usage caps. For example, Codex plans often hit rate limits during heavy review sessions, so falling back to Claude Code keeps reviews flowing.
 
 ```toml
 # ~/.roborev/config.toml
@@ -344,14 +344,14 @@ backup_agent = "claude-code"          # Repo-level fallback
 review_backup_agent = "gemini"        # Workflow-specific override
 ```
 
-When a job fails with an agent error (not a review finding), roborev resolves the backup agent in this order:
+When a workflow needs a backup agent, roborev resolves it in this order:
 
 1. Repo-level workflow-specific backup (e.g. `review_backup_agent` in `.roborev.toml`)
 2. Repo-level generic `backup_agent`
 3. Global workflow-specific backup (e.g. `review_backup_agent` in `config.toml`)
 4. Global `default_backup_agent`
 
-If a backup agent is found and installed, the job is retried with that agent. The failover is logged in the daemon output. If no backup is configured or the backup agent isn't installed, the job fails normally.
+If a backup agent is found and installed, roborev uses that agent instead. If no backup is configured or the backup agent isn't installed, the job fails normally. roborev does not choose unrelated installed agents from the built-in agent list for workflow-configured reviews or fixes.
 
 ### Agent Command Overrides
 
@@ -494,7 +494,7 @@ column_borders = true             # Show separators between TUI columns
 | Option | Type | Default | Description | Hot-Reload |
 |--------|------|---------|-------------|------------|
 | `default_agent` | string | auto-detect | Default AI agent to use | Yes |
-| `default_backup_agent` | string | - | Fallback agent when the primary fails | Yes |
+| `default_backup_agent` | string | - | Fallback agent when the primary is unavailable or fails | Yes |
 | `default_backup_model` | string | - | Fallback model used when a backup agent runs | Yes |
 | `default_model` | string | agent default | Model to use (format varies by agent) | Yes |
 | `server_addr` | string | 127.0.0.1:7373 | Daemon listen address. Use `unix://` for Unix domain socket (see [Unix Domain Socket](#unix-domain-socket)) | No |

--- a/internal/agent/acp_resolution.go
+++ b/internal/agent/acp_resolution.go
@@ -1,7 +1,9 @@
 package agent
 
 import (
+	"fmt"
 	"os/exec"
+	"sort"
 	"strings"
 
 	"go.kenn.io/roborev/internal/config"
@@ -133,6 +135,94 @@ func isAvailableWithConfig(name string, cfg *config.Config) bool {
 	}
 	// Fall back to the default (hardcoded) command.
 	return firstAvailableCommand(ca) != ""
+}
+
+// GetPreferredOrBackupWithConfig resolves an available workflow agent while
+// honoring runtime ACP config and command overrides. Unlike GetAvailable, it is
+// strict: it only considers the preferred agent and explicitly configured
+// backups, never the package-wide hardcoded fallback chain.
+func GetPreferredOrBackupWithConfig(
+	repoPath string,
+	preferred string,
+	cfg *config.Config,
+	backups ...string,
+) (Agent, error) {
+	var repoCfg *config.RepoConfig
+	if strings.TrimSpace(repoPath) != "" {
+		repoCfg, _ = config.LoadRepoConfig(repoPath)
+	}
+	return GetPreferredOrBackupWithConfigFromConfig(
+		repoCfg, preferred, cfg, backups...,
+	)
+}
+
+// GetPreferredOrBackupWithConfigFromConfig is the config-taking core of
+// GetPreferredOrBackupWithConfig; it never reads repo config from disk.
+func GetPreferredOrBackupWithConfigFromConfig(
+	repoCfg *config.RepoConfig,
+	preferred string,
+	cfg *config.Config,
+	backups ...string,
+) (Agent, error) {
+	rawPreferred := strings.TrimSpace(preferred)
+	preferred = resolveAlias(rawPreferred)
+
+	if isConfiguredACPAgentNameFromConfig(rawPreferred, cfg, repoCfg) {
+		acpAgent := configuredACPAgentFromConfig(repoCfg, cfg)
+		if _, err := exec.LookPath(acpAgent.CommandName()); err == nil {
+			return acpAgent, nil
+		}
+		if canonicalACP, err := Get(defaultACPName); err == nil {
+			if commandAgent, ok := canonicalACP.(CommandAgent); !ok {
+				return canonicalACP, nil
+			} else if _, err := exec.LookPath(commandAgent.CommandName()); err == nil {
+				return canonicalACP, nil
+			}
+		}
+		if backup, ok := resolveAvailableBackupWithConfig("", backups, repoCfg, cfg); ok {
+			return backup, nil
+		}
+		return nil, unavailablePreferredBackupError(preferred, backups)
+	}
+
+	if preferred != "" {
+		registryMu.RLock()
+		_, knownAgent := registry[preferred]
+		registryMu.RUnlock()
+		if !knownAgent {
+			known := Available()
+			sort.Strings(known)
+			return nil, &UnknownAgentError{Name: preferred, Known: known}
+		}
+		if isAvailableWithConfig(preferred, cfg) {
+			a, _ := Get(preferred)
+			return applyAvailableCommand(a, cfg), nil
+		}
+	}
+
+	if backup, ok := resolveAvailableBackupWithConfig(preferred, backups, repoCfg, cfg); ok {
+		return backup, nil
+	}
+
+	return nil, unavailablePreferredBackupError(preferred, backups)
+}
+
+func unavailablePreferredBackupError(preferred string, backups []string) error {
+	return fmt.Errorf(
+		"no configured agent available (preferred: %q, backups: %s)\nYou may need to run 'roborev daemon restart' from a shell that has access to your agents",
+		preferred,
+		strings.Join(nonEmptyResolvedAgentNames(backups), ", "),
+	)
+}
+
+func nonEmptyResolvedAgentNames(names []string) []string {
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		if s := strings.TrimSpace(name); s != "" {
+			out = append(out, resolveAlias(s))
+		}
+	}
+	return out
 }
 
 // GetAvailableWithConfig resolves an available agent while honoring runtime ACP config.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1930,6 +1930,84 @@ func TestResolveAgentForWorkflow(t *testing.T) {
 	}
 }
 
+func TestHasWorkflowAgentOverrideFromConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		repo     *RepoConfig
+		global   *Config
+		workflow string
+		level    string
+		want     bool
+	}{
+		{
+			name:     "repo generic is not workflow specific",
+			repo:     &RepoConfig{Agent: "claude-code"},
+			workflow: "review",
+			level:    "thorough",
+			want:     false,
+		},
+		{
+			name:     "repo generic shadows global workflow",
+			repo:     &RepoConfig{Agent: "claude-code"},
+			global:   &Config{ReviewAgent: "gemini"},
+			workflow: "review",
+			level:    "thorough",
+			want:     false,
+		},
+		{
+			name:     "repo workflow specific",
+			repo:     &RepoConfig{ReviewAgent: "claude-code"},
+			workflow: "review",
+			level:    "thorough",
+			want:     true,
+		},
+		{
+			name:     "repo level specific",
+			repo:     &RepoConfig{ReviewAgentThorough: "claude-code"},
+			workflow: "review",
+			level:    "thorough",
+			want:     true,
+		},
+		{
+			name:     "global workflow specific",
+			global:   &Config{ReviewAgent: "gemini"},
+			workflow: "review",
+			level:    "thorough",
+			want:     true,
+		},
+		{
+			name:     "global level specific",
+			global:   &Config{ReviewAgentThorough: "gemini"},
+			workflow: "review",
+			level:    "thorough",
+			want:     true,
+		},
+		{
+			name:     "global default is not workflow specific",
+			global:   &Config{DefaultAgent: "gemini"},
+			workflow: "review",
+			level:    "thorough",
+			want:     false,
+		},
+		{
+			name:     "repo generic shadows global design",
+			repo:     &RepoConfig{Agent: "claude-code"},
+			global:   &Config{DesignAgent: "gemini"},
+			workflow: "design",
+			level:    "thorough",
+			want:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HasWorkflowAgentOverrideFromConfig(
+				tt.repo, tt.global, tt.workflow, tt.level,
+			)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestResolveModelForWorkflow(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/config/panels.go
+++ b/internal/config/panels.go
@@ -154,16 +154,17 @@ func SelectPanelName(requested, source string, merged ReviewConfig) string {
 // ResolvedMember is a fully-resolved panel member. It is the value serialized
 // into the review_jobs.panel_member_config_json column for reproducibility.
 type ResolvedMember struct {
-	Name         string `json:"name"`
-	Index        int    `json:"index"`
-	Agent        string `json:"agent"`
-	Model        string `json:"model"`
-	Provider     string `json:"provider"`
-	Reasoning    string `json:"reasoning"`
-	ReviewType   string `json:"review_type"`
-	Instructions string `json:"instructions"`
-	AllowFailure bool   `json:"allow_failure,omitempty"`
-	Timeout      string `json:"timeout,omitempty"`
+	Name          string `json:"name"`
+	Index         int    `json:"index"`
+	Agent         string `json:"agent"`
+	AgentExplicit bool   `json:"agent_explicit,omitempty"`
+	Model         string `json:"model"`
+	Provider      string `json:"provider"`
+	Reasoning     string `json:"reasoning"`
+	ReviewType    string `json:"review_type"`
+	Instructions  string `json:"instructions"`
+	AllowFailure  bool   `json:"allow_failure,omitempty"`
+	Timeout       string `json:"timeout,omitempty"`
 }
 
 // SynthesisSpec is the resolved agent/model/reasoning for a panel's synthesis
@@ -334,16 +335,17 @@ func resolveMemberFromConfig(
 		}
 	}
 	return ResolvedMember{
-		Name:         name,
-		Index:        index,
-		Agent:        agent,
-		Model:        model,
-		Provider:     spec.Provider,
-		Reasoning:    reasoning,
-		ReviewType:   reviewType,
-		Instructions: spec.Instructions,
-		AllowFailure: spec.AllowFailure,
-		Timeout:      spec.Timeout,
+		Name:          name,
+		Index:         index,
+		Agent:         agent,
+		AgentExplicit: strings.TrimSpace(spec.Agent) != "",
+		Model:         model,
+		Provider:      spec.Provider,
+		Reasoning:     reasoning,
+		ReviewType:    reviewType,
+		Instructions:  spec.Instructions,
+		AllowFailure:  spec.AllowFailure,
+		Timeout:       spec.Timeout,
 	}, nil
 }
 

--- a/internal/config/workflow.go
+++ b/internal/config/workflow.go
@@ -441,6 +441,30 @@ func ResolveAgentForWorkflowFromConfig(
 	return "codex"
 }
 
+// HasWorkflowAgentOverrideFromConfig reports whether repo/global config has a
+// workflow-specific primary agent override for the given workflow and reasoning
+// level. It intentionally excludes generic repo agent and global default_agent
+// values because those are preferences, not workflow pins.
+func HasWorkflowAgentOverrideFromConfig(
+	repoCfg *RepoConfig,
+	globalCfg *Config,
+	workflow, level string,
+) bool {
+	if repoCfg != nil {
+		if repoWorkflowField(repoCfg, workflow, level, true) != "" ||
+			repoWorkflowField(repoCfg, workflow, "", true) != "" {
+			return true
+		}
+	}
+	if globalCfg != nil {
+		if globalWorkflowField(globalCfg, workflow, level, true) != "" ||
+			globalWorkflowField(globalCfg, workflow, "", true) != "" {
+			return true
+		}
+	}
+	return false
+}
+
 // ResolveModelForWorkflow determines which model to use based on workflow and level.
 // Same priority as ResolveAgentForWorkflow, but returns empty string as default.
 func ResolveModelForWorkflow(cli, repoPath string, globalCfg *Config, workflow, level string) string {

--- a/internal/config/workflow.go
+++ b/internal/config/workflow.go
@@ -455,6 +455,9 @@ func HasWorkflowAgentOverrideFromConfig(
 			repoWorkflowField(repoCfg, workflow, "", true) != "" {
 			return true
 		}
+		if strings.TrimSpace(repoCfg.Agent) != "" {
+			return false
+		}
 	}
 	if globalCfg != nil {
 		if globalWorkflowField(globalCfg, workflow, level, true) != "" ||

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -658,7 +658,7 @@ func (p *CIPoller) resolveCIPanelMemberExecution(
 			return "", "", fmt.Errorf("%w for type=%s: %w", errNoCIAgent, member.ReviewType, err)
 		}
 		resolvedAgent = name
-	} else if resolved, err := agent.GetAvailableWithConfigFromConfig(
+	} else if resolved, err := agent.GetPreferredOrBackupWithConfigFromConfig(
 		repoCfg, resolvedAgent, cfg, resolution.BackupAgent,
 	); err != nil {
 		return "", "", fmt.Errorf("%w for type=%s: %w", errNoCIAgent, member.ReviewType, err)
@@ -696,7 +696,7 @@ func (p *CIPoller) resolveMatrixMemberAgent(
 			return "", "", fmt.Errorf("%w for type=%s: %w", errNoCIAgent, entry.ReviewType, err)
 		}
 		resolvedAgent = name
-	} else if resolved, err := agent.GetAvailableWithConfigFromConfig(
+	} else if resolved, err := agent.GetPreferredOrBackupWithConfigFromConfig(
 		repoCfg, resolvedAgent, cfg, resolution.BackupAgent,
 	); err != nil {
 		return "", "", fmt.Errorf("%w for type=%s: %w", errNoCIAgent, entry.ReviewType, err)
@@ -823,7 +823,7 @@ func resolveCIAutoDesignAgent(repoCfg *config.RepoConfig, cfg *config.Config) (s
 		}
 		return designAgent, designModel
 	}
-	chosen, err := agent.GetAvailableWithConfigFromConfig(
+	chosen, err := agent.GetPreferredOrBackupWithConfigFromConfig(
 		repoCfg, resolution.PreferredAgent, cfg, resolution.BackupAgent,
 	)
 	if err != nil {

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -835,7 +835,9 @@ func resolveCIAutoDesignAgent(repoCfg *config.RepoConfig, cfg *config.Config) (s
 		}
 		return designAgent, designModel
 	}
-	strictDesignAgent := explicitDesignAgentConfigured(repoCfg, cfg, reasoning) ||
+	strictDesignAgent := config.HasWorkflowAgentOverrideFromConfig(
+		repoCfg, cfg, "design", reasoning,
+	) ||
 		strings.TrimSpace(resolution.BackupAgent) != ""
 	var chosen agent.Agent
 	if strictDesignAgent {
@@ -851,56 +853,6 @@ func resolveCIAutoDesignAgent(repoCfg *config.RepoConfig, cfg *config.Config) (s
 		return resolution.PreferredAgent, resolution.ModelForSelectedAgent(resolution.PreferredAgent, ciModel)
 	}
 	return chosen.Name(), resolution.ModelForSelectedAgent(chosen.Name(), ciModel)
-}
-
-func explicitDesignAgentConfigured(repoCfg *config.RepoConfig, cfg *config.Config, reasoning string) bool {
-	if repoCfg != nil {
-		if strings.TrimSpace(repoCfg.DesignAgent) != "" ||
-			strings.TrimSpace(repoDesignAgentForReasoning(repoCfg, reasoning)) != "" {
-			return true
-		}
-	}
-	if cfg != nil {
-		if strings.TrimSpace(cfg.DesignAgent) != "" ||
-			strings.TrimSpace(globalDesignAgentForReasoning(cfg, reasoning)) != "" {
-			return true
-		}
-	}
-	return false
-}
-
-func repoDesignAgentForReasoning(repoCfg *config.RepoConfig, reasoning string) string {
-	switch reasoning {
-	case string(agent.ReasoningFast):
-		return repoCfg.DesignAgentFast
-	case string(agent.ReasoningStandard):
-		return repoCfg.DesignAgentStandard
-	case string(agent.ReasoningMedium):
-		return repoCfg.DesignAgentMedium
-	case string(agent.ReasoningThorough):
-		return repoCfg.DesignAgentThorough
-	case string(agent.ReasoningMaximum):
-		return repoCfg.DesignAgentMaximum
-	default:
-		return ""
-	}
-}
-
-func globalDesignAgentForReasoning(cfg *config.Config, reasoning string) string {
-	switch reasoning {
-	case string(agent.ReasoningFast):
-		return cfg.DesignAgentFast
-	case string(agent.ReasoningStandard):
-		return cfg.DesignAgentStandard
-	case string(agent.ReasoningMedium):
-		return cfg.DesignAgentMedium
-	case string(agent.ReasoningThorough):
-		return cfg.DesignAgentThorough
-	case string(agent.ReasoningMaximum):
-		return cfg.DesignAgentMaximum
-	default:
-		return ""
-	}
 }
 
 // maybeAppendDesignMember appends exactly one whole-range design member to the

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -852,8 +852,7 @@ func resolveCIAutoDesignAgent(repoCfg *config.RepoConfig, cfg *config.Config) (s
 
 func explicitDesignAgentConfigured(repoCfg *config.RepoConfig, cfg *config.Config, reasoning string) bool {
 	if repoCfg != nil {
-		if strings.TrimSpace(repoCfg.Agent) != "" ||
-			strings.TrimSpace(repoCfg.DesignAgent) != "" ||
+		if strings.TrimSpace(repoCfg.DesignAgent) != "" ||
 			strings.TrimSpace(repoDesignAgentForReasoning(repoCfg, reasoning)) != "" {
 			return true
 		}
@@ -863,8 +862,6 @@ func explicitDesignAgentConfigured(repoCfg *config.RepoConfig, cfg *config.Confi
 			strings.TrimSpace(globalDesignAgentForReasoning(cfg, reasoning)) != "" {
 			return true
 		}
-		defaultAgent := strings.TrimSpace(cfg.DefaultAgent)
-		return defaultAgent != "" && defaultAgent != config.DefaultConfig().DefaultAgent
 	}
 	return false
 }

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -698,7 +698,9 @@ func (p *CIPoller) resolveMatrixMemberAgent(
 		}
 		resolvedAgent = name
 	} else if autoDetectAgent {
-		resolved, err := agent.GetAvailableWithConfigFromConfig(repoCfg, "", cfg)
+		resolved, err := agent.GetAvailableWithConfigFromConfig(
+			repoCfg, resolvedAgent, cfg, resolution.BackupAgent,
+		)
 		if err != nil {
 			return "", "", fmt.Errorf("%w for type=%s: %w", errNoCIAgent, entry.ReviewType, err)
 		}
@@ -830,13 +832,75 @@ func resolveCIAutoDesignAgent(repoCfg *config.RepoConfig, cfg *config.Config) (s
 		}
 		return designAgent, designModel
 	}
-	chosen, err := agent.GetPreferredOrBackupWithConfigFromConfig(
-		repoCfg, resolution.PreferredAgent, cfg, resolution.BackupAgent,
-	)
+	strictDesignAgent := explicitDesignAgentConfigured(repoCfg, cfg, reasoning) ||
+		strings.TrimSpace(resolution.BackupAgent) != ""
+	var chosen agent.Agent
+	if strictDesignAgent {
+		chosen, err = agent.GetPreferredOrBackupWithConfigFromConfig(
+			repoCfg, resolution.PreferredAgent, cfg, resolution.BackupAgent,
+		)
+	} else {
+		chosen, err = agent.GetAvailableWithConfigFromConfig(
+			repoCfg, resolution.PreferredAgent, cfg,
+		)
+	}
 	if err != nil {
 		return resolution.PreferredAgent, resolution.ModelForSelectedAgent(resolution.PreferredAgent, ciModel)
 	}
 	return chosen.Name(), resolution.ModelForSelectedAgent(chosen.Name(), ciModel)
+}
+
+func explicitDesignAgentConfigured(repoCfg *config.RepoConfig, cfg *config.Config, reasoning string) bool {
+	if repoCfg != nil {
+		if strings.TrimSpace(repoCfg.Agent) != "" ||
+			strings.TrimSpace(repoCfg.DesignAgent) != "" ||
+			strings.TrimSpace(repoDesignAgentForReasoning(repoCfg, reasoning)) != "" {
+			return true
+		}
+	}
+	if cfg != nil {
+		if strings.TrimSpace(cfg.DesignAgent) != "" ||
+			strings.TrimSpace(globalDesignAgentForReasoning(cfg, reasoning)) != "" {
+			return true
+		}
+		defaultAgent := strings.TrimSpace(cfg.DefaultAgent)
+		return defaultAgent != "" && defaultAgent != config.DefaultConfig().DefaultAgent
+	}
+	return false
+}
+
+func repoDesignAgentForReasoning(repoCfg *config.RepoConfig, reasoning string) string {
+	switch reasoning {
+	case string(agent.ReasoningFast):
+		return repoCfg.DesignAgentFast
+	case string(agent.ReasoningStandard):
+		return repoCfg.DesignAgentStandard
+	case string(agent.ReasoningMedium):
+		return repoCfg.DesignAgentMedium
+	case string(agent.ReasoningThorough):
+		return repoCfg.DesignAgentThorough
+	case string(agent.ReasoningMaximum):
+		return repoCfg.DesignAgentMaximum
+	default:
+		return ""
+	}
+}
+
+func globalDesignAgentForReasoning(cfg *config.Config, reasoning string) string {
+	switch reasoning {
+	case string(agent.ReasoningFast):
+		return cfg.DesignAgentFast
+	case string(agent.ReasoningStandard):
+		return cfg.DesignAgentStandard
+	case string(agent.ReasoningMedium):
+		return cfg.DesignAgentMedium
+	case string(agent.ReasoningThorough):
+		return cfg.DesignAgentThorough
+	case string(agent.ReasoningMaximum):
+		return cfg.DesignAgentMaximum
+	default:
+		return ""
+	}
 }
 
 // maybeAppendDesignMember appends exactly one whole-range design member to the

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -652,12 +652,25 @@ func (p *CIPoller) resolveCIPanelMemberExecution(
 		return "", "", fmt.Errorf("resolve workflow config: %w", err)
 	}
 	resolvedAgent := resolution.PreferredAgent
+	strictWorkflowAgent := member.AgentExplicit ||
+		config.HasWorkflowAgentOverrideFromConfig(
+			repoCfg, cfg, workflow, member.Reasoning,
+		) ||
+		strings.TrimSpace(resolution.BackupAgent) != ""
 	if p.agentResolverFn != nil {
 		name, err := p.agentResolverFn(resolvedAgent)
 		if err != nil {
 			return "", "", fmt.Errorf("%w for type=%s: %w", errNoCIAgent, member.ReviewType, err)
 		}
 		resolvedAgent = name
+	} else if !strictWorkflowAgent {
+		resolved, err := agent.GetAvailableWithConfigFromConfig(
+			repoCfg, resolvedAgent, cfg, resolution.BackupAgent,
+		)
+		if err != nil {
+			return "", "", fmt.Errorf("%w for type=%s: %w", errNoCIAgent, member.ReviewType, err)
+		}
+		resolvedAgent = resolved.Name()
 	} else if resolved, err := agent.GetPreferredOrBackupWithConfigFromConfig(
 		repoCfg, resolvedAgent, cfg, resolution.BackupAgent,
 	); err != nil {

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -690,7 +690,10 @@ func (p *CIPoller) resolveMatrixMemberAgent(
 		return "", "", fmt.Errorf("resolve workflow config: %w", err)
 	}
 	resolvedAgent := resolution.PreferredAgent
-	autoDetectAgent := strings.TrimSpace(entry.Agent) == "" && p.agentResolverFn == nil
+	strictWorkflowAgent := config.HasWorkflowAgentOverrideFromConfig(
+		repoCfg, cfg, workflow, reasoning,
+	) || strings.TrimSpace(resolution.BackupAgent) != ""
+	autoDetectAgent := strings.TrimSpace(entry.Agent) == "" && p.agentResolverFn == nil && !strictWorkflowAgent
 	if p.agentResolverFn != nil {
 		name, err := p.agentResolverFn(resolvedAgent)
 		if err != nil {

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -833,39 +833,11 @@ func ciReasoning(repoCfg *config.RepoConfig) string {
 }
 
 func resolveCIAutoDesignAgent(repoCfg *config.RepoConfig, cfg *config.Config) (string, string) {
-	reasoning := ciReasoning(repoCfg)
 	ciModel := ""
 	if cfg != nil {
 		ciModel = cfg.CI.Model
 	}
-	resolution, err := agent.ResolveWorkflowConfigFromConfig(
-		"", repoCfg, cfg, "design", reasoning,
-	)
-	if err != nil || resolution.PreferredAgent == "" {
-		designAgent, designModel := config.DesignAgentFromConfig(repoCfg, cfg)
-		if strings.TrimSpace(ciModel) != "" {
-			designModel = ciModel
-		}
-		return designAgent, designModel
-	}
-	strictDesignAgent := config.HasWorkflowAgentOverrideFromConfig(
-		repoCfg, cfg, "design", reasoning,
-	) ||
-		strings.TrimSpace(resolution.BackupAgent) != ""
-	var chosen agent.Agent
-	if strictDesignAgent {
-		chosen, err = agent.GetPreferredOrBackupWithConfigFromConfig(
-			repoCfg, resolution.PreferredAgent, cfg, resolution.BackupAgent,
-		)
-	} else {
-		chosen, err = agent.GetAvailableWithConfigFromConfig(
-			repoCfg, resolution.PreferredAgent, cfg,
-		)
-	}
-	if err != nil {
-		return resolution.PreferredAgent, resolution.ModelForSelectedAgent(resolution.PreferredAgent, ciModel)
-	}
-	return chosen.Name(), resolution.ModelForSelectedAgent(chosen.Name(), ciModel)
+	return resolveDesignFollowUpAgentFromConfig(repoCfg, cfg, ciReasoning(repoCfg), ciModel)
 }
 
 // maybeAppendDesignMember appends exactly one whole-range design member to the

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -690,12 +690,19 @@ func (p *CIPoller) resolveMatrixMemberAgent(
 		return "", "", fmt.Errorf("resolve workflow config: %w", err)
 	}
 	resolvedAgent := resolution.PreferredAgent
+	autoDetectAgent := strings.TrimSpace(entry.Agent) == "" && p.agentResolverFn == nil
 	if p.agentResolverFn != nil {
 		name, err := p.agentResolverFn(resolvedAgent)
 		if err != nil {
 			return "", "", fmt.Errorf("%w for type=%s: %w", errNoCIAgent, entry.ReviewType, err)
 		}
 		resolvedAgent = name
+	} else if autoDetectAgent {
+		resolved, err := agent.GetAvailableWithConfigFromConfig(repoCfg, "", cfg)
+		if err != nil {
+			return "", "", fmt.Errorf("%w for type=%s: %w", errNoCIAgent, entry.ReviewType, err)
+		}
+		resolvedAgent = resolved.Name()
 	} else if resolved, err := agent.GetPreferredOrBackupWithConfigFromConfig(
 		repoCfg, resolvedAgent, cfg, resolution.BackupAgent,
 	); err != nil {

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -3403,6 +3403,20 @@ func TestResolveCIAutoDesignAgentGenericDefaultAgentCanAutoDetect(t *testing.T) 
 	assert.Empty(t, designModel)
 }
 
+func TestResolveCIAutoDesignAgentRepoGenericShadowsGlobalDesignAgent(t *testing.T) {
+	t.Setenv("PATH", "")
+	agent.Register(&agent.FakeAgent{NameStr: "ci-auto-design-shadowed"})
+	t.Cleanup(func() { agent.Unregister("ci-auto-design-shadowed") })
+
+	repoCfg := &config.RepoConfig{Agent: "claude-code"}
+	cfg := config.DefaultConfig()
+	cfg.DesignAgent = "gemini"
+	designAgent, designModel := resolveCIAutoDesignAgent(repoCfg, cfg)
+
+	assert.Equal(t, "ci-auto-design-shadowed", designAgent)
+	assert.Empty(t, designModel)
+}
+
 // TestProcessPRSynthesisAndMembersUseSeparateMinSeverity verifies the CI
 // min_severity threshold reaches only the synthesis job, while member reviews
 // use the review_min_severity setting from normal review config.

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -3350,6 +3350,19 @@ func TestResolveCIAutoDesignAgentExplicitDesignAgentStaysStrict(t *testing.T) {
 	assert.Empty(t, designModel)
 }
 
+func TestResolveCIAutoDesignAgentGenericDefaultAgentCanAutoDetect(t *testing.T) {
+	t.Setenv("PATH", "")
+	agent.Register(&agent.FakeAgent{NameStr: "ci-auto-design-generic"})
+	t.Cleanup(func() { agent.Unregister("ci-auto-design-generic") })
+
+	cfg := config.DefaultConfig()
+	cfg.DefaultAgent = "claude-code"
+	designAgent, designModel := resolveCIAutoDesignAgent(nil, cfg)
+
+	assert.Equal(t, "ci-auto-design-generic", designAgent)
+	assert.Empty(t, designModel)
+}
+
 // TestProcessPRSynthesisAndMembersUseSeparateMinSeverity verifies the CI
 // min_severity threshold reaches only the synthesis job, while member reviews
 // use the review_min_severity setting from normal review config.

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -3565,6 +3565,50 @@ func TestProcessPRNamedPanelMemberUsesBackupModelWhenPreferredUnavailable(t *tes
 	assert.Equal("named-panel-backup-model", members[0].Model)
 }
 
+func TestProcessPRNamedPanelOmittedAgentAutoDetectsAvailableAgent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("minimal PATH setup uses POSIX symlink")
+	}
+	assert := assert.New(t)
+	p, db, _, repo, cfg := newCIPanelGitHarness(t)
+	p.agentResolverFn = nil
+	gitPath, gitErr := exec.LookPath("git")
+	require.NoError(t, gitErr)
+	binDir := t.TempDir()
+	require.NoError(t, os.Symlink(gitPath, filepath.Join(binDir, "git")))
+	t.Setenv("PATH", binDir)
+	agent.Register(&agent.FakeAgent{NameStr: "ci-named-panel-auto"})
+	t.Cleanup(func() { agent.Unregister("ci-named-panel-auto") })
+
+	cfg.CI.Panel = "ci"
+	cfg.Review = config.ReviewConfig{
+		Subagents: map[string]config.SubagentSpec{
+			"rev": {ReviewType: "review"},
+		},
+		Panels: map[string]config.PanelSpec{
+			"ci": {Members: []string{"rev"}, SynthesisAgent: "test"},
+		},
+	}
+	p.loadRepoConfigFn = func(string) (*config.RepoConfig, error) { return &config.RepoConfig{}, nil }
+
+	base := repo.HeadSHA()
+	head := repo.CommitFile("app.go", "package app\n", "feat: app")
+	p.mergeBaseFn = func(_, _, _ string) (string, error) { return base, nil }
+
+	err := p.processPR(context.Background(), "acme/api", ghPR{
+		Number: 16, HeadRefOid: head, BaseRefName: "main",
+	}, cfg)
+	require.NoError(t, err, "processPR")
+
+	panel, err := db.GetCIPanelByPRSHA("acme/api", 16, head)
+	require.NoError(t, err)
+	require.NotNil(t, panel)
+	members, err := db.GetPanelMembers(panel.PanelRunUUID)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	assert.Equal("ci-named-panel-auto", members[0].Agent)
+}
+
 // TestProcessPRAutoDesignAppendsNoneWhenNotWarranted verifies that an enabled
 // auto-design router appends no design member when no commit in the range
 // warrants one (a trivial doc/test change that the heuristics skip).

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -2895,6 +2895,46 @@ func TestResolveMatrixMemberAgentBlankAgentHonorsConfiguredCommandOverride(t *te
 	assert.Empty(t, resolvedModel)
 }
 
+func TestResolveMatrixMemberAgentBlankAgentWithExplicitBackupStaysStrict(t *testing.T) {
+	h := newCIPollerHarness(t, "git@github.com:acme/api.git")
+	t.Setenv("PATH", "")
+	h.Cfg.ReviewBackupAgent = "claude-code"
+	agent.Register(&agent.FakeAgent{NameStr: "ci-unrelated-daemon"})
+	t.Cleanup(func() { agent.Unregister("ci-unrelated-daemon") })
+
+	resolvedAgent, resolvedModel, err := h.Poller.resolveMatrixMemberAgent(
+		h.Repo,
+		nil,
+		h.Cfg,
+		config.AgentReviewType{Agent: "", ReviewType: "default"},
+		"thorough",
+	)
+	require.Error(t, err)
+	assert.Empty(t, resolvedAgent)
+	assert.Empty(t, resolvedModel)
+	assert.Contains(t, err.Error(), "no configured agent available")
+}
+
+func TestResolveMatrixMemberAgentBlankAgentWithExplicitPrimaryStaysStrict(t *testing.T) {
+	h := newCIPollerHarness(t, "git@github.com:acme/api.git")
+	t.Setenv("PATH", "")
+	h.Cfg.ReviewAgent = "claude-code"
+	agent.Register(&agent.FakeAgent{NameStr: "ci-unrelated-primary"})
+	t.Cleanup(func() { agent.Unregister("ci-unrelated-primary") })
+
+	resolvedAgent, resolvedModel, err := h.Poller.resolveMatrixMemberAgent(
+		h.Repo,
+		nil,
+		h.Cfg,
+		config.AgentReviewType{Agent: "", ReviewType: "default"},
+		"thorough",
+	)
+	require.Error(t, err)
+	assert.Empty(t, resolvedAgent)
+	assert.Empty(t, resolvedModel)
+	assert.Contains(t, err.Error(), "no configured agent available")
+}
+
 func TestResolveMatrixMemberAgentUsesPassedRepoConfigForACPAvailability(t *testing.T) {
 	h := newCIPollerHarness(t, "git@github.com:acme/api.git")
 	binDir := t.TempDir()

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -2872,6 +2872,29 @@ func TestResolveMatrixMemberAgentBlankAgentAutoDetectsAvailableAgent(t *testing.
 	assert.Empty(t, resolvedModel)
 }
 
+func TestResolveMatrixMemberAgentBlankAgentHonorsConfiguredCommandOverride(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fake command uses POSIX permissions")
+	}
+	h := newCIPollerHarness(t, "git@github.com:acme/api.git")
+	binDir := t.TempDir()
+	cmdPath := filepath.Join(binDir, "ci-codex")
+	require.NoError(t, os.WriteFile(cmdPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("PATH", binDir)
+	h.Cfg.CodexCmd = "ci-codex"
+
+	resolvedAgent, resolvedModel, err := h.Poller.resolveMatrixMemberAgent(
+		h.Repo,
+		nil,
+		h.Cfg,
+		config.AgentReviewType{Agent: "", ReviewType: "default"},
+		"thorough",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "codex", resolvedAgent)
+	assert.Empty(t, resolvedModel)
+}
+
 func TestResolveMatrixMemberAgentUsesPassedRepoConfigForACPAvailability(t *testing.T) {
 	h := newCIPollerHarness(t, "git@github.com:acme/api.git")
 	binDir := t.TempDir()
@@ -3295,6 +3318,36 @@ func TestProcessPRAutoDesignUsesCIModelOverride(t *testing.T) {
 	require.NotNil(t, design, "design member appended")
 	assert.Equal("test", design.Agent)
 	assert.Equal("ci-model-override", design.Model)
+}
+
+func TestResolveCIAutoDesignAgentBlankAgentAutoDetectsAvailableAgent(t *testing.T) {
+	t.Setenv("PATH", "")
+	agent.Register(&agent.FakeAgent{NameStr: "ci-auto-design"})
+	t.Cleanup(func() { agent.Unregister("ci-auto-design") })
+
+	designAgent, designModel := resolveCIAutoDesignAgent(nil, config.DefaultConfig())
+
+	assert.Equal(t, "ci-auto-design", designAgent)
+	assert.Empty(t, designModel)
+}
+
+func TestResolveCIAutoDesignAgentExplicitDesignAgentStaysStrict(t *testing.T) {
+	t.Setenv("PATH", "")
+	const primaryAgent = "ci-explicit-design-primary"
+	agent.Register(&unavailableSynthesisCommandAgent{
+		name:    primaryAgent,
+		command: "roborev-missing-explicit-design-primary",
+	})
+	t.Cleanup(func() { agent.Unregister(primaryAgent) })
+	agent.Register(&agent.FakeAgent{NameStr: "ci-auto-design-available"})
+	t.Cleanup(func() { agent.Unregister("ci-auto-design-available") })
+
+	cfg := config.DefaultConfig()
+	cfg.DesignAgent = primaryAgent
+	designAgent, designModel := resolveCIAutoDesignAgent(nil, cfg)
+
+	assert.Equal(t, primaryAgent, designAgent)
+	assert.Empty(t, designModel)
 }
 
 // TestProcessPRSynthesisAndMembersUseSeparateMinSeverity verifies the CI

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -2854,6 +2854,24 @@ func TestResolveCIMatrixMembersUsesPassedRepoConfigForAgentModel(t *testing.T) {
 	assert.Equal(t, "default-branch-model", members[0].Model)
 }
 
+func TestResolveMatrixMemberAgentBlankAgentAutoDetectsAvailableAgent(t *testing.T) {
+	h := newCIPollerHarness(t, "git@github.com:acme/api.git")
+	t.Setenv("PATH", "")
+	agent.Register(&agent.FakeAgent{NameStr: "ci-auto-daemon"})
+	t.Cleanup(func() { agent.Unregister("ci-auto-daemon") })
+
+	resolvedAgent, resolvedModel, err := h.Poller.resolveMatrixMemberAgent(
+		h.Repo,
+		nil,
+		h.Cfg,
+		config.AgentReviewType{Agent: "", ReviewType: "default"},
+		"thorough",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "ci-auto-daemon", resolvedAgent)
+	assert.Empty(t, resolvedModel)
+}
+
 func TestResolveMatrixMemberAgentUsesPassedRepoConfigForACPAvailability(t *testing.T) {
 	h := newCIPollerHarness(t, "git@github.com:acme/api.git")
 	binDir := t.TempDir()

--- a/internal/daemon/panel_enqueue.go
+++ b/internal/daemon/panel_enqueue.go
@@ -508,9 +508,21 @@ func resolvePanelMemberExecution(
 	if err != nil {
 		return agentName, model
 	}
-	selected, err := agent.GetPreferredOrBackupWithConfig(
-		repoPath, resolution.PreferredAgent, cfg, resolution.BackupAgent,
-	)
+	strictWorkflowAgent := m.AgentExplicit ||
+		config.HasWorkflowAgentOverrideFromConfig(
+			resolution.RepoConfig, cfg, resolution.Workflow, resolution.Reasoning,
+		) ||
+		strings.TrimSpace(resolution.BackupAgent) != ""
+	var selected agent.Agent
+	if strictWorkflowAgent {
+		selected, err = agent.GetPreferredOrBackupWithConfig(
+			repoPath, resolution.PreferredAgent, cfg, resolution.BackupAgent,
+		)
+	} else {
+		selected, err = agent.GetAvailableWithConfig(
+			repoPath, resolution.PreferredAgent, cfg, resolution.BackupAgent,
+		)
+	}
 	if err != nil {
 		return agentName, model
 	}

--- a/internal/daemon/panel_enqueue.go
+++ b/internal/daemon/panel_enqueue.go
@@ -508,7 +508,7 @@ func resolvePanelMemberExecution(
 	if err != nil {
 		return agentName, model
 	}
-	selected, err := agent.GetAvailableWithConfig(
+	selected, err := agent.GetPreferredOrBackupWithConfig(
 		repoPath, resolution.PreferredAgent, cfg, resolution.BackupAgent,
 	)
 	if err != nil {

--- a/internal/daemon/panel_enqueue_test.go
+++ b/internal/daemon/panel_enqueue_test.go
@@ -4,6 +4,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -478,6 +482,56 @@ synthesis_agent = "test"
 	require.Len(t, members, 1)
 	assert.Equal("test", members[0].Agent)
 	assert.Equal("backup-model", members[0].Model)
+}
+
+func TestEnqueuePanelOmittedMemberAgentAutoDetectsAvailableAgent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("minimal PATH setup uses POSIX symlink")
+	}
+	assert := assert.New(t)
+	server, db, _ := newTestServer(t)
+
+	const primaryAgent = "panel-unavailable-default"
+	agent.Register(&unavailableSynthesisCommandAgent{
+		name:    primaryAgent,
+		command: "roborev-missing-panel-default",
+	})
+	t.Cleanup(func() { agent.Unregister(primaryAgent) })
+	agent.Register(&agent.FakeAgent{NameStr: "panel-auto-detected"})
+	t.Cleanup(func() { agent.Unregister("panel-auto-detected") })
+
+	gitPath, gitErr := exec.LookPath("git")
+	require.NoError(t, gitErr)
+	binDir := t.TempDir()
+	require.NoError(t, os.Symlink(gitPath, filepath.Join(binDir, "git")))
+	t.Setenv("PATH", binDir)
+
+	const panelWithOmittedAgent = `
+agent = "panel-unavailable-default"
+
+[review]
+default_panel = "solo"
+
+[review.subagents.only]
+review_type = "default"
+
+[review.panels.solo]
+members = ["only"]
+synthesis_agent = "test"
+`
+	repo := testutil.NewGitRepo(t)
+	repo.WriteFile(".roborev.toml", panelWithOmittedAgent)
+	repo.CommitFile("a.txt", "a", "add a")
+
+	resp := enqueuePanelViaHTTP(t, server, EnqueueRequest{
+		RepoPath: repo.Path(),
+		GitRef:   "HEAD",
+	})
+
+	members, err := db.GetPanelMembers(resp.PanelRunUUID)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	assert.Equal("panel-auto-detected", members[0].Agent)
 }
 
 // TestEnqueuePanelSynthesisBackupPersisted verifies a panel's

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -703,7 +703,11 @@ func resolveRerunModelProvider(job *storage.ReviewJob, cfg *config.Config) (stri
 		return "", "", fmt.Errorf("resolve workflow config: %w", err)
 	}
 
-	if err := validateRerunAgent(resolutionPath, job.Agent, resolution.BackupAgent, cfg); err != nil {
+	backupAgent := resolution.BackupAgent
+	if strings.TrimSpace(job.BackupAgent) != "" {
+		backupAgent = job.BackupAgent
+	}
+	if err := validateRerunAgent(resolutionPath, job.Agent, backupAgent, cfg); err != nil {
 		return "", "", err
 	}
 

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -682,10 +682,6 @@ func validatedWorktreePath(worktreePath, repoPath string) string {
 }
 
 func resolveRerunModelProvider(job *storage.ReviewJob, cfg *config.Config) (string, string, error) {
-	if err := validateRerunAgent(job.RepoPath, job.Agent, cfg); err != nil {
-		return "", "", err
-	}
-
 	resolutionPath := job.RepoPath
 	if job.WorktreePath != "" {
 		worktreePath := validatedWorktreePath(job.WorktreePath, job.RepoPath)
@@ -699,11 +695,6 @@ func resolveRerunModelProvider(job *storage.ReviewJob, cfg *config.Config) (stri
 		return "", "", fmt.Errorf("resolve workflow config: %w", err)
 	}
 
-	provider := strings.TrimSpace(job.RequestedProvider)
-	if model := strings.TrimSpace(job.RequestedModel); model != "" {
-		return model, provider, nil
-	}
-
 	workflow := workflowForJob(job.JobType, job.ReviewType)
 	resolution, err := agent.ResolveWorkflowConfig(
 		"", resolutionPath, cfg, workflow, job.Reasoning,
@@ -711,12 +702,22 @@ func resolveRerunModelProvider(job *storage.ReviewJob, cfg *config.Config) (stri
 	if err != nil {
 		return "", "", fmt.Errorf("resolve workflow config: %w", err)
 	}
+
+	if err := validateRerunAgent(resolutionPath, job.Agent, resolution.BackupAgent, cfg); err != nil {
+		return "", "", err
+	}
+
+	provider := strings.TrimSpace(job.RequestedProvider)
+	if model := strings.TrimSpace(job.RequestedModel); model != "" {
+		return model, provider, nil
+	}
+
 	model := resolution.ModelForSelectedAgent(job.Agent, "")
 	return model, provider, nil
 }
 
-func validateRerunAgent(repoPath string, agentName string, cfg *config.Config) error {
-	_, err := agent.GetPreferredOrBackupWithConfig(repoPath, agentName, cfg)
+func validateRerunAgent(repoPath string, agentName string, backupAgent string, cfg *config.Config) error {
+	_, err := agent.GetPreferredOrBackupWithConfig(repoPath, agentName, cfg, backupAgent)
 	if err != nil {
 		var unknownErr *agent.UnknownAgentError
 		if errors.As(err, &unknownErr) {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -716,7 +716,7 @@ func resolveRerunModelProvider(job *storage.ReviewJob, cfg *config.Config) (stri
 }
 
 func validateRerunAgent(repoPath string, agentName string, cfg *config.Config) error {
-	_, err := agent.GetAvailableWithConfig(repoPath, agentName, cfg)
+	_, err := agent.GetPreferredOrBackupWithConfig(repoPath, agentName, cfg)
 	if err != nil {
 		var unknownErr *agent.UnknownAgentError
 		if errors.As(err, &unknownErr) {
@@ -1941,7 +1941,7 @@ func (s *Server) resolveSingleAgent(
 		return "", "", out
 	}
 	agentName := resolution.PreferredAgent
-	resolved, err := agent.GetAvailableWithConfig(
+	resolved, err := agent.GetPreferredOrBackupWithConfig(
 		in.resolutionPath, agentName, in.cfg, resolution.BackupAgent,
 	)
 	if err != nil {
@@ -2383,7 +2383,7 @@ func (s *Server) humaFixJob(
 		)
 	}
 	agentName := resolution.PreferredAgent
-	if resolved, err := agent.GetAvailableWithConfig(
+	if resolved, err := agent.GetPreferredOrBackupWithConfig(
 		resolutionPath, agentName, cfg, resolution.BackupAgent,
 	); err != nil {
 		var unknownErr *agent.UnknownAgentError

--- a/internal/daemon/server_actions_test.go
+++ b/internal/daemon/server_actions_test.go
@@ -742,6 +742,26 @@ func TestResolveRerunModelProviderAllowsUnavailablePrimaryWithBackup(t *testing.
 	assert.Empty(t, provider)
 }
 
+func TestResolveRerunModelProviderAllowsUnavailablePrimaryWithStoredBackup(t *testing.T) {
+	t.Setenv("PATH", "")
+	mainRepo := t.TempDir()
+
+	job := &storage.ReviewJob{
+		Agent:       "claude-code",
+		BackupAgent: "test",
+		JobType:     storage.JobTypeReview,
+		ReviewType:  config.ReviewTypeDefault,
+		Reasoning:   "thorough",
+		RepoPath:    mainRepo,
+	}
+
+	model, provider, err := resolveRerunModelProvider(job, config.DefaultConfig())
+
+	require.NoError(t, err)
+	assert.Empty(t, model)
+	assert.Empty(t, provider)
+}
+
 // TestHandleAddCommentToJobStates tests that comments can be added to jobs
 // in any state: queued, running, done, failed, and canceled.
 func TestHandleAddCommentToJobStates(t *testing.T) {

--- a/internal/daemon/server_actions_test.go
+++ b/internal/daemon/server_actions_test.go
@@ -721,6 +721,27 @@ func TestResolveRerunModelProviderRejectsInvalidAgentWithRequestedOverrides(t *t
 	assert.Empty(t, provider)
 }
 
+func TestResolveRerunModelProviderAllowsUnavailablePrimaryWithBackup(t *testing.T) {
+	t.Setenv("PATH", "")
+	mainRepo := t.TempDir()
+
+	job := &storage.ReviewJob{
+		Agent:      "claude-code",
+		JobType:    storage.JobTypeReview,
+		ReviewType: config.ReviewTypeDefault,
+		Reasoning:  "thorough",
+		RepoPath:   mainRepo,
+	}
+	cfg := config.DefaultConfig()
+	cfg.ReviewBackupAgent = "test"
+
+	model, provider, err := resolveRerunModelProvider(job, cfg)
+
+	require.NoError(t, err)
+	assert.Empty(t, model)
+	assert.Empty(t, provider)
+}
+
 // TestHandleAddCommentToJobStates tests that comments can be added to jobs
 // in any state: queued, running, done, failed, and canceled.
 func TestHandleAddCommentToJobStates(t *testing.T) {

--- a/internal/daemon/server_auto_design.go
+++ b/internal/daemon/server_auto_design.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"strings"
 	"sync/atomic"
 
 	"go.kenn.io/roborev/internal/agent"
@@ -245,27 +246,50 @@ func (s *Server) enqueueDesignFollowUp(parent *storage.ReviewJob) error {
 	return err
 }
 
-// resolveDesignAgent returns the (agent, model) pair the auto-design
-// follow-up should persist for execution. It resolves to an *installed*
-// preferred or configured backup agent; otherwise the row would
-// carry an unavailable primary name and the worker would fail when it
-// claims the job, even though an explicit backup agent is installed
-// and configured.
+// resolveDesignAgent returns the (agent, model) pair the auto-design follow-up
+// should persist for execution. Workflow-specific design agents and backups
+// stay strict, while generic defaults can auto-detect an installed agent like
+// the normal blank-agent path.
 func resolveDesignAgent(repoPath string, cfg *config.Config) (string, string) {
-	resolution, err := agent.ResolveWorkflowConfig(
-		"", repoPath, cfg, "design", "")
+	repoCfg, _ := config.LoadRepoConfig(repoPath)
+	return resolveDesignFollowUpAgentFromConfig(repoCfg, cfg, "" /* default reasoning */, "")
+}
+
+func resolveDesignFollowUpAgentFromConfig(
+	repoCfg *config.RepoConfig,
+	cfg *config.Config,
+	reasoning string,
+	modelOverride string,
+) (string, string) {
+	resolution, err := agent.ResolveWorkflowConfigFromConfig(
+		"", repoCfg, cfg, "design", reasoning)
 	if err != nil || resolution.PreferredAgent == "" {
-		return config.ResolveAgent("", repoPath, cfg), ""
+		designAgent, designModel := config.DesignAgentFromConfig(repoCfg, cfg)
+		if modelOverride != "" {
+			designModel = modelOverride
+		}
+		return designAgent, designModel
 	}
 	primary := resolution.PreferredAgent
-	chosen, err := agent.GetPreferredOrBackupWithConfig(repoPath, primary, cfg, resolution.BackupAgent)
+	strictDesignAgent := config.HasWorkflowAgentOverrideFromConfig(
+		repoCfg, cfg, "design", reasoning,
+	) ||
+		strings.TrimSpace(resolution.BackupAgent) != ""
+	var chosen agent.Agent
+	if strictDesignAgent {
+		chosen, err = agent.GetPreferredOrBackupWithConfigFromConfig(
+			repoCfg, primary, cfg, resolution.BackupAgent,
+		)
+	} else {
+		chosen, err = agent.GetAvailableWithConfigFromConfig(repoCfg, primary, cfg)
+	}
 	if err != nil {
 		// Nothing installed — fall back to the primary name anyway so
 		// the row has a readable agent value, even if the worker will
 		// error. Better than persisting the sentinel.
-		return primary, resolution.ModelForSelectedAgent(primary, "")
+		return primary, resolution.ModelForSelectedAgent(primary, modelOverride)
 	}
-	return chosen.Name(), resolution.ModelForSelectedAgent(chosen.Name(), "")
+	return chosen.Name(), resolution.ModelForSelectedAgent(chosen.Name(), modelOverride)
 }
 
 func (s *Server) insertSkippedDesign(parent *storage.ReviewJob, reason string) error {

--- a/internal/daemon/server_auto_design.go
+++ b/internal/daemon/server_auto_design.go
@@ -247,7 +247,7 @@ func (s *Server) enqueueDesignFollowUp(parent *storage.ReviewJob) error {
 
 // resolveDesignAgent returns the (agent, model) pair the auto-design
 // follow-up should persist for execution. It resolves to an *installed*
-// agent via agent.GetAvailableWithConfig — otherwise the row would
+// preferred or configured backup agent; otherwise the row would
 // carry an unavailable primary name and the worker would fail when it
 // claims the job, even though an explicit backup agent is installed
 // and configured.
@@ -258,7 +258,7 @@ func resolveDesignAgent(repoPath string, cfg *config.Config) (string, string) {
 		return config.ResolveAgent("", repoPath, cfg), ""
 	}
 	primary := resolution.PreferredAgent
-	chosen, err := agent.GetAvailableWithConfig(repoPath, primary, cfg, resolution.BackupAgent)
+	chosen, err := agent.GetPreferredOrBackupWithConfig(repoPath, primary, cfg, resolution.BackupAgent)
 	if err != nil {
 		// Nothing installed — fall back to the primary name anyway so
 		// the row has a readable agent value, even if the worker will

--- a/internal/daemon/server_auto_design.go
+++ b/internal/daemon/server_auto_design.go
@@ -29,7 +29,10 @@ type AutoDesignMetrics struct {
 // autoDesignMetrics is the process-global instance.
 var autoDesignMetrics = &AutoDesignMetrics{}
 
-const autoDesignHookSource = "post_commit"
+const (
+	autoDesignHookSource           = "post_commit"
+	localAutoDesignReviewReasoning = "thorough"
+)
 
 func (s *Server) autoDesignConfig() *config.Config {
 	if s != nil && s.configWatcher != nil {
@@ -252,7 +255,9 @@ func (s *Server) enqueueDesignFollowUp(parent *storage.ReviewJob) error {
 // the normal blank-agent path.
 func resolveDesignAgent(repoPath string, cfg *config.Config) (string, string) {
 	repoCfg, _ := config.LoadRepoConfig(repoPath)
-	return resolveDesignFollowUpAgentFromConfig(repoCfg, cfg, "" /* default reasoning */, "")
+	return resolveDesignFollowUpAgentFromConfig(
+		repoCfg, cfg, localAutoDesignReviewReasoning, "",
+	)
 }
 
 func resolveDesignFollowUpAgentFromConfig(

--- a/internal/daemon/server_auto_design_test.go
+++ b/internal/daemon/server_auto_design_test.go
@@ -100,6 +100,65 @@ func TestMaybeDispatchAutoDesign_HeuristicTrigger(t *testing.T) {
 	assert.Equal(t, "review", found.JobType, "direct heuristic trigger enqueues a design review, not a classify")
 }
 
+func TestMaybeDispatchAutoDesign_HeuristicUsesThoroughDesignAgentConfig(t *testing.T) {
+	srv, repo := newAutoDesignTestServer(t)
+
+	const primaryAgent = "local-design-thorough-primary"
+	agent.Register(&unavailableSynthesisCommandAgent{
+		name:    primaryAgent,
+		command: "roborev-missing-local-design-thorough-primary",
+	})
+	t.Cleanup(func() { agent.Unregister(primaryAgent) })
+	agent.Register(&agent.FakeAgent{NameStr: "local-design-auto-detect"})
+	t.Cleanup(func() { agent.Unregister("local-design-auto-detect") })
+	t.Setenv("PATH", "")
+
+	require.NoError(t, os.WriteFile(filepath.Join(repo.RootPath, ".roborev.toml"), []byte(`
+design_agent_thorough = "local-design-thorough-primary"
+design_model_thorough = "local-thorough-model"
+
+[auto_design_review]
+enabled = true
+`), 0o644))
+
+	commit, err := srv.db.GetOrCreateCommit(repo.ID, "decafbad", "Author", "refactor: rework api", time.Now())
+	require.NoError(t, err)
+	diff := "+x\n+y\n+a\n+b\n+c\n+d\n+e\n+f\n+g\n+h\n+i\n+j\n+k\n+l\n"
+	parent := &storage.ReviewJob{
+		ID:            1000,
+		RepoID:        repo.ID,
+		CommitID:      &commit.ID,
+		GitRef:        "decafbad",
+		Agent:         "test",
+		JobType:       storage.JobTypeReview,
+		Status:        storage.JobStatusQueued,
+		EnqueuedAt:    time.Now(),
+		RepoPath:      repo.RootPath,
+		CommitSubject: "refactor: rework api",
+		DiffContent:   &diff,
+	}
+
+	require.NoError(t, srv.maybeDispatchAutoDesign(context.Background(), parent))
+
+	queued, err := srv.db.ListJobsByStatus(repo.ID, storage.JobStatusQueued)
+	require.NoError(t, err)
+	var found *storage.ReviewJob
+	for i := range queued {
+		j := queued[i]
+		if j.GitRef == "decafbad" && j.ReviewType == "design" && j.Source == "auto_design" {
+			found = &j
+			break
+		}
+	}
+	require.NotNil(t, found, "expected an auto_design design row")
+	full, err := srv.db.GetJobByID(found.ID)
+	require.NoError(t, err)
+	assert := assert.New(t)
+	assert.Equal(primaryAgent, full.Agent)
+	assert.Equal("local-thorough-model", full.Model)
+	assert.Equal("thorough", full.Reasoning)
+}
+
 func TestMaybeDispatchAutoDesign_HeuristicSkip_TrivialDiff(t *testing.T) {
 	srv, repo := newAutoDesignTestServer(t)
 	enableAutoDesignReviewForRepo(t, repo.RootPath)

--- a/internal/daemon/server_auto_design_test.go
+++ b/internal/daemon/server_auto_design_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testutil"
@@ -43,6 +44,19 @@ func enableHookAutoDesignReviewForRepo(t *testing.T, repoPath string) {
 		[]byte(`[auto_design_review]
 hook_enabled = true
 `), 0o644))
+}
+
+func TestResolveDesignAgentGenericDefaultAgentCanAutoDetect(t *testing.T) {
+	t.Setenv("PATH", "")
+	agent.Register(&agent.FakeAgent{NameStr: "local-auto-design"})
+	t.Cleanup(func() { agent.Unregister("local-auto-design") })
+
+	cfg := config.DefaultConfig()
+	cfg.DefaultAgent = "claude-code"
+	designAgent, designModel := resolveDesignAgent(t.TempDir(), cfg)
+
+	assert.Equal(t, "local-auto-design", designAgent)
+	assert.Empty(t, designModel)
 }
 
 func TestMaybeDispatchAutoDesign_HeuristicTrigger(t *testing.T) {

--- a/internal/daemon/server_jobs_test.go
+++ b/internal/daemon/server_jobs_test.go
@@ -1965,6 +1965,7 @@ func TestHandleEnqueueAgentAvailability(t *testing.T) {
 		name          string
 		requestAgent  string
 		defaultAgent  string
+		backupAgent   string
 		mockBinaries  []string // binary names to place in PATH
 		expectedAgent string   // expected agent stored in job
 		expectedCode  int      // expected HTTP status code
@@ -1977,17 +1978,23 @@ func TestHandleEnqueueAgentAvailability(t *testing.T) {
 			expectedCode:  http.StatusCreated,
 		},
 		{
-			name:          "unavailable codex falls back to claude-code",
-			requestAgent:  "codex",
-			mockBinaries:  []string{"claude"},
-			expectedAgent: "claude-code",
-			expectedCode:  http.StatusCreated,
+			name:         "unavailable explicit codex without backup returns 503",
+			requestAgent: "codex",
+			mockBinaries: []string{"claude"},
+			expectedCode: http.StatusServiceUnavailable,
 		},
 		{
-			name:          "default agent falls back when codex not installed",
+			name:         "default agent without backup returns 503 when unavailable",
+			requestAgent: "",
+			mockBinaries: []string{"claude"},
+			expectedCode: http.StatusServiceUnavailable,
+		},
+		{
+			name:          "configured backup used when default agent unavailable",
 			requestAgent:  "",
-			mockBinaries:  []string{"claude"},
-			expectedAgent: "claude-code",
+			backupAgent:   "gemini",
+			mockBinaries:  []string{"gemini"},
+			expectedAgent: "gemini",
 			expectedCode:  http.StatusCreated,
 		},
 		{
@@ -2013,11 +2020,10 @@ func TestHandleEnqueueAgentAvailability(t *testing.T) {
 			expectedCode:  http.StatusCreated,
 		},
 		{
-			name:          "default falls back to kilo when only kilo available",
-			requestAgent:  "",
-			mockBinaries:  []string{"kilo"},
-			expectedAgent: "kilo",
-			expectedCode:  http.StatusCreated,
+			name:         "default does not use hardcoded fallback when only kilo available",
+			requestAgent: "",
+			mockBinaries: []string{"kilo"},
+			expectedCode: http.StatusServiceUnavailable,
 		},
 		{
 			name:         "no agents available returns 503",
@@ -2039,6 +2045,9 @@ func TestHandleEnqueueAgentAvailability(t *testing.T) {
 			server, _, _ := newTestServer(t)
 			if tt.defaultAgent != "" {
 				server.configWatcher.Config().DefaultAgent = tt.defaultAgent
+			}
+			if tt.backupAgent != "" {
+				server.configWatcher.Config().DefaultBackupAgent = tt.backupAgent
 			}
 
 			// Isolate PATH: only mock binaries + git (no real agent CLIs)
@@ -2696,7 +2705,7 @@ func TestHandleEnqueueAgentOverrideModel(t *testing.T) {
 	}
 }
 
-func TestHandleEnqueueFallbackAgentUsesDefaultModelForActualAgent(t *testing.T) {
+func TestHandleEnqueueBackupAgentUsesBackupModel(t *testing.T) {
 	gitPath, err := exec.LookPath("git")
 	if err != nil {
 		t.Skip("git not installed")
@@ -2737,6 +2746,8 @@ func TestHandleEnqueueFallbackAgentUsesDefaultModelForActualAgent(t *testing.T) 
 	cfg.DefaultAgent = "claude-code"
 	cfg.DefaultModel = "gpt-5.4"
 	cfg.ReviewAgent = "codex"
+	cfg.ReviewBackupAgent = "claude-code"
+	cfg.ReviewBackupModel = "backup-sonnet"
 	server := NewServer(db, cfg, "")
 
 	reqData := EnqueueRequest{
@@ -2763,10 +2774,10 @@ func TestHandleEnqueueFallbackAgentUsesDefaultModelForActualAgent(t *testing.T) 
 			return false
 		}, "agent = %q, want %q", job.Agent, "claude-code")
 	}
-	if job.Model != "gpt-5.4" {
+	if job.Model != "backup-sonnet" {
 		require.Condition(t, func() bool {
 			return false
-		}, "model = %q, want %q", job.Model, "gpt-5.4")
+		}, "model = %q, want %q", job.Model, "backup-sonnet")
 	}
 }
 

--- a/internal/daemon/synthesis_worker.go
+++ b/internal/daemon/synthesis_worker.go
@@ -333,7 +333,7 @@ func (wp *WorkerPool) configureSynthesisAgent(
 	workerID string, job *storage.ReviewJob,
 ) (agent.Agent, string, error) {
 	cfg := wp.cfgGetter.Config()
-	baseAgent, err := agent.GetAvailableWithConfig(job.RepoPath, job.Agent, cfg, job.BackupAgent)
+	baseAgent, err := agent.GetPreferredOrBackupWithConfig(job.RepoPath, job.Agent, cfg, job.BackupAgent)
 	if err != nil {
 		wp.failOrRetryAgent(workerID, job, job.Agent, fmt.Sprintf("get agent: %v", err))
 		return nil, "", err

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -1222,9 +1222,10 @@ func (wp *WorkerPool) resolveBackupAgent(job *storage.ReviewJob) string {
 	if backup == "" {
 		return ""
 	}
-	// Canonicalize: resolve alias, verify installed, skip if same as primary
-	resolved, err := agent.Get(backup)
-	if err != nil || !agent.IsAvailable(resolved.Name()) {
+	// Canonicalize and verify availability using the config-aware path so
+	// command overrides and configured ACP aliases participate in failover.
+	resolved, err := agent.GetPreferredOrBackupWithConfig(job.RepoPath, backup, cfg)
+	if err != nil {
 		return ""
 	}
 	if resolution.AgentMatches(resolved.Name(), job.Agent) {

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -695,8 +695,9 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 		log.Printf("[%s] Error saving prompt: %v", workerID, err)
 	}
 
-	// Get the agent (falls back to available agent if preferred not installed)
-	baseAgent, err := agent.GetAvailableWithConfig(job.RepoPath, job.Agent, cfg)
+	// Get the configured job agent. Backup failover is handled explicitly by
+	// failOrRetryAgent so jobs never silently run on the hardcoded fallback chain.
+	baseAgent, err := agent.GetPreferredOrBackupWithConfig(job.RepoPath, job.Agent, cfg)
 	if err != nil {
 		log.Printf("[%s] Error getting agent: %v", workerID, err)
 		wp.failOrRetryAgent(workerID, job, job.Agent, fmt.Sprintf("get agent: %v", err))

--- a/internal/daemon/worker_classify.go
+++ b/internal/daemon/worker_classify.go
@@ -231,22 +231,15 @@ func (wp *WorkerPool) applyClassifyVerdict(workerID string, job *storage.ReviewJ
 }
 
 // resolveDesignFollowUp returns the (agent, model) pair to persist on a
-// promoted design review. Resolves to an *installed* agent via
-// preferred-or-backup resolution so the worker that claims the promoted row
-// next can actually run it without using unrelated fallback agents.
+// promoted design review. It shares heuristic auto-design resolution so generic
+// defaults can auto-detect, while workflow-specific pins and backups stay
+// strict.
 func (wp *WorkerPool) resolveDesignFollowUp(repoPath string) (string, string) {
 	cfg := wp.cfgGetter.Config()
-	resolution, err := agent.ResolveWorkflowConfig(
-		"" /* no CLI override */, repoPath, cfg, "design", "" /* default reasoning */)
-	if err != nil || resolution.PreferredAgent == "" {
-		return config.ResolveAgent("", repoPath, cfg), ""
-	}
-	primary := resolution.PreferredAgent
-	chosen, err := agent.GetPreferredOrBackupWithConfig(repoPath, primary, cfg, resolution.BackupAgent)
-	if err != nil {
-		return primary, resolution.ModelForSelectedAgent(primary, "")
-	}
-	return chosen.Name(), resolution.ModelForSelectedAgent(chosen.Name(), "")
+	repoCfg, _ := config.LoadRepoConfig(repoPath)
+	return resolveDesignFollowUpAgentFromConfig(
+		repoCfg, cfg, "" /* default reasoning */, "",
+	)
 }
 
 // completeClassifyAsSkip is the failure path: the classifier couldn't

--- a/internal/daemon/worker_classify.go
+++ b/internal/daemon/worker_classify.go
@@ -238,7 +238,7 @@ func (wp *WorkerPool) resolveDesignFollowUp(repoPath string) (string, string) {
 	cfg := wp.cfgGetter.Config()
 	repoCfg, _ := config.LoadRepoConfig(repoPath)
 	return resolveDesignFollowUpAgentFromConfig(
-		repoCfg, cfg, "" /* default reasoning */, "",
+		repoCfg, cfg, localAutoDesignReviewReasoning, "",
 	)
 }
 

--- a/internal/daemon/worker_classify.go
+++ b/internal/daemon/worker_classify.go
@@ -232,8 +232,8 @@ func (wp *WorkerPool) applyClassifyVerdict(workerID string, job *storage.ReviewJ
 
 // resolveDesignFollowUp returns the (agent, model) pair to persist on a
 // promoted design review. Resolves to an *installed* agent via
-// agent.GetAvailableWithConfig so the worker that claims the promoted
-// row next can actually run it.
+// preferred-or-backup resolution so the worker that claims the promoted row
+// next can actually run it without using unrelated fallback agents.
 func (wp *WorkerPool) resolveDesignFollowUp(repoPath string) (string, string) {
 	cfg := wp.cfgGetter.Config()
 	resolution, err := agent.ResolveWorkflowConfig(
@@ -242,7 +242,7 @@ func (wp *WorkerPool) resolveDesignFollowUp(repoPath string) (string, string) {
 		return config.ResolveAgent("", repoPath, cfg), ""
 	}
 	primary := resolution.PreferredAgent
-	chosen, err := agent.GetAvailableWithConfig(repoPath, primary, cfg, resolution.BackupAgent)
+	chosen, err := agent.GetPreferredOrBackupWithConfig(repoPath, primary, cfg, resolution.BackupAgent)
 	if err != nil {
 		return primary, resolution.ModelForSelectedAgent(primary, "")
 	}

--- a/internal/daemon/worker_classify_test.go
+++ b/internal/daemon/worker_classify_test.go
@@ -62,6 +62,41 @@ func TestWorkerPoolResolveDesignFollowUpGenericDefaultAgentCanAutoDetect(t *test
 	assert.Empty(t, designModel)
 }
 
+func TestProcessClassifyJob_DesignPromotionUsesThoroughDesignAgentConfig(t *testing.T) {
+	tc := newWorkerTestContext(t, 0)
+
+	const primaryAgent = "classify-design-thorough-primary"
+	agent.Register(&unavailableSynthesisCommandAgent{
+		name:    primaryAgent,
+		command: "roborev-missing-classify-design-thorough-primary",
+	})
+	t.Cleanup(func() { agent.Unregister(primaryAgent) })
+	agent.Register(&agent.FakeAgent{NameStr: "classify-design-auto-detect"})
+	t.Cleanup(func() { agent.Unregister("classify-design-auto-detect") })
+	t.Setenv("PATH", "")
+
+	require.NoError(t, os.WriteFile(filepath.Join(tc.Repo.RootPath, ".roborev.toml"), []byte(`
+design_agent_thorough = "classify-design-thorough-primary"
+design_model_thorough = "classify-thorough-model"
+`), 0o644))
+
+	job := tc.createAndClaimClassifyJob(t, "f00dbabe", "feat: new package", "+lots of new code\n")
+	SetTestClassifierVerdict(true, "new package detected")
+	t.Cleanup(func() { SetTestClassifierVerdict(false, "") })
+
+	tc.Pool.processJob(testWorkerID, job)
+
+	after, err := tc.DB.GetJobByID(job.ID)
+	require.NoError(t, err)
+	assert := assert.New(t)
+	assert.Equal(storage.JobTypeReview, after.JobType)
+	assert.Equal(storage.JobStatusQueued, after.Status)
+	assert.Equal("design", after.ReviewType)
+	assert.Equal(primaryAgent, after.Agent)
+	assert.Equal("classify-thorough-model", after.Model)
+	assert.Equal("thorough", after.Reasoning)
+}
+
 type wrappedErr struct{ inner error }
 
 func (w *wrappedErr) Error() string { return "outer: " + w.inner.Error() }

--- a/internal/daemon/worker_classify_test.go
+++ b/internal/daemon/worker_classify_test.go
@@ -47,6 +47,21 @@ func TestPublicClassifierSkipReason_WrappedDeadlineExceeded(t *testing.T) {
 	assert.Equal(t, "classifier timed out", publicClassifierSkipReason(wrapped))
 }
 
+func TestWorkerPoolResolveDesignFollowUpGenericDefaultAgentCanAutoDetect(t *testing.T) {
+	t.Setenv("PATH", "")
+	agent.Register(&agent.FakeAgent{NameStr: "classify-auto-design"})
+	t.Cleanup(func() { agent.Unregister("classify-auto-design") })
+
+	cfg := config.DefaultConfig()
+	cfg.DefaultAgent = "claude-code"
+	wp := &WorkerPool{cfgGetter: NewStaticConfig(cfg)}
+
+	designAgent, designModel := wp.resolveDesignFollowUp(t.TempDir())
+
+	assert.Equal(t, "classify-auto-design", designAgent)
+	assert.Empty(t, designModel)
+}
+
 type wrappedErr struct{ inner error }
 
 func (w *wrappedErr) Error() string { return "outer: " + w.inner.Error() }

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -2041,6 +2041,27 @@ func TestResolveBackupPrefersStoredJobBackup(t *testing.T) {
 	assert.Equal("opus", pool.resolveBackupModel(synthesisStored))
 }
 
+func TestResolveBackupAgentUsesConfiguredCommandOverride(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fake command uses POSIX permissions")
+	}
+	binDir := t.TempDir()
+	cmdPath := filepath.Join(binDir, "backup-claude")
+	require.NoError(t, os.WriteFile(cmdPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("PATH", binDir)
+
+	cfg := config.DefaultConfig()
+	cfg.ReviewBackupAgent = "claude-code"
+	cfg.ClaudeCodeCmd = "backup-claude"
+	pool := NewWorkerPool(nil, NewStaticConfig(cfg), 1, NewBroadcaster(), nil, nil)
+	job := &storage.ReviewJob{
+		Agent:    "codex",
+		RepoPath: t.TempDir(),
+	}
+
+	assert.Equal(t, "claude-code", pool.resolveBackupAgent(job))
+}
+
 func TestFailOrRetryInner_QuotaSkipsRetries(t *testing.T) {
 	tc := newWorkerTestContext(t, 1)
 	sha := testutil.GetHeadSHA(t, tc.TmpDir)

--- a/internal/review/batch.go
+++ b/internal/review/batch.go
@@ -119,7 +119,7 @@ func runSingle(
 		}
 	} else if autoDetectAgent {
 		resolvedAgent, err = agent.GetAvailableWithConfig(
-			cfg.RepoPath, "", cfg.GlobalConfig)
+			cfg.RepoPath, resolvedName, cfg.GlobalConfig, backupAgent)
 	} else {
 		resolvedAgent, err = agent.GetPreferredOrBackupWithConfig(
 			cfg.RepoPath, resolvedName, cfg.GlobalConfig, backupAgent)

--- a/internal/review/batch.go
+++ b/internal/review/batch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 
 	"go.kenn.io/roborev/internal/agent"
@@ -107,6 +108,7 @@ func runSingle(
 		resolvedName = resolution.PreferredAgent
 		backupAgent = resolution.BackupAgent
 	}
+	autoDetectAgent := strings.TrimSpace(agentName) == "" && cfg.AgentRegistry == nil
 
 	var resolvedAgent agent.Agent
 	if cfg.AgentRegistry != nil {
@@ -115,6 +117,9 @@ func runSingle(
 		} else {
 			err = fmt.Errorf("no agents available (mock registry)")
 		}
+	} else if autoDetectAgent {
+		resolvedAgent, err = agent.GetAvailableWithConfig(
+			cfg.RepoPath, "", cfg.GlobalConfig)
 	} else {
 		resolvedAgent, err = agent.GetPreferredOrBackupWithConfig(
 			cfg.RepoPath, resolvedName, cfg.GlobalConfig, backupAgent)

--- a/internal/review/batch.go
+++ b/internal/review/batch.go
@@ -116,7 +116,7 @@ func runSingle(
 			err = fmt.Errorf("no agents available (mock registry)")
 		}
 	} else {
-		resolvedAgent, err = agent.GetAvailableWithConfig(
+		resolvedAgent, err = agent.GetPreferredOrBackupWithConfig(
 			cfg.RepoPath, resolvedName, cfg.GlobalConfig, backupAgent)
 	}
 

--- a/internal/review/batch.go
+++ b/internal/review/batch.go
@@ -108,7 +108,10 @@ func runSingle(
 		resolvedName = resolution.PreferredAgent
 		backupAgent = resolution.BackupAgent
 	}
-	autoDetectAgent := strings.TrimSpace(agentName) == "" && cfg.AgentRegistry == nil
+	strictWorkflowAgent := cfg.GlobalConfig != nil && (config.HasWorkflowAgentOverrideFromConfig(
+		resolution.RepoConfig, cfg.GlobalConfig, workflow, cfg.Reasoning,
+	) || strings.TrimSpace(backupAgent) != "")
+	autoDetectAgent := strings.TrimSpace(agentName) == "" && cfg.AgentRegistry == nil && !strictWorkflowAgent
 
 	var resolvedAgent agent.Agent
 	if cfg.AgentRegistry != nil {

--- a/internal/review/batch_test.go
+++ b/internal/review/batch_test.go
@@ -289,6 +289,31 @@ func TestRunBatch_BlankCIAgentHonorsConfiguredCommandOverride(t *testing.T) {
 	assert.Contains(results[0].Error, "build prompt")
 }
 
+func TestRunBatch_BlankCIAgentWithExplicitBackupStaysStrict(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	t.Setenv("PATH", "")
+	agent.Register(&agent.FakeAgent{NameStr: "ci-unrelated-batch"})
+	t.Cleanup(func() { agent.Unregister("ci-unrelated-batch") })
+
+	globalCfg := config.DefaultConfig()
+	globalCfg.ReviewBackupAgent = "claude-code"
+	cfg := BatchConfig{
+		RepoPath:     t.TempDir(),
+		GitRef:       "abc..def",
+		Agents:       []string{""},
+		ReviewTypes:  []string{"default"},
+		GlobalConfig: globalCfg,
+	}
+
+	results := RunBatch(context.Background(), cfg)
+	require.Len(results, 1)
+	assert.Empty(results[0].Agent)
+	assert.Equal(ResultFailed, results[0].Status)
+	assert.Contains(results[0].Error, "no configured agent available")
+}
+
 func TestRunBatch_WorkflowModelResolution(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/review/batch_test.go
+++ b/internal/review/batch_test.go
@@ -260,6 +260,35 @@ func TestRunBatch_BlankCIAgentAutoDetectsAvailableAgent(t *testing.T) {
 	assert.Contains(results[0].Error, "build prompt")
 }
 
+func TestRunBatch_BlankCIAgentHonorsConfiguredCommandOverride(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fake command uses POSIX permissions")
+	}
+	assert := assert.New(t)
+	require := require.New(t)
+
+	binDir := t.TempDir()
+	cmdPath := filepath.Join(binDir, "ci-codex")
+	require.NoError(os.WriteFile(cmdPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("PATH", binDir)
+
+	globalCfg := config.DefaultConfig()
+	globalCfg.CodexCmd = "ci-codex"
+	cfg := BatchConfig{
+		RepoPath:     t.TempDir(),
+		GitRef:       "abc..def",
+		Agents:       []string{""},
+		ReviewTypes:  []string{"default"},
+		GlobalConfig: globalCfg,
+	}
+
+	results := RunBatch(context.Background(), cfg)
+	require.Len(results, 1)
+	assert.Equal("codex", results[0].Agent)
+	assert.Equal(ResultFailed, results[0].Status)
+	assert.Contains(results[0].Error, "build prompt")
+}
+
 func TestRunBatch_WorkflowModelResolution(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/review/batch_test.go
+++ b/internal/review/batch_test.go
@@ -237,6 +237,29 @@ func TestRunBatch_WorkflowAwareResolution(t *testing.T) {
 	assert.Equal("security-agent", secResult.Agent, "security type resolved to %q, want %q", secResult.Agent, "security-agent")
 }
 
+func TestRunBatch_BlankCIAgentAutoDetectsAvailableAgent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	t.Setenv("PATH", "")
+	agent.Register(&agent.FakeAgent{NameStr: "ci-auto-batch"})
+	t.Cleanup(func() { agent.Unregister("ci-auto-batch") })
+
+	cfg := BatchConfig{
+		RepoPath:     t.TempDir(),
+		GitRef:       "abc..def",
+		Agents:       []string{""},
+		ReviewTypes:  []string{"default"},
+		GlobalConfig: config.DefaultConfig(),
+	}
+
+	results := RunBatch(context.Background(), cfg)
+	require.Len(results, 1)
+	assert.Equal("ci-auto-batch", results[0].Agent)
+	assert.Equal(ResultFailed, results[0].Status)
+	assert.Contains(results[0].Error, "build prompt")
+}
+
 func TestRunBatch_WorkflowModelResolution(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/review/synthesize.go
+++ b/internal/review/synthesize.go
@@ -20,9 +20,10 @@ var ErrAllFailed = errors.New(
 	"all review jobs failed")
 
 // getAvailableWithConfig is a variable for dependency injection in tests.
-// It wraps agent.GetAvailableWithConfig with repoPath as the first parameter.
+// It wraps strict preferred-or-backup resolution with repoPath as the first
+// parameter.
 var getAvailableWithConfig = func(repoPath string, preferred string, cfg *config.Config, backups ...string) (agent.Agent, error) {
-	return agent.GetAvailableWithConfig(repoPath, preferred, cfg, backups...)
+	return agent.GetPreferredOrBackupWithConfig(repoPath, preferred, cfg, backups...)
 }
 
 // SynthesizeOpts controls synthesis behavior.

--- a/internal/review/synthesize.go
+++ b/internal/review/synthesize.go
@@ -20,9 +20,12 @@ var ErrAllFailed = errors.New(
 	"all review jobs failed")
 
 // getAvailableWithConfig is a variable for dependency injection in tests.
-// It wraps strict preferred-or-backup resolution with repoPath as the first
-// parameter.
+// It preserves SynthesizeOpts.Agent's empty-means-auto-select contract while
+// keeping explicit synthesis agents on strict preferred-or-backup resolution.
 var getAvailableWithConfig = func(repoPath string, preferred string, cfg *config.Config, backups ...string) (agent.Agent, error) {
+	if preferred == "" {
+		return agent.GetAvailableWithConfig(repoPath, preferred, cfg, backups...)
+	}
 	return agent.GetPreferredOrBackupWithConfig(repoPath, preferred, cfg, backups...)
 }
 

--- a/internal/review/synthesize_test.go
+++ b/internal/review/synthesize_test.go
@@ -326,6 +326,37 @@ func TestSynthesize_UsesSynthesisEntrypoint(t *testing.T) {
 	assert.NotContains(t, synth.synthPrompt, "Review the code changes in commit")
 }
 
+func TestSynthesize_EmptyAgentAutoSelectsAvailableAgent(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	synth := newSynthesisEntrypointAgent()
+	agent.Register(synth)
+	t.Cleanup(func() { agent.Unregister("synthesis-entrypoint") })
+
+	results := []ReviewResult{
+		{
+			Agent:      "codex",
+			ReviewType: "default",
+			Status:     "done",
+			Output:     "Found issue A",
+		},
+		{
+			Agent:      "codex",
+			ReviewType: "security",
+			Status:     "done",
+			Output:     "Found issue B",
+		},
+	}
+
+	comment, err := Synthesize(context.Background(), results, SynthesizeOpts{
+		GitRef:  "aaa111..bbb222",
+		HeadSHA: "bbb222",
+	})
+	require.NoError(t, err)
+	assertContains(t, comment, "synthesized output")
+	assert.False(t, synth.reviewCalled, "standalone synthesis must not use code-review entrypoint")
+}
+
 func TestSynthesize_PassesGlobalConfigToResolver(t *testing.T) {
 	originalResolver := getAvailableWithConfig
 	t.Cleanup(func() { getAvailableWithConfig = originalResolver })


### PR DESCRIPTION
Workflow agent resolution could still escape into roborev's built-in fallback order after config had selected a preferred review or fix agent. That made removing a panel selector feel like it had selected a backup agent, because the single-agent path could silently enqueue another installed agent even when workflow config did not authorize it.

This keeps workflow-configured reviews, fixes, panels, CI members, and synthesis on the preferred agent or an explicitly configured backup only. If neither is available, the workflow now fails normally instead of running an unrelated installed agent. The docs now spell out that backup agents cover both primary unavailability and execution failure, and that missing backups do not trigger unrelated agent selection.

The main review consequence is intentional: users who relied on implicit fallback from the built-in agent list now need to configure backup_agent or the workflow-specific backup key explicitly.