### PR TITLE
Stabilize analyze agent invocation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -361,6 +361,7 @@ If an agent binary is installed under a non-standard name or path, use a `*_cmd`
 # ~/.roborev/config.toml
 claude_code_cmd = "/opt/bin/claude"
 codex_cmd = "codex-nightly"
+gemini_cmd = "gemini"                 # Pin legacy Gemini CLI instead of auto-preferring agy
 cursor_cmd = "/usr/local/bin/agent"
 opencode_cmd = "/usr/local/bin/opencode-wrapper"
 pi_cmd = "~/bin/pi"
@@ -370,11 +371,12 @@ pi_cmd = "~/bin/pi"
 |--------|----------------|
 | `claude_code_cmd` | `claude` |
 | `codex_cmd` | `codex` |
+| `gemini_cmd` | auto (`agy`, then `gemini`) |
 | `cursor_cmd` | `agent` |
 | `opencode_cmd` | `opencode` |
 | `pi_cmd` | `pi` |
 
-These overrides affect both agent execution and availability detection. Without them, roborev only checks for the default command name when deciding whether an agent is installed.
+These overrides affect both agent execution and availability detection. Without them, roborev only checks for the default command name when deciding whether an agent is installed. Gemini is the exception: when `gemini_cmd` is unset, roborev auto-prefers `agy` before the legacy `gemini` command; set `gemini_cmd = "gemini"` to pin the legacy CLI, for example when using explicit Gemini model overrides.
 
 ### Agent Name Validation
 
@@ -524,6 +526,7 @@ column_borders = true             # Show separators between TUI columns
 | `task_column_order` | array | | Custom task column display order | N/A |
 | `claude_code_cmd` | string | `claude` | Custom path or name for the Claude Code binary | Yes |
 | `codex_cmd` | string | `codex` | Custom path or name for the Codex binary | Yes |
+| `gemini_cmd` | string | unset | Custom path or name for the Gemini-compatible binary; unset auto-prefers `agy` then `gemini` | Yes |
 | `cursor_cmd` | string | `agent` | Custom path or name for the Cursor binary | Yes |
 | `opencode_cmd` | string | `opencode` | Custom path or name for the OpenCode binary | Yes |
 | `pi_cmd` | string | `pi` | Custom path or name for the Pi binary | Yes |

--- a/internal/agent/acp_resolution.go
+++ b/internal/agent/acp_resolution.go
@@ -129,9 +129,8 @@ func isAvailableWithConfig(name string, cfg *config.Config) bool {
 	}
 	// Check the configured command first — it takes priority.
 	if override := commandOverrideForAgent(name, cfg); override != "" {
-		if _, err := exec.LookPath(override); err == nil {
-			return true
-		}
+		_, err := exec.LookPath(override)
+		return err == nil
 	}
 	// Fall back to the default (hardcoded) command.
 	return firstAvailableCommand(ca) != ""
@@ -243,6 +242,56 @@ func GetAvailableWithConfig(repoPath string, preferred string, cfg *config.Confi
 	return GetAvailableWithConfigFromConfig(repoCfg, preferred, cfg, backups...)
 }
 
+// GetAvailableExactWithConfig resolves exactly the requested agent while
+// honoring command overrides and configured ACP names. Unlike
+// GetAvailableWithConfig, it never falls through to backup agents or the global
+// fallback chain.
+func GetAvailableExactWithConfig(repoPath string, name string, cfg *config.Config) (Agent, error) {
+	var repoCfg *config.RepoConfig
+	if strings.TrimSpace(repoPath) != "" {
+		repoCfg, _ = config.LoadRepoConfig(repoPath)
+	}
+	return GetAvailableExactWithConfigFromConfig(repoCfg, name, cfg)
+}
+
+// GetAvailableExactWithConfigFromConfig is like GetAvailableExactWithConfig,
+// but uses an already-loaded repo config.
+func GetAvailableExactWithConfigFromConfig(repoCfg *config.RepoConfig, name string, cfg *config.Config) (Agent, error) {
+	rawName := strings.TrimSpace(name)
+	if rawName == "" {
+		return nil, fmt.Errorf("empty agent name")
+	}
+
+	if isConfiguredACPAgentNameFromConfig(rawName, cfg, repoCfg) {
+		configured := configuredACPAgentFromConfig(repoCfg, cfg)
+		if _, err := exec.LookPath(configured.CommandName()); err != nil {
+			return nil, fmt.Errorf("agent %q command %q unavailable: %w", rawName, configured.CommandName(), err)
+		}
+		return configured, nil
+	}
+
+	canonical := resolveAlias(rawName)
+	a, err := Get(canonical)
+	if err != nil {
+		return nil, err
+	}
+
+	if ca, ok := a.(CommandAgent); ok {
+		if override := commandOverrideForAgent(canonical, cfg); override != "" {
+			if _, err := exec.LookPath(override); err != nil {
+				return nil, fmt.Errorf("agent %q command %q unavailable: %w", canonical, override, err)
+			}
+			return applyAgentConfigOverrides(applyCommandOverrides(a, cfg), cfg), nil
+		}
+		if firstAvailableCommand(ca) == "" {
+			return nil, fmt.Errorf("agent %q unavailable", canonical)
+		}
+		return applyAgentConfigOverrides(applyResolvedCommand(a), cfg), nil
+	}
+
+	return applyAgentConfigOverrides(a, cfg), nil
+}
+
 // GetAvailableWithConfigFromConfig resolves an available agent using already
 // loaded repo config, never reading repo config from the working tree.
 func GetAvailableWithConfigFromConfig(repoCfg *config.RepoConfig, preferred string, cfg *config.Config, backups ...string) (Agent, error) {
@@ -269,8 +318,8 @@ func GetAvailableWithConfigFromConfig(repoCfg *config.RepoConfig, preferred stri
 			return backup, nil
 		}
 
-		// Finally fall back to normal auto-selection.
-		return GetAvailable("", backups...)
+		// Finally fall back to config-aware auto-selection.
+		return getAvailableFallbackWithConfig("", repoCfg, cfg)
 	}
 
 	// Check the preferred agent using config command overrides before
@@ -300,6 +349,10 @@ func GetAvailableWithConfigFromConfig(repoCfg *config.RepoConfig, preferred stri
 		return backup, nil
 	}
 
+	if cfg != nil {
+		return getAvailableFallbackWithConfig(preferred, repoCfg, cfg)
+	}
+
 	resolved, err := GetAvailable(preferred, backups...)
 	if err != nil {
 		return nil, err
@@ -313,6 +366,58 @@ func GetAvailableWithConfigFromConfig(repoCfg *config.RepoConfig, preferred stri
 	}
 
 	return applyAgentConfigOverrides(applyCommandOverrides(resolved, cfg), cfg), nil
+}
+
+func getAvailableFallbackWithConfig(preferred string, repoCfg *config.RepoConfig, cfg *config.Config) (Agent, error) {
+	for _, name := range fallbackAgentOrder {
+		if name == preferred {
+			continue
+		}
+		if !isAvailableWithConfig(name, cfg) {
+			continue
+		}
+		a, _ := Get(name)
+		resolved := applyAvailableCommand(a, cfg)
+		return applyConfiguredACPIfAvailable(resolved, repoCfg, cfg), nil
+	}
+
+	var available []string
+	registryMu.RLock()
+	for name := range registry {
+		if name != "test" && isAvailableWithConfigFromConfig(name, repoCfg, cfg) {
+			available = append(available, name)
+		}
+	}
+	registryMu.RUnlock()
+
+	if len(available) == 0 {
+		return nil, fmt.Errorf("no agents available (install one of: %s)\nYou may need to run 'roborev daemon restart' from a shell that has access to your agents", strings.Join(installHintAgentNames(), ", "))
+	}
+
+	a, _ := Get(available[0])
+	return applyConfiguredACPIfAvailable(applyAvailableCommand(a, cfg), repoCfg, cfg), nil
+}
+
+func isAvailableWithConfigFromConfig(name string, repoCfg *config.RepoConfig, cfg *config.Config) bool {
+	name = resolveAlias(name)
+	if name == defaultACPName {
+		configured := configuredACPAgentFromConfig(repoCfg, cfg)
+		if _, err := exec.LookPath(configured.CommandName()); err == nil {
+			return true
+		}
+	}
+	return isAvailableWithConfig(name, cfg)
+}
+
+func applyConfiguredACPIfAvailable(a Agent, repoCfg *config.RepoConfig, cfg *config.Config) Agent {
+	if a == nil || a.Name() != defaultACPName {
+		return a
+	}
+	configured := configuredACPAgentFromConfig(repoCfg, cfg)
+	if _, err := exec.LookPath(configured.CommandName()); err == nil {
+		return configured
+	}
+	return a
 }
 
 func applyAvailableCommand(a Agent, cfg *config.Config) Agent {

--- a/internal/agent/acp_resolution_test.go
+++ b/internal/agent/acp_resolution_test.go
@@ -183,3 +183,35 @@ func TestGetAvailableWithConfigACPAsBackup(t *testing.T) {
 		assert.Equal(t, defaultACPName, got.Name())
 	})
 }
+
+func TestGetAvailableWithConfigFinalFallbackAppliesACPConfig(t *testing.T) {
+	fakeBin := t.TempDir()
+	customBin := "custom-acp"
+	script := "#!/bin/sh\nexit 0\n"
+	if runtime.GOOS == "windows" {
+		customBin += ".cmd"
+		script = "@echo off\r\nexit /b 0\r\n"
+	}
+	customPath := filepath.Join(fakeBin, customBin)
+	require.NoError(t, os.WriteFile(customPath, []byte(script), 0o755))
+	t.Setenv("PATH", fakeBin)
+
+	originalRegistry := registry
+	registry = map[string]Agent{
+		defaultACPName: NewACPAgent(""),
+	}
+	t.Cleanup(func() { registry = originalRegistry })
+
+	cfg := &config.Config{ACP: &config.ACPAgentConfig{
+		Command: customPath,
+		Model:   "configured-model",
+	}}
+
+	got, err := GetAvailableWithConfig("", "", cfg)
+
+	require.NoError(t, err)
+	acp, ok := got.(*ACPAgent)
+	require.True(t, ok)
+	assert.Equal(t, customPath, acp.Command)
+	assert.Equal(t, "configured-model", acp.Model)
+}

--- a/internal/agent/acp_test.go
+++ b/internal/agent/acp_test.go
@@ -982,18 +982,19 @@ func TestACPNameDoesNotMatchCanonicalRequest(t *testing.T) {
 
 func TestGetAvailableWithConfigAppliesClaudeCodeCmd(t *testing.T) {
 	fakeBin := t.TempDir()
-	binName := "claude"
+	binName := "claude-wrapper"
 	if runtime.GOOS == "windows" {
 		binName += ".exe"
 	}
+	wrapperPath := filepath.Join(fakeBin, binName)
 	err := os.WriteFile(
-		filepath.Join(fakeBin, binName),
+		wrapperPath,
 		[]byte("#!/bin/sh\nexit 0\n"), 0o755,
 	)
 	require.NoError(t, err)
 	t.Setenv("PATH", fakeBin)
 
-	cfg := &config.Config{ClaudeCodeCmd: "/custom/claude-wrapper"}
+	cfg := &config.Config{ClaudeCodeCmd: wrapperPath}
 
 	resolved, err := GetAvailableWithConfig("", "claude-code", cfg)
 	require.NoError(t, err)
@@ -1001,7 +1002,7 @@ func TestGetAvailableWithConfigAppliesClaudeCodeCmd(t *testing.T) {
 	ca, ok := resolved.(CommandAgent)
 	require.True(t, ok, "resolved agent should implement CommandAgent")
 	assert.Equal(t, "claude-code", resolved.Name())
-	assert.Equal(t, "/custom/claude-wrapper", ca.CommandName(),
+	assert.Equal(t, wrapperPath, ca.CommandName(),
 		"configured claude_code_cmd should override the default command")
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -329,7 +329,13 @@ func applyResolvedCommand(a Agent) Agent {
 	if !ok || spec.CloneWithCommand == nil {
 		return a
 	}
-	return spec.CloneWithCommand(a, command)
+	resolved := spec.CloneWithCommand(a, command)
+	if gemini, ok := resolved.(*GeminiAgent); ok {
+		clone := *gemini
+		clone.CommandAuto = true
+		return &clone
+	}
+	return resolved
 }
 
 // syncWriter wraps an io.Writer with mutex protection for concurrent writes.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -580,7 +580,7 @@ func TestGetAvailablePrefersAntigravityForGemini(t *testing.T) {
 	assert.True(t, gemini.CommandAuto)
 }
 
-func TestGeminiWithModelUsesLegacyCommandWhenAutoSelectedAntigravity(t *testing.T) {
+func TestGeminiWithModelKeepsAutoSelectedAntigravity(t *testing.T) {
 	fakeBin := t.TempDir()
 	for _, bin := range []string{"agy", "gemini"} {
 		name := bin
@@ -604,9 +604,58 @@ func TestGeminiWithModelUsesLegacyCommandWhenAutoSelectedAntigravity(t *testing.
 	withModel := resolved.WithModel("gemini-1.5-pro")
 	require.IsType(t, &GeminiAgent{}, withModel)
 	gemini := withModel.(*GeminiAgent)
-	assert.Equal(t, "gemini", gemini.CommandName())
+	assert.Equal(t, "agy", gemini.CommandName())
 	assert.True(t, gemini.ModelExplicit)
+	assert.True(t, gemini.CommandAuto)
+	assert.NotContains(t, gemini.CommandLine(), "-m")
+}
+
+func TestGetAvailableWithConfigGeminiCmdPinsLegacyCommand(t *testing.T) {
+	fakeBin := t.TempDir()
+	for _, bin := range []string{"agy", "gemini"} {
+		name := bin
+		if runtime.GOOS == "windows" {
+			name += ".exe"
+		}
+		p := filepath.Join(fakeBin, name)
+		require.NoError(t, os.WriteFile(p, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	}
+	t.Setenv("PATH", fakeBin)
+
+	originalRegistry := registry
+	registry = map[string]Agent{
+		"gemini": NewGeminiAgent(""),
+	}
+	t.Cleanup(func() { registry = originalRegistry })
+
+	resolved, err := GetAvailableWithConfig("", "gemini", &config.Config{GeminiCmd: "gemini"})
+	require.NoError(t, err)
+	require.IsType(t, &GeminiAgent{}, resolved)
+	gemini := resolved.(*GeminiAgent)
+	assert.Equal(t, "gemini", gemini.CommandName())
 	assert.False(t, gemini.CommandAuto)
+}
+
+func TestGetAvailableWithConfigGeminiCmdUnavailableDoesNotFallBackToAntigravity(t *testing.T) {
+	fakeBin := t.TempDir()
+	name := "agy"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	p := filepath.Join(fakeBin, name)
+	require.NoError(t, os.WriteFile(p, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("PATH", fakeBin)
+
+	originalRegistry := registry
+	registry = map[string]Agent{
+		"gemini": NewGeminiAgent(""),
+	}
+	t.Cleanup(func() { registry = originalRegistry })
+
+	_, err := GetAvailableWithConfig("", "gemini", &config.Config{GeminiCmd: "gemini"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no agents available")
 }
 
 func TestGetAvailableFallsBackToGeminiWhenAntigravityMissing(t *testing.T) {

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -14,8 +14,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-
-	"go.kenn.io/roborev/internal/procutil"
 )
 
 // ClaudeAgent runs code reviews using Claude Code CLI
@@ -248,7 +246,7 @@ func claudeSupportsDangerousFlag(ctx context.Context, command string) (bool, err
 		return cached.(bool), nil
 	}
 	cmd := exec.CommandContext(ctx, command, "--help")
-	procutil.HideConsole(cmd)
+	configureCapabilityProbe(cmd)
 	output, err := cmd.CombinedOutput()
 	supported := strings.Contains(string(output), claudeDangerousFlag)
 	if err != nil && !supported {
@@ -263,7 +261,7 @@ func claudeSupportsEffortFlag(ctx context.Context, command string) bool {
 		return cached.(bool)
 	}
 	cmd := exec.CommandContext(ctx, command, "--help")
-	procutil.HideConsole(cmd)
+	configureCapabilityProbe(cmd)
 	output, _ := cmd.CombinedOutput()
 	supported := strings.Contains(string(output), claudeEffortFlag)
 	claudeEffortSupport.Store(command, supported)
@@ -281,7 +279,7 @@ func claudeSupportsToolsFlag(ctx context.Context, command string) bool {
 		return cached.(bool)
 	}
 	cmd := exec.CommandContext(ctx, command, "--help")
-	procutil.HideConsole(cmd)
+	configureCapabilityProbe(cmd)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		// Don't cache transient failures.
@@ -690,7 +688,7 @@ func (a *ClaudeAgent) ClassifyWithSchema(
 	}
 	args := a.classifyArgs(schema)
 	cmd := exec.CommandContext(ctx, a.Command, args...)
-	procutil.HideConsole(cmd)
+	configureSubprocess(cmd)
 	cmd.Dir = repoPath
 	env, err := buildClaudeEnv(cmd.Environ(), model, baseURL)
 	if err != nil {

--- a/internal/agent/claude_test.go
+++ b/internal/agent/claude_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"os"
 	"slices"
 	"strings"
 	"testing"
@@ -41,6 +42,38 @@ func assertTools(t *testing.T, args []string, want []string, dontWant []string) 
 	for _, d := range dontWant {
 		assert.NotContains(gotTools, d, "forbidden tool %q", d)
 	}
+}
+
+func TestClaudeHelpProbeUsesExistingWorkingDirectory(t *testing.T) {
+	skipIfWindows(t)
+
+	cmdPath := writeTempCommand(t, `#!/bin/sh
+case "$1" in *etxtbsy*) exit 0;; esac
+if ! pwd >/dev/null 2>&1; then
+  echo "getcwd: cannot access parent directories" >&2
+  exit 1
+fi
+if [ "$1" = "--help" ]; then
+  echo "--dangerously-skip-permissions"
+  exit 0
+fi
+exit 1
+`)
+
+	originalWD, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(originalWD))
+	})
+
+	deletedWD := t.TempDir()
+	require.NoError(t, os.Chdir(deletedWD))
+	require.NoError(t, os.RemoveAll(deletedWD))
+
+	supported, err := claudeSupportsDangerousFlag(context.Background(), cmdPath)
+
+	require.NoError(t, err)
+	assert.True(t, supported)
 }
 
 func TestClaudeBuildArgs(t *testing.T) {

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -10,8 +10,6 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
-
-	"go.kenn.io/roborev/internal/procutil"
 )
 
 // CodexAgent runs code reviews using the Codex CLI
@@ -226,7 +224,7 @@ func codexSupportsDangerousFlag(ctx context.Context, command string, ignoreUserC
 		return cached.(bool), nil
 	}
 	cmd := exec.CommandContext(ctx, command, codexExecHelpArgs(ignoreUserConfig)...)
-	procutil.HideConsole(cmd)
+	configureCapabilityProbe(cmd)
 	output, err := cmd.CombinedOutput()
 	supported := strings.Contains(string(output), codexDangerousFlag)
 	if err != nil && !supported {
@@ -247,7 +245,7 @@ func codexSupportsNonInteractive(ctx context.Context, command string, ignoreUser
 		return cached.(bool), nil
 	}
 	cmd := exec.CommandContext(ctx, command, codexExecHelpArgs(ignoreUserConfig)...)
-	procutil.HideConsole(cmd)
+	configureCapabilityProbe(cmd)
 	output, err := cmd.CombinedOutput()
 	supported := strings.Contains(string(output), "--sandbox")
 	if err != nil && !supported {
@@ -287,7 +285,7 @@ func codexSupportsIgnoreUserConfig(ctx context.Context, command string) (bool, e
 	}
 
 	cmd := exec.CommandContext(ctx, command, "exec", codexIgnoreUserConfigFlag, "--help")
-	procutil.HideConsole(cmd)
+	configureCapabilityProbe(cmd)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -9,8 +9,6 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
-
-	"go.kenn.io/roborev/internal/procutil"
 )
 
 var (
@@ -26,7 +24,7 @@ func copilotSupportsAllowAllTools(ctx context.Context, command string) (bool, er
 		return cached.(bool), nil
 	}
 	cmd := exec.CommandContext(ctx, command, "--help")
-	procutil.HideConsole(cmd)
+	configureCapabilityProbe(cmd)
 	output, err := cmd.CombinedOutput()
 	supported := strings.Contains(string(output), "--allow-all-tools")
 	if err != nil && !supported {
@@ -44,7 +42,7 @@ func copilotSupportsStreamOff(ctx context.Context, command string) (bool, error)
 		return cached.(bool), nil
 	}
 	cmd := exec.CommandContext(ctx, command, "--help")
-	procutil.HideConsole(cmd)
+	configureCapabilityProbe(cmd)
 	output, err := cmd.CombinedOutput()
 	supported := strings.Contains(string(output), "--stream")
 	if err != nil && !supported {

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"os/exec"
 	"path"
 	"strings"
 )
@@ -85,12 +84,6 @@ func (a *GeminiAgent) WithModel(model string) Agent {
 	}
 	clone := a.clone(withClonedModel(model))
 	clone.ModelExplicit = true
-	if clone.usesAntigravity() && clone.CommandAuto {
-		if _, err := exec.LookPath("gemini"); err == nil {
-			clone.Command = "gemini"
-			clone.CommandAuto = false
-		}
-	}
 	return clone
 }
 

--- a/internal/agent/gemini_test.go
+++ b/internal/agent/gemini_test.go
@@ -336,6 +336,26 @@ func TestGeminiAntigravityExplicitModelFailsClearly(t *testing.T) {
 	assert.Contains(t, err.Error(), "does not support explicit Gemini model selection")
 }
 
+func TestGeminiAutoSelectedAntigravityExplicitModelFailsClearly(t *testing.T) {
+	skipIfWindows(t)
+
+	scriptPath := writeTempCommand(t, `#!/bin/sh
+case "$1" in *etxtbsy*) exit 0;; esac
+echo "unexpected antigravity invocation"
+`)
+	agyPath := filepath.Join(filepath.Dir(scriptPath), "agy")
+	require.NoError(t, os.Rename(scriptPath, agyPath))
+
+	a := NewGeminiAgent(agyPath)
+	a.CommandAuto = true
+	a = a.WithModel("gemini-1.5-pro").(*GeminiAgent)
+
+	_, err := a.Review(context.Background(), t.TempDir(), "sha", "prompt", nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support explicit Gemini model selection")
+}
+
 func TestGemini_Review_Integration(t *testing.T) {
 	skipIfWindows(t)
 

--- a/internal/agent/process.go
+++ b/internal/agent/process.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"io"
 	"io/fs"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -54,6 +56,18 @@ func configureSubprocess(cmd *exec.Cmd) *subprocessTracker {
 		return err
 	}
 	return tracker
+}
+
+func configureCapabilityProbe(cmd *exec.Cmd) {
+	procutil.HideConsole(cmd)
+	if cmd.Path != "" &&
+		!filepath.IsAbs(cmd.Path) &&
+		strings.ContainsAny(cmd.Path, `/\`) {
+		if absPath, err := filepath.Abs(cmd.Path); err == nil {
+			cmd.Path = absPath
+		}
+	}
+	cmd.Dir = os.TempDir()
 }
 
 func closeOnContextDone(ctx context.Context, c io.Closer) func() {

--- a/internal/agent/process_test.go
+++ b/internal/agent/process_test.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -167,6 +168,25 @@ func TestConfigureSubprocessPreservesPWD(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, dir+"\n", string(out),
 		"configureSubprocess should preserve PWD matching cmd.Dir")
+}
+
+func TestConfigureCapabilityProbePreservesRelativeCommandPath(t *testing.T) {
+	skipIfWindows(t)
+
+	repoDir := t.TempDir()
+	binDir := filepath.Join(repoDir, "bin")
+	require.NoError(t, os.Mkdir(binDir, 0o755))
+	commandPath := filepath.Join(binDir, "codex")
+	require.NoError(t, os.WriteFile(commandPath, []byte("#!/bin/sh\necho probe-ok\n"), 0o755))
+	t.Chdir(repoDir)
+
+	cmd := exec.CommandContext(context.Background(), "./bin/codex", "--help")
+	configureCapabilityProbe(cmd)
+
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	require.Equal(t, "probe-ok\n", string(out))
+	require.Equal(t, os.TempDir(), cmd.Dir)
 }
 
 func TestConfigureSubprocessDoesNotMarkCanceledWhenProcessAlreadyExited(t *testing.T) {

--- a/internal/agent/spec.go
+++ b/internal/agent/spec.go
@@ -57,6 +57,9 @@ var allAgentSpecs = []agentSpec{
 		Name:           "gemini",
 		DefaultCommand: "gemini",
 		FallbackRank:   3,
+		CommandOverride: func(cfg *config.Config) string {
+			return cfg.GeminiCmd
+		},
 		CloneWithCommand: func(a Agent, command string) Agent {
 			agent, ok := a.(*GeminiAgent)
 			if !ok {
@@ -64,7 +67,7 @@ var allAgentSpecs = []agentSpec{
 			}
 			clone := *agent
 			clone.Command = command
-			clone.CommandAuto = true
+			clone.CommandAuto = false
 			return &clone
 		},
 	},

--- a/internal/agent/spec_test.go
+++ b/internal/agent/spec_test.go
@@ -51,6 +51,7 @@ func TestAgentSpecsCommandOverrides(t *testing.T) {
 	cfg := &config.Config{
 		CodexCmd:      "custom-codex",
 		ClaudeCodeCmd: "custom-claude",
+		GeminiCmd:     "custom-gemini",
 		CursorCmd:     "custom-cursor",
 		PiCmd:         "custom-pi",
 		OpenCodeCmd:   "custom-opencode",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -214,6 +214,7 @@ type Config struct {
 	// Agent commands
 	CodexCmd      string `toml:"codex_cmd"`
 	ClaudeCodeCmd string `toml:"claude_code_cmd"`
+	GeminiCmd     string `toml:"gemini_cmd"`
 	CursorCmd     string `toml:"cursor_cmd"`
 	PiCmd         string `toml:"pi_cmd"`
 	OpenCodeCmd   string `toml:"opencode_cmd"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -43,6 +43,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, 10*time.Second, cfg.Cost.ResolvedTimeout())
 	assert.Equal(t, "30m0s", cfg.AgentQuotaCooldown)
 	assert.Equal(t, 30*time.Minute, ResolveAgentQuotaCooldown(cfg))
+	assert.Empty(t, cfg.GeminiCmd)
 }
 
 func TestDataDir(t *testing.T) {

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -1002,13 +1002,16 @@ func (wp *WorkerPool) autoClosePassingReview(workerID string, job *storage.Revie
 }
 
 func applyCodexReviewSettings(a agent.Agent, job *storage.ReviewJob, cfg *config.Config) agent.Agent {
-	if !job.IsReviewJob() {
+	if !job.IsReviewJob() && !job.UsesStoredPrompt() {
 		return a
 	}
 	a = agent.WithCodexSkillsDisabled(
 		a,
 		config.ResolveDisableCodexReviewSkills(job.RepoPath, cfg),
 	)
+	if !job.IsReviewJob() {
+		return a
+	}
 	a = agent.WithCodexUserConfigIgnored(
 		a,
 		config.ResolveIgnoreCodexReviewUserConfig(job.RepoPath, cfg),
@@ -1222,9 +1225,10 @@ func (wp *WorkerPool) resolveBackupAgent(job *storage.ReviewJob) string {
 	if backup == "" {
 		return ""
 	}
-	// Canonicalize and verify availability using the config-aware path so
-	// command overrides and configured ACP aliases participate in failover.
-	resolved, err := agent.GetPreferredOrBackupWithConfig(job.RepoPath, backup, cfg)
+	// Resolve exactly the configured backup using the config-aware path so
+	// command overrides and configured ACP aliases participate in failover
+	// without falling through to unrelated agents.
+	resolved, err := agent.GetAvailableExactWithConfig(job.RepoPath, backup, cfg)
 	if err != nil {
 		return ""
 	}

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -1212,45 +1212,52 @@ func TestShouldAppendReviewJobLogOnlyForFirstAutoDesignAttempt(t *testing.T) {
 	assert.False(t, shouldAppendReviewJobLog(job))
 }
 
-func TestApplyCodexReviewSettingsOnlyForReviewJobs(t *testing.T) {
+func TestApplyCodexReviewSettings(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Agent.Codex.DisableReviewSkills = true
 	cfg.Agent.Codex.IgnoreReviewUserConfig = true
 
 	tests := []struct {
-		name string
-		job  storage.ReviewJob
-		want bool
+		name       string
+		job        storage.ReviewJob
+		wantSkills bool
+		wantIgnore bool
 	}{
 		{
-			name: "single commit review",
-			job:  storage.ReviewJob{JobType: storage.JobTypeReview},
-			want: true,
+			name:       "single commit review",
+			job:        storage.ReviewJob{JobType: storage.JobTypeReview},
+			wantSkills: true,
+			wantIgnore: true,
 		},
 		{
-			name: "range review",
-			job:  storage.ReviewJob{JobType: storage.JobTypeRange},
-			want: true,
+			name:       "range review",
+			job:        storage.ReviewJob{JobType: storage.JobTypeRange},
+			wantSkills: true,
+			wantIgnore: true,
 		},
 		{
-			name: "dirty review",
-			job:  storage.ReviewJob{JobType: storage.JobTypeDirty},
-			want: true,
+			name:       "dirty review",
+			job:        storage.ReviewJob{JobType: storage.JobTypeDirty},
+			wantSkills: true,
+			wantIgnore: true,
 		},
 		{
-			name: "task job",
-			job:  storage.ReviewJob{JobType: storage.JobTypeTask},
-			want: false,
+			name:       "task job",
+			job:        storage.ReviewJob{JobType: storage.JobTypeTask},
+			wantSkills: true,
+			wantIgnore: false,
 		},
 		{
-			name: "classify job",
-			job:  storage.ReviewJob{JobType: storage.JobTypeClassify},
-			want: false,
+			name:       "classify job",
+			job:        storage.ReviewJob{JobType: storage.JobTypeClassify},
+			wantSkills: false,
+			wantIgnore: false,
 		},
 		{
-			name: "fix job",
-			job:  storage.ReviewJob{JobType: storage.JobTypeFix},
-			want: false,
+			name:       "fix job",
+			job:        storage.ReviewJob{JobType: storage.JobTypeFix},
+			wantSkills: true,
+			wantIgnore: false,
 		},
 	}
 
@@ -1259,8 +1266,8 @@ func TestApplyCodexReviewSettingsOnlyForReviewJobs(t *testing.T) {
 			got := applyCodexReviewSettings(agent.NewCodexAgent("codex"), &tt.job, cfg)
 			codexAgent, ok := got.(*agent.CodexAgent)
 			require.True(t, ok)
-			assert.Equal(t, tt.want, codexAgent.SuppressSkillInstructions)
-			assert.Equal(t, tt.want, codexAgent.IgnoreUserConfig)
+			assert.Equal(t, tt.wantSkills, codexAgent.SuppressSkillInstructions)
+			assert.Equal(t, tt.wantIgnore, codexAgent.IgnoreUserConfig)
 		})
 	}
 }
@@ -2060,6 +2067,64 @@ func TestResolveBackupAgentUsesConfiguredCommandOverride(t *testing.T) {
 	}
 
 	assert.Equal(t, "claude-code", pool.resolveBackupAgent(job))
+}
+
+func TestResolveBackupAgentUsesConfigCommandOverride(t *testing.T) {
+	fakeBin := t.TempDir()
+	wrapper := "gemini-wrapper"
+	if runtime.GOOS == "windows" {
+		wrapper += ".exe"
+	}
+	wrapperPath := filepath.Join(fakeBin, wrapper)
+	require.NoError(t, os.WriteFile(wrapperPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("PATH", fakeBin)
+
+	cfg := config.DefaultConfig()
+	cfg.ReviewBackupAgent = "gemini"
+	cfg.GeminiCmd = wrapperPath
+	pool := NewWorkerPool(nil, NewStaticConfig(cfg), 1, NewBroadcaster(), nil, nil)
+	job := &storage.ReviewJob{Agent: "codex", RepoPath: t.TempDir()}
+
+	assert.Equal(t, "gemini", pool.resolveBackupAgent(job))
+}
+
+func TestResolveBackupAgentConfiguredCommandMissingDoesNotUseDefaultCandidate(t *testing.T) {
+	fakeBin := t.TempDir()
+	agy := "agy"
+	if runtime.GOOS == "windows" {
+		agy += ".exe"
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(fakeBin, agy), []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("PATH", fakeBin)
+
+	cfg := config.DefaultConfig()
+	cfg.ReviewBackupAgent = "gemini"
+	cfg.GeminiCmd = "gemini"
+	pool := NewWorkerPool(nil, NewStaticConfig(cfg), 1, NewBroadcaster(), nil, nil)
+	job := &storage.ReviewJob{Agent: "codex", RepoPath: t.TempDir()}
+
+	assert.Empty(t, pool.resolveBackupAgent(job))
+}
+
+func TestResolveBackupAgentUsesConfiguredACPName(t *testing.T) {
+	fakeBin := t.TempDir()
+	acp := "custom-acp"
+	script := "#!/bin/sh\nexit 0\n"
+	if runtime.GOOS == "windows" {
+		acp += ".cmd"
+		script = "@echo off\r\nexit /b 0\r\n"
+	}
+	acpPath := filepath.Join(fakeBin, acp)
+	require.NoError(t, os.WriteFile(acpPath, []byte(script), 0o755))
+	t.Setenv("PATH", fakeBin)
+
+	cfg := config.DefaultConfig()
+	cfg.ReviewBackupAgent = "my-acp"
+	cfg.ACP = &config.ACPAgentConfig{Name: "my-acp", Command: acpPath}
+	pool := NewWorkerPool(nil, NewStaticConfig(cfg), 1, NewBroadcaster(), nil, nil)
+	job := &storage.ReviewJob{Agent: "codex", RepoPath: t.TempDir()}
+
+	assert.Equal(t, "acp", pool.resolveBackupAgent(job))
 }
 
 func TestFailOrRetryInner_QuotaSkipsRetries(t *testing.T) {


### PR DESCRIPTION
Analyze jobs exposed daemon-side assumptions that made agent startup unreliable in common local setups. Gemini command auto-selection could be undone after model resolution, causing `--agent gemini` to launch the legacy Gemini CLI even when Antigravity was available. Agent capability probes also inherited the daemon process cwd, so a deleted worktree could break startup before the agent reached the intended repo checkout. Codex analyze jobs had a separate prompt-contamination issue: stored prompts are already the task contract, but Codex still loaded ambient skill instructions.

This keeps auto-selected Antigravity on the Antigravity path, runs capability probes from a stable temporary directory, and suppresses Codex skill instructions for stored-prompt jobs while preserving review-only user-config isolation. The reviewer-facing behavior is that `roborev analyze` should invoke the selected agent more predictably without pulling unrelated skill workflows into the analysis prompt.