### PR TITLE
Parse Copilot JSON review output

### DIFF
--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -216,7 +216,11 @@ func (a *CopilotAgent) Review(ctx context.Context, repoPath, commitSHA, prompt s
 
 	var stdout, stderr bytes.Buffer
 	if sw := newSyncWriter(output); sw != nil {
-		cmd.Stdout = io.MultiWriter(&stdout, sw)
+		if supportsJSONOutput {
+			cmd.Stdout = &stdout
+		} else {
+			cmd.Stdout = io.MultiWriter(&stdout, sw)
+		}
 		cmd.Stderr = io.MultiWriter(&stderr, sw)
 	} else {
 		cmd.Stdout = &stdout
@@ -232,12 +236,19 @@ func (a *CopilotAgent) Review(ctx context.Context, repoPath, commitSHA, prompt s
 
 	result := stdout.String()
 	if supportsJSONOutput {
+		if sessionCapture, ok := output.(*SessionCaptureWriter); ok {
+			sessionCapture.capture([]byte(result))
+		}
 		parsed, parseErr := parseCopilotJSON(strings.NewReader(result))
 		if parseErr != nil && !errors.Is(parseErr, errNoCopilotJSON) {
 			return "", parseErr
 		}
 		if parsed != "" {
+			writeCopilotReviewOutput(output, parsed)
 			return parsed, nil
+		}
+		if errors.Is(parseErr, errNoCopilotJSON) {
+			writeCopilotReviewOutput(output, result)
 		}
 	}
 	if len(result) == 0 {
@@ -245,6 +256,20 @@ func (a *CopilotAgent) Review(ctx context.Context, repoPath, commitSHA, prompt s
 	}
 
 	return result, nil
+}
+
+func writeCopilotReviewOutput(output io.Writer, text string) {
+	if text == "" {
+		return
+	}
+	sw := newSyncWriter(output)
+	if sw == nil {
+		return
+	}
+	if !strings.HasSuffix(text, "\n") {
+		text += "\n"
+	}
+	_, _ = sw.Write([]byte(text))
 }
 
 func (a *CopilotAgent) commandArgs(

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -12,9 +14,13 @@ import (
 )
 
 var (
-	copilotAllowAllToolsSupport sync.Map
-	copilotStreamOffSupport     sync.Map
+	copilotAllowAllToolsSupport      sync.Map
+	copilotStreamOffSupport          sync.Map
+	copilotJSONOutputSupport         sync.Map
+	copilotDisableBuiltInMCPsSupport sync.Map
 )
+
+var errNoCopilotJSON = errors.New("no valid copilot JSON events parsed from output")
 
 // copilotSupportsAllowAllTools checks whether the copilot binary supports
 // the --allow-all-tools flag needed for non-interactive tool approval.
@@ -52,6 +58,36 @@ func copilotSupportsStreamOff(ctx context.Context, command string) (bool, error)
 	return supported, nil
 }
 
+func copilotSupportsJSONOutput(ctx context.Context, command string) (bool, error) {
+	if cached, ok := copilotJSONOutputSupport.Load(command); ok {
+		return cached.(bool), nil
+	}
+	cmd := exec.CommandContext(ctx, command, "--help")
+	configureCapabilityProbe(cmd)
+	output, err := cmd.CombinedOutput()
+	supported := strings.Contains(string(output), "--output-format")
+	if err != nil && !supported {
+		return false, fmt.Errorf("check %s --help: %w: %s", command, err, output)
+	}
+	copilotJSONOutputSupport.Store(command, supported)
+	return supported, nil
+}
+
+func copilotSupportsDisableBuiltInMCPs(ctx context.Context, command string) (bool, error) {
+	if cached, ok := copilotDisableBuiltInMCPsSupport.Load(command); ok {
+		return cached.(bool), nil
+	}
+	cmd := exec.CommandContext(ctx, command, "--help")
+	configureCapabilityProbe(cmd)
+	output, err := cmd.CombinedOutput()
+	supported := strings.Contains(string(output), "--disable-builtin-mcps")
+	if err != nil && !supported {
+		return false, fmt.Errorf("check %s --help: %w: %s", command, err, output)
+	}
+	copilotDisableBuiltInMCPsSupport.Store(command, supported)
+	return supported, nil
+}
+
 // copilotReviewDenyTools lists tools denied in review mode to enforce read-only
 // behavior. Deny rules take precedence over --allow-all-tools in copilot's
 // permission system.
@@ -72,7 +108,7 @@ var copilotReviewDenyTools = []string{
 // In review mode, destructive tools are denied. In agentic mode, all tools
 // are allowed without restriction.
 func (a *CopilotAgent) buildArgs(agenticMode bool) []string {
-	return a.commandArgs(agenticMode, true, true)
+	return a.commandArgs(agenticMode, true, true, true, true)
 }
 
 // CopilotAgent runs code reviews using the GitHub Copilot CLI
@@ -138,7 +174,7 @@ func (a *CopilotAgent) CommandName() string {
 
 func (a *CopilotAgent) CommandLine() string {
 	agenticMode := a.Agentic || AllowUnsafeAgents()
-	args := a.commandArgs(agenticMode, false, false)
+	args := a.commandArgs(agenticMode, false, false, false, false)
 	return a.Command + " " + strings.Join(args, " ")
 }
 
@@ -155,7 +191,23 @@ func (a *CopilotAgent) Review(ctx context.Context, repoPath, commitSHA, prompt s
 		log.Printf("copilot: cannot detect --stream support: %v", err)
 	}
 
-	args := a.commandArgs(agenticMode, supportsAllowAllTools, supportsStreamOff)
+	supportsJSONOutput, err := copilotSupportsJSONOutput(ctx, a.Command)
+	if err != nil {
+		log.Printf("copilot: cannot detect --output-format support: %v", err)
+	}
+
+	supportsDisableBuiltInMCPs, err := copilotSupportsDisableBuiltInMCPs(ctx, a.Command)
+	if err != nil {
+		log.Printf("copilot: cannot detect --disable-builtin-mcps support: %v", err)
+	}
+
+	args := a.commandArgs(
+		agenticMode,
+		supportsAllowAllTools,
+		supportsStreamOff,
+		supportsJSONOutput,
+		supportsDisableBuiltInMCPs,
+	)
 
 	cmd := exec.CommandContext(ctx, a.Command, args...)
 	cmd.Stdin = strings.NewReader(prompt)
@@ -179,6 +231,15 @@ func (a *CopilotAgent) Review(ctx context.Context, repoPath, commitSHA, prompt s
 	}
 
 	result := stdout.String()
+	if supportsJSONOutput {
+		parsed, parseErr := parseCopilotJSON(strings.NewReader(result))
+		if parseErr != nil && !errors.Is(parseErr, errNoCopilotJSON) {
+			return "", parseErr
+		}
+		if parsed != "" {
+			return parsed, nil
+		}
+	}
 	if len(result) == 0 {
 		return "No review output generated", nil
 	}
@@ -186,13 +247,21 @@ func (a *CopilotAgent) Review(ctx context.Context, repoPath, commitSHA, prompt s
 	return result, nil
 }
 
-func (a *CopilotAgent) commandArgs(agenticMode, includePermissions, includeStreamOff bool) []string {
+func (a *CopilotAgent) commandArgs(
+	agenticMode, includePermissions, includeStreamOff, includeJSONOutput, includeDisableBuiltInMCPs bool,
+) []string {
 	args := []string{}
 	if includePermissions {
 		args = append(args, "-s", "--allow-all-tools")
 	}
 	if includeStreamOff {
 		args = append(args, "--stream", "off")
+	}
+	if includeJSONOutput {
+		args = append(args, "--output-format", "json")
+	}
+	if includeDisableBuiltInMCPs && !agenticMode {
+		args = append(args, "--disable-builtin-mcps")
 	}
 	if a.Model != "" {
 		args = append(args, "--model", a.Model)
@@ -203,6 +272,56 @@ func (a *CopilotAgent) commandArgs(agenticMode, includePermissions, includeStrea
 		}
 	}
 	return args
+}
+
+type copilotEvent struct {
+	Type string `json:"type"`
+	Data struct {
+		MessageID    string            `json:"messageId,omitempty"`
+		Content      string            `json:"content,omitempty"`
+		ToolCalls    []json.RawMessage `json:"toolCalls,omitempty"`
+		ToolRequests []json.RawMessage `json:"toolRequests,omitempty"`
+	} `json:"data,omitempty"`
+}
+
+func parseCopilotJSON(r io.Reader) (string, error) {
+	var validEventsParsed bool
+	assistantMessages := newTrailingReviewText()
+
+	err := scanStreamJSONLines(r, nil, func(line string) error {
+		var ev copilotEvent
+		if jsonErr := json.Unmarshal([]byte(line), &ev); jsonErr != nil {
+			return nil
+		}
+		if ev.Type == "" {
+			return nil
+		}
+		validEventsParsed = true
+
+		if ev.Type == "assistant.tool_call" ||
+			ev.Type == "assistant.tool_result" ||
+			strings.HasPrefix(ev.Type, "tool.") {
+			assistantMessages.ResetAfterTool()
+		}
+
+		if ev.Type == "assistant.message" {
+			if len(ev.Data.ToolCalls) > 0 || len(ev.Data.ToolRequests) > 0 {
+				assistantMessages.ResetAfterTool()
+				return nil
+			}
+			if ev.Data.Content != "" {
+				assistantMessages.AddWithID(ev.Data.MessageID, ev.Data.Content)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	if !validEventsParsed {
+		return "", errNoCopilotJSON
+	}
+	return assistantMessages.Join("\n"), nil
 }
 
 func init() {

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -237,7 +237,7 @@ func (a *CopilotAgent) Review(ctx context.Context, repoPath, commitSHA, prompt s
 	result := stdout.String()
 	if supportsJSONOutput {
 		if sessionCapture, ok := output.(*SessionCaptureWriter); ok {
-			sessionCapture.capture([]byte(result))
+			sessionCapture.capture([]byte(lineTerminated(result)))
 		}
 		parsed, parseErr := parseCopilotJSON(strings.NewReader(result))
 		if parseErr != nil && !errors.Is(parseErr, errNoCopilotJSON) {
@@ -258,6 +258,13 @@ func (a *CopilotAgent) Review(ctx context.Context, repoPath, commitSHA, prompt s
 	return result, nil
 }
 
+func lineTerminated(text string) string {
+	if text == "" || strings.HasSuffix(text, "\n") {
+		return text
+	}
+	return text + "\n"
+}
+
 func writeCopilotReviewOutput(output io.Writer, text string) {
 	if text == "" {
 		return
@@ -266,10 +273,7 @@ func writeCopilotReviewOutput(output io.Writer, text string) {
 	if sw == nil {
 		return
 	}
-	if !strings.HasSuffix(text, "\n") {
-		text += "\n"
-	}
-	_, _ = sw.Write([]byte(text))
+	_, _ = sw.Write([]byte(lineTerminated(text)))
 }
 
 func (a *CopilotAgent) commandArgs(

--- a/internal/agent/copilot_test.go
+++ b/internal/agent/copilot_test.go
@@ -84,6 +84,29 @@ func TestCopilotReviewParsesJSONOutput(t *testing.T) {
 	assert.Contains(t, args, "--disable-builtin-mcps")
 }
 
+func TestCopilotReviewJSONOutputCapturesSessionIDWithoutTrailingNewline(t *testing.T) {
+	skipIfWindows(t)
+
+	cmdPath := writeTempCommand(t, `#!/bin/sh
+case "$*" in *--help*) echo "--allow-all-tools --stream --output-format"; exit 0;; esac
+printf '%s\n%s' \
+'{"type":"assistant.message","data":{"messageId":"msg-1","content":"No issues found.","toolRequests":[]}}' \
+'{"type":"result","exitCode":0,"sessionId":"session-no-newline"}'
+`)
+	a := NewCopilotAgent(cmdPath)
+
+	var output bytes.Buffer
+	sessionWriter := NewSessionCaptureWriter(&output, nil)
+	res, err := a.Review(context.Background(), t.TempDir(), "HEAD", "prompt", sessionWriter)
+	sessionWriter.Flush()
+
+	require.NoError(t, err)
+	assert.Equal(t, "No issues found.", res)
+	assert.Equal(t, "session-no-newline", sessionWriter.SessionID())
+	assert.Contains(t, output.String(), "No issues found.")
+	assert.NotContains(t, output.String(), "assistant.message")
+}
+
 func TestCopilotReviewJSONOutputUsesLatestMessageContentByID(t *testing.T) {
 	skipIfWindows(t)
 

--- a/internal/agent/copilot_test.go
+++ b/internal/agent/copilot_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"strings"
@@ -69,10 +70,13 @@ func TestCopilotReviewParsesJSONOutput(t *testing.T) {
 	})
 	a := NewCopilotAgent(mock.CmdPath)
 
-	res, err := a.Review(context.Background(), t.TempDir(), "HEAD", "prompt", nil)
+	var output bytes.Buffer
+	res, err := a.Review(context.Background(), t.TempDir(), "HEAD", "prompt", &output)
 
 	require.NoError(t, err)
 	assert.Equal(t, "Full review output", res)
+	assert.Contains(t, output.String(), "Full review output")
+	assert.NotContains(t, output.String(), "assistant.message")
 	assertFileContent(t, mock.StdinFile, "prompt")
 
 	args := readFileContent(t, mock.ArgsFile)

--- a/internal/agent/copilot_test.go
+++ b/internal/agent/copilot_test.go
@@ -54,6 +54,70 @@ func TestCopilotSupportsStreamOff(t *testing.T) {
 	})
 }
 
+func TestCopilotReviewParsesJSONOutput(t *testing.T) {
+	skipIfWindows(t)
+
+	mock := mockAgentCLI(t, MockCLIOpts{
+		HelpOutput:   "--allow-all-tools\n--stream\n--output-format\n--disable-builtin-mcps",
+		CaptureArgs:  true,
+		CaptureStdin: true,
+		StdoutLines: []string{
+			`{"type":"session.mcp_servers_loaded","data":{"servers":[{"name":"github-mcp-server","status":"disabled"}]}}`,
+			`{"type":"assistant.message","data":{"messageId":"msg-1","content":"Full review output","toolRequests":[]}}`,
+			`{"type":"result","exitCode":0,"sessionId":"session-1"}`,
+		},
+	})
+	a := NewCopilotAgent(mock.CmdPath)
+
+	res, err := a.Review(context.Background(), t.TempDir(), "HEAD", "prompt", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Full review output", res)
+	assertFileContent(t, mock.StdinFile, "prompt")
+
+	args := readFileContent(t, mock.ArgsFile)
+	assert.Contains(t, args, "--output-format json")
+	assert.Contains(t, args, "--disable-builtin-mcps")
+}
+
+func TestCopilotReviewJSONOutputUsesLatestMessageContentByID(t *testing.T) {
+	skipIfWindows(t)
+
+	mock := mockAgentCLI(t, MockCLIOpts{
+		HelpOutput: "--allow-all-tools\n--stream\n--output-format",
+		StdoutLines: []string{
+			`{"type":"assistant.message","data":{"messageId":"msg-1","content":"Adds","toolRequests":[]}}`,
+			`{"type":"assistant.message","data":{"messageId":"msg-1","content":"Adds a README update.\nNo issues found.","toolRequests":[]}}`,
+			`{"type":"result","exitCode":0}`,
+		},
+	})
+	a := NewCopilotAgent(mock.CmdPath)
+
+	res, err := a.Review(context.Background(), t.TempDir(), "HEAD", "prompt", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Adds a README update.\nNo issues found.", res)
+}
+
+func TestCopilotReviewJSONOutputDropsToolRequestPreamble(t *testing.T) {
+	skipIfWindows(t)
+
+	mock := mockAgentCLI(t, MockCLIOpts{
+		HelpOutput: "--allow-all-tools\n--stream\n--output-format",
+		StdoutLines: []string{
+			`{"type":"assistant.message","data":{"messageId":"msg-1","content":"I'll inspect the files first.","toolRequests":[{"name":"read_file"}]}}`,
+			`{"type":"assistant.message","data":{"messageId":"msg-2","content":"No issues found.\nSummary: Updates docs.","toolRequests":[]}}`,
+			`{"type":"result","exitCode":0}`,
+		},
+	})
+	a := NewCopilotAgent(mock.CmdPath)
+
+	res, err := a.Review(context.Background(), t.TempDir(), "HEAD", "prompt", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "No issues found.\nSummary: Updates docs.", res)
+}
+
 func TestCopilotBuildArgs(t *testing.T) {
 	a := NewCopilotAgent("copilot")
 

--- a/internal/streamfmt/streamfmt.go
+++ b/internal/streamfmt/streamfmt.go
@@ -322,6 +322,7 @@ func (f *Formatter) processLine(line string) {
 
 	var ev streamEvent
 	if err := json.Unmarshal([]byte(line), &ev); err != nil {
+		f.writeText(SanitizeControlKeepNewlines(line))
 		return
 	}
 

--- a/internal/streamfmt/streamfmt_test.go
+++ b/internal/streamfmt/streamfmt_test.go
@@ -112,6 +112,16 @@ func runStreamTestCase(t *testing.T, tc streamTestCase) {
 	})
 }
 
+func TestFormatterTTYRendersPlainText(t *testing.T) {
+	fix := newFixture(true)
+
+	fix.writeLine("No issues found.")
+	fix.writeLine("Summary: Updates docs.")
+
+	fix.assertContains(t, "No issues found.")
+	fix.assertContains(t, "Summary: Updates docs.")
+}
+
 type toolInput struct {
 	FilePath  string `json:"file_path,omitempty"`
 	OldString string `json:"old_string,omitempty"`


### PR DESCRIPTION
Copilot CLI 1.0.64 can produce a complete review in the underlying session while roborev stores only a short text fragment from the process output. That makes successful Copilot reviews look truncated or failing in roborev even when the agent actually finished the review.

This switches the Copilot adapter to prefer the CLI's JSONL output mode when available, so roborev persists the final assistant message content instead of relying on opaque plain stdout. Older Copilot versions stay on the existing text path. Review-mode invocations also disable built-in MCP servers when supported, which reduces unnecessary GitHub MCP routing for local commit reviews without changing agentic-mode permissions.

The parser treats tool-requesting assistant messages as provisional and keeps the latest content for repeated message IDs, matching the failure mode reported in the issue where a single leading word could be stored before the full review arrived.

Fixes #891