### PR TITLE
Document 0.59.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,9 @@ roborev analyze security ./...              # Find security risks in existing co
 Available types: `test-fixtures`, `duplication`, `refactor`, `complexity`,
 `api-design`, `dead-code`, `architecture`, `security`.
 
-Analysis jobs appear in the review queue. Use `roborev fix <id>` to
-apply findings later, or pass `--fix` to apply immediately.
+Analysis jobs appear in the review queue. Use `roborev fix` to apply
+open findings later, target a specific job with `roborev fix <id>`, or
+pass `--fix` to apply immediately.
 
 ## Installation
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,26 @@ description: Release history for roborev
 
 All notable changes to roborev, grouped by minor release.
 
+## 0.59.2
+<small>2026-06-24</small>
+
+**New features**
+
+- Copilot review output now prefers structured JSON when the installed CLI supports it, so roborev can store complete assistant findings instead of truncated process output.
+- `roborev fix` now includes completed `analyze` jobs when discovering open findings, so queued analysis results can be fixed without passing each job ID explicitly. See [Applying Fixes from Analysis](/guides/assisted-refactoring/#applying-fixes-from-analysis).
+
+**Improvements**
+
+- Homebrew tap updates now open pull requests against `kenn-io/homebrew-tap` instead of pushing directly to the protected tap branch.
+- Workflow-configured reviews, fixes, panels, CI members, and synthesis now use only the preferred agent or an explicitly configured backup. See [Backup Agents](/configuration/#backup-agents).
+- `roborev analyze` agent invocation is more stable across local setups, including Gemini/Antigravity selection, capability probes from deleted worktrees, and Codex stored-prompt jobs.
+
+**Bug fixes**
+
+- Quota-only or provider-unavailable panel runs no longer store misleading failed synthesis reviews when every member was skipped for availability reasons.
+
+---
+
 ## 0.59.1
 <small>2026-06-22</small>
 

--- a/docs/guides/assisted-refactoring.md
+++ b/docs/guides/assisted-refactoring.md
@@ -46,7 +46,7 @@ roborev analyze api-design 'pkg/api/*.go'
 roborev analyze architecture internal/storage/
 ```
 
-Results appear in the TUI as jobs labeled with their analysis type (e.g. `test-fixtures`, `duplication`). Use `roborev show <job_id>` or the TUI to read findings. You can then use the job IDs to address findings at your discretion with `roborev fix <job_id>`.
+Results appear in the TUI as jobs labeled with their analysis type (e.g. `test-fixtures`, `duplication`). Use `roborev show <job_id>` or the TUI to read findings. You can then run `roborev fix` to address open findings, or pass specific job IDs with `roborev fix <job_id>`.
 
 ## Branch Mode
 
@@ -91,7 +91,7 @@ Per-file mode is useful when:
 `roborev fix` works with any review, not just analysis results. Use it to address commit reviews too:
 
 ```bash
-roborev fix                        # Fix all open reviews on this branch
+roborev fix                        # Fix all open reviews and analysis findings on this branch
 roborev fix 123                    # Fix a specific review by job ID
 roborev fix 42 43 44               # Fix multiple reviews sequentially
 roborev fix --batch                # Batch all open into one agent prompt


### PR DESCRIPTION
The 0.59.2 release includes user-facing changes in review parsing, fix discovery, release publishing, backup agent resolution, analyze stability, and panel availability handling. Those changes should be discoverable from the hosted docs now that the release has been cut, instead of requiring readers to reconstruct behavior from individual implementation PRs.

This also tightens the analysis workflow docs so `roborev fix` guidance matches the release behavior: open analysis findings can be discovered automatically, while explicit job IDs still work for targeted fixes.