### PR TITLE
Add Codex config passthrough for -c overrides

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -808,6 +808,41 @@ ignore_review_user_config = true   # Pass --ignore-user-config to Codex review j
 
 Set either to `false` to restore the prior behavior if you rely on Codex skill instructions or user-level Codex config during reviews.
 
+#### Custom Codex Config (Model Providers)
+
+`ignore_review_user_config` stops Codex review jobs from loading your
+`~/.codex/config.toml`, which also means a custom `model_provider` and its
+`[model_providers.*]` block defined there are not applied. To inject specific
+Codex options without loading your full user config, define an
+`[agent.codex.config]` table. Every key under it is passed to Codex as a
+`-c key=value` override on **every** Codex job (review, fix, refine, analyze),
+and these overrides apply even when `--ignore-user-config` is in effect.
+
+The table mirrors Codex's own `config.toml`, so you can declare a custom
+provider and select it:
+
+```toml
+# ~/.roborev/config.toml
+[agent.codex]
+ignore_review_user_config = true   # safe to leave enabled
+
+[agent.codex.config]
+model_provider = "my-custom"
+
+[agent.codex.config.model_providers.my-custom]
+name = "My Provider"
+base_url = "https://api.example.com/v1"
+env_key = "MY_API_KEY"
+wire_api = "responses"
+```
+
+roborev flattens that into `-c model_provider="my-custom"`,
+`-c model_providers.my-custom.base_url="https://api.example.com/v1"`, and so on,
+one override per leaf key. Values keep their TOML type: strings stay quoted,
+numbers and booleans stay bare, and arrays stay arrays. roborev's own review
+controls (skill suppression, sandbox mode, reasoning effort) are applied after
+your overrides, so they take precedence if a key collides.
+
 ### Pi Classifier Options
 
 Pi can be used as the auto design-review classifier because roborev runs Pi with a JSON schema output extension. The default extension source is `npm:@nqbao/pi-json-schema@0.1.1`.

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -21,6 +21,7 @@ type CodexAgent struct {
 	SessionID                 string         // Existing session/thread ID to resume
 	SuppressSkillInstructions bool           // Whether to suppress Codex skill instructions
 	IgnoreUserConfig          bool           // Whether to pass --ignore-user-config
+	ConfigOverrides           []string       // Extra `-c key=value` overrides injected from roborev config
 }
 
 const (
@@ -68,6 +69,7 @@ func (a *CodexAgent) clone(opts ...agentCloneOption) *CodexAgent {
 		SessionID:                 cfg.SessionID,
 		SuppressSkillInstructions: a.SuppressSkillInstructions,
 		IgnoreUserConfig:          a.IgnoreUserConfig,
+		ConfigOverrides:           a.ConfigOverrides,
 	}
 }
 
@@ -180,6 +182,11 @@ func (a *CodexAgent) commandArgs(opts codexArgOptions) []string {
 	args = append(args, "--json")
 	if a.IgnoreUserConfig {
 		args = append(args, codexIgnoreUserConfigFlag)
+	}
+	// User-provided overrides go before roborev's own -c flags so roborev's
+	// safety settings (skills, sandbox, reasoning) win on any key conflict.
+	for _, override := range a.ConfigOverrides {
+		args = append(args, "-c", override)
 	}
 	if opts.agenticMode {
 		args = append(args, codexDangerousFlag)

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -130,6 +131,33 @@ func TestCodexBuildArgsLoadsUserConfigByDefault(t *testing.T) {
 	args := a.buildArgs("/repo", false, true, false)
 
 	assert.NotContains(t, args, codexIgnoreUserConfigFlag)
+}
+
+func TestCodexBuildArgsIncludesConfigOverrides(t *testing.T) {
+	a := NewCodexAgent("codex")
+	a.ConfigOverrides = []string{
+		`model_provider="my-custom"`,
+		`model_providers.my-custom.base_url="https://api.example.com/v1"`,
+	}
+
+	args := a.buildArgs("/repo", false, true, false)
+
+	for _, override := range a.ConfigOverrides {
+		assertContainsArg(t, args, override)
+	}
+}
+
+func TestCodexBuildArgsConfigOverridesPrecedeSafetyFlags(t *testing.T) {
+	a := WithCodexSkillsDisabled(NewCodexAgent("codex"), true).(*CodexAgent)
+	a.ConfigOverrides = []string{`skills.include_instructions=true`}
+
+	args := a.buildArgs("/repo", false, true, false)
+
+	userIdx := slices.Index(args, `skills.include_instructions=true`)
+	safetyIdx := slices.Index(args, codexDisableSkillsConfig)
+	require.GreaterOrEqual(t, userIdx, 0)
+	require.GreaterOrEqual(t, safetyIdx, 0)
+	assert.Less(t, userIdx, safetyIdx, "roborev safety -c flag must follow user override so roborev wins on conflict")
 }
 
 func TestCodexBuildArgsRejectsInvalidSessionResume(t *testing.T) {

--- a/internal/agent/spec.go
+++ b/internal/agent/spec.go
@@ -239,13 +239,22 @@ func applyAgentConfigOverrides(a Agent, cfg *config.Config) Agent {
 	if cfg == nil || a == nil {
 		return a
 	}
-	if pi, ok := a.(*PiAgent); ok {
+	switch agent := a.(type) {
+	case *PiAgent:
 		ext := strings.TrimSpace(cfg.Agent.Pi.JSONSchemaExtension)
-		if ext == "" || ext == pi.JSONSchemaExtension {
+		if ext == "" || ext == agent.JSONSchemaExtension {
 			return a
 		}
-		clone := *pi
+		clone := *agent
 		clone.JSONSchemaExtension = ext
+		return &clone
+	case *CodexAgent:
+		overrides := cfg.Agent.Codex.ConfigOverrideArgs()
+		if len(overrides) == 0 {
+			return a
+		}
+		clone := *agent
+		clone.ConfigOverrides = overrides
 		return &clone
 	}
 	return a

--- a/internal/agent/spec_test.go
+++ b/internal/agent/spec_test.go
@@ -96,3 +96,32 @@ func TestApplyAgentConfigOverridesPiJSONSchemaExtension(t *testing.T) {
 	assert.Equal(t, "/opt/roborev/pi-json-schema/index.ts", pi.JSONSchemaExtension)
 	assert.Equal(t, config.DefaultPiJSONSchemaExtension, agent.JSONSchemaExtension)
 }
+
+func TestApplyAgentConfigOverridesCodexConfig(t *testing.T) {
+	t.Parallel()
+
+	base := NewCodexAgent("codex")
+	overridden := applyAgentConfigOverrides(base, &config.Config{
+		Agent: config.AgentConfig{
+			Codex: config.CodexConfig{
+				Config: map[string]any{"model_provider": "my-custom"},
+			},
+		},
+	})
+
+	codex, ok := overridden.(*CodexAgent)
+	require.True(t, ok)
+	assert.Equal(t, []string{`model_provider="my-custom"`}, codex.ConfigOverrides)
+	assert.Empty(t, base.ConfigOverrides, "original agent must not be mutated")
+}
+
+func TestApplyAgentConfigOverridesCodexNoConfigLeavesAgentUnchanged(t *testing.T) {
+	t.Parallel()
+
+	base := NewCodexAgent("codex")
+	overridden := applyAgentConfigOverrides(base, &config.Config{})
+
+	codex, ok := overridden.(*CodexAgent)
+	require.True(t, ok)
+	assert.Empty(t, codex.ConfigOverrides)
+}

--- a/internal/config/codex.go
+++ b/internal/config/codex.go
@@ -30,9 +30,9 @@ func (c CodexConfig) ConfigOverrideArgs() []string {
 
 func flattenCodexConfigOverrides(prefix string, table map[string]any, out *[]string) {
 	for key, val := range table {
-		fullKey := key
+		fullKey := tomlOverrideKeySegment(key)
 		if prefix != "" {
-			fullKey = prefix + "." + key
+			fullKey = prefix + "." + fullKey
 		}
 		if sub, ok := val.(map[string]any); ok {
 			flattenCodexConfigOverrides(fullKey, sub, out)
@@ -42,6 +42,35 @@ func flattenCodexConfigOverrides(prefix string, table map[string]any, out *[]str
 			*out = append(*out, fullKey+"="+encoded)
 		}
 	}
+}
+
+// tomlOverrideKeySegment returns key unchanged when it is a valid TOML bare key,
+// otherwise as a TOML-quoted key segment. Without this, a provider name with
+// dots or other non-bare characters (e.g. model_providers."foo.bar") would be
+// joined raw and parsed by Codex as extra nested path segments, targeting the
+// wrong key or producing an invalid override.
+func tomlOverrideKeySegment(key string) string {
+	if isBareTOMLKey(key) {
+		return key
+	}
+	if quoted, ok := encodeTOMLOverrideValue(key); ok {
+		return quoted
+	}
+	return key
+}
+
+func isBareTOMLKey(key string) bool {
+	if key == "" {
+		return false
+	}
+	for _, r := range key {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // encodeTOMLOverrideValue renders a single leaf value as the TOML literal Codex

--- a/internal/config/codex.go
+++ b/internal/config/codex.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"bytes"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// ConfigOverrideArgs flattens the passthrough Codex config table (the
+// `[agent.codex.config]` block) into Codex `-c key=value` override strings,
+// one per leaf key, sorted for deterministic output. Nested tables become
+// dotted keys (e.g. model_providers.foo.base_url) and values are TOML-encoded
+// so Codex parses them as the intended type.
+//
+// Codex applies `-c` overrides as its highest-precedence config layer,
+// independently of --ignore-user-config, so callers can inject a
+// model_provider / [model_providers.*] block without loading the user's
+// ~/.codex/config.toml.
+func (c CodexConfig) ConfigOverrideArgs() []string {
+	if len(c.Config) == 0 {
+		return nil
+	}
+	var out []string
+	flattenCodexConfigOverrides("", c.Config, &out)
+	sort.Strings(out)
+	return out
+}
+
+func flattenCodexConfigOverrides(prefix string, table map[string]any, out *[]string) {
+	for key, val := range table {
+		fullKey := key
+		if prefix != "" {
+			fullKey = prefix + "." + key
+		}
+		if sub, ok := val.(map[string]any); ok {
+			flattenCodexConfigOverrides(fullKey, sub, out)
+			continue
+		}
+		if encoded, ok := encodeTOMLOverrideValue(val); ok {
+			*out = append(*out, fullKey+"="+encoded)
+		}
+	}
+}
+
+// encodeTOMLOverrideValue renders a single leaf value as the TOML literal Codex
+// expects on the right-hand side of `-c key=value`. It reuses the TOML encoder
+// for correct quoting/escaping by encoding a synthetic `v = <value>` line and
+// stripping the key. Table-valued or multi-line encodings are rejected, since
+// flattenCodexConfigOverrides only passes scalars and flat arrays.
+func encodeTOMLOverrideValue(val any) (string, bool) {
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(map[string]any{"v": val}); err != nil {
+		return "", false
+	}
+	encoded := strings.TrimSpace(buf.String())
+	idx := strings.IndexByte(encoded, '=')
+	if idx < 0 {
+		return "", false
+	}
+	encoded = strings.TrimSpace(encoded[idx+1:])
+	if encoded == "" || strings.ContainsAny(encoded, "\r\n") {
+		return "", false
+	}
+	return encoded, true
+}

--- a/internal/config/codex_test.go
+++ b/internal/config/codex_test.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	tomlv2 "github.com/pelletier/go-toml/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodexConfigOverrideArgsFlattensModelProviders(t *testing.T) {
+	const tomlConfig = `
+[agent.codex.config]
+model_provider = "my-custom"
+
+[agent.codex.config.model_providers.my-custom]
+name = "My Provider"
+base_url = "https://api.example.com/v1"
+env_key = "MY_API_KEY"
+wire_api = "responses"
+request_max_retries = 5
+`
+	var cfg Config
+	_, err := toml.Decode(tomlConfig, &cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		`model_provider="my-custom"`,
+		`model_providers.my-custom.base_url="https://api.example.com/v1"`,
+		`model_providers.my-custom.env_key="MY_API_KEY"`,
+		`model_providers.my-custom.name="My Provider"`,
+		`model_providers.my-custom.request_max_retries=5`,
+		`model_providers.my-custom.wire_api="responses"`,
+	}, cfg.Agent.Codex.ConfigOverrideArgs())
+}
+
+func TestCodexConfigOverrideArgsEncodesScalarAndArrayTypes(t *testing.T) {
+	cfg := CodexConfig{Config: map[string]any{
+		"a_string": "x",
+		"a_bool":   true,
+		"an_int":   int64(7),
+		"a_float":  1.5,
+		"a_list":   []any{"one", "two"},
+	}}
+
+	assert.Equal(t, []string{
+		`a_bool=true`,
+		`a_float=1.5`,
+		`a_list=["one", "two"]`,
+		`a_string="x"`,
+		`an_int=7`,
+	}, cfg.ConfigOverrideArgs())
+}
+
+func TestCodexConfigOverrideArgsEmpty(t *testing.T) {
+	assert := assert.New(t)
+	assert.Nil(CodexConfig{}.ConfigOverrideArgs())
+	assert.Nil(CodexConfig{Config: map[string]any{}}.ConfigOverrideArgs())
+}
+
+func TestCodexConfigSurvivesSaveLoadRoundTrip(t *testing.T) {
+	original := DefaultConfig()
+	original.Agent.Codex.Config = map[string]any{
+		"model_provider": "my-custom",
+		"model_providers": map[string]any{
+			"my-custom": map[string]any{
+				"base_url": "https://api.example.com/v1",
+				"env_key":  "MY_API_KEY",
+			},
+		},
+	}
+
+	encoded, err := tomlv2.Marshal(original)
+	require.NoError(t, err)
+
+	var reloaded Config
+	_, err = toml.Decode(string(encoded), &reloaded)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.Agent.Codex.ConfigOverrideArgs(), reloaded.Agent.Codex.ConfigOverrideArgs())
+	assert.Equal(t, []string{
+		`model_provider="my-custom"`,
+		`model_providers.my-custom.base_url="https://api.example.com/v1"`,
+		`model_providers.my-custom.env_key="MY_API_KEY"`,
+	}, reloaded.Agent.Codex.ConfigOverrideArgs())
+}

--- a/internal/config/codex_test.go
+++ b/internal/config/codex_test.go
@@ -59,6 +59,20 @@ func TestCodexConfigOverrideArgsEmpty(t *testing.T) {
 	assert.Nil(CodexConfig{Config: map[string]any{}}.ConfigOverrideArgs())
 }
 
+func TestCodexConfigOverrideArgsQuotesNonBareKeys(t *testing.T) {
+	cfg := CodexConfig{Config: map[string]any{
+		"model_providers": map[string]any{
+			"foo.bar":   map[string]any{"base_url": "https://x"},
+			"has space": map[string]any{"k": "v"},
+		},
+	}}
+
+	assert.Equal(t, []string{
+		`model_providers."foo.bar".base_url="https://x"`,
+		`model_providers."has space".k="v"`,
+	}, cfg.ConfigOverrideArgs())
+}
+
 func TestCodexConfigSurvivesSaveLoadRoundTrip(t *testing.T) {
 	original := DefaultConfig()
 	original.Agent.Codex.Config = map[string]any{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,9 @@ type AgentHookConfig struct {
 type CodexConfig struct {
 	DisableReviewSkills    bool `toml:"disable_review_skills" comment:"Disable Codex skill instructions for review jobs."`
 	IgnoreReviewUserConfig bool `toml:"ignore_review_user_config" comment:"Pass --ignore-user-config to Codex for review jobs."`
+	// Config holds passthrough Codex options that ConfigOverrideArgs flattens
+	// into `-c key=value` overrides on every Codex job (see ConfigOverrideArgs).
+	Config map[string]any `toml:"config" comment:"Codex config injected as -c overrides on every Codex job (e.g. model_provider and [agent.codex.config.model_providers.*]). Survives --ignore-user-config."`
 }
 
 type PiConfig struct {

--- a/internal/testutil/git.go
+++ b/internal/testutil/git.go
@@ -83,6 +83,8 @@ func mustWrite(dir, name, content string) {
 func configureTemplateUser(dir string) {
 	mustGit(dir, "config", "user.email", GitUserEmail)
 	mustGit(dir, "config", "user.name", GitUserName)
+	mustGit(dir, "config", "gc.auto", "0")
+	mustGit(dir, "config", "maintenance.auto", "false")
 }
 
 // copyTree recursively copies the contents of src into dst. Files are written

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -62,6 +62,19 @@ func TestCommitFileCreatesParentDirectories(t *testing.T) {
 	require.Equal(t, "hello", string(content))
 }
 
+func TestGitRepoHelpersDisableAutoMaintenance(t *testing.T) {
+	repo := InitTestRepo(t)
+
+	require.Equal(t, "0", repo.Run("config", "--get", "gc.auto"))
+	require.Equal(t, "false", repo.Run("config", "--get", "maintenance.auto"))
+
+	dir := filepath.Join(t.TempDir(), "repo")
+	InitTestGitRepo(t, dir)
+
+	require.Equal(t, "0", runGit(t, dir, nil, "config", "--get", "gc.auto"))
+	require.Equal(t, "false", runGit(t, dir, nil, "config", "--get", "maintenance.auto"))
+}
+
 func TestNewGitRepoReturnsResolvedPath(t *testing.T) {
 	repo := NewGitRepo(t)
 


### PR DESCRIPTION
## Why

roborev passes `--ignore-user-config` to Codex so review jobs don't load the user's `~/.codex/config.toml` (skills, etc.). A side effect is that a custom `model_provider` / `[model_providers.*]` defined there is also ignored, so there was no way to point roborev's Codex at a non-default provider.

## What

Adds an `[agent.codex.config]` passthrough table. Its leaf keys are flattened into Codex `-c key=value` overrides and applied to every Codex job (review, fix, refine, analyze). Codex applies `-c` overrides as its highest-precedence config layer regardless of `--ignore-user-config`, so only the explicitly listed options are injected; the user's full config is still not loaded.

```toml
[agent.codex.config]
model_provider = "my-custom"

[agent.codex.config.model_providers.my-custom]
name = "My Provider"
base_url = "https://api.example.com/v1"
env_key = "MY_API_KEY"
wire_api = "responses"
```

This flattens to `-c model_provider="my-custom"`, `-c model_providers.my-custom.base_url="https://api.example.com/v1"`, and so on.

## Design notes / risk

- Wired through `applyAgentConfigOverrides` (the shared agent-resolution choke point that already injects Pi's extension), so one wiring point covers all Codex job types.
- roborev's own `-c` flags (skill suppression, sandbox mode, reasoning effort) are emitted **after** the user overrides, so roborev's safety controls win on any key collision.
- Values are TOML-encoded to preserve type (quoted strings, bare numbers/bools, arrays).
- The `config` field is a generic `map[string]any`: set it by editing TOML directly (`roborev config set` does not support nested map keys).

Docs updated in `docs/configuration.md`. Changelog left untouched (release-driven).
