### PR TITLE
Prefer managed roborev shims in hook installs

### DIFF
--- a/internal/githook/githook.go
+++ b/internal/githook/githook.go
@@ -36,6 +36,7 @@ type InstallOptions struct {
 type binaryResolverDeps struct {
 	executable  func() (string, error)
 	lookPath    func(string) (string, error)
+	lookPathAll func(string) []string
 	userHomeDir func() (string, error)
 }
 
@@ -43,6 +44,7 @@ func defaultBinaryResolverDeps() binaryResolverDeps {
 	return binaryResolverDeps{
 		executable:  os.Executable,
 		lookPath:    exec.LookPath,
+		lookPathAll: lookPathAll,
 		userHomeDir: os.UserHomeDir,
 	}
 }
@@ -190,14 +192,18 @@ func resolveRoborevPathWithDeps(override string, deps binaryResolverDeps) (Binar
 			}, nil
 		}
 	}
-	if shim, ok := miseShimForInstall(current); ok {
-		return BinaryResolution{
-			Path: shim,
-			Notice: fmt.Sprintf(
-				"Detected roborev managed by mise; installing hooks with %s instead of versioned binary %s",
-				shim, current,
-			),
-		}, nil
+	if versionedManagerInstall(current) != "" && deps.lookPathAll != nil {
+		for _, path := range deps.lookPathAll("roborev") {
+			if manager, ok := managedBinaryShim(current, path); ok {
+				return BinaryResolution{
+					Path: path,
+					Notice: fmt.Sprintf(
+						"Detected roborev managed by %s; installing hooks with %s instead of versioned binary %s",
+						manager, path, current,
+					),
+				}, nil
+			}
+		}
 	}
 
 	if manager := versionedManagerInstall(current); manager != "" {
@@ -211,6 +217,51 @@ func resolveRoborevPathWithDeps(override string, deps binaryResolverDeps) (Binar
 	}
 
 	return BinaryResolution{Path: current}, nil
+}
+
+func lookPathAll(file string) []string {
+	var matches []string
+	seen := make(map[string]bool)
+	add := func(path string) {
+		if seen[path] || !isExecutableFile(path) {
+			return
+		}
+		seen[path] = true
+		matches = append(matches, path)
+	}
+
+	if hasPathSeparator(file) {
+		add(file)
+		return matches
+	}
+
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		if dir == "" {
+			dir = "."
+		}
+		base := filepath.Join(dir, file)
+		add(base)
+		if runtime.GOOS == "windows" && filepath.Ext(file) == "" {
+			for _, ext := range windowsPathExts() {
+				add(base + ext)
+			}
+		}
+	}
+	return matches
+}
+
+func windowsPathExts() []string {
+	pathext := os.Getenv("PATHEXT")
+	if pathext == "" {
+		pathext = ".COM;.EXE;.BAT;.CMD"
+	}
+	exts := filepath.SplitList(pathext)
+	for i, ext := range exts {
+		if ext != "" && !strings.HasPrefix(ext, ".") {
+			exts[i] = "." + ext
+		}
+	}
+	return exts
 }
 
 // resolveRoborevPath returns the path to use in generated hooks. It is kept
@@ -303,23 +354,6 @@ func versionedManagerInstall(current string) string {
 func isMiseManagedRoborev(path string) bool {
 	return strings.Contains(path, "/mise/installs/") &&
 		strings.HasSuffix(path, "/roborev")
-}
-
-func miseShimForInstall(current string) (string, bool) {
-	current = filepath.ToSlash(current)
-	if !isMiseManagedRoborev(current) {
-		return "", false
-	}
-	marker := "/mise/installs/"
-	before, _, ok := strings.Cut(current, marker)
-	if !ok {
-		return "", false
-	}
-	shim := filepath.FromSlash(before + "/mise/shims/roborev")
-	if !isExecutableFile(shim) {
-		return "", false
-	}
-	return shim, true
 }
 
 func isExecutableFile(path string) bool {

--- a/internal/githook/githook.go
+++ b/internal/githook/githook.go
@@ -325,8 +325,8 @@ func hasPathSeparator(path string) bool {
 }
 
 func managedBinaryShim(current, pathRoborev string) (string, bool) {
-	current = filepath.ToSlash(current)
-	pathRoborev = filepath.ToSlash(pathRoborev)
+	current = slashPath(current)
+	pathRoborev = slashPath(pathRoborev)
 	switch {
 	case isMiseManagedRoborev(current) &&
 		strings.Contains(pathRoborev, "/mise/shims/roborev"):
@@ -340,7 +340,7 @@ func managedBinaryShim(current, pathRoborev string) (string, bool) {
 }
 
 func versionedManagerInstall(current string) string {
-	current = filepath.ToSlash(current)
+	current = slashPath(current)
 	switch {
 	case isMiseManagedRoborev(current):
 		return "mise"
@@ -351,9 +351,14 @@ func versionedManagerInstall(current string) string {
 	}
 }
 
+func slashPath(path string) string {
+	return strings.ReplaceAll(filepath.ToSlash(path), "\\", "/")
+}
+
 func isMiseManagedRoborev(path string) bool {
 	return strings.Contains(path, "/mise/installs/") &&
-		strings.HasSuffix(path, "/roborev")
+		(strings.HasSuffix(path, "/roborev") ||
+			strings.HasSuffix(strings.ToLower(path), "/roborev.exe"))
 }
 
 func isExecutableFile(path string) bool {

--- a/internal/githook/githook.go
+++ b/internal/githook/githook.go
@@ -190,6 +190,15 @@ func resolveRoborevPathWithDeps(override string, deps binaryResolverDeps) (Binar
 			}, nil
 		}
 	}
+	if shim, ok := miseShimForInstall(current); ok {
+		return BinaryResolution{
+			Path: shim,
+			Notice: fmt.Sprintf(
+				"Detected roborev managed by mise; installing hooks with %s instead of versioned binary %s",
+				shim, current,
+			),
+		}, nil
+	}
 
 	if manager := versionedManagerInstall(current); manager != "" {
 		return BinaryResolution{
@@ -294,6 +303,31 @@ func versionedManagerInstall(current string) string {
 func isMiseManagedRoborev(path string) bool {
 	return strings.Contains(path, "/mise/installs/") &&
 		strings.HasSuffix(path, "/roborev")
+}
+
+func miseShimForInstall(current string) (string, bool) {
+	current = filepath.ToSlash(current)
+	if !isMiseManagedRoborev(current) {
+		return "", false
+	}
+	marker := "/mise/installs/"
+	before, _, ok := strings.Cut(current, marker)
+	if !ok {
+		return "", false
+	}
+	shim := filepath.FromSlash(before + "/mise/shims/roborev")
+	if !isExecutableFile(shim) {
+		return "", false
+	}
+	return shim, true
+}
+
+func isExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	return runtime.GOOS == "windows" || info.Mode()&0o111 != 0
 }
 
 func isHomebrewBin(path string) bool {

--- a/internal/githook/githook.go
+++ b/internal/githook/githook.go
@@ -325,8 +325,8 @@ func hasPathSeparator(path string) bool {
 }
 
 func managedBinaryShim(current, pathRoborev string) (string, bool) {
-	current = slashPath(current)
-	pathRoborev = slashPath(pathRoborev)
+	current = filepath.ToSlash(current)
+	pathRoborev = filepath.ToSlash(pathRoborev)
 	switch {
 	case isMiseManagedRoborev(current) &&
 		strings.Contains(pathRoborev, "/mise/shims/roborev"):
@@ -340,7 +340,7 @@ func managedBinaryShim(current, pathRoborev string) (string, bool) {
 }
 
 func versionedManagerInstall(current string) string {
-	current = slashPath(current)
+	current = filepath.ToSlash(current)
 	switch {
 	case isMiseManagedRoborev(current):
 		return "mise"
@@ -349,10 +349,6 @@ func versionedManagerInstall(current string) string {
 	default:
 		return ""
 	}
-}
-
-func slashPath(path string) string {
-	return strings.ReplaceAll(filepath.ToSlash(path), "\\", "/")
 }
 
 func isMiseManagedRoborev(path string) bool {

--- a/internal/githook/githook_test.go
+++ b/internal/githook/githook_test.go
@@ -239,6 +239,14 @@ func TestResolveRoborevPathDoesNotGuessUnsupportedManagers(t *testing.T) {
 	}
 }
 
+func TestVersionedManagerInstallRecognizesWindowsMiseExecutable(t *testing.T) {
+	path := `C:\Users\alice\.local\share\mise\installs\roborev\1.2.3\bin\roborev.exe`
+
+	manager := versionedManagerInstall(path)
+
+	assert.Equal(t, "mise", manager)
+}
+
 func TestResolveRoborevPathUsesExplicitBinary(t *testing.T) {
 	binPath := filepath.Join(t.TempDir(), "roborev")
 	require.NoError(t, os.WriteFile(binPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))

--- a/internal/githook/githook_test.go
+++ b/internal/githook/githook_test.go
@@ -240,7 +240,7 @@ func TestResolveRoborevPathDoesNotGuessUnsupportedManagers(t *testing.T) {
 }
 
 func TestVersionedManagerInstallRecognizesWindowsMiseExecutable(t *testing.T) {
-	path := `C:\Users\alice\.local\share\mise\installs\roborev\1.2.3\bin\roborev.exe`
+	path := filepath.FromSlash("C:/Users/alice/.local/share/mise/installs/roborev/1.2.3/bin/roborev.exe")
 
 	manager := versionedManagerInstall(path)
 

--- a/internal/githook/githook_test.go
+++ b/internal/githook/githook_test.go
@@ -151,12 +151,9 @@ func TestResolveRoborevPathPrefersVersionManagerShim(t *testing.T) {
 	}
 }
 
-func TestResolveRoborevPathDerivesMiseShimFromInstallPath(t *testing.T) {
-	home := t.TempDir()
-	current := filepath.Join(home, ".local", "share", "mise", "installs", "roborev", "1.2.3", "bin", "roborev")
-	shim := filepath.Join(home, ".local", "share", "mise", "shims", "roborev")
-	require.NoError(t, os.MkdirAll(filepath.Dir(shim), 0o755))
-	require.NoError(t, os.WriteFile(shim, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+func TestResolveRoborevPathPrefersMiseShimLaterOnPath(t *testing.T) {
+	current := "/Users/alice/.local/share/mise/installs/roborev/1.2.3/bin/roborev"
+	shim := "/Users/alice/.local/share/mise/shims/roborev"
 	deps := binaryResolverDeps{
 		executable: func() (string, error) {
 			return current, nil
@@ -165,8 +162,16 @@ func TestResolveRoborevPathDerivesMiseShimFromInstallPath(t *testing.T) {
 			require.Equal(t, "roborev", file)
 			return current, nil
 		},
+		lookPathAll: func(file string) []string {
+			require.Equal(t, "roborev", file)
+			return []string{
+				current,
+				"/usr/local/bin/roborev",
+				shim,
+			}
+		},
 		userHomeDir: func() (string, error) {
-			return home, nil
+			return "/Users/alice", nil
 		},
 	}
 
@@ -176,6 +181,20 @@ func TestResolveRoborevPathDerivesMiseShimFromInstallPath(t *testing.T) {
 	assert.Equal(t, shim, resolution.Path)
 	assert.Contains(t, resolution.Notice, "mise")
 	assert.Contains(t, resolution.Notice, "versioned binary")
+}
+
+func TestLookPathAllFindsExecutableMatchesOnPath(t *testing.T) {
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+	bin1 := filepath.Join(dir1, "roborev")
+	bin2 := filepath.Join(dir2, "roborev")
+	require.NoError(t, os.WriteFile(bin1, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	require.NoError(t, os.WriteFile(bin2, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("PATH", filepath.Join(t.TempDir(), "missing")+string(os.PathListSeparator)+dir1+string(os.PathListSeparator)+dir2)
+
+	matches := lookPathAll("roborev")
+
+	assert.Equal(t, []string{bin1, bin2}, matches)
 }
 
 func TestResolveRoborevPathWarnsForVersionedInstallWithoutShim(t *testing.T) {

--- a/internal/githook/githook_test.go
+++ b/internal/githook/githook_test.go
@@ -151,6 +151,33 @@ func TestResolveRoborevPathPrefersVersionManagerShim(t *testing.T) {
 	}
 }
 
+func TestResolveRoborevPathDerivesMiseShimFromInstallPath(t *testing.T) {
+	home := t.TempDir()
+	current := filepath.Join(home, ".local", "share", "mise", "installs", "roborev", "1.2.3", "bin", "roborev")
+	shim := filepath.Join(home, ".local", "share", "mise", "shims", "roborev")
+	require.NoError(t, os.MkdirAll(filepath.Dir(shim), 0o755))
+	require.NoError(t, os.WriteFile(shim, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	deps := binaryResolverDeps{
+		executable: func() (string, error) {
+			return current, nil
+		},
+		lookPath: func(file string) (string, error) {
+			require.Equal(t, "roborev", file)
+			return current, nil
+		},
+		userHomeDir: func() (string, error) {
+			return home, nil
+		},
+	}
+
+	resolution, err := resolveRoborevPathWithDeps("", deps)
+
+	require.NoError(t, err)
+	assert.Equal(t, shim, resolution.Path)
+	assert.Contains(t, resolution.Notice, "mise")
+	assert.Contains(t, resolution.Notice, "versioned binary")
+}
+
 func TestResolveRoborevPathWarnsForVersionedInstallWithoutShim(t *testing.T) {
 	current := "/Users/alice/.local/share/mise/installs/go-go-kenn-io-roborev-cmd-roborev/1.2.3/bin/roborev"
 	deps := stubRoborevPathDeps(t, current, "")


### PR DESCRIPTION
Mise can launch roborev from a versioned install path while the stable shim is still present elsewhere on PATH. Baking that versioned path into git hooks or agent hooks makes hook installs fragile across version-manager upgrades.

This teaches the shared hook binary resolver to inspect every matching roborev command on PATH and prefer an existing managed shim when the active executable is a versioned install. Because roborev init, install-hook, and agent-hook install all resolve through that shared path, the generated git hooks and agent hook commands now converge on the same stable command.

The PATH scan uses filepath path-list semantics, honors Windows PATHEXT, recognizes roborev.exe for Windows mise installs, and keeps explicit --binary or --command overrides authoritative.

Repo-wide Go tests pass locally.

<sup>generated by a clanker</sup>