### PR TITLE
Update flake.nix for v0.60.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         packages = {
           default = pkgs.buildGoModule {
             pname = "roborev";
-            version = "0.59.2";
+            version = "0.60.0";
             go = pkgs.go_1_26;
 
             src = ./.;


### PR DESCRIPTION
Updates flake.nix version to 0.60.0 for the v0.60.0 release.