### PR TITLE
Support per-analysis agent config

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,15 @@ Analysis jobs appear in the review queue. Use `roborev fix` to apply
 open findings later, target a specific job with `roborev fix <id>`, or
 pass `--fix` to apply immediately.
 
+Analysis types can pin their own agent settings in config:
+
+```toml
+[analyze.refactor]
+agent = "claude-code"
+model = "sonnet"
+reasoning = "fast"
+```
+
 ## Installation
 
 **Shell Script (macOS / Linux):**

--- a/cmd/roborev/analyze.go
+++ b/cmd/roborev/analyze.go
@@ -511,14 +511,27 @@ func enqueueAnalysisJob(ctx context.Context, ep daemon.DaemonEndpoint, repoRoot,
 		branch = opts.branch
 	}
 
+	reviewType := analysisReviewType(label)
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+	resolved, err := config.ResolveAnalyzeConfig(
+		opts.agentName, opts.model, opts.reasoning, repoRoot, cfg,
+		label, analysisWorkflow(label), "",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("resolve analyze config: %w", err)
+	}
+
 	reqBody, _ := json.Marshal(daemon.EnqueueRequest{
 		RepoPath:     repoRoot,
 		GitRef:       label, // Use analysis type name as the TUI label
 		Branch:       branch,
-		Agent:        opts.agentName,
-		Model:        opts.model,
-		Reasoning:    opts.reasoning,
-		ReviewType:   analysisReviewType(label),
+		Agent:        resolved.Agent,
+		Model:        resolved.Model,
+		Reasoning:    resolved.Reasoning,
+		ReviewType:   reviewType,
 		CustomPrompt: prompt,
 		OutputPrefix: outputPrefix,
 		Agentic:      true, // Agentic mode needed for reading files when prompt exceeds size limit
@@ -552,6 +565,13 @@ func analysisReviewType(label string) string {
 		return config.ReviewTypeSecurity
 	}
 	return ""
+}
+
+func analysisWorkflow(label string) string {
+	if label == config.ReviewTypeSecurity {
+		return config.ReviewTypeSecurity
+	}
+	return "review"
 }
 
 // runAnalyzeAndFix waits for analysis to complete, runs a fixer agent, then marks closed

--- a/cmd/roborev/analyze_test.go
+++ b/cmd/roborev/analyze_test.go
@@ -519,6 +519,42 @@ func TestEnqueueSecurityAnalysisJobUsesSecurityReviewType(t *testing.T) {
 	assert.Equal(t, "security", gotReviewType, "security analysis should resolve security workflow config")
 }
 
+func TestEnqueueAnalysisJobAppliesAnalyzeConfig(t *testing.T) {
+	repo := newTestGitRepo(t)
+	repo.CommitFile("main.go", "package main", "initial")
+	require.NoError(t, os.WriteFile(filepath.Join(repo.Dir, ".roborev.toml"), []byte(`
+[analyze.refactor]
+agent = "configured-agent"
+model = "configured-model"
+reasoning = "fast"
+`), 0o644))
+
+	var got daemon.EnqueueRequest
+	ts, _ := newMockServer(t, MockServerOpts{
+		OnEnqueue: func(w http.ResponseWriter, r *http.Request) {
+			if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&got)) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(storage.ReviewJob{
+				ID:     42,
+				Agent:  "configured-agent",
+				Status: storage.JobStatusQueued,
+			})
+		},
+	})
+
+	_, err := enqueueAnalysisJob(t.Context(), mustParseEndpoint(t, ts.URL), repo.Dir, "test prompt", "", "refactor", analyzeOptions{})
+	require.NoError(t, err, "enqueueAnalysisJob")
+
+	assert.Equal(t, "configured-agent", got.Agent)
+	assert.Equal(t, "configured-model", got.Model)
+	assert.Equal(t, "fast", got.Reasoning)
+	assert.Empty(t, got.ReviewType)
+}
+
 func TestEnqueueAnalysisJobBranchName(t *testing.T) {
 	// Create a real git repo so GetCurrentBranch returns a known value
 	repo := newTestGitRepo(t)

--- a/internal/config/analyze.go
+++ b/internal/config/analyze.go
@@ -1,0 +1,217 @@
+package config
+
+import (
+	"strings"
+)
+
+// AnalyzeConfig holds per-analysis-type overrides such as:
+//
+//	[analyze.refactor]
+//	agent = "claude-code"
+//	model = "sonnet"
+//	reasoning = "fast"
+type AnalyzeConfig struct {
+	Agent     string `toml:"agent" comment:"Agent override for this analysis type."`
+	Model     string `toml:"model" comment:"Model override for this analysis type."`
+	Reasoning string `toml:"reasoning" comment:"Reasoning level for this analysis type: fast, standard, medium, thorough, or maximum."`
+}
+
+// ResolveAnalyzeConfig resolves the agent/model/reasoning that should be sent
+// on an analyze enqueue request. It keeps the usual config layering:
+// CLI > repo analyze.<type> > repo workflow/generic > global analyze.<type> >
+// global workflow/generic > default.
+func ResolveAnalyzeConfig(
+	cliAgent, cliModel, cliReasoning string,
+	repoPath string,
+	globalCfg *Config,
+	analysisType string,
+	fallbackWorkflow string,
+	fallbackLevel string,
+) (AnalyzeConfig, error) {
+	repoCfg, _ := LoadRepoConfig(repoPath)
+	return ResolveAnalyzeConfigFromConfig(
+		cliAgent, cliModel, cliReasoning,
+		repoCfg, globalCfg, analysisType, fallbackWorkflow, fallbackLevel,
+	)
+}
+
+// ResolveAnalyzeConfigFromConfig is the config-taking core of
+// ResolveAnalyzeConfig, never reading the working tree.
+func ResolveAnalyzeConfigFromConfig(
+	cliAgent, cliModel, cliReasoning string,
+	repoCfg *RepoConfig,
+	globalCfg *Config,
+	analysisType string,
+	fallbackWorkflow string,
+	fallbackLevel string,
+) (AnalyzeConfig, error) {
+	reasoning, err := resolveAnalyzeReasoning(
+		cliReasoning, repoCfg, globalCfg, analysisType, fallbackLevel,
+	)
+	if err != nil {
+		return AnalyzeConfig{}, err
+	}
+
+	return AnalyzeConfig{
+		Agent: resolveAnalyzeAgent(
+			cliAgent, repoCfg, globalCfg, analysisType,
+			fallbackWorkflow, reasoning,
+		),
+		Model: resolveAnalyzeModel(
+			cliModel, repoCfg, globalCfg, analysisType,
+			fallbackWorkflow, reasoning,
+		),
+		Reasoning: reasoning,
+	}, nil
+}
+
+func resolveAnalyzeAgent(
+	cli string,
+	repoCfg *RepoConfig,
+	globalCfg *Config,
+	analysisType string,
+	fallbackWorkflow string,
+	level string,
+) string {
+	if s := strings.TrimSpace(cli); s != "" {
+		return s
+	}
+	if s := repoAnalyzeField(repoCfg, analysisType, true); s != "" {
+		return s
+	}
+	if s := repoWorkflowField(repoCfg, fallbackWorkflow, level, true); s != "" {
+		return s
+	}
+	if s := repoWorkflowField(repoCfg, fallbackWorkflow, "", true); s != "" {
+		return s
+	}
+	if repoCfg != nil && strings.TrimSpace(repoCfg.Agent) != "" {
+		return strings.TrimSpace(repoCfg.Agent)
+	}
+	if s := globalAnalyzeField(globalCfg, analysisType, true); s != "" {
+		return s
+	}
+	if s := globalWorkflowField(globalCfg, fallbackWorkflow, level, true); s != "" {
+		return s
+	}
+	if s := globalWorkflowField(globalCfg, fallbackWorkflow, "", true); s != "" {
+		return s
+	}
+	if globalCfg != nil && strings.TrimSpace(globalCfg.DefaultAgent) != "" {
+		return strings.TrimSpace(globalCfg.DefaultAgent)
+	}
+	return "codex"
+}
+
+func resolveAnalyzeModel(
+	cli string,
+	repoCfg *RepoConfig,
+	globalCfg *Config,
+	analysisType string,
+	fallbackWorkflow string,
+	level string,
+) string {
+	if s := strings.TrimSpace(cli); s != "" {
+		return s
+	}
+	if s := repoAnalyzeField(repoCfg, analysisType, false); s != "" {
+		return s
+	}
+	if s := repoWorkflowField(repoCfg, fallbackWorkflow, level, false); s != "" {
+		return s
+	}
+	if s := repoWorkflowField(repoCfg, fallbackWorkflow, "", false); s != "" {
+		return s
+	}
+	if repoCfg != nil && strings.TrimSpace(repoCfg.Model) != "" {
+		return strings.TrimSpace(repoCfg.Model)
+	}
+	if s := globalAnalyzeField(globalCfg, analysisType, false); s != "" {
+		return s
+	}
+	if s := globalWorkflowField(globalCfg, fallbackWorkflow, level, false); s != "" {
+		return s
+	}
+	if s := globalWorkflowField(globalCfg, fallbackWorkflow, "", false); s != "" {
+		return s
+	}
+	if globalCfg != nil && strings.TrimSpace(globalCfg.DefaultModel) != "" {
+		return strings.TrimSpace(globalCfg.DefaultModel)
+	}
+	return ""
+}
+
+func resolveAnalyzeReasoning(
+	cli string,
+	repoCfg *RepoConfig,
+	globalCfg *Config,
+	analysisType string,
+	fallbackLevel string,
+) (string, error) {
+	if s := strings.TrimSpace(cli); s != "" {
+		return NormalizeReasoning(s)
+	}
+	if s := repoAnalyzeReasoning(repoCfg, analysisType); s != "" {
+		return NormalizeReasoning(s)
+	}
+	if repoCfg != nil && strings.TrimSpace(repoCfg.ReviewReasoning) != "" {
+		return NormalizeReasoning(repoCfg.ReviewReasoning)
+	}
+	if s := globalAnalyzeReasoning(globalCfg, analysisType); s != "" {
+		return NormalizeReasoning(s)
+	}
+	if globalCfg != nil && strings.TrimSpace(globalCfg.ReviewReasoning) != "" {
+		return NormalizeReasoning(globalCfg.ReviewReasoning)
+	}
+	if s := strings.TrimSpace(fallbackLevel); s != "" {
+		return NormalizeReasoning(s)
+	}
+	return "thorough", nil
+}
+
+func repoAnalyzeField(repoCfg *RepoConfig, analysisType string, isAgent bool) string {
+	if repoCfg == nil {
+		return ""
+	}
+	return analyzeField(repoCfg.Analyze, analysisType, isAgent)
+}
+
+func globalAnalyzeField(globalCfg *Config, analysisType string, isAgent bool) string {
+	if globalCfg == nil {
+		return ""
+	}
+	return analyzeField(globalCfg.Analyze, analysisType, isAgent)
+}
+
+func analyzeField(configs map[string]AnalyzeConfig, analysisType string, isAgent bool) string {
+	cfg, ok := configs[strings.TrimSpace(analysisType)]
+	if !ok {
+		return ""
+	}
+	if isAgent {
+		return strings.TrimSpace(cfg.Agent)
+	}
+	return strings.TrimSpace(cfg.Model)
+}
+
+func repoAnalyzeReasoning(repoCfg *RepoConfig, analysisType string) string {
+	if repoCfg == nil {
+		return ""
+	}
+	return analyzeReasoning(repoCfg.Analyze, analysisType)
+}
+
+func globalAnalyzeReasoning(globalCfg *Config, analysisType string) string {
+	if globalCfg == nil {
+		return ""
+	}
+	return analyzeReasoning(globalCfg.Analyze, analysisType)
+}
+
+func analyzeReasoning(configs map[string]AnalyzeConfig, analysisType string) string {
+	cfg, ok := configs[strings.TrimSpace(analysisType)]
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(cfg.Reasoning)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,6 +118,9 @@ type Config struct {
 	RefineReasoning            string `toml:"refine_reasoning" comment:"Default reasoning level for refine: fast, standard, medium, thorough, or maximum."`
 	FixReasoning               string `toml:"fix_reasoning" comment:"Default reasoning level for fix: fast, standard, medium, thorough, or maximum."`
 
+	// Analysis-type-specific agent/model configuration
+	Analyze map[string]AnalyzeConfig `toml:"analyze"`
+
 	// Workflow-specific agent/model configuration
 	ReviewAgent           string `toml:"review_agent"`
 	ReviewAgentFast       string `toml:"review_agent_fast"`
@@ -332,6 +335,9 @@ type RepoConfig struct {
 
 	// Subagent review panel overrides for this repo (opt-in)
 	Review ReviewConfig `toml:"review"`
+
+	// Analysis-type-specific agent/model configuration
+	Analyze map[string]AnalyzeConfig `toml:"analyze"`
 
 	// Workflow-specific agent/model configuration
 	ReviewAgent           string `toml:"review_agent" comment:"Agent override for standard review in this repo."`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2011,6 +2011,70 @@ func TestHasWorkflowAgentOverrideFromConfig(t *testing.T) {
 	}
 }
 
+func TestResolveAnalyzeConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		cliAgent  string
+		cliModel  string
+		repo      string
+		global    *Config
+		analysis  string
+		fallback  string
+		reasoning string
+		wantAgent string
+		wantModel string
+	}{
+		{
+			name:     "repo analysis table overrides workflow fallback",
+			repo:     "[analyze.refactor]\nagent = \"repo-agent\"\nmodel = \"repo-model\"\n",
+			global:   &Config{ReviewAgent: "global-review", ReviewModel: "global-review-model"},
+			analysis: "refactor", fallback: "review", reasoning: "standard",
+			wantAgent: "repo-agent", wantModel: "repo-model",
+		},
+		{
+			name:     "global analysis table used when repo lacks entry",
+			repo:     "review_agent = \"repo-review\"\n",
+			global:   &Config{Analyze: map[string]AnalyzeConfig{"refactor": {Agent: "global-agent", Model: "global-model"}}},
+			analysis: "refactor", fallback: "review", reasoning: "standard",
+			wantAgent: "repo-review", wantModel: "global-model",
+		},
+		{
+			name:     "cli agent and model override analysis table",
+			cliAgent: "cli-agent", cliModel: "cli-model",
+			repo:     "[analyze.refactor]\nagent = \"repo-agent\"\nmodel = \"repo-model\"\n",
+			analysis: "refactor", fallback: "review", reasoning: "standard",
+			wantAgent: "cli-agent", wantModel: "cli-model",
+		},
+		{
+			name:     "missing analysis table falls back to workflow",
+			repo:     "review_agent = \"repo-review\"\nreview_model = \"repo-review-model\"\n",
+			analysis: "duplication", fallback: "review", reasoning: "standard",
+			wantAgent: "repo-review", wantModel: "repo-review-model",
+		},
+		{
+			name:     "security analysis falls back to security workflow",
+			repo:     "review_agent = \"repo-review\"\nsecurity_agent = \"repo-security\"\n",
+			analysis: "security", fallback: "security", reasoning: "standard",
+			wantAgent: "repo-security",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoPath := newTempRepo(t, tt.repo)
+
+			got, err := ResolveAnalyzeConfig(
+				tt.cliAgent, tt.cliModel, "", repoPath, tt.global,
+				tt.analysis, tt.fallback, tt.reasoning,
+			)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantAgent, got.Agent)
+			assert.Equal(t, tt.wantModel, got.Model)
+		})
+	}
+}
+
 func TestResolveModelForWorkflow(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -1272,6 +1272,52 @@ func TestApplyCodexReviewSettings(t *testing.T) {
 	}
 }
 
+func TestAnalyzeTaskCodexCommandLinePreservesAgentConfig(t *testing.T) {
+	fakeBin := t.TempDir()
+	codex := "codex"
+	script := "#!/bin/sh\nexit 0\n"
+	if runtime.GOOS == "windows" {
+		codex += ".cmd"
+		script = "@echo off\r\nexit /b 0\r\n"
+	}
+	codexPath := filepath.Join(fakeBin, codex)
+	require.NoError(t, os.WriteFile(codexPath, []byte(script), 0o755))
+	t.Setenv("PATH", fakeBin)
+
+	cfg := config.DefaultConfig()
+	cfg.CodexCmd = codexPath
+	cfg.Agent.Codex.DisableReviewSkills = true
+	cfg.Agent.Codex.IgnoreReviewUserConfig = true
+	cfg.Agent.Codex.Config = map[string]any{
+		"model_provider": "my-custom",
+	}
+
+	base, err := agent.GetPreferredOrBackupWithConfig("", "codex", cfg)
+	require.NoError(t, err)
+
+	job := storage.ReviewJob{
+		JobType:   storage.JobTypeTask,
+		GitRef:    "refactor",
+		Agent:     "codex",
+		Model:     "o4-mini",
+		Reasoning: "fast",
+		Agentic:   true,
+	}
+	configured := applyCodexReviewSettings(
+		base.WithReasoning(agent.ParseReasoningLevel(job.Reasoning)).
+			WithAgentic(job.Agentic).
+			WithModel(job.Model),
+		&job,
+		cfg,
+	)
+
+	commandLine := configured.CommandLine()
+	assert.Contains(t, commandLine, `-c model_provider="my-custom"`)
+	assert.Contains(t, commandLine, "-m o4-mini")
+	assert.Contains(t, commandLine, "-c skills.include_instructions=false")
+	assert.NotContains(t, commandLine, "--ignore-user-config")
+}
+
 func TestProcessJob_RebuildsAndPersistsFreshPromptForReviewRetry(t *testing.T) {
 	tc := newWorkerTestContext(t, 1)
 	sha := testutil.GetHeadSHA(t, tc.TmpDir)


### PR DESCRIPTION
## Summary

Add per-analysis-type configuration so built-in analysis runs can pin agent, model, and reasoning independently from the broader review/security workflow defaults.

This supports TOML like:

```toml
[analyze.refactor]
agent = "claude-code"
model = "sonnet"
reasoning = "fast"
```

The resolver keeps existing layering semantics: explicit CLI flags win first, then repo-local analyze config, repo workflow/default config, global analyze config, global workflow/default config, and finally the existing hardcoded default. Analyze jobs still flow through the normal daemon agent resolution and invocation path, so agent-specific settings such as `[agent.codex]` command/config overrides continue to apply after an analysis type picks Codex.

<sup>generated by a clanker</sup>