### PR TITLE
Use idle read timeout for updates instead of total deadline

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -26,6 +27,14 @@ const (
 	checksumsAssetName   = "SHA256SUMS"
 	defaultGitHubBaseURL = "https://github.com"
 	maxChecksumsBytes    = 1 << 20
+
+	// dialTimeout bounds how long establishing a TCP connection may take.
+	dialTimeout = 30 * time.Second
+	// idleTimeout aborts a transfer only when no data has been received for
+	// this long, which indicates a dropped connection. Unlike an overall
+	// request deadline it does not penalise slow-but-progressing downloads, so
+	// large release assets keep downloading on slow connections.
+	idleTimeout = 30 * time.Second
 )
 
 type UpdateInfo = selfupdate.Info
@@ -79,7 +88,7 @@ func GetCacheDir() string {
 
 func NewUpdater(deps Deps) *Updater {
 	if deps.Client == nil {
-		deps.Client = &http.Client{Timeout: 30 * time.Second}
+		deps.Client = defaultHTTPClient()
 	}
 	if deps.Now == nil {
 		deps.Now = time.Now
@@ -107,6 +116,46 @@ func NewUpdater(deps Deps) *Updater {
 
 func defaultUpdater() *Updater {
 	return NewUpdater(Deps{})
+}
+
+// defaultHTTPClient builds the client used for update checks and downloads. It
+// deliberately omits http.Client.Timeout (an overall deadline that would abort
+// otherwise-healthy large downloads on slow links) in favour of a per-read
+// idle timeout: the transfer fails only when no data arrives for idleTimeout,
+// signalling a dropped connection.
+func defaultHTTPClient() *http.Client {
+	dialer := &net.Dialer{Timeout: dialTimeout}
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			conn, err := dialer.DialContext(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			return &idleTimeoutConn{Conn: conn, timeout: idleTimeout}, nil
+		},
+		ForceAttemptHTTP2:     true,
+		TLSHandshakeTimeout:   dialTimeout,
+		ExpectContinueTimeout: time.Second,
+		IdleConnTimeout:       90 * time.Second,
+	}
+	return &http.Client{Transport: transport}
+}
+
+// idleTimeoutConn enforces an idle read timeout by refreshing the read
+// deadline before every Read. A Read fails only if no bytes arrive within
+// timeout, so a transfer that keeps making progress never trips it while a
+// genuinely stalled connection is aborted.
+type idleTimeoutConn struct {
+	net.Conn
+	timeout time.Duration
+}
+
+func (c *idleTimeoutConn) Read(b []byte) (int, error) {
+	if err := c.SetReadDeadline(time.Now().Add(c.timeout)); err != nil {
+		return 0, err
+	}
+	return c.Conn.Read(b)
 }
 
 func (u *Updater) CheckForUpdate(forceCheck bool) (*UpdateInfo, error) {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -526,6 +527,63 @@ func writeCachedCheck(t *testing.T, cacheDir, cachedVersion string, checkedAt ti
 	})
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, cacheFileName), data, 0o600))
+}
+
+func TestDefaultHTTPClientUsesIdleTimeoutNotOverallDeadline(t *testing.T) {
+	client := defaultHTTPClient()
+	// An overall http.Client.Timeout aborts large-but-healthy downloads on
+	// slow links (issue #895); the client must rely on the per-read idle
+	// timeout instead.
+	assert.Zero(t, client.Timeout)
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+	assert.NotNil(t, transport.DialContext)
+}
+
+func TestIdleTimeoutConnAbortsWhenNoDataArrives(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	conn := &idleTimeoutConn{Conn: client, timeout: 50 * time.Millisecond}
+	_, err := conn.Read(make([]byte, 8))
+	require.Error(t, err)
+	var netErr net.Error
+	require.ErrorAs(t, err, &netErr)
+	assert.True(t, netErr.Timeout())
+}
+
+func TestIdleTimeoutConnSucceedsWhileDataKeepsFlowing(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+
+	conn := &idleTimeoutConn{Conn: client, timeout: 50 * time.Millisecond}
+
+	// Trickle one byte every 20ms (under the 50ms idle timeout) for a total
+	// span far longer than the idle timeout. A total request deadline would
+	// abort this healthy slow transfer; the idle deadline must not.
+	const chunks = 10
+	go func() {
+		defer server.Close()
+		for i := range chunks {
+			time.Sleep(20 * time.Millisecond)
+			if _, err := server.Write([]byte{byte(i)}); err != nil {
+				return
+			}
+		}
+	}()
+
+	read := 0
+	buf := make([]byte, 1)
+	for {
+		n, err := conn.Read(buf)
+		read += n
+		if err != nil {
+			require.ErrorIs(t, err, io.EOF)
+			break
+		}
+	}
+	assert.Equal(t, chunks, read)
 }
 
 func newHTTPResponse(statusCode int, body string) *http.Response {


### PR DESCRIPTION
## Summary

- Fixes #895: `roborev update` aborted with `context deadline exceeded` partway through downloading a release asset on slow connections.
- The update HTTP client used `http.Client.Timeout = 30s`, an **overall** deadline covering the entire request including the body download — a ~12MB asset can't finish within 30s on slow wifi even when data is flowing steadily.
- Replaced the overall timeout with a **per-read idle timeout**: a custom transport wraps each connection and refreshes the read deadline before every `Read`, so a transfer fails only when no data has arrived for 30s (a dropped connection). Slow-but-progressing downloads now succeed.
- Kept bounded setup timeouts (`dialTimeout`, `TLSHandshakeTimeout`) so unreachable hosts still fail fast.
- Added tests covering the no-overall-deadline guard, idle-timeout abort on a stalled connection, and success on a slow-but-steady trickle.