### PR TITLE
Document [analyze.<type>] config for fieldless review types

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -307,6 +307,21 @@ Base keys use the pattern `{workflow}_agent` and `{workflow}_model` (e.g. `revie
 The fallback hierarchy for each workflow is:
 - **CLI flag** > **repo `{workflow}_agent_{level}`** > **repo `{workflow}_agent`** > **repo `agent`** > **global `{workflow}_agent_{level}`** > **global `{workflow}_agent`** > **global `default_agent`** > `codex`
 
+#### Per-type `[analyze.<type>]` override
+
+Some review types have no dedicated `{type}_agent` / `{type}_model` keys. Those are pinned through a generic per-type block keyed by the type name, which sets `agent` and `model`. Today this applies to the `lookahead` review type:
+
+```toml
+[analyze.lookahead]
+agent = "claude-code"
+model = "sonnet"
+```
+
+For such a type the fallback hierarchy is:
+- **CLI flag** > **repo `[analyze.<type>]`** > **repo `agent`** > **global `[analyze.<type>]`** > **global `default_agent`** > `codex` (model follows the same chain, ending at the agent's own default)
+
+This block is consulted **only** for review types that lack dedicated fields. Types that have them — `review`, `refine`, `fix`, `security`, `design` — ignore `[analyze.<type>]` when running reviews and use their `{type}_agent` / `{type}_model` keys instead. So an `[analyze.security]` table written for `roborev analyze security` never changes `roborev review --type security`. Reasoning is unaffected by this block for reviews; it follows `review_reasoning` (the block's `reasoning` field applies only to `roborev analyze <type>` runs).
+
 ### Review Panels
 
 Use `[review]` to configure subagent review panels. A panel fans one daemon review target out to named reviewers and stores one synthesis parent review:


### PR DESCRIPTION
## Summary

- Document the generic `[analyze.<type>]` per-type override in the configuration reference, which was missing after the lookahead review type landed in #904.
- Spell out the fallback hierarchy for review types without dedicated fields (CLI > repo `[analyze.<type>]` > repo `agent` > global `[analyze.<type>]` > global `default_agent` > `codex`).
- Clarify scope: the block is consulted only for types lacking `{type}_agent`/`{type}_model` (today, `lookahead`); `review`/`refine`/`fix`/`security`/`design` keep using their dedicated keys, so `[analyze.security]` never affects `review --type security`.
- Note that reasoning for reviews follows `review_reasoning`; the block's `reasoning` field applies only to `roborev analyze <type>`.

<sup>generated by a clanker</sup>