### PR TITLE
Harden Postgres job sync against binary text

### DIFF
--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -1052,7 +1052,7 @@ func nullString(s string) any {
 }
 
 func sanitizePostgresText(s string) string {
-	return strings.ToValidUTF8(s, "\uFFFD")
+	return strings.ReplaceAll(strings.ToValidUTF8(s, "\uFFFD"), "\x00", "\uFFFD")
 }
 
 func sanitizePostgresTextPointer(s *string) *string {

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -1051,6 +1051,18 @@ func nullString(s string) any {
 	return s
 }
 
+func sanitizePostgresText(s string) string {
+	return strings.ToValidUTF8(s, "\uFFFD")
+}
+
+func sanitizePostgresTextPointer(s *string) *string {
+	if s == nil {
+		return nil
+	}
+	sanitized := sanitizePostgresText(*s)
+	return &sanitized
+}
+
 // defaultStr returns s if non-empty, otherwise returns the default.
 // Used for NOT NULL columns that should never be nil.
 func defaultStr(s, def string) string {
@@ -1152,14 +1164,80 @@ func (p *PgPool) BatchUpsertJobs(ctx context.Context, jobs []JobWithPgIDs) ([]bo
 		return nil, nil
 	}
 
+	success, err := p.batchUpsertJobs(ctx, jobs)
+	if err == nil || len(jobs) == 1 {
+		return success, err
+	}
+	return p.upsertJobsIndividually(ctx, jobs)
+}
+
+func (p *PgPool) batchUpsertJobs(ctx context.Context, jobs []JobWithPgIDs) ([]bool, error) {
 	batch := &pgx.Batch{}
 	for _, jw := range jobs {
-		j := jw.Job
-		dirtyFilesJSON, err := encodeDirtyFiles(j.DirtyFiles)
-		if err != nil {
+		if err := queueJobUpsert(batch, jw); err != nil {
 			return nil, err
 		}
-		batch.Queue(`
+	}
+
+	br := p.pool.SendBatch(ctx, batch)
+
+	success := make([]bool, len(jobs))
+	var firstErr error
+	for i := range jobs {
+		_, err := br.Exec()
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		success[i] = true
+	}
+	if err := br.Close(); err != nil && firstErr == nil {
+		firstErr = err
+	}
+
+	return success, firstErr
+}
+
+func (p *PgPool) upsertJobsIndividually(ctx context.Context, jobs []JobWithPgIDs) ([]bool, error) {
+	success := make([]bool, len(jobs))
+	var firstErr error
+	for i, jw := range jobs {
+		batch := &pgx.Batch{}
+		if err := queueJobUpsert(batch, jw); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		br := p.pool.SendBatch(ctx, batch)
+		_, execErr := br.Exec()
+		closeErr := br.Close()
+		if execErr != nil {
+			if firstErr == nil {
+				firstErr = execErr
+			}
+			continue
+		}
+		if closeErr != nil {
+			if firstErr == nil {
+				firstErr = closeErr
+			}
+			continue
+		}
+		success[i] = true
+	}
+	return success, firstErr
+}
+
+func queueJobUpsert(batch *pgx.Batch, jw JobWithPgIDs) error {
+	j := jw.Job
+	dirtyFilesJSON, err := encodeDirtyFiles(j.DirtyFiles)
+	if err != nil {
+		return err
+	}
+	batch.Queue(`
 			INSERT INTO review_jobs (
 				uuid, repo_id, commit_id, git_ref, session_id, agent, model, provider, requested_model, requested_provider, reasoning, job_type, review_type, patch_id, status, agentic,
 				enqueued_at, started_at, finished_at, prompt, diff_content, dirty_files, error, token_usage,
@@ -1195,27 +1273,9 @@ func (p *PgPool) BatchUpsertJobs(ctx context.Context, jobs []JobWithPgIDs) ([]bo
 				panel_member_config_json = EXCLUDED.panel_member_config_json,
 				updated_at = clock_timestamp()
 		`, j.UUID, jw.PgRepoID, jw.PgCommitID, j.GitRef, nullString(j.SessionID), j.Agent, nullString(j.Model), nullString(j.Provider), nullString(j.RequestedModel), nullString(j.RequestedProvider), nullString(j.Reasoning),
-			defaultStr(j.JobType, "review"), j.ReviewType, nullString(j.PatchID), j.Status, j.Agentic, j.EnqueuedAt, j.StartedAt, j.FinishedAt,
-			nullString(j.Prompt), j.DiffContent, nullString(dirtyFilesJSON), nullString(j.Error), nullString(j.TokenUsage), nullString(j.WorktreePath), nullString(j.Source), normalizeMinSeverityForWrite(j.MinSeverity),
-			nullString(j.PanelRunUUID), nullString(j.PanelRole), nullString(j.PanelName), nullString(j.PanelMemberName), j.PanelMemberIndex, nullString(j.PanelMemberConfigJSON),
-			j.SourceMachineID, j.BackupAgent, j.BackupModel, j.AgentInvoked)
-	}
-
-	br := p.pool.SendBatch(ctx, batch)
-	defer br.Close()
-
-	success := make([]bool, len(jobs))
-	var firstErr error
-	for i := range jobs {
-		_, err := br.Exec()
-		if err != nil {
-			if firstErr == nil {
-				firstErr = err
-			}
-			continue
-		}
-		success[i] = true
-	}
-
-	return success, firstErr
+		defaultStr(j.JobType, "review"), j.ReviewType, nullString(j.PatchID), j.Status, j.Agentic, j.EnqueuedAt, j.StartedAt, j.FinishedAt,
+		nullString(sanitizePostgresText(j.Prompt)), sanitizePostgresTextPointer(j.DiffContent), nullString(dirtyFilesJSON), nullString(sanitizePostgresText(j.Error)), nullString(j.TokenUsage), nullString(j.WorktreePath), nullString(j.Source), normalizeMinSeverityForWrite(j.MinSeverity),
+		nullString(j.PanelRunUUID), nullString(j.PanelRole), nullString(j.PanelName), nullString(j.PanelMemberName), j.PanelMemberIndex, nullString(j.PanelMemberConfigJSON),
+		j.SourceMachineID, j.BackupAgent, j.BackupModel, j.AgentInvoked)
+	return nil
 }

--- a/internal/storage/postgres_test.go
+++ b/internal/storage/postgres_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -960,6 +961,101 @@ func TestIntegration_BatchUpsertJobs(t *testing.T) {
 		assert.Equal(t, "openai", found.Provider)
 		assert.Equal(t, "requested-model", found.RequestedModel)
 		assert.Equal(t, "requested-provider", found.RequestedProvider)
+	})
+
+	t.Run("invalid utf8 text fields are sanitized", func(t *testing.T) {
+		jobUUID := uuid.NewString()
+		machineID := uuid.NewString()
+		commitSHA := "batch-invalid-utf8-sha-" + jobUUID
+		commitID := createTestCommit(t, pool.Pool(), TestCommitOpts{
+			RepoID: repoID, SHA: commitSHA,
+		})
+		invalidText := "ReportLab PDF marker: " + string([]byte{0x93}) + " after header"
+		require.False(t, utf8.ValidString(invalidText))
+		diffContent := "diff --git a/demo.pdf b/demo.pdf\n" + invalidText
+		jobs := []JobWithPgIDs{{
+			Job: SyncableJob{
+				UUID:            jobUUID,
+				RepoIdentity:    "https://github.com/test/batch-jobs-test.git",
+				CommitSHA:       commitSHA,
+				GitRef:          commitSHA,
+				Agent:           "test",
+				Status:          "failed",
+				Prompt:          invalidText,
+				DiffContent:     &diffContent,
+				Error:           invalidText,
+				SourceMachineID: machineID,
+				EnqueuedAt:      time.Now(),
+			},
+			PgRepoID:   repoID,
+			PgCommitID: &commitID,
+		}}
+
+		success, err := pool.BatchUpsertJobs(ctx, jobs)
+		require.NoError(t, err)
+		assert.Equal(t, 1, countSuccesses(success))
+
+		var storedPrompt, storedDiff, storedError string
+		err = pool.pool.QueryRow(ctx,
+			`SELECT prompt, diff_content, error FROM review_jobs WHERE uuid = $1`, jobUUID,
+		).Scan(&storedPrompt, &storedDiff, &storedError)
+		require.NoError(t, err)
+		assert.True(t, utf8.ValidString(storedPrompt))
+		assert.True(t, utf8.ValidString(storedDiff))
+		assert.True(t, utf8.ValidString(storedError))
+		assert.Contains(t, storedPrompt, "\uFFFD")
+		assert.Contains(t, storedDiff, "\uFFFD")
+		assert.Contains(t, storedError, "\uFFFD")
+	})
+
+	t.Run("valid sibling persists when one job row fails", func(t *testing.T) {
+		validJobUUID := uuid.NewString()
+		invalidJobUUID := uuid.NewString()
+		machineID := uuid.NewString()
+		commitSHA := "batch-partial-job-sha-" + validJobUUID
+		commitID := createTestCommit(t, pool.Pool(), TestCommitOpts{
+			RepoID: repoID, SHA: commitSHA,
+		})
+		jobs := []JobWithPgIDs{
+			{
+				Job: SyncableJob{
+					UUID:            validJobUUID,
+					RepoIdentity:    "https://github.com/test/batch-jobs-test.git",
+					CommitSHA:       commitSHA,
+					GitRef:          commitSHA,
+					Agent:           "test",
+					Status:          "done",
+					SourceMachineID: machineID,
+					EnqueuedAt:      time.Now(),
+				},
+				PgRepoID:   repoID,
+				PgCommitID: &commitID,
+			},
+			{
+				Job: SyncableJob{
+					UUID:            invalidJobUUID,
+					RepoIdentity:    "https://github.com/test/batch-jobs-test.git",
+					GitRef:          "invalid-repo",
+					Agent:           "test",
+					Status:          "done",
+					SourceMachineID: machineID,
+					EnqueuedAt:      time.Now(),
+				},
+				PgRepoID: -1,
+			},
+		}
+
+		success, err := pool.BatchUpsertJobs(ctx, jobs)
+
+		require.Error(t, err)
+		assert.Len(t, success, 2)
+		assert.True(t, success[0])
+		assert.False(t, success[1])
+
+		var count int
+		err = pool.pool.QueryRow(ctx, `SELECT COUNT(*) FROM review_jobs WHERE uuid = $1`, validJobUUID).Scan(&count)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
 	})
 }
 

--- a/internal/storage/postgres_test.go
+++ b/internal/storage/postgres_test.go
@@ -1008,6 +1008,51 @@ func TestIntegration_BatchUpsertJobs(t *testing.T) {
 		assert.Contains(t, storedError, "\uFFFD")
 	})
 
+	t.Run("nul text fields are sanitized", func(t *testing.T) {
+		jobUUID := uuid.NewString()
+		machineID := uuid.NewString()
+		commitSHA := "batch-nul-text-sha-" + jobUUID
+		commitID := createTestCommit(t, pool.Pool(), TestCommitOpts{
+			RepoID: repoID, SHA: commitSHA,
+		})
+		nulText := "binary marker: \x00 after header"
+		require.True(t, utf8.ValidString(nulText))
+		diffContent := "diff --git a/demo.bin b/demo.bin\n" + nulText
+		jobs := []JobWithPgIDs{{
+			Job: SyncableJob{
+				UUID:            jobUUID,
+				RepoIdentity:    "https://github.com/test/batch-jobs-test.git",
+				CommitSHA:       commitSHA,
+				GitRef:          commitSHA,
+				Agent:           "test",
+				Status:          "failed",
+				Prompt:          nulText,
+				DiffContent:     &diffContent,
+				Error:           nulText,
+				SourceMachineID: machineID,
+				EnqueuedAt:      time.Now(),
+			},
+			PgRepoID:   repoID,
+			PgCommitID: &commitID,
+		}}
+
+		success, err := pool.BatchUpsertJobs(ctx, jobs)
+		require.NoError(t, err)
+		assert.Equal(t, 1, countSuccesses(success))
+
+		var storedPrompt, storedDiff, storedError string
+		err = pool.pool.QueryRow(ctx,
+			`SELECT prompt, diff_content, error FROM review_jobs WHERE uuid = $1`, jobUUID,
+		).Scan(&storedPrompt, &storedDiff, &storedError)
+		require.NoError(t, err)
+		assert.NotContains(t, storedPrompt, "\x00")
+		assert.NotContains(t, storedDiff, "\x00")
+		assert.NotContains(t, storedError, "\x00")
+		assert.Contains(t, storedPrompt, "\uFFFD")
+		assert.Contains(t, storedDiff, "\uFFFD")
+		assert.Contains(t, storedError, "\uFFFD")
+	})
+
 	t.Run("valid sibling persists when one job row fails", func(t *testing.T) {
 		validJobUUID := uuid.NewString()
 		invalidJobUUID := uuid.NewString()

--- a/internal/storage/postgres_text_test.go
+++ b/internal/storage/postgres_text_test.go
@@ -18,6 +18,17 @@ func TestSanitizePostgresTextReplacesInvalidUTF8(t *testing.T) {
 	assert.Equal(t, "ReportLab PDF marker: \uFFFD after header", got)
 }
 
+func TestSanitizePostgresTextReplacesNUL(t *testing.T) {
+	input := "binary marker: \x00 after header"
+	require.True(t, utf8.ValidString(input))
+
+	got := sanitizePostgresText(input)
+
+	assert.True(t, utf8.ValidString(got))
+	assert.Equal(t, "binary marker: \uFFFD after header", got)
+	assert.NotContains(t, got, "\x00")
+}
+
 func TestSanitizePostgresTextPointer(t *testing.T) {
 	invalid := "diff " + string([]byte{0x93})
 	got := sanitizePostgresTextPointer(&invalid)

--- a/internal/storage/postgres_text_test.go
+++ b/internal/storage/postgres_text_test.go
@@ -1,0 +1,29 @@
+package storage
+
+import (
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizePostgresTextReplacesInvalidUTF8(t *testing.T) {
+	invalid := "ReportLab PDF marker: " + string([]byte{0x93}) + " after header"
+	require.False(t, utf8.ValidString(invalid))
+
+	got := sanitizePostgresText(invalid)
+
+	assert.True(t, utf8.ValidString(got))
+	assert.Equal(t, "ReportLab PDF marker: \uFFFD after header", got)
+}
+
+func TestSanitizePostgresTextPointer(t *testing.T) {
+	invalid := "diff " + string([]byte{0x93})
+	got := sanitizePostgresTextPointer(&invalid)
+
+	require.NotNil(t, got)
+	assert.True(t, utf8.ValidString(*got))
+	assert.Equal(t, "diff \uFFFD", *got)
+	assert.Nil(t, sanitizePostgresTextPointer(nil))
+}


### PR DESCRIPTION
Roborev can capture job prompts, dirty diffs, and errors from local SQLite rows that contain bytes PostgreSQL `TEXT` will not accept. That mismatch is especially sharp when git treats a binary fixture as a textual diff: the local daemon keeps working, but central Postgres sync can reject the row forever.

Because pgx batches job upserts together, one poisoned row can also prevent unrelated completed reviews in the same batch from reaching the central history. This PR sanitizes job text at the Postgres write boundary while leaving the local byte-tolerant store unchanged, and it retries failed job batches row-by-row so valid siblings can still drain.

Invalid UTF-8 and embedded NUL bytes now degrade to the Unicode replacement character in `prompt`, `diff_content`, and `error`, preserving the surrounding review context without allowing one binary-ish payload to wedge a repo sync stream.