### PR TITLE
Speed up Windows test fixtures

### DIFF
--- a/cmd/roborev/analyze_test.go
+++ b/cmd/roborev/analyze_test.go
@@ -558,7 +558,7 @@ reasoning = "fast"
 func TestEnqueueAnalysisJobBranchName(t *testing.T) {
 	// Create a real git repo so GetCurrentBranch returns a known value
 	repo := newTestGitRepo(t)
-	repo.Run("checkout", "-b", "test-current")
+	repo.SetHeadBranch("test-current")
 	repo.CommitFile("init.go", "package main", "initial")
 
 	captureBranch := func(t *testing.T) (mock *httptest.Server, gotBranch *string) {
@@ -657,7 +657,7 @@ func TestGetBranchFiles(t *testing.T) {
 
 	t.Run("no code files returns error", func(t *testing.T) {
 		repo := setupBranchTestRepo(t)
-		repo.Run("checkout", "-b", "docs-only", "main")
+		repo.CheckoutNewBranch("docs-only", "main")
 		repo.CommitFile("readme.md", "# Hello", "add readme")
 
 		_, err := getBranchFiles(t.Context(), cmd, repo.Dir, analyzeOptions{
@@ -685,22 +685,23 @@ func TestGetBranchFiles(t *testing.T) {
 		// Feature branch tracks upstream/main; merge-base must be taken
 		// against upstream/main, not origin/main, so commits already
 		// merged upstream aren't re-analyzed.
-		remote := newBareTestGitRepo(t)
-		stale := newBareTestGitRepo(t)
 		repo := newTestGitRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
-		repo.CommitFile("a.go", "package main", "u1")
-		repo.CommitFile("b.go", "package main", "u2")
-		repo.Run("remote", "add", "upstream", remote.Dir)
-		repo.Run("push", "-u", "upstream", "main")
+		repo.SetHeadBranch("main")
+		staleOriginSHA := repo.CommitFile("a.go", "package main", "u1")
+		upstreamSHA := repo.CommitFile("b.go", "package main", "u2")
+		repo.AddRemote("upstream", "/dev/null")
+		repo.SetRef("refs/remotes/upstream/main", upstreamSHA)
+		repo.SetBranchConfig("main", "remote", "upstream")
+		repo.SetBranchConfig("main", "merge", "refs/heads/main")
 
 		// origin lags upstream by 1 commit.
-		repo.Run("remote", "add", "origin", stale.Dir)
-		repo.Run("push", "origin", "HEAD~1:refs/heads/main")
-		repo.Run("fetch", "origin")
-		repo.Run("remote", "set-head", "origin", "main")
+		repo.AddRemote("origin", "/dev/null")
+		repo.SetRef("refs/remotes/origin/main", staleOriginSHA)
+		repo.SetRemoteHead("origin", "main")
 
-		repo.Run("checkout", "-b", "feature", "--track", "upstream/main")
+		repo.CheckoutNewBranch("feature", upstreamSHA)
+		repo.SetBranchConfig("feature", "remote", "upstream")
+		repo.SetBranchConfig("feature", "merge", "refs/heads/main")
 		repo.CommitFile("only-new.go", "package main\nfunc New() {}", "feature work")
 
 		files, err := getBranchFiles(t.Context(), cmd, repo.Dir, analyzeOptions{branch: "HEAD"})
@@ -713,12 +714,13 @@ func TestGetBranchFiles(t *testing.T) {
 	})
 
 	t.Run("blocks local main tracking non-origin upstream", func(t *testing.T) {
-		remote := newBareTestGitRepo(t)
 		repo := newTestGitRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
-		repo.CommitFile("a.go", "package main", "initial")
-		repo.Run("remote", "add", "upstream", remote.Dir)
-		repo.Run("push", "-u", "upstream", "main")
+		repo.SetHeadBranch("main")
+		mainSHA := repo.CommitFile("a.go", "package main", "initial")
+		repo.AddRemote("upstream", "/dev/null")
+		repo.SetRef("refs/remotes/upstream/main", mainSHA)
+		repo.SetBranchConfig("main", "remote", "upstream")
+		repo.SetBranchConfig("main", "merge", "refs/heads/main")
 
 		_, err := getBranchFiles(t.Context(), cmd, repo.Dir, analyzeOptions{branch: "HEAD"})
 		require.Error(t, err, "expected error when on base branch")

--- a/cmd/roborev/analyze_test.go
+++ b/cmd/roborev/analyze_test.go
@@ -603,10 +603,10 @@ func TestEnqueueAnalysisJobBranchName(t *testing.T) {
 
 func setupBranchTestRepo(t *testing.T) *TestGitRepo {
 	repo := newTestGitRepo(t)
-	repo.Run("checkout", "-b", "main")
+	repo.SetHeadBranch("main")
 	repo.CommitFile("base.go", "package main", "base")
 
-	repo.Run("checkout", "-b", "feature")
+	repo.CheckoutNewBranch("feature")
 	repo.CommitFile("new.go", "package main\nfunc New() {}", "add go file")
 	repo.CommitFile("docs.md", "# Docs", "add docs")
 	repo.CommitFile("config.yml", "key: val", "add config")
@@ -645,7 +645,7 @@ func TestGetBranchFiles(t *testing.T) {
 	t.Run("named branch reads from that branch", func(t *testing.T) {
 		repo := setupBranchTestRepo(t)
 		// Switch back to main, analyze feature branch by name
-		repo.Run("checkout", "main")
+		repo.SetHeadBranch("main")
 
 		files, err := getBranchFiles(t.Context(), cmd, repo.Dir, analyzeOptions{
 			branch:     "feature",
@@ -670,7 +670,7 @@ func TestGetBranchFiles(t *testing.T) {
 
 	t.Run("on base branch returns error", func(t *testing.T) {
 		repo := setupBranchTestRepo(t)
-		repo.Run("checkout", "main")
+		repo.SetHeadBranch("main")
 
 		_, err := getBranchFiles(t.Context(), cmd, repo.Dir, analyzeOptions{
 			branch:     "HEAD",

--- a/cmd/roborev/fix_integration_test.go
+++ b/cmd/roborev/fix_integration_test.go
@@ -107,7 +107,6 @@ func TestEnqueueIfNeeded(t *testing.T) {
 func withFreshTestAgent(t *testing.T) *agent.TestAgent {
 	t.Helper()
 	a := agent.NewTestAgent()
-	a.Delay = 0 // tests don't want the 100ms baked-in delay
 	agent.Register(a)
 	t.Cleanup(func() {
 		agent.Unregister("test")

--- a/cmd/roborev/fix_test.go
+++ b/cmd/roborev/fix_test.go
@@ -1575,7 +1575,6 @@ func TestFixJobDirect_RetryThreadsCapturedSessionID(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "dirty.txt"), []byte("uncommitted"), 0o644))
 
 	tester := agent.NewTestAgent()
-	tester.Delay = 0
 	capture := agent.NewSessionCaptureWriter(io.Discard, nil)
 
 	_, err := fixJobDirect(context.Background(), fixJobParams{

--- a/cmd/roborev/helpers.go
+++ b/cmd/roborev/helpers.go
@@ -136,8 +136,8 @@ func autoInstallHooks(ctx context.Context, repoPath string) {
 	}
 	for _, name := range []string{"post-commit", "post-rewrite"} {
 		marker := githook.VersionMarker(name)
-		if githook.NeedsUpgrade(ctx, repoPath, name, marker) ||
-			githook.Missing(ctx, repoPath, name) {
+		if githook.NeedsUpgradeInDir(hooksDir, name, marker) ||
+			githook.MissingInDir(hooksDir, name) {
 			if err := githook.Install(hooksDir, name, false); err != nil {
 				// Non-shell hooks are a persistent condition;
 				// don't warn on every invocation.

--- a/cmd/roborev/helpers_test.go
+++ b/cmd/roborev/helpers_test.go
@@ -8,16 +8,21 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/testutil"
 )
 
 // TestGitRepo wraps a temporary git repository for test use.
@@ -32,15 +37,8 @@ func newTestGitRepo(t *testing.T) *TestGitRepo {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
-	dir := t.TempDir()
-	resolved, err := filepath.EvalSymlinks(dir)
-	require.NoError(t, err, "Failed to resolve symlinks: %v")
-
-	r := &TestGitRepo{Dir: resolved, t: t}
-	r.Run("init")
-	r.Run("config", "user.email", "test@test.com")
-	r.Run("config", "user.name", "Test")
-	return r
+	repo := testutil.NewGitRepo(t)
+	return &TestGitRepo{Dir: repo.Path(), t: t}
 }
 
 // newBareTestGitRepo creates a bare git repository for use as a remote.
@@ -49,13 +47,8 @@ func newBareTestGitRepo(t *testing.T) *TestGitRepo {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
-	dir := t.TempDir()
-	resolved, err := filepath.EvalSymlinks(dir)
-	require.NoError(t, err, "Failed to resolve symlinks: %v")
-
-	r := &TestGitRepo{Dir: resolved, t: t}
-	r.Run("init", "--bare")
-	return r
+	repo := testutil.NewBareTestRepo(t)
+	return &TestGitRepo{Dir: repo.Path(), t: t}
 }
 
 // chdir changes to dir and registers a t.Cleanup to restore the original directory.
@@ -113,9 +106,72 @@ func (r *TestGitRepo) CommitFile(name, content, msg string) string {
 	require.NoError(r.t, err)
 	err = os.WriteFile(fullPath, []byte(content), 0o644)
 	require.NoError(r.t, err)
-	r.Run("add", name)
-	r.Run("commit", "-m", msg)
-	return r.Run("rev-parse", "HEAD")
+	return commitPaths(r.t, r.Dir, msg, name)
+}
+
+func (r *TestGitRepo) CommitFiles(files map[string]string, msg string) string {
+	r.t.Helper()
+	r.WriteFiles(files)
+	paths := make([]string, 0, len(files))
+	for path := range files {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return commitPaths(r.t, r.Dir, msg, paths...)
+}
+
+func commitPaths(t *testing.T, dir, msg string, paths ...string) string {
+	t.Helper()
+	if !canCommitInProcess(dir) {
+		runGitForCommit(t, dir, append([]string{"add"}, paths...)...)
+		runGitForCommit(t, dir, "commit", "-m", msg)
+		return runGitForCommit(t, dir, "rev-parse", "HEAD")
+	}
+
+	repo, err := gogit.PlainOpen(dir)
+	require.NoError(t, err, "open repo %q", dir)
+	wt, err := repo.Worktree()
+	require.NoError(t, err, "open worktree")
+	for _, path := range paths {
+		_, err = wt.Add(filepath.ToSlash(path))
+		require.NoError(t, err, "git add %s", path)
+	}
+	hash, err := wt.Commit(msg, &gogit.CommitOptions{
+		Author: &object.Signature{
+			Name:  testutil.GitUserName,
+			Email: testutil.GitUserEmail,
+			When:  time.Now(),
+		},
+	})
+	require.NoError(t, err, "commit %q", msg)
+	return hash.String()
+}
+
+func canCommitInProcess(dir string) bool {
+	info, err := os.Stat(filepath.Join(dir, ".git"))
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	entries, err := os.ReadDir(filepath.Join(dir, ".git", "hooks"))
+	if err != nil {
+		return true
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || strings.HasSuffix(entry.Name(), ".sample") {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func runGitForCommit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v failed:\n%s", args, out)
+	return strings.TrimSpace(string(out))
 }
 
 // WriteFiles writes the given files to the repository directory.
@@ -148,9 +204,7 @@ func createTestRepo(t *testing.T, files map[string]string) *TestGitRepo {
 	t.Helper()
 
 	r := newTestGitRepo(t)
-	r.WriteFiles(files)
-	r.Run("add", ".")
-	r.Run("commit", "-m", "initial")
+	r.CommitFiles(files, "initial")
 	return r
 }
 

--- a/cmd/roborev/helpers_test.go
+++ b/cmd/roborev/helpers_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -118,6 +119,95 @@ func (r *TestGitRepo) CommitFiles(files map[string]string, msg string) string {
 	}
 	sort.Strings(paths)
 	return commitPaths(r.t, r.Dir, msg, paths...)
+}
+
+func (r *TestGitRepo) HeadSHA() string {
+	r.t.Helper()
+	repo, err := gogit.PlainOpen(r.Dir)
+	require.NoError(r.t, err, "open repo %q", r.Dir)
+	head, err := repo.Head()
+	require.NoError(r.t, err, "read HEAD")
+	return head.Hash().String()
+}
+
+func (r *TestGitRepo) SetHeadBranch(branch string) {
+	r.t.Helper()
+	writeGitFile(r.t, r.Dir, "HEAD", "ref: refs/heads/"+branch+"\n")
+}
+
+func (r *TestGitRepo) DetachHead(sha string) {
+	r.t.Helper()
+	writeGitFile(r.t, r.Dir, "HEAD", sha+"\n")
+}
+
+func (r *TestGitRepo) CheckoutNewBranch(branch string, start ...string) {
+	r.t.Helper()
+	require.LessOrEqual(r.t, len(start), 1, "CheckoutNewBranch accepts at most one start ref")
+	sha := ""
+	if len(start) == 0 {
+		sha = r.HeadSHA()
+	} else {
+		sha = start[0]
+	}
+	r.SetRef("refs/heads/"+branch, sha)
+	r.SetHeadBranch(branch)
+}
+
+func (r *TestGitRepo) SetRef(ref, sha string) {
+	r.t.Helper()
+	writeGitFile(r.t, r.Dir, ref, sha+"\n")
+}
+
+func (r *TestGitRepo) AddRemote(name, url string) {
+	r.t.Helper()
+	appendGitConfig(r.t, r.Dir, "remote", name, map[string]string{
+		"url":   url,
+		"fetch": "+refs/heads/*:refs/remotes/" + name + "/*",
+	})
+}
+
+func (r *TestGitRepo) SetRemoteHead(remote, branch string) {
+	r.t.Helper()
+	writeGitFile(r.t, r.Dir, "refs/remotes/"+remote+"/HEAD",
+		"ref: refs/remotes/"+remote+"/"+branch+"\n")
+}
+
+func (r *TestGitRepo) SetBranchConfig(branch, key, value string) {
+	r.t.Helper()
+	appendGitConfig(r.t, r.Dir, "branch", branch, map[string]string{key: value})
+}
+
+func writeGitFile(t *testing.T, repoDir, relPath, content string) {
+	t.Helper()
+	path := filepath.Join(repoDir, ".git", filepath.FromSlash(relPath))
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+func appendGitConfig(t *testing.T, repoDir, section, subsection string, values map[string]string) {
+	t.Helper()
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	b.WriteByte('\n')
+	if subsection == "" {
+		fmt.Fprintf(&b, "[%s]\n", section)
+	} else {
+		fmt.Fprintf(&b, "[%s %q]\n", section, subsection)
+	}
+	for _, key := range keys {
+		fmt.Fprintf(&b, "\t%s = %s\n", key, values[key])
+	}
+
+	f, err := os.OpenFile(filepath.Join(repoDir, ".git", "config"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	require.NoError(t, err)
+	defer f.Close()
+	_, err = f.WriteString(b.String())
+	require.NoError(t, err)
 }
 
 func commitPaths(t *testing.T, dir, msg string, paths ...string) string {

--- a/cmd/roborev/helpers_test.go
+++ b/cmd/roborev/helpers_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
@@ -39,16 +40,6 @@ func newTestGitRepo(t *testing.T) *TestGitRepo {
 		t.Skip("git not available")
 	}
 	repo := testutil.NewGitRepo(t)
-	return &TestGitRepo{Dir: repo.Path(), t: t}
-}
-
-// newBareTestGitRepo creates a bare git repository for use as a remote.
-func newBareTestGitRepo(t *testing.T) *TestGitRepo {
-	t.Helper()
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("git not available")
-	}
-	repo := testutil.NewBareTestRepo(t)
 	return &TestGitRepo{Dir: repo.Path(), t: t}
 }
 
@@ -143,14 +134,26 @@ func (r *TestGitRepo) DetachHead(sha string) {
 func (r *TestGitRepo) CheckoutNewBranch(branch string, start ...string) {
 	r.t.Helper()
 	require.LessOrEqual(r.t, len(start), 1, "CheckoutNewBranch accepts at most one start ref")
-	sha := ""
-	if len(start) == 0 {
-		sha = r.HeadSHA()
+	repo, err := gogit.PlainOpen(r.Dir)
+	require.NoError(r.t, err, "open repo %q", r.Dir)
+	var hash plumbing.Hash
+	if len(start) == 1 {
+		resolved, err := repo.ResolveRevision(plumbing.Revision(start[0]))
+		require.NoError(r.t, err, "resolve ref %q", start[0])
+		hash = *resolved
 	} else {
-		sha = start[0]
+		head, err := repo.Head()
+		require.NoError(r.t, err, "read HEAD")
+		hash = head.Hash()
 	}
-	r.SetRef("refs/heads/"+branch, sha)
-	r.SetHeadBranch(branch)
+	wt, err := repo.Worktree()
+	require.NoError(r.t, err, "open worktree")
+	err = wt.Checkout(&gogit.CheckoutOptions{
+		Branch: plumbing.NewBranchReferenceName(branch),
+		Create: true,
+		Hash:   hash,
+	})
+	require.NoError(r.t, err, "checkout new branch %q", branch)
 }
 
 func (r *TestGitRepo) SetRef(ref, sha string) {

--- a/cmd/roborev/local_review_test.go
+++ b/cmd/roborev/local_review_test.go
@@ -186,20 +186,24 @@ func TestLocalReviewValidation(t *testing.T) {
 			wantErr: "invalid --type",
 		},
 		{
-			name: "Valid Security Type",
-			opts: runOpts{Agent: "test", Reasoning: "fast", ReviewType: "security"},
+			name:    "Valid Security Type",
+			opts:    runOpts{Agent: "test", Reasoning: "fast", ReviewType: "security", Dirty: true, Quiet: true},
+			wantErr: "no uncommitted changes",
 		},
 		{
-			name: "Valid Design Type",
-			opts: runOpts{Agent: "test", Reasoning: "fast", ReviewType: "design"},
+			name:    "Valid Design Type",
+			opts:    runOpts{Agent: "test", Reasoning: "fast", ReviewType: "design", Dirty: true, Quiet: true},
+			wantErr: "no uncommitted changes",
 		},
 		{
-			name: "Valid Lookahead Type",
-			opts: runOpts{Agent: "test", Reasoning: "fast", ReviewType: "lookahead"},
+			name:    "Valid Lookahead Type",
+			opts:    runOpts{Agent: "test", Reasoning: "fast", ReviewType: "lookahead", Dirty: true, Quiet: true},
+			wantErr: "no uncommitted changes",
 		},
 		{
-			name: "Empty Type Accepted",
-			opts: runOpts{Agent: "test", Reasoning: "fast", ReviewType: ""},
+			name:    "Empty Type Accepted",
+			opts:    runOpts{Agent: "test", Reasoning: "fast", ReviewType: "", Dirty: true, Quiet: true},
+			wantErr: "no uncommitted changes",
 		},
 	}
 

--- a/cmd/roborev/main_test_helpers_test.go
+++ b/cmd/roborev/main_test_helpers_test.go
@@ -21,6 +21,7 @@ import (
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/testutil"
 	"go.kenn.io/roborev/internal/version"
 )
 
@@ -33,13 +34,8 @@ type GitTestRepo struct {
 // NewGitTestRepo creates a new temporary git repository.
 func NewGitTestRepo(t *testing.T) *GitTestRepo {
 	t.Helper()
-	dir := t.TempDir()
-	r := &GitTestRepo{Dir: dir, t: t}
-	r.Run("init")
-	r.Run("symbolic-ref", "HEAD", "refs/heads/main")
-	r.Run("config", "user.email", "test@test.com")
-	r.Run("config", "user.name", "Test")
-	return r
+	repo := testutil.NewGitRepo(t)
+	return &GitTestRepo{Dir: repo.Path(), t: t}
 }
 
 // Run executes a git command in the repository.
@@ -58,9 +54,7 @@ func (r *GitTestRepo) CommitFile(name, content, msg string) string {
 	path := filepath.Join(r.Dir, name)
 	require.NoError(r.t, os.MkdirAll(filepath.Dir(path), 0o755))
 	require.NoError(r.t, os.WriteFile(path, []byte(content), 0o644))
-	r.Run("add", name)
-	r.Run("commit", "-m", msg)
-	return r.Run("rev-parse", "HEAD")
+	return commitPaths(r.t, r.Dir, msg, name)
 }
 
 // MockDaemon encapsulates a mock daemon server and its state.

--- a/cmd/roborev/refine_test.go
+++ b/cmd/roborev/refine_test.go
@@ -577,8 +577,8 @@ func TestValidateRefineContext_SinceIgnoresUpstreamMissing(t *testing.T) {
 	repo.CommitFile("second.txt", "second", "second commit")
 
 	// Configure tracking against an upstream that never resolves locally.
-	repo.Run("config", "branch.main.remote", "upstream")
-	repo.Run("config", "branch.main.merge", "refs/heads/main")
+	repo.SetBranchConfig("main", "remote", "upstream")
+	repo.SetBranchConfig("main", "merge", "refs/heads/main")
 
 	chdirForTest(t, repo.Root)
 
@@ -599,10 +599,10 @@ func TestValidateRefineContext_UpstreamMissingErrorsWithoutSince(t *testing.T) {
 	// as UpstreamMissingError rather than silently falling back to the
 	// repository default branch (which could yield the wrong range).
 	repo := testutil.InitTestRepo(t)
-	repo.RunGit("checkout", "-b", "feature")
+	repo.CheckoutNewBranch("feature")
 	repo.CommitFile("feature.txt", "feature", "feature commit")
-	repo.Run("config", "branch.feature.remote", "upstream")
-	repo.Run("config", "branch.feature.merge", "refs/heads/main")
+	repo.SetBranchConfig("feature", "remote", "upstream")
+	repo.SetBranchConfig("feature", "merge", "refs/heads/main")
 
 	chdirForTest(t, repo.Root)
 
@@ -621,7 +621,7 @@ func TestValidateRefineContext_SinceWorksOnFeatureBranch(t *testing.T) {
 	repo := testutil.InitTestRepo(t)
 	baseSHA := repo.RevParse("HEAD")
 
-	repo.RunGit("checkout", "-b", "feature")
+	repo.CheckoutNewBranch("feature")
 	repo.CommitFile("feature.txt", "feature", "feature commit")
 
 	chdirForTest(t, repo.Root)
@@ -655,11 +655,11 @@ func TestValidateRefineContext_SinceNotAncestorOfHEAD(t *testing.T) {
 
 	repo := testutil.InitTestRepo(t)
 
-	repo.RunGit("checkout", "-b", "other-branch")
+	repo.CheckoutNewBranch("other-branch")
 	repo.CommitFile("other.txt", "other", "commit on other branch")
 	otherBranchSHA := repo.RevParse("HEAD")
 
-	repo.RunGit("checkout", "main")
+	repo.CheckoutBranch("main")
 	repo.CommitFile("main2.txt", "main2", "second commit on main")
 
 	chdirForTest(t, repo.Root)
@@ -679,22 +679,21 @@ func TestValidateRefineContext_PrefersNonOriginUpstream(t *testing.T) {
 	// pick upstream/main as the base so commits already merged upstream
 	// are not refined.
 	repo := testutil.InitTestRepo(t)
-	repo.CommitFile("upstream_c2.go", "package main", "upstream c2")
-	upstreamSHA := repo.RevParse("HEAD")
+	staleOriginSHA := repo.RevParse("HEAD")
+	upstreamSHA := repo.CommitFile("upstream_c2.go", "package main", "upstream c2")
 
-	bareRemote := t.TempDir()
-	bareStale := t.TempDir()
-	repo.Run("init", "--bare", bareRemote)
-	repo.Run("init", "--bare", bareStale)
-	repo.Run("remote", "add", "upstream", bareRemote)
-	repo.Run("push", "-u", "upstream", "main")
+	repo.AddRemote("upstream", "/dev/null")
+	repo.SetRef("refs/remotes/upstream/main", upstreamSHA)
+	repo.SetBranchConfig("main", "remote", "upstream")
+	repo.SetBranchConfig("main", "merge", "refs/heads/main")
 
-	repo.Run("remote", "add", "origin", bareStale)
-	repo.Run("push", "origin", "HEAD~1:refs/heads/main")
-	repo.Run("fetch", "origin")
-	repo.Run("remote", "set-head", "origin", "main")
+	repo.AddRemote("origin", "/dev/null")
+	repo.SetRef("refs/remotes/origin/main", staleOriginSHA)
+	repo.SetRemoteHead("origin", "main")
 
-	repo.RunGit("checkout", "-b", "feature", "--track", "upstream/main")
+	repo.CheckoutNewBranch("feature", upstreamSHA)
+	repo.SetBranchConfig("feature", "remote", "upstream")
+	repo.SetBranchConfig("feature", "merge", "refs/heads/main")
 	repo.CommitFile("feature.go", "package main", "feature commit")
 
 	chdirForTest(t, repo.Root)
@@ -720,10 +719,11 @@ func TestValidateRefineContext_RefusesLocalMainTrackingNonOriginUpstream(t *test
 	// (not "origin/main"). Regression for IsOnBaseBranch's non-origin
 	// remote handling.
 	repo := testutil.InitTestRepo(t)
-	bareRemote := t.TempDir()
-	repo.Run("init", "--bare", bareRemote)
-	repo.Run("remote", "add", "upstream", bareRemote)
-	repo.Run("push", "-u", "upstream", "main")
+	mainSHA := repo.HeadSHA()
+	repo.AddRemote("upstream", "/dev/null")
+	repo.SetRef("refs/remotes/upstream/main", mainSHA)
+	repo.SetBranchConfig("main", "remote", "upstream")
+	repo.SetBranchConfig("main", "merge", "refs/heads/main")
 
 	chdirForTest(t, repo.Root)
 
@@ -740,7 +740,7 @@ func TestValidateRefineContext_FeatureBranchWithoutSinceStillWorks(t *testing.T)
 	repo := testutil.InitTestRepo(t)
 	baseSHA := repo.RevParse("HEAD")
 
-	repo.RunGit("checkout", "-b", "feature")
+	repo.CheckoutNewBranch("feature")
 	repo.CommitFile("feature.txt", "feature", "feature commit")
 
 	chdirForTest(t, repo.Root)

--- a/cmd/roborev/review_test.go
+++ b/cmd/roborev/review_test.go
@@ -428,7 +428,6 @@ func TestReviewBranchFlag(t *testing.T) {
 	t.Run("branch on default branch fails", func(t *testing.T) {
 		repo, _ := setupTestEnvironment(t)
 
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
 		repo.CommitFile("file.txt", "content", "initial")
 
 		_, _, err := executeReviewCmd("--repo", repo.Dir, "--branch")
@@ -438,9 +437,8 @@ func TestReviewBranchFlag(t *testing.T) {
 	t.Run("branch with no commits fails", func(t *testing.T) {
 		repo, _ := setupTestEnvironment(t)
 
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("checkout", "-b", "feature")
+		repo.CheckoutNewBranch("feature")
 
 		_, _, err := executeReviewCmd("--repo", repo.Dir, "--branch")
 		assertErrorContains(t, err, "no commits on branch")
@@ -450,10 +448,8 @@ func TestReviewBranchFlag(t *testing.T) {
 		repo, mux := setupTestEnvironment(t)
 		reqCh := mockEnqueue(t, mux)
 
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
-		repo.CommitFile("file.txt", "content", "initial")
-		mainSHA := repo.Run("rev-parse", "HEAD")
-		repo.Run("checkout", "-b", "feature")
+		mainSHA := repo.CommitFile("file.txt", "content", "initial")
+		repo.CheckoutNewBranch("feature")
 		repo.CommitFile("feature.txt", "feature", "feature commit")
 
 		_, _, err := executeReviewCmd("--repo", repo.Dir, "--branch")
@@ -468,13 +464,11 @@ func TestReviewBranchFlag(t *testing.T) {
 		repo, mux := setupTestEnvironment(t)
 		reqCh := mockEnqueue(t, mux)
 
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
-		repo.CommitFile("file.txt", "content", "initial")
-		mainSHA := repo.Run("rev-parse", "HEAD")
-		repo.Run("checkout", "-b", "feature")
-		repo.Run("config", "branch.feature.remote", "https://example.com/fork.git")
-		repo.Run("config", "branch.feature.merge", "refs/heads/feature")
-		repo.Run("config", "branch.feature.base", "main")
+		mainSHA := repo.CommitFile("file.txt", "content", "initial")
+		repo.CheckoutNewBranch("feature")
+		repo.SetBranchConfig("feature", "remote", "https://example.com/fork.git")
+		repo.SetBranchConfig("feature", "merge", "refs/heads/feature")
+		repo.SetBranchConfig("feature", "base", "main")
 		repo.CommitFile("feature.txt", "feature", "feature commit")
 
 		_, _, err := executeReviewCmd("--repo", repo.Dir, "--branch")
@@ -492,21 +486,18 @@ func TestReviewBranchFlag(t *testing.T) {
 		repo, mux := setupTestEnvironment(t)
 		reqCh := mockEnqueue(t, mux)
 
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
-		repo.CommitFile("base.txt", "base", "initial")
-		staleMainSHA := repo.Run("rev-parse", "HEAD")
+		staleMainSHA := repo.CommitFile("base.txt", "base", "initial")
 		// Two commits land on the trunk after local main was last updated.
 		repo.CommitFile("trunk1.txt", "t1", "trunk advance 1")
-		repo.CommitFile("trunk2.txt", "t2", "trunk advance 2")
-		freshOriginSHA := repo.Run("rev-parse", "HEAD")
+		freshOriginSHA := repo.CommitFile("trunk2.txt", "t2", "trunk advance 2")
 		// Rewind local main to simulate a stale checkout.
-		repo.Run("update-ref", "refs/heads/main", staleMainSHA)
-		repo.Run("remote", "add", "origin", "/dev/null")
-		repo.Run("update-ref", "refs/remotes/origin/main", freshOriginSHA)
+		repo.SetRef("refs/heads/main", staleMainSHA)
+		repo.AddRemote("origin", "/dev/null")
+		repo.SetRef("refs/remotes/origin/main", freshOriginSHA)
 		// Feature branch was rebased onto origin/main.
-		repo.Run("checkout", "-b", "feature", freshOriginSHA)
+		repo.CheckoutNewBranch("feature", freshOriginSHA)
 		repo.CommitFile("feature.txt", "f", "feature commit")
-		repo.Run("config", "branch.feature.base", "main")
+		repo.SetBranchConfig("feature", "base", "main")
 
 		_, _, err := executeReviewCmd("--repo", repo.Dir, "--branch")
 		require.NoError(t, err)
@@ -579,9 +570,8 @@ func writeRoborevConfig(t *testing.T, repo *TestGitRepo, content string) {
 func TestTryBranchReview(t *testing.T) {
 	t.Run("returns false when no config", func(t *testing.T) {
 		repo := newTestGitRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("checkout", "-b", "feature")
+		repo.CheckoutNewBranch("feature")
 		repo.CommitFile("feature.txt", "feature", "feature commit")
 
 		_, ok := tryBranchReview(t.Context(), repo.Dir, "")
@@ -590,9 +580,8 @@ func TestTryBranchReview(t *testing.T) {
 
 	t.Run("returns false when config is commit", func(t *testing.T) {
 		repo := newTestGitRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("checkout", "-b", "feature")
+		repo.CheckoutNewBranch("feature")
 		repo.CommitFile("feature.txt", "feature", "feature commit")
 		writeRoborevConfig(t, repo, `post_commit_review = "commit"`)
 
@@ -602,10 +591,8 @@ func TestTryBranchReview(t *testing.T) {
 
 	t.Run("returns merge-base range when config is branch", func(t *testing.T) {
 		repo := newTestGitRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
-		repo.CommitFile("file.txt", "content", "initial")
-		mainSHA := repo.Run("rev-parse", "HEAD")
-		repo.Run("checkout", "-b", "feature")
+		mainSHA := repo.CommitFile("file.txt", "content", "initial")
+		repo.CheckoutNewBranch("feature")
 		repo.CommitFile("feature.txt", "feature", "feature commit")
 		writeRoborevConfig(t, repo, `post_commit_review = "branch"`)
 
@@ -618,10 +605,8 @@ func TestTryBranchReview(t *testing.T) {
 
 	t.Run("covers multiple commits on feature branch", func(t *testing.T) {
 		repo := newTestGitRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
-		repo.CommitFile("file.txt", "content", "initial")
-		mainSHA := repo.Run("rev-parse", "HEAD")
-		repo.Run("checkout", "-b", "feature")
+		mainSHA := repo.CommitFile("file.txt", "content", "initial")
+		repo.CheckoutNewBranch("feature")
 		repo.CommitFile("a.txt", "a", "first feature commit")
 		repo.CommitFile("b.txt", "b", "second feature commit")
 		repo.CommitFile("c.txt", "c", "third feature commit")
@@ -636,7 +621,6 @@ func TestTryBranchReview(t *testing.T) {
 
 	t.Run("returns false on base branch", func(t *testing.T) {
 		repo := newTestGitRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
 		repo.CommitFile("file.txt", "content", "initial")
 		writeRoborevConfig(t, repo, `post_commit_review = "branch"`)
 
@@ -646,10 +630,9 @@ func TestTryBranchReview(t *testing.T) {
 
 	t.Run("uses baseBranch override", func(t *testing.T) {
 		repo := newTestGitRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/develop")
-		repo.CommitFile("file.txt", "content", "initial")
-		developSHA := repo.Run("rev-parse", "HEAD")
-		repo.Run("checkout", "-b", "feature")
+		repo.SetHeadBranch("develop")
+		developSHA := repo.CommitFile("file.txt", "content", "initial")
+		repo.CheckoutNewBranch("feature")
 		repo.CommitFile("feature.txt", "feature", "feature commit")
 		writeRoborevConfig(t, repo, `post_commit_review = "branch"`)
 
@@ -662,13 +645,11 @@ func TestTryBranchReview(t *testing.T) {
 
 	t.Run("uses branch base before url upstream", func(t *testing.T) {
 		repo := newTestGitRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
-		repo.CommitFile("file.txt", "content", "initial")
-		mainSHA := repo.Run("rev-parse", "HEAD")
-		repo.Run("checkout", "-b", "feature")
-		repo.Run("config", "branch.feature.remote", "https://example.com/fork.git")
-		repo.Run("config", "branch.feature.merge", "refs/heads/feature")
-		repo.Run("config", "branch.feature.base", "main")
+		mainSHA := repo.CommitFile("file.txt", "content", "initial")
+		repo.CheckoutNewBranch("feature")
+		repo.SetBranchConfig("feature", "remote", "https://example.com/fork.git")
+		repo.SetBranchConfig("feature", "merge", "refs/heads/feature")
+		repo.SetBranchConfig("feature", "base", "main")
 		repo.CommitFile("feature.txt", "feature", "feature commit")
 		writeRoborevConfig(t, repo, `post_commit_review = "branch"`)
 
@@ -679,10 +660,8 @@ func TestTryBranchReview(t *testing.T) {
 
 	t.Run("returns false on detached HEAD", func(t *testing.T) {
 		repo := newTestGitRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
-		repo.CommitFile("file.txt", "content", "initial")
-		sha := repo.Run("rev-parse", "HEAD")
-		repo.Run("checkout", sha)
+		sha := repo.CommitFile("file.txt", "content", "initial")
+		repo.DetachHead(sha)
 		writeRoborevConfig(t, repo, `post_commit_review = "branch"`)
 
 		_, ok := tryBranchReview(t.Context(), repo.Dir, "")
@@ -696,17 +675,16 @@ func TestTryBranchReview(t *testing.T) {
 		// UpstreamIsTrunk gating, origin/feature (not trunk-named) is
 		// rejected and the review falls back to the repository's default
 		// branch for the merge base.
-		remote := newBareTestGitRepo(t)
 		repo := newTestGitRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
-		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("remote", "add", "origin", remote.Dir)
-		repo.Run("push", "-u", "origin", "main")
-		repo.Run("remote", "set-head", "origin", "main")
-		mainSHA := repo.Run("rev-parse", "origin/main")
-		repo.Run("checkout", "-b", "feature")
-		repo.CommitFile("first.txt", "first", "first feature commit")
-		repo.Run("push", "-u", "origin", "feature")
+		mainSHA := repo.CommitFile("file.txt", "content", "initial")
+		repo.AddRemote("origin", "/dev/null")
+		repo.SetRef("refs/remotes/origin/main", mainSHA)
+		repo.SetRemoteHead("origin", "main")
+		repo.CheckoutNewBranch("feature")
+		firstFeatureSHA := repo.CommitFile("first.txt", "first", "first feature commit")
+		repo.SetRef("refs/remotes/origin/feature", firstFeatureSHA)
+		repo.SetBranchConfig("feature", "remote", "origin")
+		repo.SetBranchConfig("feature", "merge", "refs/heads/feature")
 		repo.CommitFile("second.txt", "second", "unpushed commit")
 		writeRoborevConfig(t, repo, `post_commit_review = "branch"`)
 
@@ -726,13 +704,12 @@ func TestTryBranchReview(t *testing.T) {
 		// would enqueue a review against the wrong commit range in fork
 		// workflows.
 		repo := newTestGitRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("checkout", "-b", "feature")
+		repo.CheckoutNewBranch("feature")
 		repo.CommitFile("feature.txt", "feature", "feature commit")
 		// Configure tracking against an upstream that never resolves locally.
-		repo.Run("config", "branch.feature.remote", "upstream")
-		repo.Run("config", "branch.feature.merge", "refs/heads/main")
+		repo.SetBranchConfig("feature", "remote", "upstream")
+		repo.SetBranchConfig("feature", "merge", "refs/heads/main")
 		writeRoborevConfig(t, repo, `post_commit_review = "branch"`)
 
 		ref, ok := tryBranchReview(t.Context(), repo.Dir, "")
@@ -744,12 +721,12 @@ func TestTryBranchReview(t *testing.T) {
 		// Regression: LocalBranchName only stripped "origin/", so
 		// current="main" vs base="upstream/main" missed the guardrail
 		// and produced a branch review on the base branch itself.
-		remote := newBareTestGitRepo(t)
 		repo := newTestGitRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
-		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("remote", "add", "upstream", remote.Dir)
-		repo.Run("push", "-u", "upstream", "main")
+		mainSHA := repo.CommitFile("file.txt", "content", "initial")
+		repo.AddRemote("upstream", "/dev/null")
+		repo.SetRef("refs/remotes/upstream/main", mainSHA)
+		repo.SetBranchConfig("main", "remote", "upstream")
+		repo.SetBranchConfig("main", "merge", "refs/heads/main")
 		writeRoborevConfig(t, repo, `post_commit_review = "branch"`)
 
 		_, ok := tryBranchReview(t.Context(), repo.Dir, "")
@@ -762,17 +739,14 @@ func TestTryBranchReview(t *testing.T) {
 		// stale local main must resolve to origin/main, not the rewound
 		// pointer, so the hook enqueues only the real branch commits.
 		repo := newTestGitRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
-		repo.CommitFile("base.txt", "base", "initial")
-		staleMainSHA := repo.Run("rev-parse", "HEAD")
-		repo.CommitFile("trunk.txt", "t", "trunk advance")
-		freshOriginSHA := repo.Run("rev-parse", "HEAD")
-		repo.Run("update-ref", "refs/heads/main", staleMainSHA)
-		repo.Run("remote", "add", "origin", "/dev/null")
-		repo.Run("update-ref", "refs/remotes/origin/main", freshOriginSHA)
-		repo.Run("checkout", "-b", "feature", freshOriginSHA)
+		staleMainSHA := repo.CommitFile("base.txt", "base", "initial")
+		freshOriginSHA := repo.CommitFile("trunk.txt", "t", "trunk advance")
+		repo.SetRef("refs/heads/main", staleMainSHA)
+		repo.AddRemote("origin", "/dev/null")
+		repo.SetRef("refs/remotes/origin/main", freshOriginSHA)
+		repo.CheckoutNewBranch("feature", freshOriginSHA)
 		repo.CommitFile("feature.txt", "f", "feature commit")
-		repo.Run("config", "branch.feature.base", "main")
+		repo.SetBranchConfig("feature", "base", "main")
 		writeRoborevConfig(t, repo, `post_commit_review = "branch"`)
 
 		ref, ok := tryBranchReview(t.Context(), repo.Dir, "")
@@ -787,30 +761,27 @@ func TestTryBranchReview(t *testing.T) {
 		// diverged from (e.g., upstream/main), the review must use the
 		// upstream tracking ref, not the default branch, so already-merged
 		// commits are not re-reviewed.
-		remote := newBareTestGitRepo(t)
 		repo := newTestGitRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
-		repo.CommitFile("file.txt", "u1", "upstream c1")
+		staleOriginSHA := repo.CommitFile("file.txt", "u1", "upstream c1")
 		repo.CommitFile("file.txt", "u1\nu2", "upstream c2")
-		repo.CommitFile("file.txt", "u1\nu2\nu3", "upstream c3")
-		repo.Run("remote", "add", "upstream", remote.Dir)
-		repo.Run("push", "-u", "upstream", "main")
+		upstreamSHA := repo.CommitFile("file.txt", "u1\nu2\nu3", "upstream c3")
+		repo.AddRemote("upstream", "/dev/null")
+		repo.SetRef("refs/remotes/upstream/main", upstreamSHA)
 
 		// Simulate origin lagging behind upstream by 2 commits.
-		staleOrigin := newBareTestGitRepo(t)
-		repo.Run("remote", "add", "origin", staleOrigin.Dir)
-		repo.Run("push", "origin", "HEAD~2:refs/heads/main")
-		repo.Run("fetch", "origin")
-		repo.Run("remote", "set-head", "origin", "main")
+		repo.AddRemote("origin", "/dev/null")
+		repo.SetRef("refs/remotes/origin/main", staleOriginSHA)
+		repo.SetRemoteHead("origin", "main")
 
-		repo.Run("checkout", "-b", "feature", "--track", "upstream/main")
+		repo.CheckoutNewBranch("feature", upstreamSHA)
+		repo.SetBranchConfig("feature", "remote", "upstream")
+		repo.SetBranchConfig("feature", "merge", "refs/heads/main")
 		repo.CommitFile("feature.txt", "only-new-commit", "feature commit")
 		writeRoborevConfig(t, repo, `post_commit_review = "branch"`)
 
 		ref, ok := tryBranchReview(t.Context(), repo.Dir, "")
 		require.True(t, ok, "expected branch review to run")
 
-		upstreamSHA := repo.Run("rev-parse", "upstream/main")
 		want := upstreamSHA + "..HEAD"
 		assert.Equal(t, want, ref,
 			"review must compare against upstream/main, not origin/main")
@@ -821,9 +792,8 @@ func TestReviewIgnoresBranchConfig(t *testing.T) {
 	repo, mux := setupTestEnvironment(t)
 	reqCh := mockEnqueue(t, mux)
 
-	repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
 	repo.CommitFile("file.txt", "content", "initial")
-	repo.Run("checkout", "-b", "feature")
+	repo.CheckoutNewBranch("feature")
 	repo.CommitFile("feature.txt", "feature", "feature commit")
 	writeRoborevConfig(t, repo, `post_commit_review = "branch"`)
 
@@ -838,9 +808,8 @@ func TestReviewQuietIgnoresBranchConfig(t *testing.T) {
 	repo, mux := setupTestEnvironment(t)
 	reqCh := mockEnqueue(t, mux)
 
-	repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
 	repo.CommitFile("file.txt", "content", "initial")
-	repo.Run("checkout", "-b", "feature")
+	repo.CheckoutNewBranch("feature")
 	repo.CommitFile("feature.txt", "feature", "feature commit")
 	writeRoborevConfig(t, repo, `post_commit_review = "branch"`)
 

--- a/cmd/roborev/review_test.go
+++ b/cmd/roborev/review_test.go
@@ -154,7 +154,7 @@ func TestEnqueueCmdPositionalArg(t *testing.T) {
 		)
 
 		shortFirstSHA := shas[0][:7]
-		_, _, err := executeReviewCmd("--repo", repo.Dir, shortFirstSHA)
+		_, _, err := executeReviewCmd("--repo", repo.Dir, shortFirstSHA, "--quiet")
 		require.NoError(t, err, "enqueue failed: %v")
 
 		req := <-reqCh
@@ -172,7 +172,7 @@ func TestEnqueueCmdPositionalArg(t *testing.T) {
 		)
 
 		shortFirstSHA := shas[0][:7]
-		_, _, err := executeReviewCmd("--repo", repo.Dir, "--sha", shortFirstSHA)
+		_, _, err := executeReviewCmd("--repo", repo.Dir, "--sha", shortFirstSHA, "--quiet")
 		require.NoError(t, err, "enqueue failed: %v")
 
 		req := <-reqCh
@@ -187,7 +187,7 @@ func TestEnqueueCmdPositionalArg(t *testing.T) {
 			repoCommitSpec{"file1.txt", "first", "first commit"},
 		)
 
-		_, _, err := executeReviewCmd("--repo", repo.Dir)
+		_, _, err := executeReviewCmd("--repo", repo.Dir, "--quiet")
 		require.NoError(t, err, "enqueue failed: %v")
 
 		req := <-reqCh
@@ -399,7 +399,7 @@ func TestReviewSinceFlag(t *testing.T) {
 			repoCommitSpec{"file2.txt", "second", "second commit"},
 		)
 
-		_, _, err := executeReviewCmd("--repo", repo.Dir, "--since", shas[0][:7])
+		_, _, err := executeReviewCmd("--repo", repo.Dir, "--since", shas[0][:7], "--quiet")
 		require.NoError(t, err)
 
 		req := <-reqCh
@@ -411,7 +411,7 @@ func TestReviewSinceFlag(t *testing.T) {
 		repo, _ := setupTestEnvironment(t)
 		repo.CommitFile("file.txt", "content", "initial")
 
-		_, _, err := executeReviewCmd("--repo", repo.Dir, "--since", "nonexistent123")
+		_, _, err := executeReviewCmd("--repo", repo.Dir, "--since", "nonexistent123", "--quiet")
 		assertErrorContains(t, err, "invalid --since commit")
 	})
 
@@ -419,7 +419,7 @@ func TestReviewSinceFlag(t *testing.T) {
 		repo, _ := setupTestEnvironment(t)
 		repo.CommitFile("file.txt", "content", "initial")
 
-		_, _, err := executeReviewCmd("--repo", repo.Dir, "--since", "HEAD")
+		_, _, err := executeReviewCmd("--repo", repo.Dir, "--since", "HEAD", "--quiet")
 		assertErrorContains(t, err, "no commits since")
 	})
 }
@@ -430,7 +430,7 @@ func TestReviewBranchFlag(t *testing.T) {
 
 		repo.CommitFile("file.txt", "content", "initial")
 
-		_, _, err := executeReviewCmd("--repo", repo.Dir, "--branch")
+		_, _, err := executeReviewCmd("--repo", repo.Dir, "--branch", "--quiet")
 		assertErrorContains(t, err, "already on main")
 	})
 
@@ -440,7 +440,7 @@ func TestReviewBranchFlag(t *testing.T) {
 		repo.CommitFile("file.txt", "content", "initial")
 		repo.CheckoutNewBranch("feature")
 
-		_, _, err := executeReviewCmd("--repo", repo.Dir, "--branch")
+		_, _, err := executeReviewCmd("--repo", repo.Dir, "--branch", "--quiet")
 		assertErrorContains(t, err, "no commits on branch")
 	})
 
@@ -452,7 +452,7 @@ func TestReviewBranchFlag(t *testing.T) {
 		repo.CheckoutNewBranch("feature")
 		repo.CommitFile("feature.txt", "feature", "feature commit")
 
-		_, _, err := executeReviewCmd("--repo", repo.Dir, "--branch")
+		_, _, err := executeReviewCmd("--repo", repo.Dir, "--branch", "--quiet")
 		require.NoError(t, err)
 
 		req := <-reqCh
@@ -471,7 +471,7 @@ func TestReviewBranchFlag(t *testing.T) {
 		repo.SetBranchConfig("feature", "base", "main")
 		repo.CommitFile("feature.txt", "feature", "feature commit")
 
-		_, _, err := executeReviewCmd("--repo", repo.Dir, "--branch")
+		_, _, err := executeReviewCmd("--repo", repo.Dir, "--branch", "--quiet")
 		require.NoError(t, err)
 
 		req := <-reqCh
@@ -499,7 +499,7 @@ func TestReviewBranchFlag(t *testing.T) {
 		repo.CommitFile("feature.txt", "f", "feature commit")
 		repo.SetBranchConfig("feature", "base", "main")
 
-		_, _, err := executeReviewCmd("--repo", repo.Dir, "--branch")
+		_, _, err := executeReviewCmd("--repo", repo.Dir, "--branch", "--quiet")
 		require.NoError(t, err)
 
 		req := <-reqCh
@@ -515,7 +515,7 @@ func TestReviewFastFlag(t *testing.T) {
 
 		repo.CommitFile("file.txt", "content", "initial")
 
-		_, _, err := executeReviewCmd("--repo", repo.Dir, "--fast")
+		_, _, err := executeReviewCmd("--repo", repo.Dir, "--fast", "--quiet")
 		require.NoError(t, err)
 
 		req := <-reqCh
@@ -528,7 +528,7 @@ func TestReviewFastFlag(t *testing.T) {
 
 		repo.CommitFile("file.txt", "content", "initial")
 
-		_, _, err := executeReviewCmd("--repo", repo.Dir, "--fast", "--reasoning", "thorough")
+		_, _, err := executeReviewCmd("--repo", repo.Dir, "--fast", "--reasoning", "thorough", "--quiet")
 		require.NoError(t, err)
 
 		req := <-reqCh
@@ -570,9 +570,6 @@ func writeRoborevConfig(t *testing.T, repo *TestGitRepo, content string) {
 func TestTryBranchReview(t *testing.T) {
 	t.Run("returns false when no config", func(t *testing.T) {
 		repo := newTestGitRepo(t)
-		repo.CommitFile("file.txt", "content", "initial")
-		repo.CheckoutNewBranch("feature")
-		repo.CommitFile("feature.txt", "feature", "feature commit")
 
 		_, ok := tryBranchReview(t.Context(), repo.Dir, "")
 		assert.False(t, ok)
@@ -580,9 +577,6 @@ func TestTryBranchReview(t *testing.T) {
 
 	t.Run("returns false when config is commit", func(t *testing.T) {
 		repo := newTestGitRepo(t)
-		repo.CommitFile("file.txt", "content", "initial")
-		repo.CheckoutNewBranch("feature")
-		repo.CommitFile("feature.txt", "feature", "feature commit")
 		writeRoborevConfig(t, repo, `post_commit_review = "commit"`)
 
 		_, ok := tryBranchReview(t.Context(), repo.Dir, "")

--- a/internal/agent/test_agent.go
+++ b/internal/agent/test_agent.go
@@ -24,7 +24,7 @@ type TestAgentCall struct {
 // new ID like "test-session-1". Resumed calls (SessionID != "") echo
 // the incoming ID. Counters are per-instance.
 type TestAgent struct {
-	Delay     time.Duration  // Simulated processing delay
+	Delay     time.Duration  // Optional simulated processing delay
 	Output    string         // Fixed output to return
 	Fail      bool           // If true, returns an error
 	Reasoning ReasoningLevel // Reasoning level (for testing)
@@ -44,7 +44,6 @@ type testAgentState struct {
 // NewTestAgent creates a new test agent with its own per-instance counter.
 func NewTestAgent() *TestAgent {
 	return &TestAgent{
-		Delay:     100 * time.Millisecond,
 		Output:    "Test review output: This commit looks good. No issues found.",
 		Reasoning: ReasoningStandard,
 		state:     &testAgentState{},
@@ -106,11 +105,19 @@ func (a *TestAgent) Calls() []TestAgentCall {
 }
 
 func (a *TestAgent) Review(ctx context.Context, repoPath, commitSHA, prompt string, output io.Writer) (string, error) {
-	// Respect context cancellation
 	select {
 	case <-ctx.Done():
 		return "", ctx.Err()
-	case <-time.After(a.Delay):
+	default:
+	}
+	if a.Delay > 0 {
+		timer := time.NewTimer(a.Delay)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-timer.C:
+		}
 	}
 
 	// Determine the session ID to advertise: echo incoming, or mint fresh.

--- a/internal/agenthook/state.go
+++ b/internal/agenthook/state.go
@@ -710,18 +710,22 @@ func currentGitScope(cwd string) (gitScope, bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	out, err := agentHookGit.Output(ctx, cwd,
-		"rev-parse", "--show-toplevel", "--git-dir", "--git-common-dir", "HEAD")
+		"rev-parse", "--show-toplevel", "--git-dir", "--git-common-dir", "HEAD", "--abbrev-ref", "HEAD")
 	if err != nil {
 		return gitScope{}, false
 	}
 	lines := strings.Split(strings.ReplaceAll(string(out), "\r\n", "\n"), "\n")
-	if len(lines) < 4 {
+	if len(lines) < 5 {
 		return gitScope{}, false
 	}
 	root := cleanGitPath(lines[0])
 	gitDir := absGitPath(cwd, cleanGitPath(lines[1]))
 	commonDir := absGitPath(cwd, cleanGitPath(lines[2]))
 	head := strings.TrimSpace(lines[3])
+	branch := strings.TrimSpace(lines[4])
+	if branch == "HEAD" {
+		branch = ""
+	}
 	if root == "" || gitDir == "" || commonDir == "" || head == "" {
 		return gitScope{}, false
 	}
@@ -730,7 +734,7 @@ func currentGitScope(cwd string) (gitScope, bool) {
 		GitDir:       gitDir,
 		CommonDir:    commonDir,
 		Head:         head,
-		Branch:       branchFromGitHead(gitDir),
+		Branch:       branch,
 	}, true
 }
 
@@ -750,18 +754,6 @@ func absGitPath(base, path string) string {
 		path = filepath.Join(base, path)
 	}
 	return filepath.Clean(path)
-}
-
-func branchFromGitHead(gitDir string) string {
-	data, err := os.ReadFile(filepath.Join(gitDir, "HEAD"))
-	if err != nil {
-		return ""
-	}
-	ref, ok := strings.CutPrefix(strings.TrimSpace(string(data)), "ref:")
-	if !ok {
-		return ""
-	}
-	return strings.TrimPrefix(strings.TrimSpace(ref), "refs/heads/")
 }
 
 func resolveHookScope(ctx context.Context, cwd, configuredAddr string) (hookScope, bool) {

--- a/internal/agenthook/state.go
+++ b/internal/agenthook/state.go
@@ -42,6 +42,14 @@ type trackedRepoResolution struct {
 	Name     string
 }
 
+type gitScope struct {
+	WorktreeRoot string
+	GitDir       string
+	CommonDir    string
+	Head         string
+	Branch       string
+}
+
 func LoadState() (*StateStore, error) {
 	path := StatePath()
 	s := &StateStore{
@@ -695,53 +703,91 @@ func repoDisplayName(repoPath string) string {
 	return base
 }
 
-func currentGitHead(cwd string) (string, string, bool) {
+func currentGitScope(cwd string) (gitScope, bool) {
 	if cwd == "" {
-		return "", "", false
+		return gitScope{}, false
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	root, err := gitrepo.Root(ctx, cwd)
-	if err != nil || strings.TrimSpace(root) == "" {
-		return "", "", false
+	out, err := agentHookGit.Output(ctx, cwd,
+		"rev-parse", "--show-toplevel", "--git-dir", "--git-common-dir", "HEAD")
+	if err != nil {
+		return gitScope{}, false
 	}
-	root = strings.TrimSpace(root)
-	head, err := gitrepo.Resolve(ctx, root, "HEAD")
-	if err != nil || head == "" {
-		return "", "", false
+	lines := strings.Split(strings.ReplaceAll(string(out), "\r\n", "\n"), "\n")
+	if len(lines) < 4 {
+		return gitScope{}, false
 	}
-	return root, head, true
+	root := cleanGitPath(lines[0])
+	gitDir := absGitPath(cwd, cleanGitPath(lines[1]))
+	commonDir := absGitPath(cwd, cleanGitPath(lines[2]))
+	head := strings.TrimSpace(lines[3])
+	if root == "" || gitDir == "" || commonDir == "" || head == "" {
+		return gitScope{}, false
+	}
+	return gitScope{
+		WorktreeRoot: root,
+		GitDir:       gitDir,
+		CommonDir:    commonDir,
+		Head:         head,
+		Branch:       branchFromGitHead(gitDir),
+	}, true
 }
 
-func currentGitBranch(repoRoot string) string {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	return gitrepo.CurrentBranch(ctx, repoRoot)
+func cleanGitPath(path string) string {
+	path = gitrepo.NormalizePath(path)
+	if path == "" {
+		return ""
+	}
+	return filepath.Clean(path)
+}
+
+func absGitPath(base, path string) string {
+	if path == "" {
+		return ""
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(base, path)
+	}
+	return filepath.Clean(path)
+}
+
+func branchFromGitHead(gitDir string) string {
+	data, err := os.ReadFile(filepath.Join(gitDir, "HEAD"))
+	if err != nil {
+		return ""
+	}
+	ref, ok := strings.CutPrefix(strings.TrimSpace(string(data)), "ref:")
+	if !ok {
+		return ""
+	}
+	return strings.TrimPrefix(strings.TrimSpace(ref), "refs/heads/")
 }
 
 func resolveHookScope(ctx context.Context, cwd, configuredAddr string) (hookScope, bool) {
-	worktreeRoot, head, ok := currentGitHead(cwd)
+	gitInfo, ok := currentGitScope(cwd)
 	if !ok {
 		return hookScope{}, false
 	}
-	trackedRoot := mainRepoRoot(worktreeRoot)
+	trackedRoot := mainRepoRoot(gitInfo)
 	tracked := true
-	if resolved, known := resolveTrackedRepo(ctx, worktreeRoot, configuredAddr); known {
+	if resolved, known := resolveTrackedRepo(ctx, gitInfo.WorktreeRoot, configuredAddr); known {
 		if !resolved.Tracked {
 			tracked = false
 		} else if strings.TrimSpace(resolved.RootPath) != "" {
 			trackedRoot = strings.TrimSpace(resolved.RootPath)
 		}
 	}
-	branch := currentGitBranch(worktreeRoot)
 	return hookScope{
-		WorktreeRoot:        worktreeRoot,
-		TrackedRepoRoot:     trackedRoot,
-		Head:                head,
-		Branch:              branch,
-		WorktreeKey:         worktreeSequenceKey(trackedRoot, worktreeRoot),
-		CandidateLineageKey: lineageSequenceKey(trackedRoot, branch, worktreeRoot, head),
-		Tracked:             tracked,
+		WorktreeRoot:    gitInfo.WorktreeRoot,
+		TrackedRepoRoot: trackedRoot,
+		Head:            gitInfo.Head,
+		Branch:          gitInfo.Branch,
+		WorktreeKey:     worktreeSequenceKey(trackedRoot, gitInfo.WorktreeRoot),
+		CandidateLineageKey: lineageSequenceKey(
+			trackedRoot, gitInfo.Branch, gitInfo.WorktreeRoot, gitInfo.Head,
+		),
+		Tracked: tracked,
 	}, true
 }
 
@@ -796,15 +842,45 @@ func resolveTrackedRepo(ctx context.Context, path, configuredAddr string) (track
 // checkout root still drives branch and HEAD detection; only the repo filter
 // needs the main root. Falls back to worktreeRoot when resolution fails (for
 // example a plain checkout, where the two roots are identical).
-func mainRepoRoot(worktreeRoot string) string {
+func mainRepoRoot(scope gitScope) string {
+	if scope.GitDir == "" || scope.CommonDir == "" || scope.GitDir == scope.CommonDir {
+		return scope.WorktreeRoot
+	}
+	if bareCommonDir(scope.CommonDir) {
+		return scope.WorktreeRoot
+	}
+	if filepath.Base(scope.CommonDir) == ".git" {
+		return filepath.Dir(scope.CommonDir)
+	}
+	worktree := configuredWorktree(scope.CommonDir)
+	if worktree == "" {
+		return scope.WorktreeRoot
+	}
+	return worktree
+}
+
+func bareCommonDir(commonDir string) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	if root, err := gitrepo.MainRoot(ctx, worktreeRoot); err == nil {
-		if trimmed := strings.TrimSpace(root); trimmed != "" {
-			return trimmed
-		}
+	out, err := agentHookGit.Output(ctx, "", "config", "--file", filepath.Join(commonDir, "config"), "--bool", "core.bare")
+	return err == nil && strings.TrimSpace(string(out)) == "true"
+}
+
+func configuredWorktree(commonDir string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	out, err := agentHookGit.Output(ctx, "", "config", "--file", filepath.Join(commonDir, "config"), "core.worktree")
+	if err != nil {
+		return ""
 	}
-	return worktreeRoot
+	worktree := cleanGitPath(string(out))
+	if worktree == "" {
+		return ""
+	}
+	if !filepath.IsAbs(worktree) {
+		worktree = filepath.Join(commonDir, worktree)
+	}
+	return filepath.Clean(worktree)
 }
 
 func newCommitSHAs(repoRoot, oldHead, newHead string) ([]string, bool) {

--- a/internal/agenthook/state_test.go
+++ b/internal/agenthook/state_test.go
@@ -87,6 +87,33 @@ func TestRepoHeadKey(t *testing.T) {
 	assert.NotEqual(repoHeadKey("/repo", "main"), repoHeadKey("/repo", "feature"))
 }
 
+func TestCurrentGitScopeReportsBranchFromRevParse(t *testing.T) {
+	t.Run("attached branch", func(t *testing.T) {
+		repo := testutil.NewGitRepo(t)
+		repo.CommitFile("base.txt", "base\n", "base")
+		repo.CheckoutNewBranch("feature/scope")
+
+		scope, ok := currentGitScope(repo.Path())
+
+		require.True(t, ok)
+		assert.Equal(t, "feature/scope", scope.Branch)
+		assert.Equal(t, repo.HeadSHA(), scope.Head)
+	})
+
+	t.Run("detached head", func(t *testing.T) {
+		repo := testutil.NewGitRepo(t)
+		repo.CommitFile("base.txt", "base\n", "base")
+		head := repo.HeadSHA()
+		repo.Checkout(head)
+
+		scope, ok := currentGitScope(repo.Path())
+
+		require.True(t, ok)
+		assert.Empty(t, scope.Branch)
+		assert.Equal(t, head, scope.Head)
+	})
+}
+
 func TestCommitsSincePromptAddsLegacyCountToSHASequence(t *testing.T) {
 	st := SessionState{
 		CommitCountsSincePrompt: map[string]int{"seq": 2},

--- a/internal/agenthook/state_test.go
+++ b/internal/agenthook/state_test.go
@@ -147,7 +147,7 @@ func TestCountOpenFailedReviewsExcludesBaseBranchBranchlessReviews(t *testing.T)
 	repo := testutil.NewGitRepo(t)
 	base := repo.CommitFile("base.txt", "base\n", "base")
 	mainOnly := repo.CommitFile("main.txt", "main\n", "main only")
-	repo.RunGit("checkout", "-b", "feature/lineage")
+	repo.CheckoutNewBranch("feature/lineage")
 	featureHead := repo.CommitFile("feature.txt", "feature\n", "feature")
 
 	closed := false
@@ -173,7 +173,7 @@ func TestCountOpenFailedReviewsCachesBranchlessLineageContext(t *testing.T) {
 	require := require.New(t)
 	repo := testutil.NewGitRepo(t)
 	repo.CommitFile("base.txt", "base\n", "base")
-	repo.RunGit("checkout", "-b", "feature/lineage")
+	repo.CheckoutNewBranch("feature/lineage")
 
 	closed := false
 	verdict := "F"
@@ -379,7 +379,7 @@ func TestRecordPostToolUseFailedReviewPromptUsesNewBranchLineageKey(t *testing.T
 	assert.True(mainResp.Triggered)
 	assert.Equal("failed_reviews", mainResp.TriggeredBy)
 
-	repo.RunGit("checkout", "-b", "feature/lineage")
+	repo.CheckoutNewBranch("feature/lineage")
 	repo.CommitFile("feature.go", "package main\n", "feature")
 	featureResp := post()
 	assert.True(featureResp.Triggered, "a descendant branch must not reuse main's failed-review dedupe key")
@@ -422,7 +422,7 @@ func TestRecordStopFailedReviewPromptUsesNewDetachedLineageKey(t *testing.T) {
 	assert.True(mainResp.Triggered)
 	assert.Equal("failed_reviews", mainResp.TriggeredBy)
 
-	repo.RunGit("checkout", "--detach")
+	repo.CheckoutDetached()
 	detachedResp := stop()
 	assert.True(detachedResp.Triggered, "detached HEAD must not reuse a prior branch failed-review dedupe key")
 	assert.Equal("failed_reviews", detachedResp.TriggeredBy)
@@ -433,7 +433,7 @@ func TestRecordStopFailedReviewPromptDoesNotReuseStaleDetachedLineage(t *testing
 	repo := testutil.NewGitRepo(t)
 	base := repo.CommitFile("base.go", "package main\n", "base")
 	firstHead := repo.CommitFile("first.go", "package main\n", "first")
-	repo.RunGit("checkout", "--detach", firstHead)
+	repo.CheckoutDetached(firstHead)
 
 	reviewRef := firstHead
 	closed := false
@@ -469,9 +469,9 @@ func TestRecordStopFailedReviewPromptDoesNotReuseStaleDetachedLineage(t *testing
 	assert.Equal(firstHead, store.sessions["session-1"].RepoHeads[worktreeKey])
 	delete(store.sessions["session-1"].RepoHeads, worktreeKey)
 
-	repo.RunGit("checkout", "-B", "unrelated", base)
+	repo.CheckoutBranchForce("unrelated", base)
 	secondHead := repo.CommitFile("second.go", "package main\n", "second")
-	repo.RunGit("checkout", "--detach", secondHead)
+	repo.CheckoutDetached(secondHead)
 	reviewRef = secondHead
 	secondResp := stop()
 	assert.True(secondResp.Triggered, "unrelated detached checkout must not inherit stale detached failed-review dedupe")
@@ -580,10 +580,10 @@ func TestRecordPostToolUseCommitReminderDoesNotFollowUnrelatedBranchInSameWorktr
 	assert.False(post("git commit -m main-pending").Triggered, "main commit waits for its review")
 
 	failed = true
-	repo.RunGit("checkout", "-b", "feature/unrelated")
+	repo.CheckoutNewBranch("feature/unrelated")
 	assert.False(post("go test ./...").Triggered, "feature must not inherit main's pending commit reminder")
 
-	repo.RunGit("checkout", "main")
+	repo.CheckoutBranch("main")
 	mainResp := post("go test ./...")
 	assert.True(mainResp.Triggered, "main's own pending commit reminder still fires")
 	assert.Equal("commit", mainResp.TriggeredBy)
@@ -944,7 +944,7 @@ func TestRecordStopTriggersFailedReviewOnDetachedHead(t *testing.T) {
 	assert := assert.New(t)
 	repo := testutil.NewGitRepo(t)
 	head := repo.CommitFile("main.go", "package main\n", "initial")
-	repo.RunGit("checkout", "--detach")
+	repo.CheckoutDetached()
 
 	closed := false
 	verdict := "F"
@@ -1005,7 +1005,7 @@ func TestRecordStopTriggersFailedRangeReviewOnDetachedHead(t *testing.T) {
 	repo := testutil.NewGitRepo(t)
 	base := repo.CommitFile("main.go", "package main\n", "initial")
 	head := repo.CommitFile("feature.go", "package main\n", "feature")
-	repo.RunGit("checkout", "--detach")
+	repo.CheckoutDetached()
 
 	closed := false
 	verdict := "F"
@@ -1061,7 +1061,7 @@ func TestRecordStopDetachedHeadCountsReachableBranchfulReview(t *testing.T) {
 	repo := testutil.NewGitRepo(t)
 	base := repo.CommitFile("main.go", "package main\n", "initial")
 	head := repo.CommitFile("feature.go", "package main\n", "feature")
-	repo.RunGit("checkout", "--detach")
+	repo.CheckoutDetached()
 
 	closed := false
 	verdict := "F"
@@ -1120,7 +1120,7 @@ func TestRecordStopDetachedHeadDoesNotTriggerForUnrelatedFailedReviews(t *testin
 	assert := assert.New(t)
 	repo := testutil.NewGitRepo(t)
 	head := repo.CommitFile("main.go", "package main\n", "initial")
-	repo.RunGit("checkout", "--detach")
+	repo.CheckoutDetached()
 
 	closed := false
 	verdict := "F"
@@ -1302,7 +1302,7 @@ func TestRecordPostToolUseCommitSliceSurvivesBranchAttachment(t *testing.T) {
 	assert := assert.New(t)
 	repo := testutil.NewGitRepo(t)
 	repo.CommitFile("main.go", "package main\n", "initial")
-	repo.RunGit("checkout", "--detach")
+	repo.CheckoutDetached()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/repos/resolve" {
@@ -1344,7 +1344,7 @@ func TestRecordPostToolUseCommitSliceSurvivesBranchAttachment(t *testing.T) {
 	_, err = store.Record(commitReq)
 	require.NoError(t, err)
 
-	repo.RunGit("checkout", "-B", "feature/attached")
+	repo.CheckoutBranchForce("feature/attached")
 	checkoutReq := baseReq
 	checkoutReq.Event.ToolInput = map[string]json.RawMessage{"command": json.RawMessage(`"git checkout -B feature/attached"`)}
 	_, err = store.Record(checkoutReq)
@@ -1367,7 +1367,7 @@ func TestRecordPostToolUseAmendAfterBranchAttachmentKeepsDetachedCommitThreshold
 	assert := assert.New(t)
 	repo := testutil.NewGitRepo(t)
 	repo.CommitFile("main.go", "package main\n", "initial")
-	repo.RunGit("checkout", "--detach")
+	repo.CheckoutDetached()
 
 	failed := false
 	closed := false
@@ -1422,7 +1422,7 @@ func TestRecordPostToolUseAmendAfterBranchAttachmentKeepsDetachedCommitThreshold
 	require.NoError(t, err)
 	assert.False(resp.Triggered)
 
-	repo.RunGit("checkout", "-B", "feature/attached")
+	repo.CheckoutBranchForce("feature/attached")
 	checkoutReq := baseReq
 	checkoutReq.Event.ToolInput = map[string]json.RawMessage{"command": json.RawMessage(`"git checkout -B feature/attached"`)}
 	_, err = store.Record(checkoutReq)
@@ -1435,8 +1435,7 @@ func TestRecordPostToolUseAmendAfterBranchAttachmentKeepsDetachedCommitThreshold
 	assert.False(resp.Triggered)
 
 	repo.WriteFile("feature-b.go", "package main\nconst amended = true\n")
-	repo.RunGit("add", "feature-b.go")
-	repo.RunGit("commit", "--amend", "-m", "attached amended")
+	repo.AmendCommit("attached amended", "feature-b.go")
 	failed = true
 	commitReq.Event.ToolInput = map[string]json.RawMessage{"command": json.RawMessage(`"git commit --amend -m attached amended"`)}
 	resp, err = store.Record(commitReq)
@@ -1501,7 +1500,7 @@ func TestRecordPostToolUseDetachedFailedReviewDedupeScopesByDetachedHead(t *test
 	assert := assert.New(t)
 	repo := testutil.NewGitRepo(t)
 	base := repo.CommitFile("main.go", "package main\n", "initial")
-	repo.RunGit("checkout", "--detach", base)
+	repo.CheckoutDetached(base)
 	firstHead := repo.CommitFile("first.go", "package main\n", "first detached")
 
 	reviewRef := firstHead
@@ -1538,7 +1537,7 @@ func TestRecordPostToolUseDetachedFailedReviewDedupeScopesByDetachedHead(t *test
 	assert.True(first.Triggered)
 	assert.Equal("failed_reviews", first.TriggeredBy)
 
-	repo.RunGit("checkout", "--detach", base)
+	repo.CheckoutDetached(base)
 	secondHead := repo.CommitFile("second.go", "package main\n", "second detached")
 	reviewRef = secondHead
 	second := post()
@@ -1765,9 +1764,7 @@ func TestRecordPostToolUseAmendPreservesDeferredCommitReminder(t *testing.T) {
 	assert.False(atCommit.Triggered, "no prompt while the commit's review is still pending")
 
 	repo.WriteFile("feature.go", "package main\nconst feature = true\n")
-	repo.RunGit("add", "feature.go")
-	repo.RunGit("commit", "--amend", "-m", "second amended")
-	amended := repo.HeadSHA()
+	amended := repo.AmendCommit("second amended", "feature.go")
 	amend := base
 	amend.Event.ToolInput = map[string]json.RawMessage{"command": json.RawMessage(`"git commit --amend -m second amended"`)}
 	atAmend, err := store.Record(amend)
@@ -1833,9 +1830,7 @@ func TestRecordPostToolUseAmendPreservesEarlierPendingCommits(t *testing.T) {
 	require.NoError(t, err)
 
 	repo.WriteFile("second.go", "package main\nconst second = true\n")
-	repo.RunGit("add", "second.go")
-	repo.RunGit("commit", "--amend", "-m", "second amended")
-	amended := repo.HeadSHA()
+	amended := repo.AmendCommit("second amended", "second.go")
 	amend := base
 	amend.Event.ToolInput = map[string]json.RawMessage{"command": json.RawMessage(`"git commit --amend -m second amended"`)}
 	atAmend, err := store.Record(amend)

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -1040,17 +1040,9 @@ func TestCIPollerProcessPR_IncludesHumanPRDiscussion(t *testing.T) {
 	h.Poller = NewCIPoller(h.DB, NewStaticConfig(h.Cfg), nil)
 	h.stubProcessPRGit()
 
-	testutil.InitTestGitRepo(t, h.RepoPath)
-	require.NoError(t, os.WriteFile(filepath.Join(h.RepoPath, "followup.txt"), []byte("followup"), 0o644))
-	cmd := exec.Command("git", "-C", h.RepoPath, "add", "followup.txt")
-	require.NoError(t, cmd.Run())
-	cmd = exec.Command("git", "-C", h.RepoPath, "commit", "-m", "followup commit")
-	require.NoError(t, cmd.Run())
-
-	headSHA := testutil.GetHeadSHA(t, h.RepoPath)
-	baseSHABytes, err := exec.Command("git", "-C", h.RepoPath, "rev-parse", "HEAD^").Output()
-	require.NoError(t, err)
-	baseSHA := strings.TrimSpace(string(baseSHABytes))
+	repo := testutil.InitTestGitRepo(t, h.RepoPath)
+	baseSHA := repo.HeadSHA()
+	headSHA := repo.CommitFile("followup.txt", "followup", "followup commit")
 
 	h.Poller.mergeBaseFn = func(_, _, _ string) (string, error) { return baseSHA, nil }
 	h.Poller.listTrustedActorsFn = func(context.Context, string) (map[string]struct{}, error) {
@@ -1084,7 +1076,7 @@ func TestCIPollerProcessPR_IncludesHumanPRDiscussion(t *testing.T) {
 		}, nil
 	}
 
-	err = h.Poller.processPR(context.Background(), "acme/api", ghPR{
+	err := h.Poller.processPR(context.Background(), "acme/api", ghPR{
 		Number: 77, HeadRefOid: headSHA, BaseRefName: "main",
 	}, h.Cfg)
 	require.NoError(t, err)
@@ -1118,17 +1110,9 @@ func TestCIPollerProcessPR_FallsBackWhenPromptPrebuildFails(t *testing.T) {
 	h.Poller = NewCIPoller(h.DB, NewStaticConfig(h.Cfg), nil)
 	h.stubProcessPRGit()
 
-	testutil.InitTestGitRepo(t, h.RepoPath)
-	require.NoError(t, os.WriteFile(filepath.Join(h.RepoPath, "followup.txt"), []byte("followup"), 0o644))
-	cmd := exec.Command("git", "-C", h.RepoPath, "add", "followup.txt")
-	require.NoError(t, cmd.Run())
-	cmd = exec.Command("git", "-C", h.RepoPath, "commit", "-m", "followup commit")
-	require.NoError(t, cmd.Run())
-
-	headSHA := testutil.GetHeadSHA(t, h.RepoPath)
-	baseSHABytes, err := exec.Command("git", "-C", h.RepoPath, "rev-parse", "HEAD^").Output()
-	require.NoError(t, err)
-	baseSHA := strings.TrimSpace(string(baseSHABytes))
+	repo := testutil.InitTestGitRepo(t, h.RepoPath)
+	baseSHA := repo.HeadSHA()
+	headSHA := repo.CommitFile("followup.txt", "followup", "followup commit")
 
 	h.Poller.mergeBaseFn = func(_, _, _ string) (string, error) { return baseSHA, nil }
 	h.Poller.listTrustedActorsFn = func(context.Context, string) (map[string]struct{}, error) {
@@ -1146,7 +1130,7 @@ func TestCIPollerProcessPR_FallsBackWhenPromptPrebuildFails(t *testing.T) {
 		return "", errors.New("prompt prebuild exploded")
 	}
 
-	err = h.Poller.processPR(context.Background(), "acme/api", ghPR{
+	err := h.Poller.processPR(context.Background(), "acme/api", ghPR{
 		Number: 78, HeadRefOid: headSHA, BaseRefName: "main",
 	}, h.Cfg)
 	require.NoError(t, err)
@@ -1163,7 +1147,8 @@ func TestCIPollerProcessPR_PrebuildsLargeCodexPromptWithDiffFileInstructions(t *
 	h.Poller = NewCIPoller(h.DB, NewStaticConfig(h.Cfg), nil)
 	h.stubProcessPRGit()
 
-	testutil.InitTestGitRepo(t, h.RepoPath)
+	repo := testutil.InitTestGitRepo(t, h.RepoPath)
+	baseSHA := repo.HeadSHA()
 
 	var content strings.Builder
 	for range 20000 {
@@ -1173,18 +1158,7 @@ func TestCIPollerProcessPR_PrebuildsLargeCodexPromptWithDiffFileInstructions(t *
 		content.WriteString(strings.Repeat("y", 20))
 		content.WriteString("\n")
 	}
-	require.NoError(t, os.WriteFile(filepath.Join(h.RepoPath, "large.txt"), []byte(content.String()), 0o644))
-	cmd := exec.Command("git", "-C", h.RepoPath, "add", "large.txt")
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, "git add failed: %s", out)
-	cmd = exec.Command("git", "-C", h.RepoPath, "commit", "-m", "large followup")
-	out, err = cmd.CombinedOutput()
-	require.NoError(t, err, "git commit failed: %s", out)
-
-	headSHA := testutil.GetHeadSHA(t, h.RepoPath)
-	baseSHABytes, err := exec.Command("git", "-C", h.RepoPath, "rev-parse", "HEAD^").Output()
-	require.NoError(t, err)
-	baseSHA := strings.TrimSpace(string(baseSHABytes))
+	headSHA := repo.CommitFile("large.txt", content.String(), "large followup")
 
 	h.Poller.mergeBaseFn = func(_, _, _ string) (string, error) { return baseSHA, nil }
 	h.Poller.listTrustedActorsFn = func(context.Context, string) (map[string]struct{}, error) {
@@ -1199,7 +1173,7 @@ func TestCIPollerProcessPR_PrebuildsLargeCodexPromptWithDiffFileInstructions(t *
 		}}, nil
 	}
 
-	err = h.Poller.processPR(context.Background(), "acme/api", ghPR{
+	err := h.Poller.processPR(context.Background(), "acme/api", ghPR{
 		Number: 79, HeadRefOid: headSHA, BaseRefName: "main",
 	}, h.Cfg)
 	require.NoError(t, err)
@@ -3914,10 +3888,7 @@ func TestProcessPRIgnoresWorkingTreeAutoDesignConfig(t *testing.T) {
 	p, db, _, repo, cfg := newCIPanelGitHarness(t)
 	// Default-branch config: auto-design omitted (disabled). Commit it to main
 	// so loadCIRepoConfig reads it from the default branch.
-	require.NoError(t, os.WriteFile(filepath.Join(repo.Path(), ".roborev.toml"),
-		[]byte("agent = \"test\"\n"), 0o644))
-	repo.RunGit("add", ".roborev.toml")
-	repo.RunGit("commit", "-m", "chore: base config without auto-design")
+	repo.CommitFile(".roborev.toml", "agent = \"test\"\n", "chore: base config without auto-design")
 
 	base := repo.HeadSHA()
 	// A migration commit that WOULD warrant design if auto-design were enabled.

--- a/internal/daemon/e2e_auto_design_test.go
+++ b/internal/daemon/e2e_auto_design_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -46,14 +45,11 @@ func newAutoDesignE2E(t *testing.T) *autoDesignE2E {
 	// up a real CLI. Commit it separately so subsequent `git add .`
 	// doesn't sweep it into the tests' commits (which would poison
 	// path-based heuristics).
-	require.NoError(t, os.WriteFile(filepath.Join(repo.Path(), ".roborev.toml"),
-		[]byte(`agent = "test"
+	repo.CommitFile(".roborev.toml", `agent = "test"
 
 [auto_design_review]
 enabled = true
-`), 0o644))
-	repo.RunGit("add", ".roborev.toml")
-	repo.RunGit("commit", "-m", "chore: enable auto design review")
+`, "chore: enable auto design review")
 
 	db, _ := testutil.OpenTestDBWithDir(t)
 	row, err := db.GetOrCreateRepo(repo.Path())
@@ -196,11 +192,10 @@ func TestE2EAutoDesign_HeuristicSkip_DocsOnly(t *testing.T) {
 	for range 20 {
 		body.WriteString("## heading\n")
 	}
-	e.repo.WriteFile("README.md", body.String())
-	e.repo.WriteFile("CHANGELOG.md", body.String())
-	e.repo.RunGit("add", ".")
-	e.repo.RunGit("commit", "-m", "update readme and changelog")
-	sha := e.repo.HeadSHA()
+	sha := e.repo.CommitFiles(map[string]string{
+		"README.md":    body.String(),
+		"CHANGELOG.md": body.String(),
+	}, "update readme and changelog")
 
 	e.enqueueReviewFor(sha, "update readme and changelog")
 
@@ -368,13 +363,11 @@ func TestE2EAutoDesign_LargeFileCount_Trigger(t *testing.T) {
 	// alone. Keep the per-file diff small so the LargeDiffLines
 	// trigger doesn't fire first (which would still be a pass but
 	// wouldn't exercise the file-count branch).
+	files := make(map[string]string, 12)
 	for i := range 12 {
-		e.repo.WriteFile(fmt.Sprintf("src/pkg%02d.go", i),
-			fmt.Sprintf("package pkg%02d\n", i))
+		files[fmt.Sprintf("src/pkg%02d.go", i)] = fmt.Sprintf("package pkg%02d\n", i)
 	}
-	e.repo.RunGit("add", ".")
-	e.repo.RunGit("commit", "-m", "feat: spread across packages")
-	sha := e.repo.HeadSHA()
+	sha := e.repo.CommitFiles(files, "feat: spread across packages")
 
 	e.enqueueReviewFor(sha, "feat: spread across packages")
 
@@ -488,16 +481,13 @@ func TestE2EAutoDesign_HeuristicTriggerPersistsAgentModel(t *testing.T) {
 	t.Cleanup(ResetAutoDesignMetricsForTest)
 
 	repo := testutil.NewTestRepoWithCommit(t)
-	require.NoError(t, os.WriteFile(filepath.Join(repo.Path(), ".roborev.toml"),
-		[]byte(`agent = "test"
+	repo.CommitFile(".roborev.toml", `agent = "test"
 design_agent = "test"
 design_model = "mock-design-model"
 
 [auto_design_review]
 enabled = true
-`), 0o644))
-	repo.RunGit("add", ".roborev.toml")
-	repo.RunGit("commit", "-m", "chore: enable auto design review")
+`, "chore: enable auto design review")
 
 	db, _ := testutil.OpenTestDBWithDir(t)
 	row, err := db.GetOrCreateRepo(repo.Path())
@@ -560,12 +550,12 @@ func TestE2EAutoDesign_HTTP_ExplicitDesignBypasses(t *testing.T) {
 	// the caller asked for — source empty, NOT auto_design. Sweep EVERY
 	// state (including skipped and failed) so a mistaken dispatch that
 	// inserted a skipped row can't sneak past the sweep.
-	repo, err := db.GetOrCreateRepo(repoDir)
+	dbRepo, err := db.GetOrCreateRepo(repoDir)
 	require.NoError(t, err)
 	var autoCount int
 	require.NoError(t, db.QueryRow(`
 		SELECT COUNT(*) FROM review_jobs WHERE repo_id = ? AND source = 'auto_design'
-	`, repo.ID).Scan(&autoCount))
+	`, dbRepo.ID).Scan(&autoCount))
 	assert.Equal(t, 0, autoCount,
 		"explicit --type design must bypass auto-design path (including skipped rows)")
 	assert.EqualValues(t, 0, AutoDesignMetricsSnapshot().TriggeredHeuristic)
@@ -584,21 +574,16 @@ func TestE2EAutoDesign_HTTP_RangeReviewBypasses(t *testing.T) {
 
 	server, db, tmpDir := newTestServer(t)
 	repoDir := filepath.Join(tmpDir, "repo")
-	testutil.InitTestGitRepo(t, repoDir)
+	repo := testutil.InitTestGitRepo(t, repoDir)
 	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".roborev.toml"),
 		[]byte("[auto_design_review]\nenabled = true\n"), 0o644))
-	base := testutil.GetHeadSHA(t, repoDir)
+	base := repo.HeadSHA()
 
 	// Add a real second commit so the range is non-degenerate. Using
 	// base..head where base == head would pass even if a future change
 	// specifically short-circuits empty ranges — we want a genuine
 	// base..head spanning at least one commit.
-	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "a.txt"), []byte("hello\n"), 0o644))
-	cmd := exec.Command("git", "-C", repoDir, "add", "a.txt")
-	require.NoError(t, cmd.Run())
-	cmd = exec.Command("git", "-C", repoDir, "commit", "-m", "feat: add a.txt")
-	require.NoError(t, cmd.Run())
-	head := testutil.GetHeadSHA(t, repoDir)
+	head := repo.CommitFile("a.txt", "hello\n", "feat: add a.txt")
 	require.NotEqual(t, base, head)
 
 	// base..head range ref — default review_type so the handler's
@@ -612,12 +597,12 @@ func TestE2EAutoDesign_HTTP_RangeReviewBypasses(t *testing.T) {
 	server.httpServer.Handler.ServeHTTP(w, req)
 	require.Equal(t, http.StatusCreated, w.Code)
 
-	repo, err := db.GetOrCreateRepo(repoDir)
+	dbRepo, err := db.GetOrCreateRepo(repoDir)
 	require.NoError(t, err)
 	var autoCount int
 	require.NoError(t, db.QueryRow(`
 		SELECT COUNT(*) FROM review_jobs WHERE repo_id = ? AND source = 'auto_design'
-	`, repo.ID).Scan(&autoCount))
+	`, dbRepo.ID).Scan(&autoCount))
 	assert.Equal(t, 0, autoCount,
 		"range jobs must bypass auto-design (no auto_design row, including skipped)")
 	assert.EqualValues(t, 0, AutoDesignMetricsSnapshot().SkippedHeuristic,
@@ -646,12 +631,12 @@ func TestE2EAutoDesign_HTTP_SecurityReviewBypasses(t *testing.T) {
 	server.httpServer.Handler.ServeHTTP(w, req)
 	require.Equal(t, http.StatusCreated, w.Code)
 
-	repo, err := db.GetOrCreateRepo(repoDir)
+	dbRepo, err := db.GetOrCreateRepo(repoDir)
 	require.NoError(t, err)
 	var autoCount int
 	require.NoError(t, db.QueryRow(`
 		SELECT COUNT(*) FROM review_jobs WHERE repo_id = ? AND source = 'auto_design'
-	`, repo.ID).Scan(&autoCount))
+	`, dbRepo.ID).Scan(&autoCount))
 	assert.Equal(t, 0, autoCount,
 		"non-default review_type must bypass auto-design (including skipped rows)")
 }

--- a/internal/daemon/e2e_auto_design_test.go
+++ b/internal/daemon/e2e_auto_design_test.go
@@ -56,13 +56,22 @@ enabled = true
 	require.NoError(t, err)
 
 	cfg := config.DefaultConfig()
+	cfg.MaxWorkers = 1
 	srv := NewServer(db, cfg, "")
 
-	// Worker pool drives classify jobs end-to-end.
-	srv.workerPool.Start()
-	t.Cleanup(func() { srv.workerPool.Stop() })
-
 	return &autoDesignE2E{t: t, repo: repo, db: db, srv: srv, row: row}
+}
+
+func (e *autoDesignE2E) startWorkers() {
+	e.t.Helper()
+	e.srv.workerPool.Start()
+	e.t.Cleanup(func() { e.srv.workerPool.Stop() })
+}
+
+func (e *autoDesignE2E) completeParentReview(job *storage.ReviewJob) {
+	e.t.Helper()
+	_, err := e.db.Exec(`UPDATE review_jobs SET status = ? WHERE id = ?`, storage.JobStatusDone, job.ID)
+	require.NoError(e.t, err)
 }
 
 // enqueueReviewFor creates a primary review job the way the HTTP
@@ -260,7 +269,9 @@ func TestE2EAutoDesign_ClassifierPath_PromotesToDesignReview(t *testing.T) {
 	SetTestClassifierVerdict(true, "new package detected")
 	t.Cleanup(func() { SetTestClassifierVerdict(false, "") })
 
-	e.enqueueReviewFor(sha, "feat: small helper")
+	parent := e.enqueueReviewFor(sha, "feat: small helper")
+	e.completeParentReview(parent)
+	e.startWorkers()
 
 	// Wait for the worker to promote the classify row in place to a
 	// real review row. The initial row appears immediately with
@@ -308,7 +319,9 @@ func TestE2EAutoDesign_ClassifierPath_SkipsAmbiguous(t *testing.T) {
 	SetTestClassifierVerdict(false, "local rename only")
 	t.Cleanup(func() { SetTestClassifierVerdict(false, "") })
 
-	e.enqueueReviewFor(sha, "feat: rename var")
+	parent := e.enqueueReviewFor(sha, "feat: rename var")
+	e.completeParentReview(parent)
+	e.startWorkers()
 
 	// Wait for the worker to transition the classify row to skipped.
 	got := e.eventuallyAutoDesignMatches(sha, "status=skipped",
@@ -436,7 +449,9 @@ classifier_timeout_seconds = 1
 
 	// Don't set test verdict — let the real path fire, which will hit
 	// config.ResolveClassifyAgent's validator and fail.
-	e.enqueueReviewFor(sha, "feat: tweak")
+	parent := e.enqueueReviewFor(sha, "feat: tweak")
+	e.completeParentReview(parent)
+	e.startWorkers()
 
 	got := e.eventuallyAutoDesignMatches(sha, "status=skipped (classifier failed)",
 		func(j *storage.ReviewJob) bool { return j.Status == storage.JobStatusSkipped })

--- a/internal/daemon/health_test.go
+++ b/internal/daemon/health_test.go
@@ -22,7 +22,7 @@ func setupTestServer(t *testing.T) *Server {
 	t.Cleanup(func() { db.Close() })
 
 	cfg := config.DefaultConfig()
-	server := NewServer(db, cfg, "")
+	server := newServerWithLogs(db, cfg, "", newTestErrorLog(), newTestActivityLog())
 	t.Cleanup(func() { server.Close() })
 	return server
 }

--- a/internal/daemon/panel_posting_test.go
+++ b/internal/daemon/panel_posting_test.go
@@ -449,8 +449,10 @@ func TestPanelPermanentPreflightErrorAbandons(t *testing.T) {
 // `## roborev:` header is wrapped exactly once; a raw/all-failed body that
 // already starts with the header is not double-wrapped.
 func TestPanelWrapperNoDoubleHeader(t *testing.T) {
+	h := newCIPollerHarness(t, "https://github.com/acme/api.git")
+
 	t.Run("plain output gets one header", func(t *testing.T) {
-		h := newCIPollerHarness(t, "https://github.com/acme/api.git")
+		h.Cfg.CI.IncludeCosts = false
 		comments := h.CaptureComments()
 		_, synth, _ := h.seedCIPanelRun(t, "acme/api", 9, "headsha555", "base..headsha555",
 			[]jobSpec{{Agent: "test", ReviewType: "review", Status: "done", Output: "x"}})
@@ -464,7 +466,7 @@ func TestPanelWrapperNoDoubleHeader(t *testing.T) {
 	})
 
 	t.Run("plain output is not collapsed", func(t *testing.T) {
-		h := newCIPollerHarness(t, "https://github.com/acme/api.git")
+		h.Cfg.CI.IncludeCosts = false
 		comments := h.CaptureComments()
 		_, synth, _ := h.seedCIPanelRun(t, "acme/api", 13, "headsha888", "base..headsha888",
 			[]jobSpec{{Agent: "test", ReviewType: "review", Status: "done", Output: "x"}})
@@ -481,7 +483,7 @@ func TestPanelWrapperNoDoubleHeader(t *testing.T) {
 	})
 
 	t.Run("plain output footer includes panel members", func(t *testing.T) {
-		h := newCIPollerHarness(t, "https://github.com/acme/api.git")
+		h.Cfg.CI.IncludeCosts = false
 		comments := h.CaptureComments()
 		const headSHA = "9999999cccccc"
 		_, synth, _ := h.seedCIPanelRun(t, "acme/api", 14, headSHA, "base.."+headSHA,
@@ -507,7 +509,7 @@ func TestPanelWrapperNoDoubleHeader(t *testing.T) {
 	})
 
 	t.Run("clean synthesis body gets one panel footer", func(t *testing.T) {
-		h := newCIPollerHarness(t, "https://github.com/acme/api.git")
+		h.Cfg.CI.IncludeCosts = false
 		comments := h.CaptureComments()
 		const headSHA = "b00cdbf1234567"
 		_, synth, _ := h.seedCIPanelRun(t, "acme/api", 22, headSHA, "base.."+headSHA,
@@ -530,7 +532,7 @@ func TestPanelWrapperNoDoubleHeader(t *testing.T) {
 	})
 
 	t.Run("footer uses synthesis review agent", func(t *testing.T) {
-		h := newCIPollerHarness(t, "https://github.com/acme/api.git")
+		h.Cfg.CI.IncludeCosts = false
 		comments := h.CaptureComments()
 		const headSHA = "facefeed1234567"
 		_, synth, _ := h.seedCIPanelRun(t, "acme/api", 20, headSHA, "base.."+headSHA,
@@ -548,7 +550,7 @@ func TestPanelWrapperNoDoubleHeader(t *testing.T) {
 	})
 
 	t.Run("headed pass output keeps result text", func(t *testing.T) {
-		h := newCIPollerHarness(t, "https://github.com/acme/api.git")
+		h.Cfg.CI.IncludeCosts = false
 		comments := h.CaptureComments()
 		const headSHA = "1234567feedface"
 		_, synth, _ := h.seedCIPanelRun(t, "acme/api", 19, headSHA, "base.."+headSHA,
@@ -565,7 +567,7 @@ func TestPanelWrapperNoDoubleHeader(t *testing.T) {
 	})
 
 	t.Run("plain output footer hides cost by default", func(t *testing.T) {
-		h := newCIPollerHarness(t, "https://github.com/acme/api.git")
+		h.Cfg.CI.IncludeCosts = false
 		comments := h.CaptureComments()
 		_, synth, members := h.seedCIPanelRun(t, "acme/api", 18, "headsha3333", "base..headsha3333",
 			[]jobSpec{
@@ -593,7 +595,6 @@ func TestPanelWrapperNoDoubleHeader(t *testing.T) {
 	})
 
 	t.Run("plain output footer includes runtime and cost when enabled", func(t *testing.T) {
-		h := newCIPollerHarness(t, "https://github.com/acme/api.git")
 		h.Cfg.CI.IncludeCosts = true
 		comments := h.CaptureComments()
 		_, synth, members := h.seedCIPanelRun(t, "acme/api", 16, "headsha1111", "base..headsha1111",
@@ -620,7 +621,6 @@ func TestPanelWrapperNoDoubleHeader(t *testing.T) {
 	})
 
 	t.Run("plain output footer shows partial cost when enabled", func(t *testing.T) {
-		h := newCIPollerHarness(t, "https://github.com/acme/api.git")
 		h.Cfg.CI.IncludeCosts = true
 		comments := h.CaptureComments()
 		_, synth, members := h.seedCIPanelRun(t, "acme/api", 17, "headsha2222", "base..headsha2222",
@@ -643,7 +643,7 @@ func TestPanelWrapperNoDoubleHeader(t *testing.T) {
 	})
 
 	t.Run("plain output footer includes failed and canceled members", func(t *testing.T) {
-		h := newCIPollerHarness(t, "https://github.com/acme/api.git")
+		h.Cfg.CI.IncludeCosts = false
 		comments := h.CaptureComments()
 		_, synth, _ := h.seedCIPanelRun(t, "acme/api", 15, "headsha000", "base..headsha000",
 			[]jobSpec{
@@ -663,7 +663,7 @@ func TestPanelWrapperNoDoubleHeader(t *testing.T) {
 	})
 
 	t.Run("prefixed output is not re-wrapped", func(t *testing.T) {
-		h := newCIPollerHarness(t, "https://github.com/acme/api.git")
+		h.Cfg.CI.IncludeCosts = false
 		comments := h.CaptureComments()
 		const headSHA = "abc1234feedface"
 		_, synth, _ := h.seedCIPanelRun(t, "acme/api", 10, headSHA, "base.."+headSHA,
@@ -683,7 +683,7 @@ func TestPanelWrapperNoDoubleHeader(t *testing.T) {
 	})
 
 	t.Run("prefixed output is bounded with footer", func(t *testing.T) {
-		h := newCIPollerHarness(t, "https://github.com/acme/api.git")
+		h.Cfg.CI.IncludeCosts = false
 		comments := h.CaptureComments()
 		const headSHA = "7654321feedface"
 		_, synth, _ := h.seedCIPanelRun(t, "acme/api", 21, headSHA, "base.."+headSHA,

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -2035,8 +2035,9 @@ type singleAgentInputs struct {
 func (s *Server) resolveSingleAgent(
 	in singleAgentInputs,
 ) (string, string, *RawJSONOutput) {
-	resolution, err := agent.ResolveWorkflowConfig(
-		in.req.Agent, in.resolutionPath, in.cfg, in.workflow, in.reasoning,
+	repoCfg, _ := config.LoadRepoConfig(in.resolutionPath)
+	resolution, err := agent.ResolveWorkflowConfigFromConfig(
+		in.req.Agent, repoCfg, in.cfg, in.workflow, in.reasoning,
 	)
 	if err != nil {
 		out, _ := rawJSONOutput(
@@ -2046,8 +2047,8 @@ func (s *Server) resolveSingleAgent(
 		return "", "", out
 	}
 	agentName := resolution.PreferredAgent
-	resolved, err := agent.GetPreferredOrBackupWithConfig(
-		in.resolutionPath, agentName, in.cfg, resolution.BackupAgent,
+	resolved, err := agent.GetPreferredOrBackupWithConfigFromConfig(
+		repoCfg, agentName, in.cfg, resolution.BackupAgent,
 	)
 	if err != nil {
 		var unknownErr *agent.UnknownAgentError

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -69,12 +69,6 @@ const dailyTelemetryInterval = 24 * time.Hour
 
 // NewServer creates a new daemon server
 func NewServer(db *storage.DB, cfg *config.Config, configPath string) *Server {
-	// Always set for deterministic state - default to false (conservative)
-	agent.SetAllowUnsafeAgents(cfg.AllowUnsafeAgents != nil && *cfg.AllowUnsafeAgents)
-	agent.SetCodexSandboxDisabled(cfg.DisableCodexSandbox)
-	agent.SetAnthropicAPIKey(cfg.AnthropicAPIKey)
-	broadcaster := NewBroadcaster()
-
 	// Initialize error log
 	errorLog, err := NewErrorLog(DefaultErrorLogPath())
 	if err != nil {
@@ -86,6 +80,22 @@ func NewServer(db *storage.DB, cfg *config.Config, configPath string) *Server {
 	if err != nil {
 		log.Printf("Warning: failed to create activity log: %v", err)
 	}
+
+	return newServerWithLogs(db, cfg, configPath, errorLog, activityLog)
+}
+
+func newServerWithLogs(
+	db *storage.DB,
+	cfg *config.Config,
+	configPath string,
+	errorLog *ErrorLog,
+	activityLog *ActivityLog,
+) *Server {
+	// Always set for deterministic state - default to false (conservative)
+	agent.SetAllowUnsafeAgents(cfg.AllowUnsafeAgents != nil && *cfg.AllowUnsafeAgents)
+	agent.SetCodexSandboxDisabled(cfg.DisableCodexSandbox)
+	agent.SetAnthropicAPIKey(cfg.AnthropicAPIKey)
+	broadcaster := NewBroadcaster()
 
 	// Create config watcher for hot-reloading
 	configWatcher := NewConfigWatcher(configPath, cfg, broadcaster, activityLog)

--- a/internal/daemon/server_jobs_test.go
+++ b/internal/daemon/server_jobs_test.go
@@ -287,100 +287,57 @@ func TestHandleEnqueueExcludedBranch(t *testing.T) {
 	})
 }
 
-func TestHandleEnqueueExcludedCommitPattern(t *testing.T) {
+func TestBuildTargetDescriptorExcludedCommitPattern(t *testing.T) {
 	t.Parallel()
 	server, db, tmpDir := newTestServer(t)
 
 	repoDir := filepath.Join(tmpDir, "testrepo")
 	repo := testutil.InitTestGitRepo(t, repoDir)
+	storedRepo, err := db.GetOrCreateRepo(repoDir)
+	require.NoError(t, err)
 
-	// Write repo config with excluded_commit_patterns
 	repoConfig := filepath.Join(repoDir, ".roborev.toml")
 	configContent := `excluded_commit_patterns = ["[skip review]", "[wip]"]`
-	if err := os.WriteFile(repoConfig, []byte(configContent), 0o644); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "Failed to write repo config: %v", err)
+	require.NoError(t, os.WriteFile(repoConfig, []byte(configContent), 0o644))
+
+	freeze := func(t *testing.T, gitRef string) (targetDescriptor, *RawJSONOutput) {
+		t.Helper()
+		return server.buildTargetDescriptor(t.Context(), freezeInputs{
+			repo:         storedRepo,
+			req:          EnqueueRequest{RepoPath: repoDir, GitRef: gitRef, Agent: "test"},
+			gitRef:       gitRef,
+			checkoutRoot: repoDir,
+			repoRoot:     repoDir,
+		})
 	}
 
-	// Create a commit whose message matches an exclusion pattern
 	repo.CommitEmpty("wip: checkpoint [skip review]")
 
 	t.Run("matching commit returns skipped", func(t *testing.T) {
-		reqData := EnqueueRequest{
-			RepoPath: repoDir, GitRef: "HEAD", Agent: "test",
-		}
-		req := testutil.MakeJSONRequest(
-			t, http.MethodPost, "/api/enqueue", reqData,
-		)
-		w := httptest.NewRecorder()
-		server.httpServer.Handler.ServeHTTP(w, req)
+		_, early := freeze(t, "HEAD")
+		require.NotNil(t, early)
+		assert.Equal(t, http.StatusOK, early.Status)
+		resp, ok := early.Body.(EnqueueSkippedResponse)
+		require.True(t, ok)
+		assert.True(t, resp.Skipped)
+		assert.Contains(t, resp.Reason, "excluded")
 
-		if w.Code != http.StatusOK {
-			assert.Condition(t, func() bool {
-				return false
-			}, "expected 200, got %d: %s",
-				w.Code, w.Body.String())
-		}
-
-		var resp struct {
-			Skipped bool   `json:"skipped"`
-			Reason  string `json:"reason"`
-		}
-		testutil.DecodeJSON(t, w, &resp)
-
-		if !resp.Skipped {
-			assert.Condition(t, func() bool {
-				return false
-			}, "expected skipped=true")
-		}
-		if !strings.Contains(resp.Reason, "excluded") {
-			assert.Condition(t, func() bool {
-				return false
-			}, "reason should mention excluded, got %q",
-				resp.Reason)
-		}
-
-		// No job should have been created
 		queued, _, _, _, _, _, _, _, _ := db.GetJobCounts()
-		if queued != 0 {
-			assert.Condition(t, func() bool {
-				return false
-			}, "expected 0 queued jobs, got %d", queued)
-		}
+		assert.Equal(t, 0, queued)
 	})
 
-	// Create a commit that does NOT match any exclusion pattern
 	repo.CommitEmpty("feat: add endpoint")
 
-	t.Run("non-matching commit enqueues normally", func(t *testing.T) {
-		reqData := EnqueueRequest{
-			RepoPath: repoDir, GitRef: "HEAD", Agent: "test",
-		}
-		req := testutil.MakeJSONRequest(
-			t, http.MethodPost, "/api/enqueue", reqData,
-		)
-		w := httptest.NewRecorder()
-		server.httpServer.Handler.ServeHTTP(w, req)
-
-		if w.Code != http.StatusCreated {
-			assert.Condition(t, func() bool {
-				return false
-			}, "expected 201, got %d: %s",
-				w.Code, w.Body.String())
-		}
-
-		queued, _, _, _, _, _, _, _, _ := db.GetJobCounts()
-		if queued != 1 {
-			assert.Condition(t, func() bool {
-				return false
-			}, "expected 1 queued job, got %d", queued)
-		}
+	t.Run("non-matching commit freezes normally", func(t *testing.T) {
+		desc, early := freeze(t, "HEAD")
+		require.Nil(t, early)
+		assert.Positive(t, desc.commitID)
+		assert.NotEmpty(t, desc.gitRef)
+		assert.Equal(t, "feat: add endpoint", desc.commitSubject)
 	})
 
 	t.Run("range where all commits excluded returns skipped",
 		func(t *testing.T) {
-			// Create a branch with only excluded commits
 			repo.CheckoutNewBranch("all-excluded")
 			base := repo.HeadSHA()
 
@@ -388,36 +345,15 @@ func TestHandleEnqueueExcludedCommitPattern(t *testing.T) {
 				repo.CommitEmpty(fmt.Sprintf("[wip] checkpoint %d", i))
 			}
 
-			ref := base + "..HEAD"
-			reqData := EnqueueRequest{
-				RepoPath: repoDir, GitRef: ref, Agent: "test",
-			}
-			req := testutil.MakeJSONRequest(
-				t, http.MethodPost, "/api/enqueue", reqData,
-			)
-			w := httptest.NewRecorder()
-			server.httpServer.Handler.ServeHTTP(w, req)
-
-			if w.Code != http.StatusOK {
-				assert.Condition(t, func() bool {
-					return false
-				}, "expected 200, got %d: %s",
-					w.Code, w.Body.String())
-			}
-
-			var resp struct {
-				Skipped bool   `json:"skipped"`
-				Reason  string `json:"reason"`
-			}
-			testutil.DecodeJSON(t, w, &resp)
-			if !resp.Skipped {
-				assert.Condition(t, func() bool {
-					return false
-				}, "expected skipped=true for all-excluded range")
-			}
+			_, early := freeze(t, base+"..HEAD")
+			require.NotNil(t, early)
+			assert.Equal(t, http.StatusOK, early.Status)
+			resp, ok := early.Body.(EnqueueSkippedResponse)
+			require.True(t, ok)
+			assert.True(t, resp.Skipped)
 		})
 
-	t.Run("range with mixed commits enqueues normally",
+	t.Run("range with mixed commits freezes normally",
 		func(t *testing.T) {
 			repo.CheckoutNewBranch("mixed-range")
 			base := repo.HeadSHA()
@@ -425,27 +361,14 @@ func TestHandleEnqueueExcludedCommitPattern(t *testing.T) {
 			repo.CommitEmpty("[wip] temp")
 			repo.CommitEmpty("feat: real work")
 
-			ref := base + "..HEAD"
-			reqData := EnqueueRequest{
-				RepoPath: repoDir, GitRef: ref, Agent: "test",
-			}
-			req := testutil.MakeJSONRequest(
-				t, http.MethodPost, "/api/enqueue", reqData,
-			)
-			w := httptest.NewRecorder()
-			server.httpServer.Handler.ServeHTTP(w, req)
-
-			if w.Code != http.StatusCreated {
-				assert.Condition(t, func() bool {
-					return false
-				}, "expected 201, got %d: %s",
-					w.Code, w.Body.String())
-			}
+			desc, early := freeze(t, base+"..HEAD")
+			require.Nil(t, early)
+			assert.Contains(t, desc.gitRef, "..")
 		})
 
 	// This test corrupts a branch's parent chain, so it must run last
 	// since the corrupt-range branch becomes unwalkable afterward.
-	t.Run("range with corrupt mid-commit enqueues normally",
+	t.Run("range with corrupt mid-commit freezes normally",
 		func(t *testing.T) {
 			// Build a synthetic tip whose `parent` line points at a SHA
 			// that does not exist in the object store. GetRangeCommits
@@ -485,23 +408,10 @@ func TestHandleEnqueueExcludedCommitPattern(t *testing.T) {
 			// synthetic tip both exist as objects), but
 			// GetRangeCommits fails because git can't load tip's
 			// fake parent. The exclusion block is skipped and the
-			// job is enqueued normally.
-			ref := base + ".." + tip
-			reqData := EnqueueRequest{
-				RepoPath: repoDir, GitRef: ref, Agent: "test",
-			}
-			req := testutil.MakeJSONRequest(
-				t, http.MethodPost, "/api/enqueue", reqData,
-			)
-			w := httptest.NewRecorder()
-			server.httpServer.Handler.ServeHTTP(w, req)
-
-			if w.Code != http.StatusCreated {
-				assert.Condition(t, func() bool {
-					return false
-				}, "expected 201, got %d: %s",
-					w.Code, w.Body.String())
-			}
+			// descriptor freezes normally.
+			desc, early := freeze(t, base+".."+tip)
+			require.Nil(t, early)
+			assert.Contains(t, desc.gitRef, "..")
 		})
 }
 
@@ -991,13 +901,13 @@ func TestFindReusableSessionIDUsesConfigurableLookback(t *testing.T) {
 			return false
 		}, "CompleteJob failed: %v", err)
 	}
-	if _, err := db.Exec(`UPDATE review_jobs SET session_id = ?, finished_at = datetime('now', '-12 minutes') WHERE id = ?`, "session-valid", validJob.ID); err != nil {
+	if _, err := db.Exec(`UPDATE review_jobs SET session_id = ?, finished_at = datetime('now', '-4 minutes') WHERE id = ?`, "session-valid", validJob.ID); err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "failed to seed valid session_id: %v", err)
 	}
 
-	for i := range 11 {
+	for i := range 3 {
 		invalidSHA := testRepo.UnrelatedCommit(fmt.Sprintf("unrelated %02d", i))
 		invalidCommit, err := db.GetOrCreateCommit(repo.ID, invalidSHA, "Author", "Subject", time.Now())
 		if err != nil {
@@ -1028,7 +938,7 @@ func TestFindReusableSessionIDUsesConfigurableLookback(t *testing.T) {
 				return false
 			}, "CompleteJob failed: %v", err)
 		}
-		offsetMinutes := 11 - i
+		offsetMinutes := 3 - i
 		if _, err := db.Exec(`UPDATE review_jobs SET session_id = ?, finished_at = datetime('now', ?) WHERE id = ?`, fmt.Sprintf("session-invalid-%02d", i), fmt.Sprintf("-%d minutes", offsetMinutes), invalidJob.ID); err != nil {
 			require.Condition(t, func() bool {
 				return false
@@ -1044,14 +954,14 @@ func TestFindReusableSessionIDUsesConfigurableLookback(t *testing.T) {
 		}, "findReusableSessionID() with default lookback = %q, want %q", got, "session-valid")
 	}
 
-	server.configWatcher.Config().ReuseReviewSessionLookback = 10
+	server.configWatcher.Config().ReuseReviewSessionLookback = 3
 	if got := server.findReusableSessionID(t.Context(), repoRoot, repo.ID, "feature/session", "test", config.ReviewTypeDefault, "", targetSHA); got != "" {
 		require.Condition(t, func() bool {
 			return false
 		}, "findReusableSessionID() with capped lookback = %q, want empty", got)
 	}
 
-	server.configWatcher.Config().ReuseReviewSessionLookback = 12
+	server.configWatcher.Config().ReuseReviewSessionLookback = 4
 	if got := server.findReusableSessionID(t.Context(), repoRoot, repo.ID, "feature/session", "test", config.ReviewTypeDefault, "", targetSHA); got != "session-valid" {
 		require.Condition(t, func() bool {
 			return false
@@ -1725,39 +1635,10 @@ func TestHandleEnqueuePromptJob(t *testing.T) {
 	})
 }
 
-func TestHandleEnqueueAgentAvailability(t *testing.T) {
-	// Shared read-only git repo created once (all subtests use different servers for DB isolation)
-	repoDir := filepath.Join(t.TempDir(), "repo")
-	testutil.InitTestGitRepo(t, repoDir)
-	headSHA := testutil.GetHeadSHA(t, repoDir)
-
-	// Create an isolated dir containing only a wrapper for git.
-	// We can't just use git's parent dir because it may contain real agent
-	// binaries (e.g. codex, claude) that would defeat the PATH isolation.
-	// Symlinks don't work reliably on Windows, so we use wrapper scripts.
-	gitPath, err := exec.LookPath("git")
-	if err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "git not found in PATH")
-	}
-	gitOnlyDir := t.TempDir()
-	if runtime.GOOS == "windows" {
-		wrapper := fmt.Sprintf("@\"%s\" %%*\r\n", gitPath)
-		if err := os.WriteFile(filepath.Join(gitOnlyDir, "git.cmd"), []byte(wrapper), 0o755); err != nil {
-			require.Condition(t, func() bool {
-				return false
-			}, err)
-		}
-	} else {
-		wrapper := fmt.Sprintf("#!/bin/sh\nexec '%s' \"$@\"\n", gitPath)
-		if err := os.WriteFile(filepath.Join(gitOnlyDir, "git"), []byte(wrapper), 0o755); err != nil {
-			require.Condition(t, func() bool {
-				return false
-			}, err)
-		}
-	}
-
+func TestResolveSingleAgentAvailability(t *testing.T) {
+	// The full enqueue handler already has broad git-target coverage. Keep this
+	// table focused on the availability/status mapper so it does not pay git
+	// root and descriptor-freezing costs for every resolver case.
 	mockScript := "#!/bin/sh\nexit 0\n"
 
 	tests := []struct {
@@ -1840,13 +1721,12 @@ func TestHandleEnqueueAgentAvailability(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Each subtest gets its own server/DB to avoid SHA dedup conflicts
-			server, _, _ := newTestServer(t)
+			cfg := config.DefaultConfig()
 			if tt.defaultAgent != "" {
-				server.configWatcher.Config().DefaultAgent = tt.defaultAgent
+				cfg.DefaultAgent = tt.defaultAgent
 			}
 			if tt.backupAgent != "" {
-				server.configWatcher.Config().DefaultBackupAgent = tt.backupAgent
+				cfg.DefaultBackupAgent = tt.backupAgent
 			}
 
 			// Isolate PATH: only mock binaries + git (no real agent CLIs)
@@ -1865,39 +1745,28 @@ func TestHandleEnqueueAgentAvailability(t *testing.T) {
 					}, err)
 				}
 			}
-			os.Setenv("PATH", mockDir+string(os.PathListSeparator)+gitOnlyDir)
+			os.Setenv("PATH", mockDir)
 			t.Cleanup(func() { os.Setenv("PATH", origPath) })
 
-			reqData := EnqueueRequest{
-				RepoPath:  repoDir,
-				CommitSHA: headSHA,
-			}
+			reqData := EnqueueRequest{}
 			if tt.requestAgent != "" {
 				reqData.Agent = tt.requestAgent
 			}
-			req := testutil.MakeJSONRequest(t, http.MethodPost, "/api/enqueue", reqData)
-			w := httptest.NewRecorder()
 
-			server.httpServer.Handler.ServeHTTP(w, req)
-
-			if w.Code != tt.expectedCode {
-				require.Condition(t, func() bool {
-					return false
-				}, "Expected status %d, got %d: %s", tt.expectedCode, w.Code, w.Body.String())
-			}
-
+			agentName, _, early := (&Server{}).resolveSingleAgent(singleAgentInputs{
+				req:       reqData,
+				cfg:       cfg,
+				workflow:  "review",
+				reasoning: "fast",
+			})
 			if tt.expectedCode != http.StatusCreated {
+				require.NotNil(t, early)
+				assert.Equal(t, tt.expectedCode, early.Status)
 				return
 			}
 
-			var job storage.ReviewJob
-			testutil.DecodeJSON(t, w, &job)
-
-			if job.Agent != tt.expectedAgent {
-				assert.Condition(t, func() bool {
-					return false
-				}, "Expected agent %q, got %q", tt.expectedAgent, job.Agent)
-			}
+			require.Nil(t, early)
+			assert.Equal(t, tt.expectedAgent, agentName)
 		})
 	}
 }
@@ -2416,15 +2285,11 @@ func TestHandleListJobsRepoPrefixFilter(t *testing.T) {
 	})
 }
 
-func TestHandleEnqueueAgentOverrideModel(t *testing.T) {
+func TestResolveSingleAgentOverrideModel(t *testing.T) {
 	t.Parallel()
 	// When the requested agent differs from config default, the generic
 	// default_model should be skipped. When they match (even via alias),
 	// default_model should apply.
-
-	repoDir := t.TempDir()
-	testutil.InitTestGitRepo(t, repoDir)
-	headSHA := testutil.GetHeadSHA(t, repoDir)
 
 	tests := []struct {
 		name         string
@@ -2467,39 +2332,19 @@ func TestHandleEnqueueAgentOverrideModel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			db, _ := testutil.OpenTestDBWithDir(t)
 			cfg := config.DefaultConfig()
 			cfg.DefaultAgent = tt.defaultAgent
 			cfg.DefaultModel = tt.defaultModel
-			server := NewServer(db, cfg, "")
 
-			reqData := EnqueueRequest{
-				RepoPath:  repoDir,
-				CommitSHA: headSHA,
-				Agent:     tt.reqAgent,
-				Model:     tt.reqModel,
-			}
-			req := testutil.MakeJSONRequest(
-				t, http.MethodPost, "/api/enqueue", reqData,
-			)
-			w := httptest.NewRecorder()
-			server.httpServer.Handler.ServeHTTP(w, req)
-
-			if w.Code != http.StatusCreated {
-				require.Condition(t, func() bool {
-					return false
-				}, "expected 201, got %d: %s", w.Code, w.Body.String())
-			}
-
-			var job storage.ReviewJob
-			testutil.DecodeJSON(t, w, &job)
-
-			if job.Model != tt.wantModel {
-				assert.Condition(t, func() bool {
-					return false
-				}, "model = %q, want %q", job.Model, tt.wantModel)
-			}
-			assert.Equal(t, tt.reqModel, job.RequestedModel)
+			_, model, early := (&Server{}).resolveSingleAgent(singleAgentInputs{
+				req:            EnqueueRequest{Agent: tt.reqAgent},
+				cfg:            cfg,
+				workflow:       "review",
+				reasoning:      "thorough",
+				requestedModel: tt.reqModel,
+			})
+			require.Nil(t, early)
+			assert.Equal(t, tt.wantModel, model)
 		})
 	}
 }

--- a/internal/daemon/server_jobs_test.go
+++ b/internal/daemon/server_jobs_test.go
@@ -208,15 +208,10 @@ func TestHandleEnqueueExcludedBranch(t *testing.T) {
 	server, db, tmpDir := newTestServer(t)
 
 	repoDir := filepath.Join(tmpDir, "testrepo")
-	testutil.InitTestGitRepo(t, repoDir)
+	repo := testutil.InitTestGitRepo(t, repoDir)
 
 	// Switch to excluded branch
-	checkoutCmd := exec.Command("git", "-C", repoDir, "checkout", "-b", "wip-feature")
-	if out, err := checkoutCmd.CombinedOutput(); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "git checkout failed: %v\n%s", err, out)
-	}
+	repo.CheckoutNewBranch("wip-feature")
 
 	// Create .roborev.toml with excluded_branches
 	repoConfig := filepath.Join(repoDir, ".roborev.toml")
@@ -268,13 +263,7 @@ func TestHandleEnqueueExcludedBranch(t *testing.T) {
 
 	t.Run("enqueue on non-excluded branch succeeds", func(t *testing.T) {
 		// Switch to a non-excluded branch
-		checkoutCmd := exec.Command("git", "checkout", "-b", "feature-ok")
-		checkoutCmd.Dir = repoDir
-		if out, err := checkoutCmd.CombinedOutput(); err != nil {
-			require.Condition(t, func() bool {
-				return false
-			}, "git checkout failed: %v\n%s", err, out)
-		}
+		repo.CheckoutNewBranch("feature-ok")
 
 		reqData := EnqueueRequest{RepoPath: repoDir, GitRef: "HEAD", Agent: "test"}
 		req := testutil.MakeJSONRequest(t, http.MethodPost, "/api/enqueue", reqData)
@@ -303,7 +292,7 @@ func TestHandleEnqueueExcludedCommitPattern(t *testing.T) {
 	server, db, tmpDir := newTestServer(t)
 
 	repoDir := filepath.Join(tmpDir, "testrepo")
-	testutil.InitTestGitRepo(t, repoDir)
+	repo := testutil.InitTestGitRepo(t, repoDir)
 
 	// Write repo config with excluded_commit_patterns
 	repoConfig := filepath.Join(repoDir, ".roborev.toml")
@@ -315,13 +304,7 @@ func TestHandleEnqueueExcludedCommitPattern(t *testing.T) {
 	}
 
 	// Create a commit whose message matches an exclusion pattern
-	addExcluded := exec.Command("git", "-C", repoDir,
-		"commit", "--allow-empty", "-m", "wip: checkpoint [skip review]")
-	if out, err := addExcluded.CombinedOutput(); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "git commit failed: %v\n%s", err, out)
-	}
+	repo.CommitEmpty("wip: checkpoint [skip review]")
 
 	t.Run("matching commit returns skipped", func(t *testing.T) {
 		reqData := EnqueueRequest{
@@ -368,13 +351,7 @@ func TestHandleEnqueueExcludedCommitPattern(t *testing.T) {
 	})
 
 	// Create a commit that does NOT match any exclusion pattern
-	addNormal := exec.Command("git", "-C", repoDir,
-		"commit", "--allow-empty", "-m", "feat: add endpoint")
-	if out, err := addNormal.CombinedOutput(); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "git commit failed: %v\n%s", err, out)
-	}
+	repo.CommitEmpty("feat: add endpoint")
 
 	t.Run("non-matching commit enqueues normally", func(t *testing.T) {
 		reqData := EnqueueRequest{
@@ -404,24 +381,11 @@ func TestHandleEnqueueExcludedCommitPattern(t *testing.T) {
 	t.Run("range where all commits excluded returns skipped",
 		func(t *testing.T) {
 			// Create a branch with only excluded commits
-			branchCmd := exec.Command("git", "-C", repoDir,
-				"checkout", "-b", "all-excluded")
-			if out, err := branchCmd.CombinedOutput(); err != nil {
-				require.Condition(t, func() bool {
-					return false
-				}, "checkout failed: %v\n%s", err, out)
-			}
-			base := testutil.GetHeadSHA(t, repoDir)
+			repo.CheckoutNewBranch("all-excluded")
+			base := repo.HeadSHA()
 
 			for i := range 2 {
-				cmd := exec.Command("git", "-C", repoDir,
-					"commit", "--allow-empty",
-					"-m", fmt.Sprintf("[wip] checkpoint %d", i))
-				if out, err := cmd.CombinedOutput(); err != nil {
-					require.Condition(t, func() bool {
-						return false
-					}, "commit failed: %v\n%s", err, out)
-				}
+				repo.CommitEmpty(fmt.Sprintf("[wip] checkpoint %d", i))
 			}
 
 			ref := base + "..HEAD"
@@ -455,28 +419,11 @@ func TestHandleEnqueueExcludedCommitPattern(t *testing.T) {
 
 	t.Run("range with mixed commits enqueues normally",
 		func(t *testing.T) {
-			branchCmd := exec.Command("git", "-C", repoDir,
-				"checkout", "-b", "mixed-range")
-			if out, err := branchCmd.CombinedOutput(); err != nil {
-				require.Condition(t, func() bool {
-					return false
-				}, "checkout failed: %v\n%s", err, out)
-			}
-			base := testutil.GetHeadSHA(t, repoDir)
+			repo.CheckoutNewBranch("mixed-range")
+			base := repo.HeadSHA()
 
-			cmds := [][]string{
-				{"commit", "--allow-empty", "-m", "[wip] temp"},
-				{"commit", "--allow-empty", "-m", "feat: real work"},
-			}
-			for _, args := range cmds {
-				cmd := exec.Command("git", append(
-					[]string{"-C", repoDir}, args...)...)
-				if out, err := cmd.CombinedOutput(); err != nil {
-					require.Condition(t, func() bool {
-						return false
-					}, "commit failed: %v\n%s", err, out)
-				}
-			}
+			repo.CommitEmpty("[wip] temp")
+			repo.CommitEmpty("feat: real work")
 
 			ref := base + "..HEAD"
 			reqData := EnqueueRequest{
@@ -510,14 +457,8 @@ func TestHandleEnqueueExcludedCommitPattern(t *testing.T) {
 			// I/O failures where GetRangeCommits succeeds but
 			// individual GetCommitInfo calls fail — git object
 			// corruption can't isolate those two calls.)
-			branchCmd := exec.Command("git", "-C", repoDir,
-				"checkout", "-b", "corrupt-range")
-			if out, err := branchCmd.CombinedOutput(); err != nil {
-				require.Condition(t, func() bool {
-					return false
-				}, "checkout failed: %v\n%s", err, out)
-			}
-			base := testutil.GetHeadSHA(t, repoDir)
+			repo.CheckoutNewBranch("corrupt-range")
+			base := repo.HeadSHA()
 
 			treeOut, err := exec.Command("git", "-C", repoDir,
 				"rev-parse", "HEAD^{tree}").Output()
@@ -538,11 +479,7 @@ func TestHandleEnqueueExcludedCommitPattern(t *testing.T) {
 			require.NoError(t, err, "hash-object")
 			tip := strings.TrimSpace(string(hashOut))
 
-			if out, err := exec.Command("git", "-C", repoDir,
-				"update-ref", "refs/heads/corrupt-range", tip).
-				CombinedOutput(); err != nil {
-				require.NoError(t, err, "update-ref: %s", out)
-			}
+			repo.SetRef("refs/heads/corrupt-range", tip)
 
 			// ResolveSHA succeeds for both endpoints (base and the
 			// synthetic tip both exist as objects), but
@@ -572,14 +509,9 @@ func TestHandleEnqueueReusesPreviousBranchSessionWhenEnabled(t *testing.T) {
 	server, db, tmpDir := newTestServer(t)
 
 	repoDir := filepath.Join(tmpDir, "testrepo")
-	testutil.InitTestGitRepo(t, repoDir)
+	testRepo := testutil.InitTestGitRepo(t, repoDir)
 
-	checkoutCmd := exec.Command("git", "-C", repoDir, "checkout", "-b", "feature/session")
-	if out, err := checkoutCmd.CombinedOutput(); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "git checkout failed: %v\n%s", err, out)
-	}
+	testRepo.CheckoutNewBranch("feature/session")
 	if branch := gitpkg.GetCurrentBranch(repoDir); branch != "feature/session" {
 		require.Condition(t, func() bool {
 			return false
@@ -755,14 +687,9 @@ func TestFindReusableSessionIDRejectsReusedBranchNameFromUnrelatedHistory(t *tes
 	server, db, tmpDir := newTestServer(t)
 
 	repoDir := filepath.Join(tmpDir, "testrepo")
-	testutil.InitTestGitRepo(t, repoDir)
+	testRepo := testutil.InitTestGitRepo(t, repoDir)
 
-	checkoutCmd := exec.Command("git", "-C", repoDir, "checkout", "-b", "feature/session")
-	if out, err := checkoutCmd.CombinedOutput(); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "git checkout failed: %v\n%s", err, out)
-	}
+	testRepo.CheckoutNewBranch("feature/session")
 
 	reuseSessions := true
 	server.configWatcher.Config().ReuseReviewSession = &reuseSessions
@@ -780,33 +707,7 @@ func TestFindReusableSessionIDRejectsReusedBranchNameFromUnrelatedHistory(t *tes
 		}, "GetOrCreateRepo failed: %v", err)
 	}
 
-	if out, err := exec.Command("git", "-C", repoDir, "checkout", "--orphan", "branch-reused").CombinedOutput(); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "git checkout --orphan failed: %v\n%s", err, out)
-	}
-	if out, err := exec.Command("git", "-C", repoDir, "rm", "-rf", ".").CombinedOutput(); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "git rm failed: %v\n%s", err, out)
-	}
-	unrelatedFile := filepath.Join(repoDir, "unrelated.txt")
-	if err := os.WriteFile(unrelatedFile, []byte("unrelated\n"), 0o644); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "WriteFile failed: %v", err)
-	}
-	if out, err := exec.Command("git", "-C", repoDir, "add", "unrelated.txt").CombinedOutput(); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "git add failed: %v\n%s", err, out)
-	}
-	if out, err := exec.Command("git", "-C", repoDir, "commit", "-m", "unrelated history").CombinedOutput(); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "git commit failed: %v\n%s", err, out)
-	}
-	unrelatedSHA := testutil.GetHeadSHA(t, repoDir)
+	unrelatedSHA := testRepo.UnrelatedCommit("unrelated history")
 
 	prevCommit, err := db.GetOrCreateCommit(repo.ID, unrelatedSHA, "Author", "Subject", time.Now())
 	if err != nil {
@@ -843,12 +744,7 @@ func TestFindReusableSessionIDRejectsReusedBranchNameFromUnrelatedHistory(t *tes
 		}, "failed to seed session_id: %v", err)
 	}
 
-	if out, err := exec.Command("git", "-C", repoDir, "checkout", "feature/session").CombinedOutput(); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "git checkout feature/session failed: %v\n%s", err, out)
-	}
-	targetSHA := testutil.GetHeadSHA(t, repoDir)
+	targetSHA := testRepo.HeadSHA()
 
 	if got := server.findReusableSessionID(t.Context(), repoRoot, repo.ID, "feature/session", "test", config.ReviewTypeDefault, "", targetSHA); got != "" {
 		require.Condition(t, func() bool {
@@ -862,14 +758,9 @@ func TestFindReusableSessionIDRejectsCandidateThatIsTooOldOnBranch(t *testing.T)
 	server, db, tmpDir := newTestServer(t)
 
 	repoDir := filepath.Join(tmpDir, "testrepo")
-	testutil.InitTestGitRepo(t, repoDir)
+	testRepo := testutil.InitTestGitRepo(t, repoDir)
 
-	checkoutCmd := exec.Command("git", "-C", repoDir, "checkout", "-b", "feature/session")
-	if out, err := checkoutCmd.CombinedOutput(); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "git checkout failed: %v\n%s", err, out)
-	}
+	testRepo.CheckoutNewBranch("feature/session")
 
 	reuseSessions := true
 	server.configWatcher.Config().ReuseReviewSession = &reuseSessions
@@ -887,7 +778,7 @@ func TestFindReusableSessionIDRejectsCandidateThatIsTooOldOnBranch(t *testing.T)
 		}, "GetOrCreateRepo failed: %v", err)
 	}
 
-	candidateSHA := testutil.GetHeadSHA(t, repoDir)
+	candidateSHA := testRepo.HeadSHA()
 	candidateCommit, err := db.GetOrCreateCommit(repo.ID, candidateSHA, "Author", "Subject", time.Now())
 	if err != nil {
 		require.Condition(t, func() bool {
@@ -924,24 +815,13 @@ func TestFindReusableSessionIDRejectsCandidateThatIsTooOldOnBranch(t *testing.T)
 	}
 
 	for i := range 51 {
-		nextFile := filepath.Join(repoDir, fmt.Sprintf("commit-%02d.txt", i))
-		if err := os.WriteFile(nextFile, fmt.Appendf(nil, "%d\n", i), 0o644); err != nil {
-			require.Condition(t, func() bool {
-				return false
-			}, "WriteFile failed: %v", err)
-		}
-		if out, err := exec.Command("git", "-C", repoDir, "add", filepath.Base(nextFile)).CombinedOutput(); err != nil {
-			require.Condition(t, func() bool {
-				return false
-			}, "git add failed: %v\n%s", err, out)
-		}
-		if out, err := exec.Command("git", "-C", repoDir, "commit", "-m", fmt.Sprintf("commit %02d", i)).CombinedOutput(); err != nil {
-			require.Condition(t, func() bool {
-				return false
-			}, "git commit failed: %v\n%s", err, out)
-		}
+		testRepo.CommitFile(
+			fmt.Sprintf("commit-%02d.txt", i),
+			fmt.Sprintf("%d\n", i),
+			fmt.Sprintf("commit %02d", i),
+		)
 	}
-	targetSHA := testutil.GetHeadSHA(t, repoDir)
+	targetSHA := testRepo.HeadSHA()
 
 	if got := server.findReusableSessionID(t.Context(), repoRoot, repo.ID, "feature/session", "test", config.ReviewTypeDefault, "", targetSHA); got != "" {
 		require.Condition(t, func() bool {
@@ -954,13 +834,9 @@ func TestFindReusableSessionIDFallsBackToOlderValidCandidate(t *testing.T) {
 	server, db, tmpDir := newTestServer(t)
 
 	repoDir := filepath.Join(tmpDir, "testrepo")
-	testutil.InitTestGitRepo(t, repoDir)
+	testRepo := testutil.InitTestGitRepo(t, repoDir)
 
-	if out, err := exec.Command("git", "-C", repoDir, "checkout", "-b", "feature/session").CombinedOutput(); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "git checkout failed: %v\n%s", err, out)
-	}
+	testRepo.CheckoutNewBranch("feature/session")
 
 	reuseSessions := true
 	server.configWatcher.Config().ReuseReviewSession = &reuseSessions
@@ -978,7 +854,7 @@ func TestFindReusableSessionIDFallsBackToOlderValidCandidate(t *testing.T) {
 		}, "GetOrCreateRepo failed: %v", err)
 	}
 
-	validSHA := testutil.GetHeadSHA(t, repoDir)
+	validSHA := testRepo.HeadSHA()
 	validCommit, err := db.GetOrCreateCommit(repo.ID, validSHA, "Author", "Subject", time.Now())
 	if err != nil {
 		require.Condition(t, func() bool {
@@ -1014,33 +890,7 @@ func TestFindReusableSessionIDFallsBackToOlderValidCandidate(t *testing.T) {
 		}, "failed to seed valid session_id: %v", err)
 	}
 
-	if out, err := exec.Command("git", "-C", repoDir, "checkout", "--orphan", "branch-reused").CombinedOutput(); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "git checkout --orphan failed: %v\n%s", err, out)
-	}
-	if out, err := exec.Command("git", "-C", repoDir, "rm", "-rf", ".").CombinedOutput(); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "git rm failed: %v\n%s", err, out)
-	}
-	unrelatedFile := filepath.Join(repoDir, "unrelated-newer.txt")
-	if err := os.WriteFile(unrelatedFile, []byte("unrelated newer\n"), 0o644); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "WriteFile failed: %v", err)
-	}
-	if out, err := exec.Command("git", "-C", repoDir, "add", filepath.Base(unrelatedFile)).CombinedOutput(); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "git add failed: %v\n%s", err, out)
-	}
-	if out, err := exec.Command("git", "-C", repoDir, "commit", "-m", "new unrelated history").CombinedOutput(); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "git commit failed: %v\n%s", err, out)
-	}
-	invalidSHA := testutil.GetHeadSHA(t, repoDir)
+	invalidSHA := testRepo.UnrelatedCommit("new unrelated history")
 	invalidCommit, err := db.GetOrCreateCommit(repo.ID, invalidSHA, "Author", "Subject", time.Now())
 	if err != nil {
 		require.Condition(t, func() bool {
@@ -1076,12 +926,7 @@ func TestFindReusableSessionIDFallsBackToOlderValidCandidate(t *testing.T) {
 		}, "failed to seed invalid session_id: %v", err)
 	}
 
-	if out, err := exec.Command("git", "-C", repoDir, "checkout", "feature/session").CombinedOutput(); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "git checkout feature/session failed: %v\n%s", err, out)
-	}
-	targetSHA := testutil.GetHeadSHA(t, repoDir)
+	targetSHA := testRepo.HeadSHA()
 
 	if got := server.findReusableSessionID(t.Context(), repoRoot, repo.ID, "feature/session", "test", config.ReviewTypeDefault, "", targetSHA); got != "session-valid" {
 		require.Condition(t, func() bool {
@@ -1095,13 +940,9 @@ func TestFindReusableSessionIDUsesConfigurableLookback(t *testing.T) {
 	server, db, tmpDir := newTestServer(t)
 
 	repoDir := filepath.Join(tmpDir, "testrepo")
-	testutil.InitTestGitRepo(t, repoDir)
+	testRepo := testutil.InitTestGitRepo(t, repoDir)
 
-	if out, err := exec.Command("git", "-C", repoDir, "checkout", "-b", "feature/session").CombinedOutput(); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "git checkout failed: %v\n%s", err, out)
-	}
+	testRepo.CheckoutNewBranch("feature/session")
 
 	reuseSessions := true
 	server.configWatcher.Config().ReuseReviewSession = &reuseSessions
@@ -1120,7 +961,7 @@ func TestFindReusableSessionIDUsesConfigurableLookback(t *testing.T) {
 		}, "GetOrCreateRepo failed: %v", err)
 	}
 
-	validSHA := testutil.GetHeadSHA(t, repoDir)
+	validSHA := testRepo.HeadSHA()
 	validCommit, err := db.GetOrCreateCommit(repo.ID, validSHA, "Author", "Subject", time.Now())
 	if err != nil {
 		require.Condition(t, func() bool {
@@ -1157,36 +998,7 @@ func TestFindReusableSessionIDUsesConfigurableLookback(t *testing.T) {
 	}
 
 	for i := range 11 {
-		branchName := fmt.Sprintf("branch-reused-%02d", i)
-		if out, err := exec.Command("git", "-C", repoDir, "checkout", "--orphan", branchName).CombinedOutput(); err != nil {
-			require.Condition(t, func() bool {
-				return false
-			}, "git checkout --orphan failed: %v\n%s", err, out)
-		}
-		if out, err := exec.Command("git", "-C", repoDir, "rm", "-rf", ".").CombinedOutput(); err != nil {
-			require.Condition(t, func() bool {
-				return false
-			}, "git rm failed: %v\n%s", err, out)
-		}
-
-		unrelatedFile := filepath.Join(repoDir, fmt.Sprintf("unrelated-%02d.txt", i))
-		if err := os.WriteFile(unrelatedFile, fmt.Appendf(nil, "unrelated %02d\n", i), 0o644); err != nil {
-			require.Condition(t, func() bool {
-				return false
-			}, "WriteFile failed: %v", err)
-		}
-		if out, err := exec.Command("git", "-C", repoDir, "add", filepath.Base(unrelatedFile)).CombinedOutput(); err != nil {
-			require.Condition(t, func() bool {
-				return false
-			}, "git add failed: %v\n%s", err, out)
-		}
-		if out, err := exec.Command("git", "-C", repoDir, "commit", "-m", fmt.Sprintf("unrelated %02d", i)).CombinedOutput(); err != nil {
-			require.Condition(t, func() bool {
-				return false
-			}, "git commit failed: %v\n%s", err, out)
-		}
-
-		invalidSHA := testutil.GetHeadSHA(t, repoDir)
+		invalidSHA := testRepo.UnrelatedCommit(fmt.Sprintf("unrelated %02d", i))
 		invalidCommit, err := db.GetOrCreateCommit(repo.ID, invalidSHA, "Author", "Subject", time.Now())
 		if err != nil {
 			require.Condition(t, func() bool {
@@ -1224,12 +1036,7 @@ func TestFindReusableSessionIDUsesConfigurableLookback(t *testing.T) {
 		}
 	}
 
-	if out, err := exec.Command("git", "-C", repoDir, "checkout", "feature/session").CombinedOutput(); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "git checkout feature/session failed: %v\n%s", err, out)
-	}
-	targetSHA := testutil.GetHeadSHA(t, repoDir)
+	targetSHA := testRepo.HeadSHA()
 
 	if got := server.findReusableSessionID(t.Context(), repoRoot, repo.ID, "feature/session", "test", config.ReviewTypeDefault, "", targetSHA); got != "session-valid" {
 		require.Condition(t, func() bool {
@@ -1256,13 +1063,9 @@ func TestFindReusableSessionIDLookbackIgnoresUnusableRefs(t *testing.T) {
 	server, db, tmpDir := newTestServer(t)
 
 	repoDir := filepath.Join(tmpDir, "testrepo")
-	testutil.InitTestGitRepo(t, repoDir)
+	testRepo := testutil.InitTestGitRepo(t, repoDir)
 
-	if out, err := exec.Command("git", "-C", repoDir, "checkout", "-b", "feature/session").CombinedOutput(); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "git checkout failed: %v\n%s", err, out)
-	}
+	testRepo.CheckoutNewBranch("feature/session")
 
 	reuseSessions := true
 	server.configWatcher.Config().ReuseReviewSession = &reuseSessions
@@ -1281,7 +1084,7 @@ func TestFindReusableSessionIDLookbackIgnoresUnusableRefs(t *testing.T) {
 		}, "GetOrCreateRepo failed: %v", err)
 	}
 
-	targetSHA := testutil.GetHeadSHA(t, repoDir)
+	targetSHA := testRepo.HeadSHA()
 	validCommit, err := db.GetOrCreateCommit(repo.ID, targetSHA, "Author", "Subject", time.Now())
 	if err != nil {
 		require.Condition(t, func() bool {
@@ -1385,13 +1188,9 @@ func TestFindReusableSessionIDSkipsInvalidStoredSessionID(t *testing.T) {
 	server, db, tmpDir := newTestServer(t)
 
 	repoDir := filepath.Join(tmpDir, "testrepo")
-	testutil.InitTestGitRepo(t, repoDir)
+	testRepo := testutil.InitTestGitRepo(t, repoDir)
 
-	if out, err := exec.Command("git", "-C", repoDir, "checkout", "-b", "feature/session").CombinedOutput(); err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "git checkout failed: %v\n%s", err, out)
-	}
+	testRepo.CheckoutNewBranch("feature/session")
 
 	reuseSessions := true
 	server.configWatcher.Config().ReuseReviewSession = &reuseSessions
@@ -1410,7 +1209,7 @@ func TestFindReusableSessionIDSkipsInvalidStoredSessionID(t *testing.T) {
 		}, "GetOrCreateRepo failed: %v", err)
 	}
 
-	targetSHA := testutil.GetHeadSHA(t, repoDir)
+	targetSHA := testRepo.HeadSHA()
 	commit, err := db.GetOrCreateCommit(repo.ID, targetSHA, "Author", "Subject", time.Now())
 	if err != nil {
 		require.Condition(t, func() bool {

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -148,8 +148,8 @@ func newTestServer(t *testing.T) (*Server, *storage.DB, string) {
 	t.Helper()
 	db, tmpDir := testutil.OpenTestDBWithDir(t)
 	cfg := config.DefaultConfig()
-	server := NewServer(db, cfg, "")
-	// NewServer spawns a HookRunner goroutine and a worker pool. Without
+	server := newServerWithLogs(db, cfg, "", newTestErrorLog(), newTestActivityLog())
+	// Server construction spawns a HookRunner goroutine and worker-pool state. Without
 	// teardown, each test that calls newTestServer leaks them; on slow
 	// Windows runners the cumulative goroutine / channel work pushes the
 	// daemon test package past its 10m timeout. Close() stops the
@@ -157,6 +157,22 @@ func newTestServer(t *testing.T) (*Server, *storage.DB, string) {
 	// background work.
 	t.Cleanup(func() { _ = server.Close() })
 	return server, db, tmpDir
+}
+
+func newTestErrorLog() *ErrorLog {
+	return &ErrorLog{
+		recent:    make([]ErrorEntry, MaxErrorLogEntries),
+		maxRecent: MaxErrorLogEntries,
+	}
+}
+
+func newTestActivityLog() *ActivityLog {
+	return &ActivityLog{
+		recent:        make([]ActivityEntry, activityLogCapacity),
+		maxRecent:     activityLogCapacity,
+		maxSize:       maxActivityLogSize,
+		checkInterval: rotateCheckInterval,
+	}
 }
 
 func TestServerStartRejectsNonLoopbackBindAddr(t *testing.T) {

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -389,7 +389,7 @@ func (wp *WorkerPool) createCIExactCheckout(
 		return "", nil, fmt.Errorf("create CI worktree parent: %w", err)
 	}
 	unlock := lockGitMetadata(job.RepoPath)
-	wt, createErr := gitworktree.Create(ctx, job.RepoPath, headRef, gitworktree.Options{
+	wt, createErr := createWorkerWorktree(ctx, job.RepoPath, headRef, gitworktree.Options{
 		ParentDir:      parentDir,
 		Prefix:         fmt.Sprintf("%s%d-", ciWorktreePrefix, job.ID),
 		InitSubmodules: true,
@@ -809,7 +809,7 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 	reviewRepoPath := checkout.agentRepoPath
 	var fixWorktree *gitworktree.Worktree
 	if job.IsFixJob() {
-		wt, wtErr := gitworktree.Create(ctx, job.RepoPath, job.GitRef, gitworktree.Options{
+		wt, wtErr := createWorkerWorktree(ctx, job.RepoPath, job.GitRef, gitworktree.Options{
 			Prefix:         "roborev-worktree-",
 			InitSubmodules: true,
 			PullLFS:        true,

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -120,17 +120,17 @@ func (wp *WorkerPool) Start() {
 // multiple times; only the first call performs shutdown.
 func (wp *WorkerPool) Stop() {
 	wp.stopOnce.Do(func() {
-		log.Println("Stopping worker pool...")
 		close(wp.stopCh)
 		// Wait for Start to finish wg.Add before calling Wait.
 		// If Start was never called, readyCh stays open but
 		// stopCh is closed, so any late workers exit immediately.
 		select {
 		case <-wp.readyCh:
+			log.Println("Stopping worker pool...")
 			wp.wg.Wait()
+			log.Println("Worker pool stopped")
 		default:
 		}
-		log.Println("Worker pool stopped")
 	})
 }
 

--- a/internal/daemon/worker_integration_test.go
+++ b/internal/daemon/worker_integration_test.go
@@ -3,12 +3,15 @@
 package daemon
 
 import (
+	"context"
+	"io"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testutil"
 )
@@ -75,6 +78,17 @@ func TestWorkerPoolE2E(t *testing.T) {
 }
 
 func TestWorkerPoolCancelRunningJob(t *testing.T) {
+	originalTestAgent, err := agent.Get("test")
+	require.NoError(t, err)
+	agent.Register(&agent.FakeAgent{
+		NameStr: "test",
+		ReviewFn: func(ctx context.Context, _, _, _ string, _ io.Writer) (string, error) {
+			<-ctx.Done()
+			return "", ctx.Err()
+		},
+	})
+	t.Cleanup(func() { agent.Register(originalTestAgent) })
+
 	tc := newWorkerTestContext(t, 1)
 	sha := testutil.GetHeadSHA(t, tc.TmpDir)
 	job := tc.createJob(t, sha)
@@ -101,7 +115,7 @@ func TestWorkerPoolCancelRunningJob(t *testing.T) {
 		}, "Expected status 'canceled', got '%s'", finalJob.Status)
 	}
 
-	_, err := tc.DB.GetReviewByJobID(job.ID)
+	_, err = tc.DB.GetReviewByJobID(job.ID)
 	if err == nil {
 		assert.Condition(t, func() bool {
 			return false

--- a/internal/daemon/worker_snapshot_test.go
+++ b/internal/daemon/worker_snapshot_test.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"io"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -26,7 +24,7 @@ import (
 // and cleans up afterward. They use FakeAgent to capture exactly what
 // the agent sees without making real AI calls.
 
-func commitLargeChange(t *testing.T, dir string) string {
+func commitLargeChange(t *testing.T, repo *testutil.TestRepo) string {
 	t.Helper()
 	var content strings.Builder
 	for range 20000 {
@@ -36,17 +34,7 @@ func commitLargeChange(t *testing.T, dir string) string {
 		content.WriteString(strings.Repeat("y", 20))
 		content.WriteString("\n")
 	}
-	require.NoError(t, os.WriteFile(
-		filepath.Join(dir, "large.txt"),
-		[]byte(content.String()), 0o644,
-	))
-	cmd := exec.Command("git", "-C", dir, "add", "large.txt")
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, "git add: %s", out)
-	cmd = exec.Command("git", "-C", dir, "commit", "-m", "large change")
-	out, err = cmd.CombinedOutput()
-	require.NoError(t, err, "git commit: %s", out)
-	return testutil.GetHeadSHA(t, dir)
+	return repo.CommitFile("large.txt", content.String(), "large change")
 }
 
 func registerFakeAgent(t *testing.T, name string, fn func(ctx context.Context, repoPath, sha, prompt string, w io.Writer) (string, error)) {
@@ -84,7 +72,7 @@ func TestSnapshotFlow_SmallDiffInlinesWithoutFile(t *testing.T) {
 
 func TestSnapshotFlow_LargeDiffWritesFileAndReferencesInPrompt(t *testing.T) {
 	tc := newWorkerTestContext(t, 1)
-	sha := commitLargeChange(t, tc.TmpDir)
+	sha := commitLargeChange(t, tc.GitRepo)
 
 	var receivedPrompt string
 	registerFakeAgent(t, "test", func(_ context.Context, _, _, p string, _ io.Writer) (string, error) {
@@ -120,7 +108,7 @@ func TestSnapshotFlow_LargeDiffWritesFileAndReferencesInPrompt(t *testing.T) {
 
 func TestSnapshotFlow_SnapshotFileContentMatchesDiff(t *testing.T) {
 	tc := newWorkerTestContext(t, 1)
-	sha := commitLargeChange(t, tc.TmpDir)
+	sha := commitLargeChange(t, tc.GitRepo)
 
 	var snapshotPath string
 	registerFakeAgent(t, "test", func(_ context.Context, _, _, p string, _ io.Writer) (string, error) {
@@ -173,7 +161,7 @@ func TestSnapshotFlow_SnapshotFileContentMatchesDiff(t *testing.T) {
 
 func TestSnapshotFlow_SnapshotFileReadableDuringReview(t *testing.T) {
 	tc := newWorkerTestContext(t, 1)
-	sha := commitLargeChange(t, tc.TmpDir)
+	sha := commitLargeChange(t, tc.GitRepo)
 
 	var fileContent string
 	var fileReadErr error
@@ -224,24 +212,10 @@ func TestSnapshotFlow_SnapshotFileReadableDuringReview(t *testing.T) {
 func TestSnapshotFlow_ExcludePatternsAppliedToSnapshot(t *testing.T) {
 	tc := newWorkerTestContext(t, 1)
 
-	// Create a commit with both a normal file and an excluded file
-	require.NoError(t, os.WriteFile(
-		filepath.Join(tc.TmpDir, "code.go"),
-		[]byte(strings.Repeat("package main\n", 15000)),
-		0o644,
-	))
-	require.NoError(t, os.WriteFile(
-		filepath.Join(tc.TmpDir, "generated.dat"),
-		[]byte(strings.Repeat("gen\n", 5000)),
-		0o644,
-	))
-	cmd := exec.Command("git", "-C", tc.TmpDir, "add", "code.go", "generated.dat")
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, "git add: %s", out)
-	cmd = exec.Command("git", "-C", tc.TmpDir, "commit", "-m", "mixed change")
-	out, err = cmd.CombinedOutput()
-	require.NoError(t, err, "git commit: %s", out)
-	sha := testutil.GetHeadSHA(t, tc.TmpDir)
+	sha := tc.GitRepo.CommitFiles(map[string]string{
+		"code.go":       strings.Repeat("package main\n", 15000),
+		"generated.dat": strings.Repeat("gen\n", 5000),
+	}, "mixed change")
 
 	// Configure exclude patterns via global config
 	cfg := tc.Pool.cfgGetter.Config()

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -39,6 +39,7 @@ const testWorkerID = "test-worker"
 type workerTestContext struct {
 	DB          *storage.DB
 	TmpDir      string
+	GitRepo     *testutil.TestRepo
 	Repo        *storage.Repo
 	Pool        *WorkerPool
 	Broadcaster Broadcaster
@@ -49,7 +50,7 @@ type workerTestContext struct {
 func newWorkerTestContext(t *testing.T, workers int) *workerTestContext {
 	t.Helper()
 	db, tmpDir := testutil.OpenTestDBWithDir(t)
-	testutil.InitTestGitRepo(t, tmpDir)
+	gitRepo := testutil.InitTestGitRepo(t, tmpDir)
 
 	cfg := config.DefaultConfig()
 	if workers > 0 {
@@ -70,6 +71,7 @@ func newWorkerTestContext(t *testing.T, workers int) *workerTestContext {
 	return &workerTestContext{
 		DB:          db,
 		TmpDir:      tmpDir,
+		GitRepo:     gitRepo,
 		Repo:        repo,
 		Pool:        pool,
 		Broadcaster: b,
@@ -455,17 +457,16 @@ func TestWorkerCIPanelPromptSnapshotUsesTrustedConfigAndAgentCheckout(t *testing
 	repo := testutil.NewGitRepo(t)
 	baseSHA := repo.CommitFile("README.md", "base\n", "base")
 	repo.Checkout("-b", "pr-head")
-	repo.WriteFile(".roborev.toml", "exclude_patterns = [\"secret.txt\"]\nsnapshot_dir = \"pr-controlled-snapshots\"\n")
-	repo.WriteFile("secret.txt", "SECRET_SENTINEL_FROM_PR\n")
 	var big strings.Builder
 	for range 400 {
 		big.WriteString(strings.Repeat("large diff content ", 8))
 		big.WriteString("\n")
 	}
-	repo.WriteFile("big.txt", big.String())
-	repo.RunGit("add", ".roborev.toml", "secret.txt", "big.txt")
-	repo.RunGit("commit", "-m", "pr adds untrusted config and files")
-	headSHA := repo.HeadSHA()
+	headSHA := repo.CommitFiles(map[string]string{
+		".roborev.toml": "exclude_patterns = [\"secret.txt\"]\nsnapshot_dir = \"pr-controlled-snapshots\"\n",
+		"secret.txt":    "SECRET_SENTINEL_FROM_PR\n",
+		"big.txt":       big.String(),
+	}, "pr adds untrusted config and files")
 	repo.Checkout("main")
 
 	storedRepo, err := db.GetOrCreateRepo(repo.Path(), "https://github.com/acme/api.git")
@@ -1558,18 +1559,7 @@ func TestProcessJob_LargeDiffUsesExternalSnapshotWhenGitDirReadOnly(t *testing.T
 		content.WriteString(strings.Repeat("y", 20))
 		content.WriteString("\n")
 	}
-	require.NoError(t, os.WriteFile(
-		filepath.Join(tc.TmpDir, "large.txt"),
-		[]byte(content.String()), 0o644,
-	))
-	cmd := exec.Command("git", "-C", tc.TmpDir, "add", "large.txt")
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, "git add failed: %s", out)
-	cmd = exec.Command("git", "-C", tc.TmpDir, "commit", "-m", "large diff")
-	out, err = cmd.CombinedOutput()
-	require.NoError(t, err, "git commit failed: %s", out)
-
-	sha := testutil.GetHeadSHA(t, tc.TmpDir)
+	sha := tc.GitRepo.CommitFile("large.txt", content.String(), "large diff")
 	commit, err := tc.DB.GetOrCreateCommit(tc.Repo.ID, sha, "Author", "large", time.Now())
 	require.NoError(t, err)
 	job, err := tc.DB.EnqueueJob(storage.EnqueueOpts{
@@ -1639,18 +1629,7 @@ func TestProcessJob_LargeDiffUsesExternalSnapshotWithoutOversizedPrompt(t *testi
 		content.WriteString(strings.Repeat("large diff content ", 8))
 		content.WriteString("\n")
 	}
-	require.NoError(t, os.WriteFile(
-		filepath.Join(tc.TmpDir, "large-agent.txt"),
-		[]byte(content.String()), 0o644,
-	))
-	cmd := exec.Command("git", "-C", tc.TmpDir, "add", "large-agent.txt")
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, "git add failed: %s", out)
-	cmd = exec.Command("git", "-C", tc.TmpDir, "commit", "-m", "large agent diff")
-	out, err = cmd.CombinedOutput()
-	require.NoError(t, err, "git commit failed: %s", out)
-
-	sha := testutil.GetHeadSHA(t, tc.TmpDir)
+	sha := tc.GitRepo.CommitFile("large-agent.txt", content.String(), "large agent diff")
 	commit, err := tc.DB.GetOrCreateCommit(tc.Repo.ID, sha, "Author", "large", time.Now())
 	require.NoError(t, err)
 	job, err := tc.DB.EnqueueJob(storage.EnqueueOpts{

--- a/internal/daemon/worktree_create.go
+++ b/internal/daemon/worktree_create.go
@@ -118,14 +118,30 @@ func configuredAttributeFileUsesGitLFS(ctx context.Context, repoPath string) (bo
 	out, err := gitOutput(ctx, repoPath, "config", "--path", "--get", "core.attributesFile")
 	if err != nil {
 		if isGitExitCode(err, 1) {
-			return false, true
+			return defaultAttributeFileUsesGitLFS(ctx, repoPath)
 		}
+		return false, false
+	}
+	attrPath := strings.TrimSpace(string(out))
+	if attrPath == "" {
+		return defaultAttributeFileUsesGitLFS(ctx, repoPath)
+	}
+	return attributePathUsesGitLFS(repoPath, attrPath)
+}
+
+func defaultAttributeFileUsesGitLFS(ctx context.Context, repoPath string) (bool, bool) {
+	out, err := gitOutput(ctx, repoPath, "var", "GIT_ATTR_GLOBAL")
+	if err != nil {
 		return false, false
 	}
 	attrPath := strings.TrimSpace(string(out))
 	if attrPath == "" {
 		return false, true
 	}
+	return attributePathUsesGitLFS(repoPath, attrPath)
+}
+
+func attributePathUsesGitLFS(repoPath, attrPath string) (bool, bool) {
 	if !filepath.IsAbs(attrPath) {
 		attrPath = filepath.Join(repoPath, attrPath)
 	}

--- a/internal/daemon/worktree_create.go
+++ b/internal/daemon/worktree_create.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 
 	gitcmd "go.kenn.io/kit/git/cmd"
@@ -21,6 +23,10 @@ func createWorkerWorktree(
 ) (*gitworktree.Worktree, error) {
 	initSubmodules := opts.InitSubmodules
 	pullLFS := opts.PullLFS
+	runner := opts.Runner
+	if runner.Env == nil {
+		runner = gitcmd.New()
+	}
 	opts.InitSubmodules = false
 	opts.PullLFS = false
 
@@ -41,7 +47,9 @@ func createWorkerWorktree(
 		}
 	}
 	if pullLFS && checkoutUsesGitLFS(ctx, wt.Dir) {
-		wt.PullLFS(ctx)
+		if err := pullGitLFS(ctx, runner, wt.Dir); err != nil {
+			return nil, err
+		}
 	}
 
 	complete = true
@@ -59,7 +67,7 @@ func checkoutUsesGitLFS(ctx context.Context, repoPath string) bool {
 		return true
 	}
 	for _, attr := range attrs {
-		uses, err := attributeFileUsesGitLFS(filepath.Join(repoPath, filepath.FromSlash(attr)))
+		uses, err := gitAttributeFileUsesGitLFS(ctx, repoPath, attr)
 		if err != nil {
 			return true
 		}
@@ -79,20 +87,72 @@ func checkoutUsesGitLFS(ctx context.Context, repoPath string) bool {
 	return false
 }
 
-func gitAttributeFiles(ctx context.Context, repoPath string) ([]string, error) {
-	out, err := gitOutput(ctx, repoPath, "ls-files", "-z", "--", ".gitattributes", "**/.gitattributes")
+const maxGitAttributeFileBytes = 1 << 20
+
+type gitAttributeFile struct {
+	Mode     string
+	ObjectID string
+	Path     string
+}
+
+func pullGitLFS(ctx context.Context, runner gitcmd.Runner, repoPath string) error {
+	if _, _, err := runner.Run(ctx, repoPath, nil, "lfs", "env"); err != nil {
+		return fmt.Errorf("git lfs unavailable: %w", err)
+	}
+	if _, _, err := runner.Run(ctx, repoPath, nil, "lfs", "pull"); err != nil {
+		return fmt.Errorf("git lfs pull: %w", err)
+	}
+	return nil
+}
+
+func gitAttributeFiles(ctx context.Context, repoPath string) ([]gitAttributeFile, error) {
+	out, err := gitOutput(ctx, repoPath, "ls-files", "-s", "-z", "--", ".gitattributes", "**/.gitattributes")
 	if err != nil {
 		return nil, err
 	}
 	parts := bytes.Split(out, []byte{0})
-	files := make([]string, 0, len(parts))
+	files := make([]gitAttributeFile, 0, len(parts))
 	for _, part := range parts {
 		if len(part) == 0 {
 			continue
 		}
-		files = append(files, string(part))
+		meta, path, ok := strings.Cut(string(part), "\t")
+		fields := strings.Fields(meta)
+		if !ok || len(fields) < 2 {
+			return nil, fmt.Errorf("parse tracked attributes entry %q", part)
+		}
+		files = append(files, gitAttributeFile{
+			Mode:     fields[0],
+			ObjectID: fields[1],
+			Path:     path,
+		})
 	}
 	return files, nil
+}
+
+func gitAttributeFileUsesGitLFS(ctx context.Context, repoPath string, attr gitAttributeFile) (bool, error) {
+	if attr.Mode != "100644" && attr.Mode != "100755" {
+		return false, fmt.Errorf("unsafe tracked attributes mode %s for %s", attr.Mode, attr.Path)
+	}
+	out, err := gitOutput(ctx, repoPath, "cat-file", "-s", attr.ObjectID)
+	if err != nil {
+		return false, err
+	}
+	size, err := strconv.ParseInt(strings.TrimSpace(string(out)), 10, 64)
+	if err != nil {
+		return false, err
+	}
+	if size > maxGitAttributeFileBytes {
+		return false, fmt.Errorf("tracked attributes file %s is too large: %d bytes", attr.Path, size)
+	}
+	out, err = gitOutput(ctx, repoPath, "cat-file", "blob", attr.ObjectID)
+	if err != nil {
+		return false, err
+	}
+	if len(out) > maxGitAttributeFileBytes {
+		return false, fmt.Errorf("tracked attributes file %s exceeded size cap", attr.Path)
+	}
+	return attributeContentUsesGitLFS(string(out)), nil
 }
 
 func gitPathAttributeFileUsesGitLFS(ctx context.Context, repoPath, path string) (bool, bool) {
@@ -153,9 +213,22 @@ func attributePathUsesGitLFS(repoPath, attrPath string) (bool, bool) {
 }
 
 func attributeFileUsesGitLFS(path string) (bool, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return false, err
+	}
+	if !info.Mode().IsRegular() {
+		return false, fmt.Errorf("attributes file %s is not regular", path)
+	}
+	if info.Size() > maxGitAttributeFileBytes {
+		return false, fmt.Errorf("attributes file %s is too large: %d bytes", path, info.Size())
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return false, err
+	}
+	if len(data) > maxGitAttributeFileBytes {
+		return false, fmt.Errorf("attributes file %s exceeded size cap", path)
 	}
 	return attributeContentUsesGitLFS(string(data)), nil
 }

--- a/internal/daemon/worktree_create.go
+++ b/internal/daemon/worktree_create.go
@@ -1,0 +1,172 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	gitcmd "go.kenn.io/kit/git/cmd"
+	gitworktree "go.kenn.io/kit/git/worktree"
+)
+
+func createWorkerWorktree(
+	ctx context.Context,
+	repoPath, ref string,
+	opts gitworktree.Options,
+) (*gitworktree.Worktree, error) {
+	initSubmodules := opts.InitSubmodules
+	pullLFS := opts.PullLFS
+	opts.InitSubmodules = false
+	opts.PullLFS = false
+
+	wt, err := gitworktree.Create(ctx, repoPath, ref, opts)
+	if err != nil {
+		return nil, err
+	}
+	complete := false
+	defer func() {
+		if !complete {
+			_ = wt.Close(context.Background())
+		}
+	}()
+
+	if initSubmodules && checkoutHasGitmodules(wt.Dir) {
+		if err := wt.InitSubmodules(ctx); err != nil {
+			return nil, err
+		}
+	}
+	if pullLFS && checkoutUsesGitLFS(ctx, wt.Dir) {
+		wt.PullLFS(ctx)
+	}
+
+	complete = true
+	return wt, nil
+}
+
+func checkoutHasGitmodules(repoPath string) bool {
+	_, err := os.Stat(filepath.Join(repoPath, ".gitmodules"))
+	return err == nil || !errors.Is(err, os.ErrNotExist)
+}
+
+func checkoutUsesGitLFS(ctx context.Context, repoPath string) bool {
+	attrs, err := gitAttributeFiles(ctx, repoPath)
+	if err != nil {
+		return true
+	}
+	for _, attr := range attrs {
+		uses, err := attributeFileUsesGitLFS(filepath.Join(repoPath, filepath.FromSlash(attr)))
+		if err != nil {
+			return true
+		}
+		if uses {
+			return true
+		}
+	}
+
+	uses, ok := gitPathAttributeFileUsesGitLFS(ctx, repoPath, "info/attributes")
+	if !ok || uses {
+		return true
+	}
+	uses, ok = configuredAttributeFileUsesGitLFS(ctx, repoPath)
+	if !ok || uses {
+		return true
+	}
+	return false
+}
+
+func gitAttributeFiles(ctx context.Context, repoPath string) ([]string, error) {
+	out, err := gitOutput(ctx, repoPath, "ls-files", "-z", "--", ".gitattributes", "**/.gitattributes")
+	if err != nil {
+		return nil, err
+	}
+	parts := bytes.Split(out, []byte{0})
+	files := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if len(part) == 0 {
+			continue
+		}
+		files = append(files, string(part))
+	}
+	return files, nil
+}
+
+func gitPathAttributeFileUsesGitLFS(ctx context.Context, repoPath, path string) (bool, bool) {
+	out, err := gitOutput(ctx, repoPath, "rev-parse", "--git-path", path)
+	if err != nil {
+		return false, false
+	}
+	attrPath := strings.TrimSpace(string(out))
+	if attrPath == "" {
+		return false, true
+	}
+	if !filepath.IsAbs(attrPath) {
+		attrPath = filepath.Join(repoPath, attrPath)
+	}
+	uses, err := attributeFileUsesGitLFS(attrPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, true
+	}
+	return uses, err == nil
+}
+
+func configuredAttributeFileUsesGitLFS(ctx context.Context, repoPath string) (bool, bool) {
+	out, err := gitOutput(ctx, repoPath, "config", "--path", "--get", "core.attributesFile")
+	if err != nil {
+		if isGitExitCode(err, 1) {
+			return false, true
+		}
+		return false, false
+	}
+	attrPath := strings.TrimSpace(string(out))
+	if attrPath == "" {
+		return false, true
+	}
+	if !filepath.IsAbs(attrPath) {
+		attrPath = filepath.Join(repoPath, attrPath)
+	}
+	uses, err := attributeFileUsesGitLFS(attrPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, true
+	}
+	return uses, err == nil
+}
+
+func attributeFileUsesGitLFS(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	return attributeContentUsesGitLFS(string(data)), nil
+}
+
+func attributeContentUsesGitLFS(content string) bool {
+	for line := range strings.Lines(content) {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		for _, field := range strings.Fields(line) {
+			if field == "filter=lfs" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func gitOutput(ctx context.Context, repoPath string, args ...string) ([]byte, error) {
+	return gitcmd.New().Output(ctx, repoPath, args...)
+}
+
+func isGitExitCode(err error, code int) bool {
+	var gitErr *gitcmd.GitError
+	if errors.As(err, &gitErr) {
+		err = gitErr.Err
+	}
+	var exitErr *exec.ExitError
+	return errors.As(err, &exitErr) && exitErr.ExitCode() == code
+}

--- a/internal/daemon/worktree_create.go
+++ b/internal/daemon/worktree_create.go
@@ -213,7 +213,7 @@ func attributePathUsesGitLFS(repoPath, attrPath string) (bool, bool) {
 }
 
 func attributeFileUsesGitLFS(path string) (bool, error) {
-	info, err := os.Lstat(path)
+	info, err := os.Stat(path)
 	if err != nil {
 		return false, err
 	}

--- a/internal/daemon/worktree_create.go
+++ b/internal/daemon/worktree_create.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	gitcmd "go.kenn.io/kit/git/cmd"
@@ -149,10 +150,8 @@ func attributeContentUsesGitLFS(content string) bool {
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
-		for _, field := range strings.Fields(line) {
-			if field == "filter=lfs" {
-				return true
-			}
+		if slices.Contains(strings.Fields(line), "filter=lfs") {
+			return true
 		}
 	}
 	return false

--- a/internal/daemon/worktree_create_test.go
+++ b/internal/daemon/worktree_create_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	gitcmd "go.kenn.io/kit/git/cmd"
 
 	"go.kenn.io/roborev/internal/testutil"

--- a/internal/daemon/worktree_create_test.go
+++ b/internal/daemon/worktree_create_test.go
@@ -70,4 +70,17 @@ func TestCheckoutUsesGitLFS(t *testing.T) {
 
 		assert.True(t, checkoutUsesGitLFS(context.Background(), repo.Path()))
 	})
+
+	t.Run("default global attributes file", func(t *testing.T) {
+		xdgConfigHome := filepath.Join(t.TempDir(), "xdg-config")
+		t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
+
+		repo := testutil.NewGitRepo(t)
+		repo.CommitFile("file.bin", "placeholder\n", "base")
+		attrPath := filepath.Join(xdgConfigHome, "git", "attributes")
+		require.NoError(t, os.MkdirAll(filepath.Dir(attrPath), 0o755))
+		require.NoError(t, os.WriteFile(attrPath, []byte("*.bin filter=lfs diff=lfs merge=lfs -text\n"), 0o644))
+
+		assert.True(t, checkoutUsesGitLFS(context.Background(), repo.Path()))
+	})
 }

--- a/internal/daemon/worktree_create_test.go
+++ b/internal/daemon/worktree_create_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	gitcmd "go.kenn.io/kit/git/cmd"
 
 	"go.kenn.io/roborev/internal/testutil"
 )
@@ -17,6 +20,27 @@ func TestAttributeContentUsesGitLFS(t *testing.T) {
 	assert.False(t, attributeContentUsesGitLFS("# *.bin filter=lfs\n*.txt text\n"))
 	assert.True(t, attributeContentUsesGitLFS("*.bin filter=lfs diff=lfs merge=lfs -text\n"))
 	assert.True(t, attributeContentUsesGitLFS("[attr]lfs filter=lfs diff=lfs merge=lfs -text\n"))
+}
+
+func TestPullGitLFSPropagatesPullFailure(t *testing.T) {
+	script := `#!/bin/sh
+if [ "$1" = "lfs" ] && [ "$2" = "env" ]; then exit 0; fi
+if [ "$1" = "lfs" ] && [ "$2" = "pull" ]; then exit 9; fi
+exit 1
+`
+	if runtime.GOOS == "windows" {
+		script = "@echo off\r\n" +
+			"if \"%1\"==\"lfs\" if \"%2\"==\"env\" exit /b 0\r\n" +
+			"if \"%1\"==\"lfs\" if \"%2\"==\"pull\" exit /b 9\r\n" +
+			"exit /b 1\r\n"
+	}
+	cleanup := testutil.MockBinaryInPath(t, "git", script)
+	t.Cleanup(cleanup)
+
+	err := pullGitLFS(context.Background(), gitcmd.New(), t.TempDir())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "git lfs pull")
 }
 
 func TestCheckoutUsesGitLFS(t *testing.T) {
@@ -43,6 +67,25 @@ func TestCheckoutUsesGitLFS(t *testing.T) {
 			"assets/.gitattributes": "*.bin filter=lfs diff=lfs merge=lfs -text\n",
 			"assets/file.bin":       "placeholder\n",
 		}, "nested lfs attrs")
+
+		assert.True(t, checkoutUsesGitLFS(context.Background(), repo.Path()))
+	})
+
+	t.Run("tracked symlink attributes fail open", func(t *testing.T) {
+		repo := testutil.NewGitRepo(t)
+		repo.CommitFile("README.md", "base\n", "base")
+		repo.WriteFile("link-target.txt", "*.bin text\n")
+		blob := strings.TrimSpace(repo.Run("hash-object", "-w", "link-target.txt"))
+		repo.RunGit("update-index", "--add", "--cacheinfo", "120000,"+blob+",.gitattributes")
+		repo.RunGit("commit", "-m", "symlink attrs")
+		repo.WriteFile(".gitattributes", "*.bin text\n")
+
+		assert.True(t, checkoutUsesGitLFS(context.Background(), repo.Path()))
+	})
+
+	t.Run("oversized tracked attributes fail open", func(t *testing.T) {
+		repo := testutil.NewGitRepo(t)
+		repo.CommitFile(".gitattributes", strings.Repeat("x", maxGitAttributeFileBytes+1), "large attrs")
 
 		assert.True(t, checkoutUsesGitLFS(context.Background(), repo.Path()))
 	})

--- a/internal/daemon/worktree_create_test.go
+++ b/internal/daemon/worktree_create_test.go
@@ -1,0 +1,73 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/testutil"
+)
+
+func TestAttributeContentUsesGitLFS(t *testing.T) {
+	assert.False(t, attributeContentUsesGitLFS("# *.bin filter=lfs\n*.txt text\n"))
+	assert.True(t, attributeContentUsesGitLFS("*.bin filter=lfs diff=lfs merge=lfs -text\n"))
+	assert.True(t, attributeContentUsesGitLFS("[attr]lfs filter=lfs diff=lfs merge=lfs -text\n"))
+}
+
+func TestCheckoutUsesGitLFS(t *testing.T) {
+	t.Run("no attributes", func(t *testing.T) {
+		repo := testutil.NewGitRepo(t)
+		repo.CommitFile("README.md", "base\n", "base")
+
+		assert.False(t, checkoutUsesGitLFS(context.Background(), repo.Path()))
+	})
+
+	t.Run("tracked root attributes", func(t *testing.T) {
+		repo := testutil.NewGitRepo(t)
+		repo.CommitFiles(map[string]string{
+			".gitattributes": "*.bin filter=lfs diff=lfs merge=lfs -text\n",
+			"file.bin":       "placeholder\n",
+		}, "lfs attrs")
+
+		assert.True(t, checkoutUsesGitLFS(context.Background(), repo.Path()))
+	})
+
+	t.Run("tracked nested attributes", func(t *testing.T) {
+		repo := testutil.NewGitRepo(t)
+		repo.CommitFiles(map[string]string{
+			"assets/.gitattributes": "*.bin filter=lfs diff=lfs merge=lfs -text\n",
+			"assets/file.bin":       "placeholder\n",
+		}, "nested lfs attrs")
+
+		assert.True(t, checkoutUsesGitLFS(context.Background(), repo.Path()))
+	})
+
+	t.Run("git info attributes", func(t *testing.T) {
+		repo := testutil.NewGitRepo(t)
+		repo.CommitFile("file.bin", "placeholder\n", "base")
+		out, err := gitOutput(context.Background(), repo.Path(), "rev-parse", "--git-path", "info/attributes")
+		require.NoError(t, err)
+		attrPath := filepath.Clean(strings.TrimSpace(string(out)))
+		if !filepath.IsAbs(attrPath) {
+			attrPath = filepath.Join(repo.Path(), attrPath)
+		}
+		require.NoError(t, os.WriteFile(attrPath, []byte("*.bin filter=lfs diff=lfs merge=lfs -text\n"), 0o644))
+
+		assert.True(t, checkoutUsesGitLFS(context.Background(), repo.Path()))
+	})
+
+	t.Run("configured attributes file", func(t *testing.T) {
+		repo := testutil.NewGitRepo(t)
+		repo.CommitFile("file.bin", "placeholder\n", "base")
+		attrPath := filepath.Join(repo.Path(), "custom.attributes")
+		require.NoError(t, os.WriteFile(attrPath, []byte("*.bin filter=lfs diff=lfs merge=lfs -text\n"), 0o644))
+		repo.Config("core.attributesFile", attrPath)
+
+		assert.True(t, checkoutUsesGitLFS(context.Background(), repo.Path()))
+	})
+}

--- a/internal/daemon/worktree_create_test.go
+++ b/internal/daemon/worktree_create_test.go
@@ -113,6 +113,20 @@ func TestCheckoutUsesGitLFS(t *testing.T) {
 		assert.True(t, checkoutUsesGitLFS(context.Background(), repo.Path()))
 	})
 
+	t.Run("configured symlink attributes file without lfs", func(t *testing.T) {
+		repo := testutil.NewGitRepo(t)
+		repo.CommitFile("file.bin", "placeholder\n", "base")
+		targetPath := filepath.Join(repo.Path(), "custom.attributes.target")
+		attrPath := filepath.Join(repo.Path(), "custom.attributes")
+		require.NoError(t, os.WriteFile(targetPath, []byte("*.bin text\n"), 0o644))
+		if err := os.Symlink(targetPath, attrPath); err != nil {
+			t.Skipf("symlink attributes file: %v", err)
+		}
+		repo.Config("core.attributesFile", attrPath)
+
+		assert.False(t, checkoutUsesGitLFS(context.Background(), repo.Path()))
+	})
+
 	t.Run("default global attributes file", func(t *testing.T) {
 		xdgConfigHome := filepath.Join(t.TempDir(), "xdg-config")
 		t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
@@ -124,5 +138,22 @@ func TestCheckoutUsesGitLFS(t *testing.T) {
 		require.NoError(t, os.WriteFile(attrPath, []byte("*.bin filter=lfs diff=lfs merge=lfs -text\n"), 0o644))
 
 		assert.True(t, checkoutUsesGitLFS(context.Background(), repo.Path()))
+	})
+
+	t.Run("default global symlink attributes file without lfs", func(t *testing.T) {
+		xdgConfigHome := filepath.Join(t.TempDir(), "xdg-config")
+		t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
+
+		repo := testutil.NewGitRepo(t)
+		repo.CommitFile("file.bin", "placeholder\n", "base")
+		targetPath := filepath.Join(xdgConfigHome, "git", "attributes.target")
+		attrPath := filepath.Join(xdgConfigHome, "git", "attributes")
+		require.NoError(t, os.MkdirAll(filepath.Dir(attrPath), 0o755))
+		require.NoError(t, os.WriteFile(targetPath, []byte("*.bin text\n"), 0o644))
+		if err := os.Symlink(targetPath, attrPath); err != nil {
+			t.Skipf("symlink attributes file: %v", err)
+		}
+
+		assert.False(t, checkoutUsesGitLFS(context.Background(), repo.Path()))
 	})
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -2,15 +2,20 @@ package git
 
 import (
 	"context"
+	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 	"unicode/utf8"
 
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -48,8 +53,63 @@ func cleanHookPWDPath(path string) string {
 }
 
 type TestRepo struct {
-	T   *testing.T
-	Dir string
+	T      *testing.T
+	Dir    string
+	Author string
+}
+
+var (
+	testRepoTemplateMu   sync.Mutex
+	testRepoTemplateDirs = map[string]string{}
+)
+
+func instantiateTestRepoTemplate(t *testing.T, key string, build func(string), dst string) {
+	t.Helper()
+	src := testRepoTemplate(t, key, build)
+	require.NoError(t, copyTestRepoTree(dst, src), "copy git template %s", key)
+}
+
+func testRepoTemplate(t *testing.T, key string, build func(string)) string {
+	t.Helper()
+	testRepoTemplateMu.Lock()
+	defer testRepoTemplateMu.Unlock()
+	if dir, ok := testRepoTemplateDirs[key]; ok {
+		return dir
+	}
+	dir, err := os.MkdirTemp("", "roborev-git-test-"+key+"-*")
+	require.NoError(t, err, "create git template")
+	build(dir)
+	testRepoTemplateDirs[key] = dir
+	return dir
+}
+
+func copyTestRepoTree(dst, src string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0o644)
+	})
+}
+
+func mustTemplateGit(dir string, args ...string) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		panic(fmt.Sprintf("git template %v failed: %v\n%s", args, err, out))
+	}
 }
 
 func NewTestRepo(t *testing.T) *TestRepo {
@@ -60,10 +120,11 @@ func NewTestRepo(t *testing.T) *TestRepo {
 func NewTestRepoWithAuthor(t *testing.T, author string) *TestRepo {
 	t.Helper()
 	dir := t.TempDir()
-	r := &TestRepo{T: t, Dir: dir}
-	r.Run("init")
-	r.Run("config", "user.email", "test@test.com")
-	r.Run("config", "user.name", author)
+	instantiateTestRepoTemplate(t, "init", func(d string) {
+		mustTemplateGit(d, "init")
+	}, dir)
+	r := &TestRepo{T: t, Dir: dir, Author: author}
+	r.writeConfig(author)
 	return r
 }
 
@@ -77,14 +138,25 @@ func NewTestRepoWithCommit(t *testing.T) *TestRepo {
 func NewBareTestRepo(t *testing.T) *TestRepo {
 	t.Helper()
 	dir := t.TempDir()
-	r := &TestRepo{T: t, Dir: dir}
-	r.Run("init", "--bare")
-	return r
+	instantiateTestRepoTemplate(t, "bare", func(d string) {
+		mustTemplateGit(d, "init", "--bare")
+	}, dir)
+	return &TestRepo{T: t, Dir: dir, Author: "Test"}
 }
 
 func (r *TestRepo) Run(args ...string) string {
 	r.T.Helper()
 	return runGit(r.T, r.Dir, args...)
+}
+
+func (r *TestRepo) writeConfig(author string) {
+	r.T.Helper()
+	configPath := filepath.Join(r.Dir, ".git", "config")
+	f, err := os.OpenFile(configPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(r.T, err, "open git config")
+	defer f.Close()
+	_, err = f.WriteString("\n[user]\n\temail = test@test.com\n\tname = " + author + "\n")
+	require.NoError(r.T, err, "write git config")
 }
 
 func TestIsTransientGitError(t *testing.T) {
@@ -119,14 +191,66 @@ func TestIsTransientGitError(t *testing.T) {
 func (r *TestRepo) CommitFile(filename, content, msg string) {
 	r.T.Helper()
 	r.WriteFile(filename, content)
-	r.Run("add", filename)
-	r.Run("commit", "-m", msg)
+	if !r.canCommitInProcess() {
+		r.Run("add", filename)
+		r.Run("commit", "-m", msg)
+		return
+	}
+	r.commitPaths(msg, filename)
 }
 
 func (r *TestRepo) CommitAll(msg string) {
 	r.T.Helper()
-	r.Run("add", ".")
-	r.Run("commit", "-m", msg)
+	if !r.canCommitInProcess() {
+		r.Run("add", ".")
+		r.Run("commit", "-m", msg)
+		return
+	}
+	repo, err := gogit.PlainOpen(r.Dir)
+	require.NoError(r.T, err, "open repo")
+	wt, err := repo.Worktree()
+	require.NoError(r.T, err, "open worktree")
+	require.NoError(r.T, wt.AddGlob("."), "git add .")
+	r.commitWorktree(wt, msg)
+}
+
+func (r *TestRepo) canCommitInProcess() bool {
+	info, err := os.Stat(filepath.Join(r.Dir, ".git"))
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	entries, err := os.ReadDir(filepath.Join(r.Dir, ".git", "hooks"))
+	if err != nil {
+		return true
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || strings.HasSuffix(entry.Name(), ".sample") {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func (r *TestRepo) commitPaths(msg string, paths ...string) {
+	r.T.Helper()
+	repo, err := gogit.PlainOpen(r.Dir)
+	require.NoError(r.T, err, "open repo")
+	wt, err := repo.Worktree()
+	require.NoError(r.T, err, "open worktree")
+	for _, path := range paths {
+		_, err = wt.Add(filepath.ToSlash(path))
+		require.NoError(r.T, err, "git add %s", path)
+	}
+	r.commitWorktree(wt, msg)
+}
+
+func (r *TestRepo) commitWorktree(wt *gogit.Worktree, msg string) {
+	r.T.Helper()
+	_, err := wt.Commit(msg, &gogit.CommitOptions{
+		Author: &object.Signature{Name: r.Author, Email: "test@test.com", When: time.Now()},
+	})
+	require.NoError(r.T, err, "commit")
 }
 
 func (r *TestRepo) WriteFile(filename, content string) {
@@ -152,7 +276,7 @@ func (r *TestRepo) AddWorktree(branchName string) *TestRepo {
 		cmd.Dir = r.Dir
 		_ = cmd.Run()
 	})
-	return &TestRepo{T: r.T, Dir: wtDir}
+	return &TestRepo{T: r.T, Dir: wtDir, Author: r.Author}
 }
 
 func (r *TestRepo) InstallHook(name, script string) {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -15,6 +15,7 @@ import (
 	"unicode/utf8"
 
 	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -147,6 +148,116 @@ func NewBareTestRepo(t *testing.T) *TestRepo {
 func (r *TestRepo) Run(args ...string) string {
 	r.T.Helper()
 	return runGit(r.T, r.Dir, args...)
+}
+
+func (r *TestRepo) SetHeadBranch(branch string) {
+	r.T.Helper()
+	repo, err := gogit.PlainOpen(r.Dir)
+	require.NoError(r.T, err, "open repo")
+	ref := plumbing.NewBranchReferenceName(branch)
+	err = repo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, ref))
+	require.NoError(r.T, err, "set HEAD branch %q", branch)
+}
+
+func (r *TestRepo) SetRef(ref, sha string) {
+	r.T.Helper()
+	repo, err := gogit.PlainOpen(r.Dir)
+	require.NoError(r.T, err, "open repo")
+	err = repo.Storer.SetReference(plumbing.NewHashReference(
+		plumbing.ReferenceName(ref),
+		plumbing.NewHash(sha),
+	))
+	require.NoError(r.T, err, "set ref %q", ref)
+}
+
+func (r *TestRepo) SetSymbolicRef(ref, target string) {
+	r.T.Helper()
+	repo, err := gogit.PlainOpen(r.Dir)
+	require.NoError(r.T, err, "open repo")
+	err = repo.Storer.SetReference(plumbing.NewSymbolicReference(
+		plumbing.ReferenceName(ref),
+		plumbing.ReferenceName(target),
+	))
+	require.NoError(r.T, err, "set symbolic ref %q", ref)
+}
+
+func (r *TestRepo) CheckoutNewBranch(branch string, start ...string) {
+	r.T.Helper()
+	require.LessOrEqual(r.T, len(start), 1, "CheckoutNewBranch accepts at most one start ref")
+	repo, err := gogit.PlainOpen(r.Dir)
+	require.NoError(r.T, err, "open repo")
+	var hash plumbing.Hash
+	if len(start) == 1 {
+		resolved, err := repo.ResolveRevision(plumbing.Revision(start[0]))
+		require.NoError(r.T, err, "resolve start ref %q", start[0])
+		hash = *resolved
+	} else {
+		head, err := repo.Head()
+		require.NoError(r.T, err, "read HEAD")
+		hash = head.Hash()
+	}
+	wt, err := repo.Worktree()
+	require.NoError(r.T, err, "open worktree")
+	err = wt.Checkout(&gogit.CheckoutOptions{
+		Branch: plumbing.NewBranchReferenceName(branch),
+		Create: true,
+		Hash:   hash,
+	})
+	require.NoError(r.T, err, "checkout new branch %q", branch)
+}
+
+func (r *TestRepo) CheckoutBranch(branch string) {
+	r.T.Helper()
+	repo, err := gogit.PlainOpen(r.Dir)
+	require.NoError(r.T, err, "open repo")
+	wt, err := repo.Worktree()
+	require.NoError(r.T, err, "open worktree")
+	err = wt.Checkout(&gogit.CheckoutOptions{
+		Branch: plumbing.NewBranchReferenceName(branch),
+		Force:  true,
+	})
+	require.NoError(r.T, err, "checkout branch %q", branch)
+}
+
+func (r *TestRepo) AddRemote(name, url string) {
+	r.T.Helper()
+	r.appendConfig("remote", name,
+		"url", url,
+		"fetch", "+refs/heads/*:refs/remotes/"+name+"/*",
+	)
+}
+
+func (r *TestRepo) SetBranchUpstream(branch, remote, mergeBranch string) {
+	r.T.Helper()
+	r.appendConfig("branch", branch,
+		"remote", remote,
+		"merge", "refs/heads/"+mergeBranch,
+	)
+}
+
+func (r *TestRepo) SetBranchBase(branch, base string) {
+	r.T.Helper()
+	r.appendConfig("branch", branch, "base", base)
+}
+
+func (r *TestRepo) appendConfig(section, subsection string, keyValues ...string) {
+	r.T.Helper()
+	require.Zero(r.T, len(keyValues)%2, "config key/value arguments must be paired")
+	configPath := filepath.Join(r.Dir, ".git", "config")
+	f, err := os.OpenFile(configPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(r.T, err, "open git config")
+	defer f.Close()
+	_, err = fmt.Fprintf(f, "\n[%s %s]\n", section, quoteGitConfigSubsection(subsection))
+	require.NoError(r.T, err, "write config section")
+	for i := 0; i < len(keyValues); i += 2 {
+		_, err = fmt.Fprintf(f, "\t%s = %s\n", keyValues[i], keyValues[i+1])
+		require.NoError(r.T, err, "write config value")
+	}
+}
+
+func quoteGitConfigSubsection(subsection string) string {
+	escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(subsection)
+	return `"` + escaped + `"`
 }
 
 func (r *TestRepo) writeConfig(author string) {
@@ -908,15 +1019,16 @@ func TestGetUpstream(t *testing.T) {
 	})
 
 	t.Run("returns upstream tracking branch", func(t *testing.T) {
-		remote := NewBareTestRepo(t)
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
+		head := repo.HeadSHA()
 
 		// Name the remote "upstream" to match the user's fork-style setup.
-		repo.Run("remote", "add", "upstream", remote.Dir)
-		repo.Run("push", "-u", "upstream", "main")
-		repo.Run("checkout", "-b", "feature", "--track", "upstream/main")
+		repo.AddRemote("upstream", "/dev/null")
+		repo.SetRef("refs/remotes/upstream/main", head)
+		repo.CheckoutNewBranch("feature", head)
+		repo.SetBranchUpstream("feature", "upstream", "main")
 
 		upstream, err := GetUpstream(repo.Dir, "HEAD")
 		require.NoError(t, err)
@@ -924,14 +1036,15 @@ func TestGetUpstream(t *testing.T) {
 	})
 
 	t.Run("returns upstream for named ref", func(t *testing.T) {
-		remote := NewBareTestRepo(t)
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
+		head := repo.HeadSHA()
 
-		repo.Run("remote", "add", "origin", remote.Dir)
-		repo.Run("push", "-u", "origin", "main")
-		repo.Run("checkout", "-b", "feature")
+		repo.AddRemote("origin", "/dev/null")
+		repo.SetRef("refs/remotes/origin/main", head)
+		repo.SetBranchUpstream("main", "origin", "main")
+		repo.CheckoutNewBranch("feature")
 
 		// feature has no upstream, but main does.
 		upstream, err := GetUpstream(repo.Dir, "main")
@@ -944,13 +1057,14 @@ func TestGetUpstream(t *testing.T) {
 	})
 
 	t.Run("empty ref defaults to HEAD", func(t *testing.T) {
-		remote := NewBareTestRepo(t)
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
+		head := repo.HeadSHA()
 
-		repo.Run("remote", "add", "origin", remote.Dir)
-		repo.Run("push", "-u", "origin", "main")
+		repo.AddRemote("origin", "/dev/null")
+		repo.SetRef("refs/remotes/origin/main", head)
+		repo.SetBranchUpstream("main", "origin", "main")
 
 		upstream, err := GetUpstream(repo.Dir, "")
 		require.NoError(t, err)
@@ -963,10 +1077,10 @@ func TestGetUpstream(t *testing.T) {
 		// reject this as "missing" just because refs/remotes/<upstream>
 		// doesn't exist.
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("checkout", "-b", "dev")
-		repo.Run("branch", "-u", "main", "dev")
+		repo.CheckoutNewBranch("dev")
+		repo.SetBranchUpstream("dev", ".", "main")
 
 		upstream, err := GetUpstream(repo.Dir, "HEAD")
 		require.NoError(t, err)
@@ -980,14 +1094,11 @@ func TestGetUpstream(t *testing.T) {
 		// able to distinguish this from "no upstream configured" so the
 		// user isn't silently switched to a different base branch that
 		// could yield the wrong commit range.
-		remote := NewBareTestRepo(t)
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("remote", "add", "upstream", remote.Dir)
-		repo.Run("push", "-u", "upstream", "main")
-		// Tracking config now points at refs/remotes/upstream/main. Remove it.
-		repo.Run("update-ref", "-d", "refs/remotes/upstream/main")
+		repo.AddRemote("upstream", "/dev/null")
+		repo.SetBranchUpstream("main", "upstream", "main")
 
 		upstream, err := GetUpstream(repo.Dir, "HEAD")
 		assert.Empty(t, upstream)
@@ -1002,10 +1113,9 @@ func TestGetUpstream(t *testing.T) {
 		// but branch.<name>.remote/merge are set, so callers must still
 		// see UpstreamMissingError, not ("", nil).
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("config", "branch.main.remote", "upstream")
-		repo.Run("config", "branch.main.merge", "refs/heads/main")
+		repo.SetBranchUpstream("main", "upstream", "main")
 
 		upstream, err := GetUpstream(repo.Dir, "HEAD")
 		assert.Empty(t, upstream)
@@ -1016,10 +1126,9 @@ func TestGetUpstream(t *testing.T) {
 
 	t.Run("errors for missing slash-named remote tracking config", func(t *testing.T) {
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("config", "branch.main.remote", "company/fork")
-		repo.Run("config", "branch.main.merge", "refs/heads/main")
+		repo.SetBranchUpstream("main", "company/fork", "main")
 
 		upstream, err := GetUpstream(repo.Dir, "HEAD")
 		assert.Empty(t, upstream)
@@ -1030,11 +1139,10 @@ func TestGetUpstream(t *testing.T) {
 
 	t.Run("ignores url remote tracking config", func(t *testing.T) {
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("checkout", "-b", "feature")
-		repo.Run("config", "branch.feature.remote", "https://example.com/fork.git")
-		repo.Run("config", "branch.feature.merge", "refs/heads/feature")
+		repo.CheckoutNewBranch("feature")
+		repo.SetBranchUpstream("feature", "https://example.com/fork.git", "feature")
 
 		upstream, err := GetUpstream(repo.Dir, "HEAD")
 		require.NoError(t, err)
@@ -1047,14 +1155,12 @@ func TestGetUpstream(t *testing.T) {
 		// extracts subsection "release/1.2.3" and key "remote". Confirm
 		// GetUpstream returns UpstreamMissingError for a dotted branch name
 		// whose tracking ref has been removed.
-		remote := NewBareTestRepo(t)
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("remote", "add", "upstream", remote.Dir)
-		repo.Run("push", "-u", "upstream", "main")
-		repo.Run("checkout", "-b", "release/1.2.3", "--track", "upstream/main")
-		repo.Run("update-ref", "-d", "refs/remotes/upstream/main")
+		repo.AddRemote("upstream", "/dev/null")
+		repo.CheckoutNewBranch("release/1.2.3")
+		repo.SetBranchUpstream("release/1.2.3", "upstream", "main")
 
 		upstream, err := GetUpstream(repo.Dir, "HEAD")
 		assert.Empty(t, upstream)
@@ -1070,18 +1176,15 @@ func TestGetUpstream(t *testing.T) {
 		// a missing refs/remotes/<upstream>/... and causing downstream
 		// merge-base to use the wrong ref. Verify the tracking config's
 		// qualified ref explicitly.
-		remote := NewBareTestRepo(t)
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("remote", "add", "upstream", remote.Dir)
-		repo.Run("push", "-u", "upstream", "main")
-		// Remove the remote-tracking ref that @{upstream} points to…
-		repo.Run("update-ref", "-d", "refs/remotes/upstream/main")
-		// …and create a local ref with the identical short name so an
+		repo.AddRemote("upstream", "/dev/null")
+		repo.SetBranchUpstream("main", "upstream", "main")
+		// Create a local ref with the identical short name so an
 		// unqualified rev-parse would succeed.
 		head := repo.HeadSHA()
-		repo.Run("update-ref", "refs/heads/upstream/main", head)
+		repo.SetRef("refs/heads/upstream/main", head)
 
 		upstream, err := GetUpstream(repo.Dir, "HEAD")
 		assert.Empty(t, upstream)
@@ -1631,27 +1734,30 @@ func TestResetWorkingTree(t *testing.T) {
 
 func TestUpstreamIsTrunk(t *testing.T) {
 	t.Run("trunk-named upstream matches", func(t *testing.T) {
-		remote := NewBareTestRepo(t)
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("remote", "add", "origin", remote.Dir)
-		repo.Run("push", "-u", "origin", "main")
-		repo.Run("remote", "set-head", "origin", "main")
+		head := repo.HeadSHA()
+		repo.AddRemote("origin", "/dev/null")
+		repo.SetRef("refs/remotes/origin/main", head)
+		repo.SetSymbolicRef("refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+		repo.SetBranchUpstream("main", "origin", "main")
 
 		assert.True(t, UpstreamIsTrunk(repo.Dir, "HEAD"))
 	})
 
 	t.Run("self-counterpart upstream does not match", func(t *testing.T) {
-		remote := NewBareTestRepo(t)
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("remote", "add", "origin", remote.Dir)
-		repo.Run("push", "-u", "origin", "main")
-		repo.Run("remote", "set-head", "origin", "main")
-		repo.Run("checkout", "-b", "feature")
-		repo.Run("push", "-u", "origin", "feature")
+		mainHead := repo.HeadSHA()
+		repo.AddRemote("origin", "/dev/null")
+		repo.SetRef("refs/remotes/origin/main", mainHead)
+		repo.SetSymbolicRef("refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+		repo.CheckoutNewBranch("feature")
+		featureHead := repo.HeadSHA()
+		repo.SetRef("refs/remotes/origin/feature", featureHead)
+		repo.SetBranchUpstream("feature", "origin", "feature")
 
 		// feature tracks origin/feature (its own remote counterpart) — not trunk.
 		assert.False(t, UpstreamIsTrunk(repo.Dir, "HEAD"))
@@ -1660,17 +1766,16 @@ func TestUpstreamIsTrunk(t *testing.T) {
 	t.Run("multi-remote trunk matches", func(t *testing.T) {
 		// Fork workflow: local main tracks upstream/main while the default
 		// branch is origin/main. Both refs strip to "main" → trunk.
-		remote := NewBareTestRepo(t)
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("remote", "add", "origin", remote.Dir)
-		repo.Run("push", "-u", "origin", "main")
-		repo.Run("remote", "set-head", "origin", "main")
-		upRemote := NewBareTestRepo(t)
-		repo.Run("remote", "add", "upstream", upRemote.Dir)
-		repo.Run("push", "upstream", "main")
-		repo.Run("branch", "-u", "upstream/main", "main")
+		head := repo.HeadSHA()
+		repo.AddRemote("origin", "/dev/null")
+		repo.SetRef("refs/remotes/origin/main", head)
+		repo.SetSymbolicRef("refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+		repo.AddRemote("upstream", "/dev/null")
+		repo.SetRef("refs/remotes/upstream/main", head)
+		repo.SetBranchUpstream("main", "upstream", "main")
 
 		assert.True(t, UpstreamIsTrunk(repo.Dir, "HEAD"))
 	})
@@ -1683,12 +1788,13 @@ func TestUpstreamIsTrunk(t *testing.T) {
 	t.Run("returns false when default branch cannot be detected", func(t *testing.T) {
 		// Branch tracks some upstream, but origin/HEAD and main/master are
 		// all missing so GetDefaultBranch fails.
-		remote := NewBareTestRepo(t)
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/trunk")
+		repo.SetHeadBranch("trunk")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("remote", "add", "origin", remote.Dir)
-		repo.Run("push", "-u", "origin", "trunk")
+		head := repo.HeadSHA()
+		repo.AddRemote("origin", "/dev/null")
+		repo.SetRef("refs/remotes/origin/trunk", head)
+		repo.SetBranchUpstream("trunk", "origin", "trunk")
 
 		assert.False(t, UpstreamIsTrunk(repo.Dir, "HEAD"))
 	})
@@ -1698,20 +1804,18 @@ func TestUpstreamIsTrunk(t *testing.T) {
 		// last path segment "main" and would wrongly match the default
 		// leaf. UpstreamIsTrunk must compare the full branch name after
 		// stripping the configured remote prefix, not just the leaf.
-		remote := NewBareTestRepo(t)
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("remote", "add", "origin", remote.Dir)
-		repo.Run("push", "-u", "origin", "main")
-		repo.Run("remote", "set-head", "origin", "main")
+		head := repo.HeadSHA()
+		repo.AddRemote("origin", "/dev/null")
+		repo.SetRef("refs/remotes/origin/main", head)
+		repo.SetSymbolicRef("refs/remotes/origin/HEAD", "refs/remotes/origin/main")
 		// Simulate a feature branch whose remote-tracking ref ends in "main"
 		// but isn't trunk.
-		head := repo.HeadSHA()
-		repo.Run("update-ref", "refs/remotes/origin/team/main", head)
-		repo.Run("checkout", "-b", "team/main")
-		repo.Run("config", "branch.team/main.remote", "origin")
-		repo.Run("config", "branch.team/main.merge", "refs/heads/team/main")
+		repo.SetRef("refs/remotes/origin/team/main", head)
+		repo.CheckoutNewBranch("team/main")
+		repo.SetBranchUpstream("team/main", "origin", "team/main")
 
 		assert.False(t, UpstreamIsTrunk(repo.Dir, "HEAD"),
 			"branch tracking origin/team/main is not trunk — its branch part is team/main, not main")
@@ -1721,13 +1825,14 @@ func TestUpstreamIsTrunk(t *testing.T) {
 		// Regression: callers that pass a fully-qualified ref (e.g.,
 		// "refs/heads/feature" or output of ResolveSHA) must still hit
 		// the branch.<name>.* config keys after the prefix is stripped.
-		remote := NewBareTestRepo(t)
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("remote", "add", "origin", remote.Dir)
-		repo.Run("push", "-u", "origin", "main")
-		repo.Run("remote", "set-head", "origin", "main")
+		head := repo.HeadSHA()
+		repo.AddRemote("origin", "/dev/null")
+		repo.SetRef("refs/remotes/origin/main", head)
+		repo.SetSymbolicRef("refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+		repo.SetBranchUpstream("main", "origin", "main")
 
 		assert.True(t, UpstreamIsTrunk(repo.Dir, "refs/heads/main"),
 			"refs/heads/-qualified ref should resolve to the same branch config as 'HEAD'")
@@ -1741,20 +1846,18 @@ func TestUpstreamIsTrunk(t *testing.T) {
 		// and misclassify the local upstream as trunk. The namespace
 		// check (refs/heads/... vs refs/remotes/...) must reject the
 		// local-branch upstream.
-		remote := NewBareTestRepo(t)
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("remote", "add", "origin", remote.Dir)
-		repo.Run("push", "-u", "origin", "main")
-		repo.Run("remote", "set-head", "origin", "main")
 		head := repo.HeadSHA()
+		repo.AddRemote("origin", "/dev/null")
+		repo.SetRef("refs/remotes/origin/main", head)
+		repo.SetSymbolicRef("refs/remotes/origin/HEAD", "refs/remotes/origin/main")
 		// Local branch literally named "origin/main".
-		repo.Run("update-ref", "refs/heads/origin/main", head)
+		repo.SetRef("refs/heads/origin/main", head)
 		// New branch whose upstream is the LOCAL "origin/main", via remote=".".
-		repo.Run("checkout", "-b", "pinned", head)
-		repo.Run("config", "branch.pinned.remote", ".")
-		repo.Run("config", "branch.pinned.merge", "refs/heads/origin/main")
+		repo.CheckoutNewBranch("pinned", head)
+		repo.SetBranchUpstream("pinned", ".", "origin/main")
 
 		assert.False(t, UpstreamIsTrunk(repo.Dir, "HEAD"),
 			"local-branch upstream named origin/main must not be classified as trunk")
@@ -1769,24 +1872,24 @@ func TestIsOnBaseBranch(t *testing.T) {
 	})
 
 	t.Run("matches origin-prefixed ref", func(t *testing.T) {
-		remote := NewBareTestRepo(t)
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("remote", "add", "origin", remote.Dir)
-		repo.Run("push", "-u", "origin", "main")
+		head := repo.HeadSHA()
+		repo.AddRemote("origin", "/dev/null")
+		repo.SetRef("refs/remotes/origin/main", head)
 
 		assert.True(t, IsOnBaseBranch(repo.Dir, "main", "origin/main"))
 		assert.False(t, IsOnBaseBranch(repo.Dir, "feature", "origin/main"))
 	})
 
 	t.Run("matches non-origin remote prefix", func(t *testing.T) {
-		remote := NewBareTestRepo(t)
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("remote", "add", "upstream", remote.Dir)
-		repo.Run("push", "-u", "upstream", "main")
+		head := repo.HeadSHA()
+		repo.AddRemote("upstream", "/dev/null")
+		repo.SetRef("refs/remotes/upstream/main", head)
 
 		assert.True(t, IsOnBaseBranch(repo.Dir, "main", "upstream/main"))
 		assert.False(t, IsOnBaseBranch(repo.Dir, "feature", "upstream/main"))
@@ -1797,14 +1900,13 @@ func TestIsOnBaseBranch(t *testing.T) {
 		// remote named "feature" is configured, we must not treat base
 		// "feature/foo" as if it were a remote-tracking ref and strip the
 		// prefix — that would falsely match a local branch named "foo".
-		remote := NewBareTestRepo(t)
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("remote", "add", "feature", remote.Dir)
-		repo.Run("checkout", "-b", "feature/foo")
+		repo.AddRemote("feature", "/dev/null")
+		repo.CheckoutNewBranch("feature/foo")
 		repo.CommitFile("b.txt", "b", "work")
-		repo.Run("checkout", "-b", "foo", "main")
+		repo.CheckoutNewBranch("foo", "main")
 
 		// Current branch "foo" vs base "feature/foo" — refs/remotes/feature/foo
 		// does not exist, so the prefix must not be stripped.
@@ -1824,12 +1926,12 @@ func TestIsOnBaseBranch(t *testing.T) {
 		// slash ("company/") would leave "fork/main" and wrongly match
 		// a local branch of that name. The full remote prefix
 		// "company/fork/" must be stripped to yield "main".
-		remote := NewBareTestRepo(t)
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("remote", "add", "company/fork", remote.Dir)
-		repo.Run("push", "-u", "company/fork", "main")
+		head := repo.HeadSHA()
+		repo.AddRemote("company/fork", "/dev/null")
+		repo.SetRef("refs/remotes/company/fork/main", head)
 
 		assert.True(t, IsOnBaseBranch(repo.Dir, "main", "company/fork/main"),
 			"current=main on base=company/fork/main must strip full remote prefix")
@@ -1843,16 +1945,15 @@ func TestIsOnBaseBranch(t *testing.T) {
 		// remote-tracking ref of the same short name. The two are distinct
 		// refs in different namespaces; when both exist, the guardrail
 		// must refuse to match rather than assume they're the same.
-		remote := NewBareTestRepo(t)
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("remote", "add", "origin", remote.Dir)
-		repo.Run("push", "-u", "origin", "main")
 		head := repo.HeadSHA()
+		repo.AddRemote("origin", "/dev/null")
+		repo.SetRef("refs/remotes/origin/main", head)
 		// Create a local branch literally named "origin/main" so both
 		// refs/heads/origin/main AND refs/remotes/origin/main resolve.
-		repo.Run("update-ref", "refs/heads/origin/main", head)
+		repo.SetRef("refs/heads/origin/main", head)
 
 		assert.False(t, IsOnBaseBranch(repo.Dir, "origin/main", "origin/main"),
 			"ambiguous name in both refs/heads and refs/remotes must not match")
@@ -1865,10 +1966,10 @@ func TestIsOnBaseBranch(t *testing.T) {
 		// "already on base origin/foo". That would wrongly block
 		// review --branch / refine on a perfectly valid feature branch.
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
 		// Create a local branch literally named "origin/foo" — no remote involved.
-		repo.Run("branch", "origin/foo")
+		repo.SetRef("refs/heads/origin/foo", repo.HeadSHA())
 
 		assert.False(t, IsOnBaseBranch(repo.Dir, "foo", "origin/foo"),
 			"local branch origin/foo without a remote-tracking ref must not match 'foo'")
@@ -1882,14 +1983,13 @@ func TestIsOnBaseBranch(t *testing.T) {
 		// (local branch or remote-tracking?), so the safe response is to
 		// refuse to match either way. The downstream merge-base / range
 		// check will surface any real "nothing to review" condition.
-		remote := NewBareTestRepo(t)
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("file.txt", "content", "initial")
-		repo.Run("remote", "add", "feature", remote.Dir)
-		repo.Run("branch", "feature/foo")
 		head := repo.HeadSHA()
-		repo.Run("update-ref", "refs/remotes/feature/foo", head)
+		repo.AddRemote("feature", "/dev/null")
+		repo.SetRef("refs/heads/feature/foo", head)
+		repo.SetRef("refs/remotes/feature/foo", head)
 
 		assert.False(t, IsOnBaseBranch(repo.Dir, "foo", "feature/foo"),
 			"ambiguous ref must not be stripped")
@@ -2749,19 +2849,19 @@ func TestLooksLikeSHA(t *testing.T) {
 func TestGetBranchBase(t *testing.T) {
 	t.Run("returns empty when not configured", func(t *testing.T) {
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("base.txt", "base", "initial")
-		repo.Run("checkout", "-b", "feature")
+		repo.CheckoutNewBranch("feature")
 
 		assert.Empty(t, GetBranchBase(repo.Dir, "HEAD"))
 	})
 
 	t.Run("returns local bare name when no remote-tracking exists", func(t *testing.T) {
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("base.txt", "base", "initial")
-		repo.Run("checkout", "-b", "feature")
-		repo.Run("config", "branch.feature.base", "main")
+		repo.CheckoutNewBranch("feature")
+		repo.SetBranchBase("feature", "main")
 
 		assert.Equal(t, "main", GetBranchBase(repo.Dir, "HEAD"))
 	})
@@ -2772,18 +2872,18 @@ func TestGetBranchBase(t *testing.T) {
 		// base..HEAD range. The fix translates the bare name to origin/main
 		// when local main is just an ancestor of origin/main.
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("base.txt", "base", "initial")
 		staleMainSHA := repo.HeadSHA()
 		repo.CommitFile("trunk.txt", "trunk", "trunk advance")
 		freshOriginSHA := repo.HeadSHA()
 		// Rewind local main so it lags one commit behind origin/main.
-		repo.Run("update-ref", "refs/heads/main", staleMainSHA)
-		repo.Run("remote", "add", "origin", "/dev/null")
-		repo.Run("update-ref", "refs/remotes/origin/main", freshOriginSHA)
-		repo.Run("checkout", "-b", "feature", freshOriginSHA)
+		repo.SetRef("refs/heads/main", staleMainSHA)
+		repo.AddRemote("origin", "/dev/null")
+		repo.SetRef("refs/remotes/origin/main", freshOriginSHA)
+		repo.CheckoutNewBranch("feature", freshOriginSHA)
 		repo.CommitFile("feature.txt", "f", "feature commit")
-		repo.Run("config", "branch.feature.base", "main")
+		repo.SetBranchBase("feature", "main")
 
 		assert.Equal(t, "origin/main", GetBranchBase(repo.Dir, "HEAD"))
 	})
@@ -2793,44 +2893,44 @@ func TestGetBranchBase(t *testing.T) {
 		// user's local branch is not just stale — respect their config
 		// rather than silently picking a different base.
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("base.txt", "base", "initial")
 		baseSHA := repo.HeadSHA()
 		repo.CommitFile("origin.txt", "origin", "origin-only commit")
 		originMainSHA := repo.HeadSHA()
 		// Local main diverges with its own commit not present on origin/main.
-		repo.Run("update-ref", "refs/heads/main", baseSHA)
-		repo.Run("checkout", "main")
+		repo.SetRef("refs/heads/main", baseSHA)
+		repo.CheckoutBranch("main")
 		repo.CommitFile("local.txt", "local", "local-only commit")
-		repo.Run("remote", "add", "origin", "/dev/null")
-		repo.Run("update-ref", "refs/remotes/origin/main", originMainSHA)
-		repo.Run("checkout", "-b", "feature")
-		repo.Run("config", "branch.feature.base", "main")
+		repo.AddRemote("origin", "/dev/null")
+		repo.SetRef("refs/remotes/origin/main", originMainSHA)
+		repo.CheckoutNewBranch("feature")
+		repo.SetBranchBase("feature", "main")
 
 		assert.Equal(t, "main", GetBranchBase(repo.Dir, "HEAD"))
 	})
 
 	t.Run("returns origin counterpart when local branch is missing", func(t *testing.T) {
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/scratch")
+		repo.SetHeadBranch("scratch")
 		repo.CommitFile("base.txt", "base", "initial")
 		originSHA := repo.HeadSHA()
-		repo.Run("remote", "add", "origin", "/dev/null")
-		repo.Run("update-ref", "refs/remotes/origin/main", originSHA)
+		repo.AddRemote("origin", "/dev/null")
+		repo.SetRef("refs/remotes/origin/main", originSHA)
 		// Note: no refs/heads/main. Branch from origin/main directly.
-		repo.Run("checkout", "-b", "feature", originSHA)
+		repo.CheckoutNewBranch("feature", originSHA)
 		repo.CommitFile("feature.txt", "f", "feature commit")
-		repo.Run("config", "branch.feature.base", "main")
+		repo.SetBranchBase("feature", "main")
 
 		assert.Equal(t, "origin/main", GetBranchBase(repo.Dir, "HEAD"))
 	})
 
 	t.Run("returns qualified ref unchanged", func(t *testing.T) {
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("base.txt", "base", "initial")
-		repo.Run("checkout", "-b", "feature")
-		repo.Run("config", "branch.feature.base", "upstream/main")
+		repo.CheckoutNewBranch("feature")
+		repo.SetBranchBase("feature", "upstream/main")
 
 		assert.Equal(t, "upstream/main", GetBranchBase(repo.Dir, "HEAD"))
 	})
@@ -2840,17 +2940,17 @@ func TestGetBranchBase(t *testing.T) {
 		// names must still get stale-ancestor translation — treating any
 		// '/' as a remote prefix would skip the fix for these cases.
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/release/1.2")
+		repo.SetHeadBranch("release/1.2")
 		repo.CommitFile("base.txt", "base", "initial")
 		staleSHA := repo.HeadSHA()
 		repo.CommitFile("trunk.txt", "t", "trunk advance")
 		freshSHA := repo.HeadSHA()
-		repo.Run("update-ref", "refs/heads/release/1.2", staleSHA)
-		repo.Run("remote", "add", "origin", "/dev/null")
-		repo.Run("update-ref", "refs/remotes/origin/release/1.2", freshSHA)
-		repo.Run("checkout", "-b", "feature", freshSHA)
+		repo.SetRef("refs/heads/release/1.2", staleSHA)
+		repo.AddRemote("origin", "/dev/null")
+		repo.SetRef("refs/remotes/origin/release/1.2", freshSHA)
+		repo.CheckoutNewBranch("feature", freshSHA)
 		repo.CommitFile("feature.txt", "f", "feature commit")
-		repo.Run("config", "branch.feature.base", "release/1.2")
+		repo.SetBranchBase("feature", "release/1.2")
 
 		assert.Equal(t, "origin/release/1.2", GetBranchBase(repo.Dir, "HEAD"))
 	})
@@ -2859,13 +2959,13 @@ func TestGetBranchBase(t *testing.T) {
 		// An unambiguous remote-tracking ref (refs/remotes/<value> exists,
 		// no shadowing local branch) is not subject to translation.
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("base.txt", "base", "initial")
 		mainSHA := repo.HeadSHA()
-		repo.Run("remote", "add", "upstream", "/dev/null")
-		repo.Run("update-ref", "refs/remotes/upstream/main", mainSHA)
-		repo.Run("checkout", "-b", "feature")
-		repo.Run("config", "branch.feature.base", "upstream/main")
+		repo.AddRemote("upstream", "/dev/null")
+		repo.SetRef("refs/remotes/upstream/main", mainSHA)
+		repo.CheckoutNewBranch("feature")
+		repo.SetBranchBase("feature", "upstream/main")
 
 		assert.Equal(t, "upstream/main", GetBranchBase(repo.Dir, "HEAD"))
 	})
@@ -2876,17 +2976,16 @@ func TestGetBranchBase(t *testing.T) {
 		// fork) must NOT be silently substituted — that would compute the
 		// merge-base against a different remote than the user intended.
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("base.txt", "base", "initial")
 		mainSHA := repo.HeadSHA()
-		repo.Run("remote", "add", "origin", "/dev/null")
-		repo.Run("update-ref", "refs/remotes/origin/main", mainSHA)
+		repo.AddRemote("origin", "/dev/null")
+		repo.SetRef("refs/remotes/origin/main", mainSHA)
 		// Configure local main to track upstream/main, but never set up
 		// the corresponding remote-tracking ref.
-		repo.Run("config", "branch.main.remote", "upstream")
-		repo.Run("config", "branch.main.merge", "refs/heads/main")
-		repo.Run("checkout", "-b", "feature")
-		repo.Run("config", "branch.feature.base", "main")
+		repo.SetBranchUpstream("main", "upstream", "main")
+		repo.CheckoutNewBranch("feature")
+		repo.SetBranchBase("feature", "main")
 
 		assert.Equal(t, "main", GetBranchBase(repo.Dir, "HEAD"),
 			"missing upstream must not be substituted with origin counterpart")
@@ -2899,16 +2998,16 @@ func TestGetBranchBase(t *testing.T) {
 		// upstream/main happens to exist. The user explicitly remote-
 		// qualified the value; either it resolves or git surfaces an error.
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("base.txt", "base", "initial")
 		mainSHA := repo.HeadSHA()
-		repo.Run("remote", "add", "origin", "/dev/null")
+		repo.AddRemote("origin", "/dev/null")
 		// origin holds a stray ref shaped like a remote-qualified path —
 		// e.g., a past push of a local branch literally named
 		// "upstream/main". refs/remotes/upstream/main remains absent.
-		repo.Run("update-ref", "refs/remotes/origin/upstream/main", mainSHA)
-		repo.Run("checkout", "-b", "feature")
-		repo.Run("config", "branch.feature.base", "upstream/main")
+		repo.SetRef("refs/remotes/origin/upstream/main", mainSHA)
+		repo.CheckoutNewBranch("feature")
+		repo.SetBranchBase("feature", "upstream/main")
 
 		assert.Equal(t, "upstream/main", GetBranchBase(repo.Dir, "HEAD"),
 			"explicit remote-qualified value must not collapse to origin/<value>")
@@ -2919,16 +3018,15 @@ func TestGetBranchBase(t *testing.T) {
 		// targets another local branch. origin/<name> is unrelated and
 		// must not be silently substituted.
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/develop")
+		repo.SetHeadBranch("develop")
 		repo.CommitFile("base.txt", "base", "initial")
 		developSHA := repo.HeadSHA()
-		repo.Run("checkout", "-b", "main")
-		repo.Run("config", "branch.main.remote", ".")
-		repo.Run("config", "branch.main.merge", "refs/heads/develop")
-		repo.Run("remote", "add", "origin", "/dev/null")
-		repo.Run("update-ref", "refs/remotes/origin/main", developSHA)
-		repo.Run("checkout", "-b", "feature")
-		repo.Run("config", "branch.feature.base", "main")
+		repo.CheckoutNewBranch("main")
+		repo.SetBranchUpstream("main", ".", "develop")
+		repo.AddRemote("origin", "/dev/null")
+		repo.SetRef("refs/remotes/origin/main", developSHA)
+		repo.CheckoutNewBranch("feature")
+		repo.SetBranchBase("feature", "main")
 
 		assert.Equal(t, "main", GetBranchBase(repo.Dir, "HEAD"),
 			"local-branch tracking must not be substituted with origin counterpart")
@@ -2939,21 +3037,20 @@ func TestGetBranchBase(t *testing.T) {
 		// also exists (e.g., points at the user's fork). The base should
 		// resolve to upstream/main because that's what local main tracks.
 		repo := NewTestRepo(t)
-		repo.Run("symbolic-ref", "HEAD", "refs/heads/main")
+		repo.SetHeadBranch("main")
 		repo.CommitFile("base.txt", "base", "initial")
 		mainSHA := repo.HeadSHA()
 		repo.CommitFile("trunk.txt", "trunk", "upstream advance")
 		upstreamSHA := repo.HeadSHA()
-		repo.Run("update-ref", "refs/heads/main", mainSHA)
-		repo.Run("remote", "add", "origin", "/dev/null")
-		repo.Run("remote", "add", "upstream", "/dev/null")
-		repo.Run("update-ref", "refs/remotes/origin/main", mainSHA)
-		repo.Run("update-ref", "refs/remotes/upstream/main", upstreamSHA)
-		repo.Run("config", "branch.main.remote", "upstream")
-		repo.Run("config", "branch.main.merge", "refs/heads/main")
-		repo.Run("checkout", "-b", "feature", upstreamSHA)
+		repo.SetRef("refs/heads/main", mainSHA)
+		repo.AddRemote("origin", "/dev/null")
+		repo.AddRemote("upstream", "/dev/null")
+		repo.SetRef("refs/remotes/origin/main", mainSHA)
+		repo.SetRef("refs/remotes/upstream/main", upstreamSHA)
+		repo.SetBranchUpstream("main", "upstream", "main")
+		repo.CheckoutNewBranch("feature", upstreamSHA)
 		repo.CommitFile("feature.txt", "f", "feature commit")
-		repo.Run("config", "branch.feature.base", "main")
+		repo.SetBranchBase("feature", "main")
 
 		assert.Equal(t, "upstream/main", GetBranchBase(repo.Dir, "HEAD"))
 	})

--- a/internal/githook/githook.go
+++ b/internal/githook/githook.go
@@ -101,6 +101,13 @@ func NeedsUpgrade(ctx context.Context, repoPath, hookName, versionMarker string)
 	if err != nil {
 		return false
 	}
+	return NeedsUpgradeInDir(hooksDir, hookName, versionMarker)
+}
+
+// NeedsUpgradeInDir checks whether a hook in hooksDir contains roborev but is
+// outdated. Callers that already resolved the hooks directory can use this to
+// avoid repeated git config lookups.
+func NeedsUpgradeInDir(hooksDir, hookName, versionMarker string) bool {
 	content, err := os.ReadFile(filepath.Join(hooksDir, hookName))
 	if err != nil {
 		return false
@@ -135,6 +142,12 @@ func Missing(ctx context.Context, repoPath, hookName string) bool {
 	if err != nil {
 		return false
 	}
+	return MissingInDir(hooksDir, hookName)
+}
+
+// MissingInDir checks whether hooksDir has roborev installed in post-commit
+// but is missing the named hook.
+func MissingInDir(hooksDir, hookName string) bool {
 	pcContent, err := os.ReadFile(
 		filepath.Join(hooksDir, "post-commit"),
 	)

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -722,6 +722,11 @@ func deterministicGuidelineLen(t *testing.T, prefixLenAtOne, targetPrefixLen int
 // Tests that use NewBuilder(nil) resolve to this value.
 var defaultPromptCap = config.DefaultMaxPromptSize
 
+const (
+	oversizedRangeMetadataCommitCount = 16
+	oversizedRangeMetadataSubjectLen  = 16 * 1024
+)
+
 func singleCommitNearCapRepo(t *testing.T, remainingBudget int) (string, string) {
 	t.Helper()
 	repoPath, sha := setupLargeDiffRepoWithGuidelines(t, 1)
@@ -879,7 +884,11 @@ func TestBuildRangePromptCodexOversizedDiffKeepsCurrentRangeMetadataWhenTrimming
 }
 
 func TestBuildRangePromptCodexOversizedDiffWithLargeRangeMetadataStaysWithinMaxPromptSize(t *testing.T) {
-	repoPath, rangeRef := setupLargeRangeMetadataRepo(t, 80, 4096)
+	repoPath, rangeRef := setupLargeRangeMetadataRepo(
+		t,
+		oversizedRangeMetadataCommitCount,
+		oversizedRangeMetadataSubjectLen,
+	)
 
 	b := NewBuilder(nil)
 	prompt, err := b.ForRepo(repoPath, 0).Build(rangeRef, 0, "codex", "", "")
@@ -888,7 +897,7 @@ func TestBuildRangePromptCodexOversizedDiffWithLargeRangeMetadataStaysWithinMaxP
 	assert.LessOrEqual(t, len(prompt), defaultPromptCap, "expected large range metadata to still stay within the prompt cap")
 	assertContains(t, prompt, "git diff", "expected Codex range fallback guidance to remain present when range metadata is oversized")
 	assertContains(t, prompt, "## Commit Range", "expected the commit range section header to remain intact")
-	assertContains(t, prompt, "Reviewing 80 commits:", "expected the range summary to remain intact")
+	assertContains(t, prompt, "Reviewing 16 commits:", "expected the range summary to remain intact")
 }
 
 func TestSelectRichestRangePromptViewPrefersRicherVariantOnEqualMetadataLoss(t *testing.T) {
@@ -1575,7 +1584,11 @@ func TestBuildPromptCodexTinyCapStillStaysWithinCap(t *testing.T) {
 }
 
 func TestBuildRangePromptCodexTinyCapStillStaysWithinCap(t *testing.T) {
-	repoPath, rangeRef := setupLargeRangeMetadataRepo(t, 80, 4096)
+	repoPath, rangeRef := setupLargeRangeMetadataRepo(
+		t,
+		oversizedRangeMetadataCommitCount,
+		oversizedRangeMetadataSubjectLen,
+	)
 	cap := 256
 	cfg := &config.Config{DefaultMaxPromptSize: cap}
 	b := NewBuilderWithConfig(nil, cfg)

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -103,22 +103,21 @@ func TestBuildPromptWithAdditionalContextAndPreviousAttemptsPreservesSectionOrde
 func TestBuildRangePromptSummarizesExcludedDependencyMetadata(t *testing.T) {
 	repo := newTestRepo(t)
 	require.NoError(t, os.MkdirAll(filepath.Join(repo.dir, "frontend"), 0o755))
-	repo.writeFile("frontend/package.json", `{"dependencies":{"react":"18.2.0"}}`+"\n")
-	repo.writeFile("frontend/package-lock.json", `{"packages":{"":{"dependencies":{"react":"18.2.0"}}}}`+"\n")
-	repo.writeFile("go.mod", "module example.com/app\n\nrequire github.com/jackc/pgx/v5 v5.9.0\n")
-	repo.writeFile("go.sum", "github.com/jackc/pgx/v5 v5.9.0 h1:old\n")
-	repo.git("add", "-A")
-	repo.git("commit", "-m", "add dependency metadata")
-	baseSHA := repo.git("rev-parse", "HEAD")
+	baseSHA := repo.fastCommitFiles(map[string]string{
+		"frontend/package.json":      `{"dependencies":{"react":"18.2.0"}}` + "\n",
+		"frontend/package-lock.json": `{"packages":{"":{"dependencies":{"react":"18.2.0"}}}}` + "\n",
+		"go.mod":                     "module example.com/app\n\nrequire github.com/jackc/pgx/v5 v5.9.0\n",
+		"go.sum":                     "github.com/jackc/pgx/v5 v5.9.0 h1:old\n",
+	}, "add dependency metadata")
 
-	repo.writeFile("frontend/package.json", `{"dependencies":{"react":"18.3.1"}}`+"\n")
-	repo.writeFile("frontend/package-lock.json", `{"packages":{"":{"dependencies":{"react":"18.3.1"}}}}`+"\n")
-	repo.writeFile("go.mod", "module example.com/app\n\nrequire github.com/jackc/pgx/v5 v5.10.0\n")
-	repo.writeFile("go.sum", "github.com/jackc/pgx/v5 v5.10.0 h1:new\n")
-	repo.git("add", "-A")
-	repo.git("commit", "-m", "bump dependency metadata")
+	headSHA := repo.fastCommitFiles(map[string]string{
+		"frontend/package.json":      `{"dependencies":{"react":"18.3.1"}}` + "\n",
+		"frontend/package-lock.json": `{"packages":{"":{"dependencies":{"react":"18.3.1"}}}}` + "\n",
+		"go.mod":                     "module example.com/app\n\nrequire github.com/jackc/pgx/v5 v5.10.0\n",
+		"go.sum":                     "github.com/jackc/pgx/v5 v5.10.0 h1:new\n",
+	}, "bump dependency metadata")
 
-	rangeRef := baseSHA + ".." + repo.git("rev-parse", "HEAD")
+	rangeRef := baseSHA + ".." + headSHA
 	prompt, err := NewBuilder(nil).ForRepo(repo.dir, 0).Build(rangeRef, 0, "test", "", "")
 	require.NoError(t, err)
 

--- a/internal/prompt/test_helpers_test.go
+++ b/internal/prompt/test_helpers_test.go
@@ -308,14 +308,6 @@ func setupLargeCommitAuthorRepo(t *testing.T, authorLen int) (string, string) {
 	return r.dir, r.git("rev-parse", "HEAD")
 }
 
-func (r *testRepo) commitWithMessage(message string) {
-	r.t.Helper()
-	msgPath := filepath.Join(r.dir, "commit-message.txt")
-	require.NoError(r.t, os.WriteFile(msgPath, []byte(message), 0o644))
-	r.git("commit", "--quiet", "-F", msgPath)
-	require.NoError(r.t, os.Remove(msgPath))
-}
-
 func setupLargeRangeMetadataRepo(t *testing.T, commitCount, subjectLen int) (string, string) {
 	t.Helper()
 	r := newTestRepo(t)

--- a/internal/prompt/test_helpers_test.go
+++ b/internal/prompt/test_helpers_test.go
@@ -4,10 +4,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -16,8 +19,9 @@ import (
 )
 
 type testRepo struct {
-	t   *testing.T
-	dir string
+	t    *testing.T
+	dir  string
+	repo *testutil.TestRepo
 }
 
 const (
@@ -37,18 +41,26 @@ func newTestRepoWithBranch(t *testing.T, branch string) *testRepo {
 
 func initTestRepo(t *testing.T, initArgs ...string) *testRepo {
 	t.Helper()
-	r := &testRepo{t: t, dir: t.TempDir()}
-	r.git(append([]string{"init"}, initArgs...)...)
+	repo := testutil.NewGitRepo(t)
+	r := &testRepo{t: t, dir: repo.Path(), repo: repo}
+	if len(initArgs) == 2 && initArgs[0] == "-b" && initArgs[1] != "main" {
+		require.NoError(t,
+			os.WriteFile(filepath.Join(r.dir, ".git", "HEAD"), []byte("ref: refs/heads/"+initArgs[1]+"\n"), 0o644),
+			"set initial branch")
+	}
 	r.configure()
 	return r
 }
 
 func (r *testRepo) configure() {
 	r.t.Helper()
-	r.git("config", "user.email", testGitEmail)
-	r.git("config", "user.name", testGitUser)
-	r.git("config", "gc.auto", "0")
-	r.git("config", "maintenance.auto", "false")
+	configPath := filepath.Join(r.dir, ".git", "config")
+	data, err := os.ReadFile(configPath)
+	require.NoError(r.t, err, "read git config")
+	text := string(data)
+	text = strings.Replace(text, "email = "+testutil.GitUserEmail, "email = "+testGitEmail, 1)
+	text = strings.Replace(text, "name = "+testutil.GitUserName, "name = "+testGitUser, 1)
+	require.NoError(r.t, os.WriteFile(configPath, []byte(text), 0o644), "write git config")
 }
 
 func TestNewTestRepoDisablesGitAutoMaintenance(t *testing.T) {
@@ -73,6 +85,46 @@ func (r *testRepo) git(args ...string) string {
 	return strings.TrimSpace(string(out))
 }
 
+func (r *testRepo) fastCommitFile(name, content, message string) string {
+	r.t.Helper()
+	r.writeFile(name, content)
+	return r.fastCommitPaths(message, name)
+}
+
+func (r *testRepo) fastCommitFiles(files map[string]string, message string) string {
+	r.t.Helper()
+	paths := make([]string, 0, len(files))
+	for name, content := range files {
+		r.writeFile(name, content)
+		paths = append(paths, name)
+	}
+	sort.Strings(paths)
+	return r.fastCommitPaths(message, paths...)
+}
+
+func (r *testRepo) fastCommitPaths(message string, paths ...string) string {
+	r.t.Helper()
+	repo, err := gogit.PlainOpen(r.dir)
+	require.NoError(r.t, err, "open repo")
+	wt, err := repo.Worktree()
+	require.NoError(r.t, err, "open worktree")
+	for _, path := range paths {
+		_, err = wt.Add(filepath.ToSlash(path))
+		require.NoError(r.t, err, "git add %s", path)
+	}
+	when := time.Now()
+	if raw := os.Getenv("GIT_AUTHOR_DATE"); raw != "" {
+		if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
+			when = parsed
+		}
+	}
+	hash, err := wt.Commit(message, &gogit.CommitOptions{
+		Author: &object.Signature{Name: testGitUser, Email: testGitEmail, When: when},
+	})
+	require.NoError(r.t, err, "commit")
+	return hash.String()
+}
+
 func assertContains(t *testing.T, doc, substring, msg string) {
 	t.Helper()
 	assert.Contains(t, doc, substring, msg)
@@ -94,13 +146,8 @@ func setupTestRepo(t *testing.T) (string, []string) {
 
 	// Create 6 commits so we can test with 5 previous commits
 	for i := 1; i <= 6; i++ {
-		filename := filepath.Join(r.dir, "file.txt")
 		content := strings.Repeat("x", i) // Different content each time
-		require.NoError(t, os.WriteFile(filename, []byte(content), 0o644))
-		r.git("add", "file.txt")
-		r.git("commit", "-m", "commit "+string(rune('0'+i)))
-
-		sha := r.git("rev-parse", "HEAD")
+		sha := r.fastCommitFile("file.txt", content, "commit "+string(rune('0'+i)))
 		commits = append(commits, sha)
 	}
 
@@ -111,12 +158,7 @@ func setupLargeDiffRepo(t *testing.T) (string, string) {
 	t.Helper()
 	r := newTestRepo(t)
 
-	require.NoError(t, os.WriteFile(
-		filepath.Join(r.dir, "base.txt"),
-		[]byte("base\n"), 0o644,
-	))
-	r.git("add", "base.txt")
-	r.git("commit", "-m", "initial")
+	r.fastCommitFile("base.txt", "base\n", "initial")
 
 	var content strings.Builder
 	for range 20000 {
@@ -127,26 +169,14 @@ func setupLargeDiffRepo(t *testing.T) (string, string) {
 		content.WriteString("\n")
 	}
 
-	require.NoError(t, os.WriteFile(
-		filepath.Join(r.dir, "large.txt"),
-		[]byte(content.String()), 0o644,
-	))
-	r.git("add", "large.txt")
-	r.git("commit", "-m", "large change")
-
-	return r.dir, r.git("rev-parse", "HEAD")
+	return r.dir, r.fastCommitFile("large.txt", content.String(), "large change")
 }
 
 func setupLargeExcludePatternRepo(t *testing.T) (string, string) {
 	t.Helper()
 	r := newTestRepo(t)
 
-	require.NoError(t, os.WriteFile(
-		filepath.Join(r.dir, "base.txt"),
-		[]byte("base\n"), 0o644,
-	))
-	r.git("add", "base.txt")
-	r.git("commit", "-m", "initial")
+	r.fastCommitFile("base.txt", "base\n", "initial")
 
 	var content strings.Builder
 	for range 20000 {
@@ -157,18 +187,10 @@ func setupLargeExcludePatternRepo(t *testing.T) (string, string) {
 		content.WriteString("\n")
 	}
 
-	require.NoError(t, os.WriteFile(
-		filepath.Join(r.dir, "large.txt"),
-		[]byte(content.String()), 0o644,
-	))
-	require.NoError(t, os.WriteFile(
-		filepath.Join(r.dir, "custom.dat"),
-		[]byte(content.String()), 0o644,
-	))
-	r.git("add", "large.txt", "custom.dat")
-	r.git("commit", "-m", "large change")
-
-	return r.dir, r.git("rev-parse", "HEAD")
+	return r.dir, r.fastCommitFiles(map[string]string{
+		"large.txt":  content.String(),
+		"custom.dat": content.String(),
+	}, "large change")
 }
 
 func setupLargeDiffRepoWithGuidelines(t *testing.T, guidelineLen int) (string, string) {
@@ -177,16 +199,10 @@ func setupLargeDiffRepoWithGuidelines(t *testing.T, guidelineLen int) (string, s
 
 	guidelines := strings.Repeat("g", guidelineLen)
 	toml := `review_guidelines = """` + "\n" + guidelines + "\n" + `"""` + "\n"
-	require.NoError(t, os.WriteFile(
-		filepath.Join(r.dir, ".roborev.toml"),
-		[]byte(toml), 0o644,
-	))
-	require.NoError(t, os.WriteFile(
-		filepath.Join(r.dir, "base.txt"),
-		[]byte("base\n"), 0o644,
-	))
-	r.git("add", ".roborev.toml", "base.txt")
-	r.git("commit", "-m", "initial")
+	r.fastCommitFiles(map[string]string{
+		".roborev.toml": toml,
+		"base.txt":      "base\n",
+	}, "initial")
 
 	r.git("remote", "add", "origin", r.dir)
 	r.git("fetch", "origin")
@@ -201,26 +217,14 @@ func setupLargeDiffRepoWithGuidelines(t *testing.T, guidelineLen int) (string, s
 		content.WriteString("\n")
 	}
 
-	require.NoError(t, os.WriteFile(
-		filepath.Join(r.dir, "large.txt"),
-		[]byte(content.String()), 0o644,
-	))
-	r.git("add", "large.txt")
-	r.git("commit", "-m", "large change")
-
-	return r.dir, r.git("rev-parse", "HEAD")
+	return r.dir, r.fastCommitFile("large.txt", content.String(), "large change")
 }
 
 func setupLargeCommitBodyRepo(t *testing.T, bodyLen int) (string, string) {
 	t.Helper()
 	r := newTestRepo(t)
 
-	require.NoError(t, os.WriteFile(
-		filepath.Join(r.dir, "base.txt"),
-		[]byte("base\n"), 0o644,
-	))
-	r.git("add", "base.txt")
-	r.git("commit", "-m", "initial")
+	r.fastCommitFile("base.txt", "base\n", "initial")
 
 	require.NoError(t, os.WriteFile(
 		filepath.Join(r.dir, "base.txt"),
@@ -268,12 +272,7 @@ func setupLargeCommitSubjectRepo(t *testing.T, subjectLen int) (string, string) 
 	t.Helper()
 	r := newTestRepo(t)
 
-	require.NoError(t, os.WriteFile(
-		filepath.Join(r.dir, "base.txt"),
-		[]byte("base\n"), 0o644,
-	))
-	r.git("add", "base.txt")
-	r.git("commit", "-m", "initial")
+	r.fastCommitFile("base.txt", "base\n", "initial")
 
 	require.NoError(t, os.WriteFile(
 		filepath.Join(r.dir, "base.txt"),
@@ -293,12 +292,7 @@ func setupLargeCommitAuthorRepo(t *testing.T, authorLen int) (string, string) {
 	t.Helper()
 	r := newTestRepo(t)
 
-	require.NoError(t, os.WriteFile(
-		filepath.Join(r.dir, "base.txt"),
-		[]byte("base\n"), 0o644,
-	))
-	r.git("add", "base.txt")
-	r.git("commit", "-m", "initial")
+	r.fastCommitFile("base.txt", "base\n", "initial")
 
 	require.NoError(t, os.WriteFile(
 		filepath.Join(r.dir, "base.txt"),
@@ -326,22 +320,10 @@ func setupLargeRangeMetadataRepo(t *testing.T, commitCount, subjectLen int) (str
 	t.Helper()
 	r := newTestRepo(t)
 
-	require.NoError(t, os.WriteFile(
-		filepath.Join(r.dir, "base.txt"),
-		[]byte("base\n"), 0o644,
-	))
-	r.git("add", "base.txt")
-	r.git("commit", "-m", "initial")
-
-	startSHA := r.git("rev-parse", "HEAD")
+	startSHA := r.fastCommitFile("base.txt", "base\n", "initial")
 	subject := strings.Repeat("s", subjectLen)
 	for i := range commitCount {
-		require.NoError(t, os.WriteFile(
-			filepath.Join(r.dir, "base.txt"),
-			[]byte(strings.Repeat("x\n", i+2)), 0o644,
-		))
-		r.git("add", "base.txt")
-		r.commitWithMessage(subject + "\n")
+		r.fastCommitFile("base.txt", strings.Repeat("x\n", i+2), subject+"\n")
 	}
 
 	endSHA := r.git("rev-parse", "HEAD")
@@ -386,15 +368,14 @@ func setupGuidelinesRepo(t *testing.T, defaultBranch, baseGuidelines, branchGuid
 	}
 
 	// Initial commit with base guidelines
+	files := map[string]string{}
 	if baseGuidelines != "" {
 		toml := `review_guidelines = """` + "\n" + baseGuidelines + "\n" + `"""` + "\n"
-		require.NoError(t, os.WriteFile(filepath.Join(r.dir, ".roborev.toml"), []byte(toml), 0o644), "write .roborev.toml")
+		files[".roborev.toml"] = toml
 	} else {
-		require.NoError(t, os.WriteFile(filepath.Join(r.dir, "README.md"), []byte("init"), 0o644), "write README.md")
+		files["README.md"] = "init"
 	}
-	r.git("add", "-A")
-	r.git("commit", "-m", "initial")
-	baseSHA := r.git("rev-parse", "HEAD")
+	baseSHA := r.fastCommitFiles(files, "initial")
 
 	// Set up origin pointing to itself so origin/<branch> exists
 	r.git("remote", "add", "origin", r.dir)
@@ -407,10 +388,7 @@ func setupGuidelinesRepo(t *testing.T, defaultBranch, baseGuidelines, branchGuid
 	if branchGuidelines != "" {
 		r.git("checkout", "-b", "feature-branch")
 		toml := `review_guidelines = """` + "\n" + branchGuidelines + "\n" + `"""` + "\n"
-		require.NoError(t, os.WriteFile(filepath.Join(r.dir, ".roborev.toml"), []byte(toml), 0o644), "write .roborev.toml")
-		r.git("add", ".roborev.toml")
-		r.git("commit", "-m", "update guidelines on branch")
-		featureSHA = r.git("rev-parse", "HEAD")
+		featureSHA = r.fastCommitFile(".roborev.toml", toml, "update guidelines on branch")
 		r.git("checkout", defaultBranch)
 	}
 

--- a/internal/testutil/git.go
+++ b/internal/testutil/git.go
@@ -15,6 +15,7 @@ import (
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/stretchr/testify/require"
 )
 
 // TestRepo encapsulates a temporary git repository for tests.
@@ -389,7 +390,7 @@ func (r *TestRepo) CheckoutNewBranch(branch string, start ...string) {
 	if err != nil {
 		r.t.Fatalf("open repo %q: %v", r.Root, err)
 	}
-	hash := plumbing.ZeroHash
+	var hash plumbing.Hash
 	if len(start) == 1 {
 		hash = plumbing.NewHash(start[0])
 	} else {
@@ -411,6 +412,82 @@ func (r *TestRepo) CheckoutNewBranch(branch string, start ...string) {
 	if err != nil {
 		r.t.Fatalf("checkout new branch %q: %v", branch, err)
 	}
+}
+
+// CheckoutBranch checks out an existing branch without spawning a git process.
+func (r *TestRepo) CheckoutBranch(branch string) {
+	r.t.Helper()
+	repo, err := gogit.PlainOpen(r.Root)
+	require.NoError(r.t, err, "open repo %q", r.Root)
+	wt, err := repo.Worktree()
+	require.NoError(r.t, err, "worktree")
+	err = wt.Checkout(&gogit.CheckoutOptions{
+		Branch: plumbing.NewBranchReferenceName(branch),
+		Force:  true,
+	})
+	require.NoError(r.t, err, "checkout branch %q", branch)
+}
+
+// CheckoutBranchForce creates or resets branch to start, then checks it out.
+func (r *TestRepo) CheckoutBranchForce(branch string, start ...string) {
+	r.t.Helper()
+	require.LessOrEqual(r.t, len(start), 1, "CheckoutBranchForce accepts at most one start ref")
+	repo, err := gogit.PlainOpen(r.Root)
+	require.NoError(r.t, err, "open repo %q", r.Root)
+	var hash plumbing.Hash
+	if len(start) == 1 {
+		hash = plumbing.NewHash(start[0])
+	} else {
+		head, err := repo.Head()
+		require.NoError(r.t, err, "read HEAD")
+		hash = head.Hash()
+	}
+	ref := plumbing.NewBranchReferenceName(branch)
+	err = repo.Storer.SetReference(plumbing.NewHashReference(ref, hash))
+	require.NoError(r.t, err, "set branch %q", branch)
+	wt, err := repo.Worktree()
+	require.NoError(r.t, err, "worktree")
+	err = wt.Checkout(&gogit.CheckoutOptions{Branch: ref, Force: true})
+	require.NoError(r.t, err, "checkout branch %q", branch)
+}
+
+// CheckoutDetached detaches HEAD at start, or at the current HEAD when omitted.
+func (r *TestRepo) CheckoutDetached(start ...string) {
+	r.t.Helper()
+	require.LessOrEqual(r.t, len(start), 1, "CheckoutDetached accepts at most one start ref")
+	repo, err := gogit.PlainOpen(r.Root)
+	require.NoError(r.t, err, "open repo %q", r.Root)
+	var hash plumbing.Hash
+	if len(start) == 1 {
+		hash = plumbing.NewHash(start[0])
+	} else {
+		head, err := repo.Head()
+		require.NoError(r.t, err, "read HEAD")
+		hash = head.Hash()
+	}
+	wt, err := repo.Worktree()
+	require.NoError(r.t, err, "worktree")
+	err = wt.Checkout(&gogit.CheckoutOptions{Hash: hash, Force: true})
+	require.NoError(r.t, err, "checkout detached %q", hash.String())
+}
+
+// AmendCommit stages paths, amends HEAD, and returns the new HEAD SHA.
+func (r *TestRepo) AmendCommit(msg string, paths ...string) string {
+	r.t.Helper()
+	repo, err := gogit.PlainOpen(r.Root)
+	require.NoError(r.t, err, "open repo %q", r.Root)
+	wt, err := repo.Worktree()
+	require.NoError(r.t, err, "worktree")
+	for _, path := range paths {
+		_, err := wt.Add(filepath.ToSlash(path))
+		require.NoError(r.t, err, "git add %s", path)
+	}
+	hash, err := wt.Commit(msg, &gogit.CommitOptions{
+		Amend:  true,
+		Author: testSignature(),
+	})
+	require.NoError(r.t, err, "amend commit")
+	return hash.String()
 }
 
 // SetRef writes a hash ref directly.

--- a/internal/testutil/git.go
+++ b/internal/testutil/git.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -252,6 +253,23 @@ func (r *TestRepo) CommitFile(filename, content, msg string) string {
 	r.t.Helper()
 
 	r.WriteFile(filename, content)
+	return r.commitPaths(msg, filename)
+}
+
+// CommitFiles writes files, stages them, commits, and returns the new HEAD SHA.
+func (r *TestRepo) CommitFiles(files map[string]string, msg string) string {
+	r.t.Helper()
+	paths := make([]string, 0, len(files))
+	for name, content := range files {
+		r.WriteFile(name, content)
+		paths = append(paths, name)
+	}
+	sort.Strings(paths)
+	return r.commitPaths(msg, paths...)
+}
+
+func (r *TestRepo) commitPaths(msg string, paths ...string) string {
+	r.t.Helper()
 
 	repo, err := gogit.PlainOpen(r.Root)
 	if err != nil {
@@ -261,8 +279,10 @@ func (r *TestRepo) CommitFile(filename, content, msg string) string {
 	if err != nil {
 		r.t.Fatalf("worktree: %v", err)
 	}
-	if _, err := wt.Add(filepath.ToSlash(filename)); err != nil {
-		r.t.Fatalf("git add %s: %v", filename, err)
+	for _, path := range paths {
+		if _, err := wt.Add(filepath.ToSlash(path)); err != nil {
+			r.t.Fatalf("git add %s: %v", path, err)
+		}
 	}
 	hash, err := wt.Commit(msg, &gogit.CommitOptions{
 		Author: &object.Signature{Name: GitUserName, Email: GitUserEmail, When: time.Now()},
@@ -300,10 +320,33 @@ func NewGitRepo(t *testing.T) *TestRepo {
 	})
 }
 
+// NewBareTestRepo creates a bare temporary repository suitable for use as a
+// test remote. The bare repository shape is copied from a cached template to
+// avoid paying for `git init --bare` in every test case.
+func NewBareTestRepo(t *testing.T) *TestRepo {
+	t.Helper()
+	dir := t.TempDir()
+	instantiateInto(t, dir, "bare", func(d string) {
+		mustGit(d, "init", "--bare")
+	})
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		resolved = dir
+	}
+	return &TestRepo{
+		Root:         dir,
+		GitDir:       dir,
+		HooksDir:     filepath.Join(dir, "hooks"),
+		HookPath:     filepath.Join(dir, "hooks", "post-commit"),
+		resolvedPath: resolved,
+		t:            t,
+	}
+}
+
 // InitTestGitRepo initializes a git repository with a commit in the given directory.
 // Creates the directory if it doesn't exist, runs git init, configures user, creates
 // a test file, and makes an initial commit.
-func InitTestGitRepo(t *testing.T, dir string) {
+func InitTestGitRepo(t *testing.T, dir string) *TestRepo {
 	t.Helper()
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("create repo dir %q: %v", dir, err)
@@ -315,6 +358,13 @@ func InitTestGitRepo(t *testing.T, dir string) {
 		mustGit(d, "add", "test.txt")
 		mustGit(d, "commit", "-m", "initial commit")
 	})
+	return &TestRepo{
+		Root:     dir,
+		GitDir:   filepath.Join(dir, ".git"),
+		HooksDir: filepath.Join(dir, ".git", "hooks"),
+		HookPath: filepath.Join(dir, ".git", "hooks", "post-commit"),
+		t:        t,
+	}
 }
 
 // GetHeadSHA returns the HEAD commit SHA for the git repo at dir.

--- a/internal/testutil/git.go
+++ b/internal/testutil/git.go
@@ -224,6 +224,13 @@ func (r *TestRepo) HeadSHA() string {
 	return r.RevParse("HEAD")
 }
 
+func (r *TestRepo) resolveRevision(repo *gogit.Repository, rev string) plumbing.Hash {
+	r.t.Helper()
+	resolved, err := repo.ResolveRevision(plumbing.Revision(rev))
+	require.NoError(r.t, err, "resolve ref %q", rev)
+	return *resolved
+}
+
 // RunGit runs a git command in the repo directory.
 func (r *TestRepo) RunGit(args ...string) {
 	r.t.Helper()
@@ -380,7 +387,7 @@ func headSHA(dir string) (string, error) {
 }
 
 // CheckoutNewBranch creates and checks out branch at the current HEAD or the
-// optional starting SHA, without spawning a git process.
+// optional starting ref, without spawning a git process.
 func (r *TestRepo) CheckoutNewBranch(branch string, start ...string) {
 	r.t.Helper()
 	if len(start) > 1 {
@@ -392,7 +399,7 @@ func (r *TestRepo) CheckoutNewBranch(branch string, start ...string) {
 	}
 	var hash plumbing.Hash
 	if len(start) == 1 {
-		hash = plumbing.NewHash(start[0])
+		hash = r.resolveRevision(repo, start[0])
 	} else {
 		head, err := repo.Head()
 		if err != nil {
@@ -436,7 +443,7 @@ func (r *TestRepo) CheckoutBranchForce(branch string, start ...string) {
 	require.NoError(r.t, err, "open repo %q", r.Root)
 	var hash plumbing.Hash
 	if len(start) == 1 {
-		hash = plumbing.NewHash(start[0])
+		hash = r.resolveRevision(repo, start[0])
 	} else {
 		head, err := repo.Head()
 		require.NoError(r.t, err, "read HEAD")
@@ -459,7 +466,7 @@ func (r *TestRepo) CheckoutDetached(start ...string) {
 	require.NoError(r.t, err, "open repo %q", r.Root)
 	var hash plumbing.Hash
 	if len(start) == 1 {
-		hash = plumbing.NewHash(start[0])
+		hash = r.resolveRevision(repo, start[0])
 	} else {
 		head, err := repo.Head()
 		require.NoError(r.t, err, "read HEAD")
@@ -504,6 +511,57 @@ func (r *TestRepo) SetRef(ref, sha string) {
 	if err != nil {
 		r.t.Fatalf("set ref %q: %v", ref, err)
 	}
+}
+
+func (r *TestRepo) AddRemote(name, url string) {
+	r.t.Helper()
+	r.appendConfig("remote", name, map[string]string{
+		"url":   url,
+		"fetch": "+refs/heads/*:refs/remotes/" + name + "/*",
+	})
+}
+
+func (r *TestRepo) SetRemoteHead(remote, branch string) {
+	r.t.Helper()
+	r.writeGitFile("refs/remotes/"+remote+"/HEAD", "ref: refs/remotes/"+remote+"/"+branch+"\n")
+}
+
+func (r *TestRepo) SetBranchConfig(branch, key, value string) {
+	r.t.Helper()
+	r.appendConfig("branch", branch, map[string]string{key: value})
+}
+
+func (r *TestRepo) writeGitFile(relPath, content string) {
+	r.t.Helper()
+	path := filepath.Join(r.GitDir, filepath.FromSlash(relPath))
+	require.NoError(r.t, os.MkdirAll(filepath.Dir(path), 0o755), "create git dir for %s", relPath)
+	require.NoError(r.t, os.WriteFile(path, []byte(content), 0o644), "write git file %s", relPath)
+}
+
+func (r *TestRepo) appendConfig(section, subsection string, values map[string]string) {
+	r.t.Helper()
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	b.WriteByte('\n')
+	if subsection == "" {
+		fmt.Fprintf(&b, "[%s]\n", section)
+	} else {
+		fmt.Fprintf(&b, "[%s %q]\n", section, subsection)
+	}
+	for _, key := range keys {
+		fmt.Fprintf(&b, "\t%s = %s\n", key, values[key])
+	}
+
+	f, err := os.OpenFile(filepath.Join(r.GitDir, "config"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	require.NoError(r.t, err, "open git config")
+	defer f.Close()
+	_, err = f.WriteString(b.String())
+	require.NoError(r.t, err, "write git config")
 }
 
 // Config sets a git config value.

--- a/internal/testutil/git.go
+++ b/internal/testutil/git.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
@@ -216,6 +217,9 @@ func (r *TestRepo) Path() string {
 
 func (r *TestRepo) HeadSHA() string {
 	r.t.Helper()
+	if sha, err := headSHA(r.Root); err == nil {
+		return sha
+	}
 	return r.RevParse("HEAD")
 }
 
@@ -268,6 +272,64 @@ func (r *TestRepo) CommitFiles(files map[string]string, msg string) string {
 	return r.commitPaths(msg, paths...)
 }
 
+// CommitEmpty creates an empty commit with the given message and returns HEAD.
+func (r *TestRepo) CommitEmpty(msg string) string {
+	r.t.Helper()
+
+	repo, err := gogit.PlainOpen(r.Root)
+	if err != nil {
+		r.t.Fatalf("open repo %q: %v", r.Root, err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		r.t.Fatalf("worktree: %v", err)
+	}
+	hash, err := wt.Commit(msg, &gogit.CommitOptions{
+		AllowEmptyCommits: true,
+		Author:            testSignature(),
+	})
+	if err != nil {
+		r.t.Fatalf("empty commit: %v", err)
+	}
+	return hash.String()
+}
+
+// UnrelatedCommit writes an unreferenced root commit object using the current
+// HEAD tree. It is useful for ancestry tests that need real but unreachable
+// commits without paying for orphan-branch checkout/reset subprocesses.
+func (r *TestRepo) UnrelatedCommit(msg string) string {
+	r.t.Helper()
+
+	repo, err := gogit.PlainOpen(r.Root)
+	if err != nil {
+		r.t.Fatalf("open repo %q: %v", r.Root, err)
+	}
+	head, err := repo.Head()
+	if err != nil {
+		r.t.Fatalf("read HEAD: %v", err)
+	}
+	headCommit, err := repo.CommitObject(head.Hash())
+	if err != nil {
+		r.t.Fatalf("read HEAD commit: %v", err)
+	}
+	sig := testSignature()
+	commit := &object.Commit{
+		Author:    *sig,
+		Committer: *sig,
+		Message:   msg,
+		TreeHash:  headCommit.TreeHash,
+	}
+	obj := repo.Storer.NewEncodedObject()
+	if err := commit.Encode(obj); err != nil {
+		r.t.Fatalf("encode unrelated commit: %v", err)
+	}
+	hash, err := repo.Storer.SetEncodedObject(obj)
+	if err != nil {
+		r.t.Fatalf("store unrelated commit: %v", err)
+	}
+	return hash.String()
+}
+
 func (r *TestRepo) commitPaths(msg string, paths ...string) string {
 	r.t.Helper()
 
@@ -285,12 +347,86 @@ func (r *TestRepo) commitPaths(msg string, paths ...string) string {
 		}
 	}
 	hash, err := wt.Commit(msg, &gogit.CommitOptions{
-		Author: &object.Signature{Name: GitUserName, Email: GitUserEmail, When: time.Now()},
+		Author: testSignature(),
 	})
 	if err != nil {
 		r.t.Fatalf("commit: %v", err)
 	}
 	return hash.String()
+}
+
+func testSignature() *object.Signature {
+	return &object.Signature{Name: GitUserName, Email: GitUserEmail, When: time.Now()}
+}
+
+func headSHA(dir string) (string, error) {
+	info, err := os.Stat(filepath.Join(dir, ".git"))
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%s is not a plain .git directory", filepath.Join(dir, ".git"))
+	}
+	repo, err := gogit.PlainOpen(dir)
+	if err != nil {
+		return "", err
+	}
+	head, err := repo.Head()
+	if err != nil {
+		return "", err
+	}
+	return head.Hash().String(), nil
+}
+
+// CheckoutNewBranch creates and checks out branch at the current HEAD or the
+// optional starting SHA, without spawning a git process.
+func (r *TestRepo) CheckoutNewBranch(branch string, start ...string) {
+	r.t.Helper()
+	if len(start) > 1 {
+		r.t.Fatalf("CheckoutNewBranch accepts at most one start ref")
+	}
+	repo, err := gogit.PlainOpen(r.Root)
+	if err != nil {
+		r.t.Fatalf("open repo %q: %v", r.Root, err)
+	}
+	hash := plumbing.ZeroHash
+	if len(start) == 1 {
+		hash = plumbing.NewHash(start[0])
+	} else {
+		head, err := repo.Head()
+		if err != nil {
+			r.t.Fatalf("read HEAD: %v", err)
+		}
+		hash = head.Hash()
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		r.t.Fatalf("worktree: %v", err)
+	}
+	err = wt.Checkout(&gogit.CheckoutOptions{
+		Branch: plumbing.NewBranchReferenceName(branch),
+		Create: true,
+		Hash:   hash,
+	})
+	if err != nil {
+		r.t.Fatalf("checkout new branch %q: %v", branch, err)
+	}
+}
+
+// SetRef writes a hash ref directly.
+func (r *TestRepo) SetRef(ref, sha string) {
+	r.t.Helper()
+	repo, err := gogit.PlainOpen(r.Root)
+	if err != nil {
+		r.t.Fatalf("open repo %q: %v", r.Root, err)
+	}
+	err = repo.Storer.SetReference(plumbing.NewHashReference(
+		plumbing.ReferenceName(ref),
+		plumbing.NewHash(sha),
+	))
+	if err != nil {
+		r.t.Fatalf("set ref %q: %v", ref, err)
+	}
 }
 
 // Config sets a git config value.
@@ -370,5 +506,8 @@ func InitTestGitRepo(t *testing.T, dir string) *TestRepo {
 // GetHeadSHA returns the HEAD commit SHA for the git repo at dir.
 func GetHeadSHA(t *testing.T, dir string) string {
 	t.Helper()
+	if sha, err := headSHA(dir); err == nil {
+		return sha
+	}
 	return runGit(t, dir, nil, "rev-parse", "HEAD")
 }


### PR DESCRIPTION
Reduces Windows test wall time by removing avoidable filesystem and git work from test fixtures while preserving the behavior those tests cover.

The changes focus on replacing duplicate subprocess-heavy git fixture setup with in-process helpers, reusing isolated fixtures where tests do not require fresh repositories, trimming daemon handler-test log I/O, and avoiding unnecessary worker/worktree setup in tests that are asserting higher-level behavior.

Most production-adjacent changes are small fixture enablers or no-op cleanup improvements, such as allowing daemon tests to inject in-memory logs and avoiding worker-pool shutdown logging/waiting when the pool was never started. The intent is to keep runtime behavior unchanged while making the Windows CI path spend less time on setup and teardown.