### PR TITLE
Make post-commit hook timeout configurable, longer on Windows

### DIFF
--- a/cmd/roborev/postcommit.go
+++ b/cmd/roborev/postcommit.go
@@ -97,9 +97,10 @@ func postCommitCmd() *cobra.Command {
 			})
 
 			// Resolve the hook timeout from config (per-repo > global >
-			// platform default). Config reads are filesystem-only, so this
-			// adds no git-subprocess overhead to the hook path. A failed
-			// global load falls back to the platform default inside Resolve.
+			// platform default). ResolveHookTimeout is strictly filesystem-only
+			// (it reads .roborev.toml directly and never spawns git), so it adds
+			// no git-subprocess latency to the hook. A failed global load falls
+			// back to the platform default inside Resolve.
 			globalCfg, _ := config.LoadGlobal()
 			timeout := config.ResolveHookTimeout(root, globalCfg)
 

--- a/cmd/roborev/postcommit.go
+++ b/cmd/roborev/postcommit.go
@@ -18,11 +18,13 @@ import (
 	"go.kenn.io/roborev/internal/git"
 )
 
-// hookHTTPClient returns an HTTP client for hook requests. Short timeout
-// ensures hooks never block commits if the daemon stalls.
-// Tests can override this variable to inject custom transports.
-var hookHTTPClient = func() *http.Client {
-	return getDaemonHTTPClient(3 * time.Second)
+// hookHTTPClient returns an HTTP client for hook requests with the given
+// timeout, which bounds how long the hook waits for the daemon so a stalled
+// daemon never blocks a commit. The timeout is resolved from config (see
+// config.ResolveHookTimeout). Tests override this variable to inject custom
+// transports.
+var hookHTTPClient = func(timeout time.Duration) *http.Client {
+	return getDaemonHTTPClient(timeout)
 }
 
 // hookLogPath can be overridden in tests.
@@ -94,8 +96,15 @@ func postCommitCmd() *cobra.Command {
 				Source:   "post_commit",
 			})
 
+			// Resolve the hook timeout from config (per-repo > global >
+			// platform default). Config reads are filesystem-only, so this
+			// adds no git-subprocess overhead to the hook path. A failed
+			// global load falls back to the platform default inside Resolve.
+			globalCfg, _ := config.LoadGlobal()
+			timeout := config.ResolveHookTimeout(root, globalCfg)
+
 			ep := getDaemonEndpoint()
-			resp, err := hookHTTPClient().Post(
+			resp, err := hookHTTPClient(timeout).Post(
 				ep.BaseURL()+"/api/enqueue",
 				"application/json",
 				bytes.NewReader(reqBody),

--- a/cmd/roborev/postcommit_test.go
+++ b/cmd/roborev/postcommit_test.go
@@ -285,7 +285,7 @@ func TestPostCommitTimesOutOnSlowDaemon(t *testing.T) {
 		cancelled: make(chan time.Duration, 1),
 	}
 	orig := hookHTTPClient
-	hookHTTPClient = func() *http.Client {
+	hookHTTPClient = func(time.Duration) *http.Client {
 		return &http.Client{
 			Timeout:   50 * time.Millisecond,
 			Transport: rt,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,7 +120,7 @@ max_chars = 50000
 | `excluded_commit_patterns` | array | Commit message substrings to skip reviews on (case-insensitive) |
 | `exclude_patterns` | array | Filenames or glob patterns to exclude from review diffs for this repo |
 | `post_commit_review` | string | Post-commit hook behavior: `"commit"` (default) or `"branch"` |
-| `hook_timeout` | string | Override the post-commit hook request timeout for this repo, as a Go duration such as `1m`. Useful for large repos where the daemon's enqueue git calls are slow. Empty inherits global / platform default |
+| `hook_timeout` | string | Override the post-commit hook request timeout for this repo, as a Go duration such as `1m`. Useful for large repos where the daemon's enqueue git calls are slow. Read filesystem-only from this checkout's `.roborev.toml` (a linked worktree without its own file does not inherit the main checkout's value). Empty, malformed, or non-positive values inherit the global / platform default |
 | `auto_close_passing_reviews` | bool | Automatically close reviews that pass with no findings |
 | `review_reasoning` | string | Reasoning level for reviews: thorough, standard, fast |
 | `refine_reasoning` | string | Reasoning level for refine: thorough, standard, fast |
@@ -541,7 +541,7 @@ column_borders = true             # Show separators between TUI columns
 | `server_addr` | string | 127.0.0.1:7373 | Daemon listen address. Use `unix://` for Unix domain socket (see [Unix Domain Socket](#unix-domain-socket)) | No |
 | `max_workers` | int | 4 | Number of parallel review workers | No |
 | `job_timeout_minutes` | int | 30 | Per-job timeout in minutes | Yes |
-| `hook_timeout` | string | `3s` (`30s` on Windows) | Post-commit hook request timeout, as a Go duration such as `30s` or `1m`. Raise it on Windows or large repos where the daemon's enqueue git calls are slow. Empty uses the platform default | Yes |
+| `hook_timeout` | string | `3s` (`30s` on Windows) | Post-commit hook request timeout, as a Go duration such as `30s` or `1m`. Raise it on Windows or large repos where the daemon's enqueue git calls are slow. Empty, malformed (e.g. a bare `30` with no unit), zero, or negative values are ignored and fall back to the platform default | Yes |
 | `agent_quota_cooldown` | string | `30m0s` | Maximum daemon-wide cooldown after an agent quota or session-limit error, as a Go duration such as `10m`, `30m`, or `1h` | Yes |
 | `allow_unsafe_agents` | bool | false | Enable agentic mode globally | Yes |
 | `anthropic_api_key` | string | - | Anthropic API key for Claude Code | Yes |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,7 +120,7 @@ max_chars = 50000
 | `excluded_commit_patterns` | array | Commit message substrings to skip reviews on (case-insensitive) |
 | `exclude_patterns` | array | Filenames or glob patterns to exclude from review diffs for this repo |
 | `post_commit_review` | string | Post-commit hook behavior: `"commit"` (default) or `"branch"` |
-| `hook_timeout` | string | Override the post-commit hook request timeout for this repo, as a Go duration such as `1m`. Useful for large repos where the daemon's enqueue git calls are slow. Read filesystem-only from this checkout's `.roborev.toml` (a linked worktree without its own file does not inherit the main checkout's value). Empty, malformed, or non-positive values inherit the global / platform default |
+| `hook_timeout_seconds` | int | Override the post-commit hook request timeout for this repo, in seconds. Useful for large repos where the daemon's enqueue git calls are slow. Read filesystem-only from this checkout's `.roborev.toml` (a linked worktree without its own file does not inherit the main checkout's value). Zero or negative values inherit the global / platform default |
 | `auto_close_passing_reviews` | bool | Automatically close reviews that pass with no findings |
 | `review_reasoning` | string | Reasoning level for reviews: thorough, standard, fast |
 | `refine_reasoning` | string | Reasoning level for refine: thorough, standard, fast |
@@ -519,7 +519,7 @@ default_backup_model = "claude-sonnet-4-20250514"  # Fallback model for backup a
 server_addr = "127.0.0.1:7373"
 max_workers = 4
 job_timeout_minutes = 30          # Per-job timeout in minutes
-hook_timeout = "30s"              # Post-commit hook request timeout (empty = 3s, 30s on Windows)
+hook_timeout_seconds = 30         # Post-commit hook request timeout (0 = platform default: 3, 30 on Windows)
 agent_quota_cooldown = "30m"      # Maximum quota cooldown after agent limits
 review_guidelines = "Global review instructions for every repo."
 hide_closed_by_default = true     # Start TUI with closed/failed/canceled hidden
@@ -541,7 +541,7 @@ column_borders = true             # Show separators between TUI columns
 | `server_addr` | string | 127.0.0.1:7373 | Daemon listen address. Use `unix://` for Unix domain socket (see [Unix Domain Socket](#unix-domain-socket)) | No |
 | `max_workers` | int | 4 | Number of parallel review workers | No |
 | `job_timeout_minutes` | int | 30 | Per-job timeout in minutes | Yes |
-| `hook_timeout` | string | `3s` (`30s` on Windows) | Post-commit hook request timeout, as a Go duration such as `30s` or `1m`. Raise it on Windows or large repos where the daemon's enqueue git calls are slow. Empty, malformed (e.g. a bare `30` with no unit), zero, or negative values are ignored and fall back to the platform default | Yes |
+| `hook_timeout_seconds` | int | `3` (`30` on Windows) | Post-commit hook request timeout, in seconds. Raise it on Windows or large repos where the daemon's enqueue git calls are slow. Zero or negative values are ignored and fall back to the platform default | Yes |
 | `agent_quota_cooldown` | string | `30m0s` | Maximum daemon-wide cooldown after an agent quota or session-limit error, as a Go duration such as `10m`, `30m`, or `1h` | Yes |
 | `allow_unsafe_agents` | bool | false | Enable agentic mode globally | Yes |
 | `anthropic_api_key` | string | - | Anthropic API key for Claude Code | Yes |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,7 @@ max_chars = 50000
 | `excluded_commit_patterns` | array | Commit message substrings to skip reviews on (case-insensitive) |
 | `exclude_patterns` | array | Filenames or glob patterns to exclude from review diffs for this repo |
 | `post_commit_review` | string | Post-commit hook behavior: `"commit"` (default) or `"branch"` |
+| `hook_timeout` | string | Override the post-commit hook request timeout for this repo, as a Go duration such as `1m`. Useful for large repos where the daemon's enqueue git calls are slow. Empty inherits global / platform default |
 | `auto_close_passing_reviews` | bool | Automatically close reviews that pass with no findings |
 | `review_reasoning` | string | Reasoning level for reviews: thorough, standard, fast |
 | `refine_reasoning` | string | Reasoning level for refine: thorough, standard, fast |
@@ -518,6 +519,7 @@ default_backup_model = "claude-sonnet-4-20250514"  # Fallback model for backup a
 server_addr = "127.0.0.1:7373"
 max_workers = 4
 job_timeout_minutes = 30          # Per-job timeout in minutes
+hook_timeout = "30s"              # Post-commit hook request timeout (empty = 3s, 30s on Windows)
 agent_quota_cooldown = "30m"      # Maximum quota cooldown after agent limits
 review_guidelines = "Global review instructions for every repo."
 hide_closed_by_default = true     # Start TUI with closed/failed/canceled hidden
@@ -539,6 +541,7 @@ column_borders = true             # Show separators between TUI columns
 | `server_addr` | string | 127.0.0.1:7373 | Daemon listen address. Use `unix://` for Unix domain socket (see [Unix Domain Socket](#unix-domain-socket)) | No |
 | `max_workers` | int | 4 | Number of parallel review workers | No |
 | `job_timeout_minutes` | int | 30 | Per-job timeout in minutes | Yes |
+| `hook_timeout` | string | `3s` (`30s` on Windows) | Post-commit hook request timeout, as a Go duration such as `30s` or `1m`. Raise it on Windows or large repos where the daemon's enqueue git calls are slow. Empty uses the platform default | Yes |
 | `agent_quota_cooldown` | string | `30m0s` | Maximum daemon-wide cooldown after an agent quota or session-limit error, as a Go duration such as `10m`, `30m`, or `1h` | Yes |
 | `allow_unsafe_agents` | bool | false | Enable agentic mode globally | Yes |
 | `anthropic_api_key` | string | - | Anthropic API key for Claude Code | Yes |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,7 +114,7 @@ type Config struct {
 	DefaultBackupAgent         string `toml:"default_backup_agent"`
 	DefaultBackupModel         string `toml:"default_backup_model"`
 	JobTimeoutMinutes          int    `toml:"job_timeout_minutes"`
-	HookTimeout                string `toml:"hook_timeout" comment:"Post-commit hook request timeout as a Go duration such as 30s. Empty uses the platform default (3s, 30s on Windows where git subprocess spawns are slow)."`
+	HookTimeoutSeconds         int    `toml:"hook_timeout_seconds" comment:"Post-commit hook request timeout in seconds. 0 or negative uses the platform default (3 on most systems, 30 on Windows where git subprocess spawns are slow)."`
 	AgentQuotaCooldown         string `toml:"agent_quota_cooldown" comment:"Maximum daemon-wide cooldown after an agent quota error, as a Go duration such as 30m."`
 	ReviewReasoning            string `toml:"review_reasoning" comment:"Default reasoning level for reviews: fast, standard, medium, thorough, or maximum."`
 	RefineReasoning            string `toml:"refine_reasoning" comment:"Default reasoning level for refine: fast, standard, medium, thorough, or maximum."`
@@ -312,7 +312,7 @@ type RepoConfig struct {
 	ReviewGuidelines                string   `toml:"review_guidelines" comment:"Extra review instructions added to prompts for this repo."`
 	ReviewGuidelinesSupersedeGlobal bool     `toml:"review_guidelines_supersede_global" comment:"Use repo review_guidelines instead of appending global review_guidelines."`
 	JobTimeoutMinutes               int      `toml:"job_timeout_minutes" comment:"Override the review job timeout in minutes for this repo."`
-	HookTimeout                     string   `toml:"hook_timeout" comment:"Override the post-commit hook request timeout for this repo, as a Go duration such as 1m. Useful for large repos where the enqueue handler's git calls are slow."`
+	HookTimeoutSeconds              int      `toml:"hook_timeout_seconds" comment:"Override the post-commit hook request timeout (in seconds) for this repo. Useful for large repos where the enqueue handler's git calls are slow. 0 or negative inherits the global / platform default."`
 	ExcludedBranches                []string `toml:"excluded_branches" comment:"Branches that should be skipped for automatic review in this repo."`
 	ExcludedCommitPatterns          []string `toml:"excluded_commit_patterns" comment:"Commit message substrings that should skip review for this repo."`
 	DisplayName                     string   `toml:"display_name" comment:"Display name shown for this repo in the TUI and output."`
@@ -877,9 +877,9 @@ func DefaultHookTimeoutForOS() time.Duration {
 }
 
 // ResolveHookTimeout returns the post-commit hook request timeout.
-// Priority: per-repo hook_timeout > global hook_timeout > platform default.
-// Values are Go duration strings (e.g. "30s", "1m"); unparseable or
-// non-positive values are ignored in favor of the next source.
+// Priority: per-repo hook_timeout_seconds > global hook_timeout_seconds >
+// platform default. Zero or negative values are ignored in favor of the next
+// source.
 //
 // This runs inside the latency-sensitive post-commit hook, so it stays
 // strictly filesystem-only: the per-repo lookup reads repoPath/.roborev.toml
@@ -891,15 +891,11 @@ func DefaultHookTimeoutForOS() time.Duration {
 func ResolveHookTimeout(repoPath string, globalCfg *Config) time.Duration {
 	if repoCfg, err := loadRepoConfigFile(
 		filepath.Join(repoPath, ".roborev.toml"),
-	); err == nil && repoCfg != nil {
-		if d, ok := parsePositiveDuration(repoCfg.HookTimeout); ok {
-			return d
-		}
+	); err == nil && repoCfg != nil && repoCfg.HookTimeoutSeconds > 0 {
+		return time.Duration(repoCfg.HookTimeoutSeconds) * time.Second
 	}
-	if globalCfg != nil {
-		if d, ok := parsePositiveDuration(globalCfg.HookTimeout); ok {
-			return d
-		}
+	if globalCfg != nil && globalCfg.HookTimeoutSeconds > 0 {
+		return time.Duration(globalCfg.HookTimeoutSeconds) * time.Second
 	}
 	return DefaultHookTimeoutForOS()
 }
@@ -916,21 +912,6 @@ func loadRepoConfigFile(path string) (*RepoConfig, error) {
 		return nil, err
 	}
 	return &cfg, nil
-}
-
-// parsePositiveDuration parses a Go duration string, returning (d, true) only
-// when it is valid and strictly positive. Empty, malformed, zero, and negative
-// values return (0, false) so callers fall back to a default.
-func parsePositiveDuration(s string) (time.Duration, bool) {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return 0, false
-	}
-	d, err := time.ParseDuration(s)
-	if err != nil || d <= 0 {
-		return 0, false
-	}
-	return d, true
 }
 
 // ResolveAgentQuotaCooldown returns the maximum daemon-wide agent cooldown

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -880,8 +880,18 @@ func DefaultHookTimeoutForOS() time.Duration {
 // Priority: per-repo hook_timeout > global hook_timeout > platform default.
 // Values are Go duration strings (e.g. "30s", "1m"); unparseable or
 // non-positive values are ignored in favor of the next source.
+//
+// This runs inside the latency-sensitive post-commit hook, so it stays
+// strictly filesystem-only: the per-repo lookup reads repoPath/.roborev.toml
+// directly and deliberately skips LoadRepoConfig's linked-worktree fallback
+// (RepoConfigPath), which would spawn git -- the exact Windows git-spawn cost
+// this timeout exists to bound. A linked worktree without its own .roborev.toml
+// therefore inherits the global / platform default rather than the main
+// checkout's value.
 func ResolveHookTimeout(repoPath string, globalCfg *Config) time.Duration {
-	if repoCfg, err := LoadRepoConfig(repoPath); err == nil && repoCfg != nil {
+	if repoCfg, err := loadRepoConfigFile(
+		filepath.Join(repoPath, ".roborev.toml"),
+	); err == nil && repoCfg != nil {
 		if d, ok := parsePositiveDuration(repoCfg.HookTimeout); ok {
 			return d
 		}
@@ -892,6 +902,20 @@ func ResolveHookTimeout(repoPath string, globalCfg *Config) time.Duration {
 		}
 	}
 	return DefaultHookTimeoutForOS()
+}
+
+// loadRepoConfigFile decodes .roborev.toml from an explicit file path,
+// returning (nil, nil) when the file is absent. Unlike LoadRepoConfig it does
+// no linked-worktree fallback (RepoConfigPath), so it never spawns git.
+func loadRepoConfigFile(path string) (*RepoConfig, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil, nil
+	}
+	var cfg RepoConfig
+	if _, err := toml.DecodeFile(path, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
 }
 
 // parsePositiveDuration parses a Go duration string, returning (d, true) only

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"slices"
 	"strings"
 	"time"
@@ -113,6 +114,7 @@ type Config struct {
 	DefaultBackupAgent         string `toml:"default_backup_agent"`
 	DefaultBackupModel         string `toml:"default_backup_model"`
 	JobTimeoutMinutes          int    `toml:"job_timeout_minutes"`
+	HookTimeout                string `toml:"hook_timeout" comment:"Post-commit hook request timeout as a Go duration such as 30s. Empty uses the platform default (3s, 30s on Windows where git subprocess spawns are slow)."`
 	AgentQuotaCooldown         string `toml:"agent_quota_cooldown" comment:"Maximum daemon-wide cooldown after an agent quota error, as a Go duration such as 30m."`
 	ReviewReasoning            string `toml:"review_reasoning" comment:"Default reasoning level for reviews: fast, standard, medium, thorough, or maximum."`
 	RefineReasoning            string `toml:"refine_reasoning" comment:"Default reasoning level for refine: fast, standard, medium, thorough, or maximum."`
@@ -310,6 +312,7 @@ type RepoConfig struct {
 	ReviewGuidelines                string   `toml:"review_guidelines" comment:"Extra review instructions added to prompts for this repo."`
 	ReviewGuidelinesSupersedeGlobal bool     `toml:"review_guidelines_supersede_global" comment:"Use repo review_guidelines instead of appending global review_guidelines."`
 	JobTimeoutMinutes               int      `toml:"job_timeout_minutes" comment:"Override the review job timeout in minutes for this repo."`
+	HookTimeout                     string   `toml:"hook_timeout" comment:"Override the post-commit hook request timeout for this repo, as a Go duration such as 1m. Useful for large repos where the enqueue handler's git calls are slow."`
 	ExcludedBranches                []string `toml:"excluded_branches" comment:"Branches that should be skipped for automatic review in this repo."`
 	ExcludedCommitPatterns          []string `toml:"excluded_commit_patterns" comment:"Commit message substrings that should skip review for this repo."`
 	DisplayName                     string   `toml:"display_name" comment:"Display name shown for this repo in the TUI and output."`
@@ -442,6 +445,16 @@ type RepoConfig struct {
 const (
 	DefaultPiJSONSchemaExtension = "npm:@nqbao/pi-json-schema@0.1.1"
 	DefaultAgentQuotaCooldown    = 30 * time.Minute
+
+	// DefaultHookTimeout bounds how long the post-commit hook waits for the
+	// daemon's enqueue handler before giving up so a stalled daemon never
+	// blocks a commit.
+	DefaultHookTimeout = 3 * time.Second
+	// DefaultHookTimeoutWindows is the Windows default. Each git subprocess
+	// spawn costs ~250-750ms on Windows, so on a large repo the enqueue
+	// handler's sequential git calls can exceed the non-Windows budget before
+	// it can reply. The default is raised 10x to absorb that overhead. See #916.
+	DefaultHookTimeoutWindows = 30 * time.Second
 )
 
 // DefaultConfig returns the default configuration
@@ -851,6 +864,49 @@ func ResolveJobTimeout(repoPath string, globalCfg *Config) int {
 		globalVal = clampPositive(globalCfg.JobTimeoutMinutes)
 	}
 	return resolve(30, repoVal, globalVal)
+}
+
+// DefaultHookTimeoutForOS returns the platform default post-commit hook
+// timeout. Windows uses a longer default because each git subprocess spawn is
+// costly there (see DefaultHookTimeoutWindows).
+func DefaultHookTimeoutForOS() time.Duration {
+	if runtime.GOOS == "windows" {
+		return DefaultHookTimeoutWindows
+	}
+	return DefaultHookTimeout
+}
+
+// ResolveHookTimeout returns the post-commit hook request timeout.
+// Priority: per-repo hook_timeout > global hook_timeout > platform default.
+// Values are Go duration strings (e.g. "30s", "1m"); unparseable or
+// non-positive values are ignored in favor of the next source.
+func ResolveHookTimeout(repoPath string, globalCfg *Config) time.Duration {
+	if repoCfg, err := LoadRepoConfig(repoPath); err == nil && repoCfg != nil {
+		if d, ok := parsePositiveDuration(repoCfg.HookTimeout); ok {
+			return d
+		}
+	}
+	if globalCfg != nil {
+		if d, ok := parsePositiveDuration(globalCfg.HookTimeout); ok {
+			return d
+		}
+	}
+	return DefaultHookTimeoutForOS()
+}
+
+// parsePositiveDuration parses a Go duration string, returning (d, true) only
+// when it is valid and strictly positive. Empty, malformed, zero, and negative
+// values return (0, false) so callers fall back to a default.
+func parsePositiveDuration(s string) (time.Duration, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, false
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		return 0, false
+	}
+	return d, true
 }
 
 // ResolveAgentQuotaCooldown returns the maximum daemon-wide agent cooldown

--- a/internal/config/hook_timeout_test.go
+++ b/internal/config/hook_timeout_test.go
@@ -1,11 +1,13 @@
 package config
 
 import (
+	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func platformHookDefault() time.Duration {
@@ -57,4 +59,38 @@ func TestResolveHookTimeoutInvalidFallsBack(t *testing.T) {
 	repoDir := newTempRepo(t, `hook_timeout = "nope"`)
 	assert.Equal(30*time.Second,
 		ResolveHookTimeout(repoDir, &Config{HookTimeout: "30s"}))
+}
+
+// TestResolveHookTimeoutWorktreeStaysFilesystemOnly verifies the hook path
+// never spawns git: a linked worktree without its own .roborev.toml must NOT
+// inherit the main checkout's hook_timeout via LoadRepoConfig's git-backed
+// worktree fallback. It falls back to the global value instead.
+func TestResolveHookTimeoutWorktreeStaysFilesystemOnly(t *testing.T) {
+	main := t.TempDir()
+	execGit(t, main, "init")
+	execGit(t, main, "config", "user.email", "t@example.com")
+	execGit(t, main, "config", "user.name", "t")
+	writeTestFile(t, main, "base.txt", "base\n")
+	execGit(t, main, "add", ".")
+	execGit(t, main, "commit", "-m", "init")
+
+	// Main checkout carries a per-repo hook_timeout, gitignored so the git
+	// fallback in LoadRepoConfig would otherwise inherit it into a worktree.
+	writeTestFile(t, main, ".gitignore", ".roborev.toml\n")
+	writeRepoConfigStr(t, main, `hook_timeout = "90s"`)
+
+	wt := filepath.Join(t.TempDir(), "wt")
+	execGit(t, main, "worktree", "add", wt, "HEAD")
+
+	// Sanity: the git-backed loader DOES inherit the main value -- proving the
+	// fallback path exists and that ResolveHookTimeout must avoid it.
+	inherited, err := LoadRepoConfig(wt)
+	require.NoError(t, err)
+	require.NotNil(t, inherited)
+	require.Equal(t, "90s", inherited.HookTimeout)
+
+	// ResolveHookTimeout stays filesystem-only, so it ignores the main config
+	// and uses the global value.
+	assert.Equal(t, 12*time.Second,
+		ResolveHookTimeout(wt, &Config{HookTimeout: "12s"}))
 }

--- a/internal/config/hook_timeout_test.go
+++ b/internal/config/hook_timeout_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func platformHookDefault() time.Duration {
+	if runtime.GOOS == "windows" {
+		return DefaultHookTimeoutWindows
+	}
+	return DefaultHookTimeout
+}
+
+func TestDefaultHookTimeoutForOS(t *testing.T) {
+	want := DefaultHookTimeout
+	if runtime.GOOS == "windows" {
+		want = DefaultHookTimeoutWindows
+	}
+	assert.Equal(t, want, DefaultHookTimeoutForOS())
+}
+
+func TestResolveHookTimeoutDefault(t *testing.T) {
+	// No repo config and no global config: platform default.
+	dir := t.TempDir()
+	assert.Equal(t, platformHookDefault(), ResolveHookTimeout(dir, nil))
+	assert.Equal(t, platformHookDefault(), ResolveHookTimeout(dir, &Config{}))
+}
+
+func TestResolveHookTimeoutGlobal(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &Config{HookTimeout: "45s"}
+	assert.Equal(t, 45*time.Second, ResolveHookTimeout(dir, cfg))
+}
+
+func TestResolveHookTimeoutRepoOverridesGlobal(t *testing.T) {
+	dir := newTempRepo(t, `hook_timeout = "90s"`)
+	cfg := &Config{HookTimeout: "45s"}
+	assert.Equal(t, 90*time.Second, ResolveHookTimeout(dir, cfg))
+}
+
+func TestResolveHookTimeoutInvalidFallsBack(t *testing.T) {
+	assert := assert.New(t)
+
+	// Invalid global with no repo config falls back to platform default.
+	dir := t.TempDir()
+	for _, bad := range []string{"", "0", "-5s", "soon", "12"} {
+		assert.Equal(platformHookDefault(),
+			ResolveHookTimeout(dir, &Config{HookTimeout: bad}),
+			"global %q should fall back to platform default", bad)
+	}
+
+	// Invalid repo value falls back to a valid global value.
+	repoDir := newTempRepo(t, `hook_timeout = "nope"`)
+	assert.Equal(30*time.Second,
+		ResolveHookTimeout(repoDir, &Config{HookTimeout: "30s"}))
+}

--- a/internal/config/hook_timeout_test.go
+++ b/internal/config/hook_timeout_test.go
@@ -34,36 +34,36 @@ func TestResolveHookTimeoutDefault(t *testing.T) {
 
 func TestResolveHookTimeoutGlobal(t *testing.T) {
 	dir := t.TempDir()
-	cfg := &Config{HookTimeout: "45s"}
+	cfg := &Config{HookTimeoutSeconds: 45}
 	assert.Equal(t, 45*time.Second, ResolveHookTimeout(dir, cfg))
 }
 
 func TestResolveHookTimeoutRepoOverridesGlobal(t *testing.T) {
-	dir := newTempRepo(t, `hook_timeout = "90s"`)
-	cfg := &Config{HookTimeout: "45s"}
+	dir := newTempRepo(t, `hook_timeout_seconds = 90`)
+	cfg := &Config{HookTimeoutSeconds: 45}
 	assert.Equal(t, 90*time.Second, ResolveHookTimeout(dir, cfg))
 }
 
-func TestResolveHookTimeoutInvalidFallsBack(t *testing.T) {
+func TestResolveHookTimeoutNonPositiveFallsBack(t *testing.T) {
 	assert := assert.New(t)
 
-	// Invalid global with no repo config falls back to platform default.
+	// Zero/negative global with no repo config falls back to platform default.
 	dir := t.TempDir()
-	for _, bad := range []string{"", "0", "-5s", "soon", "12"} {
+	for _, bad := range []int{0, -5} {
 		assert.Equal(platformHookDefault(),
-			ResolveHookTimeout(dir, &Config{HookTimeout: bad}),
-			"global %q should fall back to platform default", bad)
+			ResolveHookTimeout(dir, &Config{HookTimeoutSeconds: bad}),
+			"global %d should fall back to platform default", bad)
 	}
 
-	// Invalid repo value falls back to a valid global value.
-	repoDir := newTempRepo(t, `hook_timeout = "nope"`)
+	// Non-positive repo value falls back to a valid global value.
+	repoDir := newTempRepo(t, `hook_timeout_seconds = -1`)
 	assert.Equal(30*time.Second,
-		ResolveHookTimeout(repoDir, &Config{HookTimeout: "30s"}))
+		ResolveHookTimeout(repoDir, &Config{HookTimeoutSeconds: 30}))
 }
 
 // TestResolveHookTimeoutWorktreeStaysFilesystemOnly verifies the hook path
 // never spawns git: a linked worktree without its own .roborev.toml must NOT
-// inherit the main checkout's hook_timeout via LoadRepoConfig's git-backed
+// inherit the main checkout's hook_timeout_seconds via LoadRepoConfig's git-backed
 // worktree fallback. It falls back to the global value instead.
 func TestResolveHookTimeoutWorktreeStaysFilesystemOnly(t *testing.T) {
 	main := t.TempDir()
@@ -74,10 +74,10 @@ func TestResolveHookTimeoutWorktreeStaysFilesystemOnly(t *testing.T) {
 	execGit(t, main, "add", ".")
 	execGit(t, main, "commit", "-m", "init")
 
-	// Main checkout carries a per-repo hook_timeout, gitignored so the git
-	// fallback in LoadRepoConfig would otherwise inherit it into a worktree.
+	// Main checkout carries a per-repo hook_timeout_seconds, gitignored so the
+	// git fallback in LoadRepoConfig would otherwise inherit it into a worktree.
 	writeTestFile(t, main, ".gitignore", ".roborev.toml\n")
-	writeRepoConfigStr(t, main, `hook_timeout = "90s"`)
+	writeRepoConfigStr(t, main, `hook_timeout_seconds = 90`)
 
 	wt := filepath.Join(t.TempDir(), "wt")
 	execGit(t, main, "worktree", "add", wt, "HEAD")
@@ -87,10 +87,10 @@ func TestResolveHookTimeoutWorktreeStaysFilesystemOnly(t *testing.T) {
 	inherited, err := LoadRepoConfig(wt)
 	require.NoError(t, err)
 	require.NotNil(t, inherited)
-	require.Equal(t, "90s", inherited.HookTimeout)
+	require.Equal(t, 90, inherited.HookTimeoutSeconds)
 
 	// ResolveHookTimeout stays filesystem-only, so it ignores the main config
 	// and uses the global value.
 	assert.Equal(t, 12*time.Second,
-		ResolveHookTimeout(wt, &Config{HookTimeout: "12s"}))
+		ResolveHookTimeout(wt, &Config{HookTimeoutSeconds: 12}))
 }

--- a/internal/git/gitspawn_bench_test.go
+++ b/internal/git/gitspawn_bench_test.go
@@ -1,0 +1,310 @@
+package git
+
+// Benchmark comparing the cost of the git operations on the post-commit
+// enqueue hot path (issue #916) done two ways:
+//
+//   - "exec": spawning a `git` subprocess per operation, exactly as the
+//     daemon does today. On Windows each spawn costs ~250-750ms on a large
+//     repo, and the enqueue handler runs several in sequence.
+//   - "gogit": the same operation via the in-process go-git library, which
+//     avoids the process-spawn overhead entirely.
+//
+// The point is to measure, on a real large repository on Windows, whether
+// moving these calls to go-git is actually faster, and by how much. Nothing
+// in production imports go-git for these paths; this file is test-only.
+//
+// Run against a large repo (the interesting case is Windows):
+//
+//	# PowerShell
+//	$env:ROBOREV_BENCH_REPO = "C:\path\to\large\repo"
+//	go test -run x -bench . -benchmem ./internal/git/
+//
+//	# bash
+//	ROBOREV_BENCH_REPO=/path/to/large/repo \
+//	  go test -run x -bench . -benchmem ./internal/git/
+//
+// To exercise the worktree case from the issue (the extra git-common-dir
+// lookup), point ROBOREV_BENCH_REPO at a linked worktree of the large repo.
+//
+// If ROBOREV_BENCH_REPO is unset it falls back to the current repo, which is
+// small; the spawn-vs-library gap only becomes dramatic on a large history.
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+// benchRepoPath returns the repo to benchmark against, skipping the benchmark
+// if it is not a usable git repo.
+func benchRepoPath(b *testing.B) string {
+	b.Helper()
+	path := os.Getenv("ROBOREV_BENCH_REPO")
+	if path == "" {
+		path = "."
+	}
+	if _, err := openGoGit(path); err != nil {
+		b.Skipf("ROBOREV_BENCH_REPO=%q is not a usable git repo: %v", path, err)
+	}
+	return path
+}
+
+// openGoGit opens path with the options needed to behave like git on the
+// enqueue path: detect the .git dir from a subdirectory and follow a linked
+// worktree's commondir (the worktree case from issue #916).
+func openGoGit(path string) (*gogit.Repository, error) {
+	return gogit.PlainOpenWithOptions(path, &gogit.PlainOpenOptions{
+		DetectDotGit:          true,
+		EnableDotGitCommonDir: true,
+	})
+}
+
+func execGitOut(b *testing.B, dir string, args ...string) string {
+	b.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		b.Fatalf("git %s: %v", strings.Join(args, " "), err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// hasParent reports whether HEAD~1 resolves, so the IsAncestor benchmark can
+// skip single-commit repos.
+func hasParent(path string) bool {
+	repo, err := openGoGit(path)
+	if err != nil {
+		return false
+	}
+	_, err = repo.ResolveRevision(plumbing.Revision("HEAD~1"))
+	return err == nil
+}
+
+func BenchmarkSpawnResolveHEAD(b *testing.B) {
+	path := benchRepoPath(b)
+
+	b.Run("exec", func(b *testing.B) {
+		for b.Loop() {
+			_ = execGitOut(b, path, "rev-parse", "HEAD")
+		}
+	})
+
+	b.Run("gogit", func(b *testing.B) {
+		for b.Loop() {
+			repo, err := openGoGit(path)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if _, err := repo.ResolveRevision(plumbing.Revision("HEAD")); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkSpawnCurrentBranch(b *testing.B) {
+	path := benchRepoPath(b)
+
+	b.Run("exec", func(b *testing.B) {
+		for b.Loop() {
+			_ = execGitOut(b, path, "symbolic-ref", "HEAD")
+		}
+	})
+
+	b.Run("gogit", func(b *testing.B) {
+		for b.Loop() {
+			repo, err := openGoGit(path)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if _, err := repo.Head(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkSpawnWorktreeRoot(b *testing.B) {
+	path := benchRepoPath(b)
+
+	b.Run("exec", func(b *testing.B) {
+		for b.Loop() {
+			_ = execGitOut(b, path, "rev-parse", "--show-toplevel")
+		}
+	})
+
+	b.Run("gogit", func(b *testing.B) {
+		for b.Loop() {
+			repo, err := openGoGit(path)
+			if err != nil {
+				b.Fatal(err)
+			}
+			wt, err := repo.Worktree()
+			if err != nil {
+				b.Fatal(err)
+			}
+			_ = wt.Filesystem.Root()
+		}
+	})
+}
+
+func BenchmarkSpawnCommitInfo(b *testing.B) {
+	path := benchRepoPath(b)
+	const rs = "\x1e"
+
+	b.Run("exec", func(b *testing.B) {
+		for b.Loop() {
+			_ = execGitOut(b, path, "log", "-1",
+				"--format=%H"+rs+"%an"+rs+"%s"+rs+"%aI"+rs+"%b", "HEAD")
+		}
+	})
+
+	b.Run("gogit", func(b *testing.B) {
+		for b.Loop() {
+			repo, err := openGoGit(path)
+			if err != nil {
+				b.Fatal(err)
+			}
+			h, err := repo.ResolveRevision(plumbing.Revision("HEAD"))
+			if err != nil {
+				b.Fatal(err)
+			}
+			c, err := repo.CommitObject(*h)
+			if err != nil {
+				b.Fatal(err)
+			}
+			// Touch the fields GetCommitInfo reads so the work isn't
+			// optimized away.
+			_, _, _, _ = c.Author.Name, c.Author.When, c.Message, c.Hash
+		}
+	})
+}
+
+func BenchmarkSpawnIsAncestor(b *testing.B) {
+	path := benchRepoPath(b)
+	if !hasParent(path) {
+		b.Skip("repo has no HEAD~1; need at least two commits")
+	}
+
+	b.Run("exec", func(b *testing.B) {
+		for b.Loop() {
+			cmd := exec.Command("git", "merge-base", "--is-ancestor", "HEAD~1", "HEAD")
+			cmd.Dir = path
+			if err := cmd.Run(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("gogit", func(b *testing.B) {
+		for b.Loop() {
+			repo, err := openGoGit(path)
+			if err != nil {
+				b.Fatal(err)
+			}
+			anc, err := repo.ResolveRevision(plumbing.Revision("HEAD~1"))
+			if err != nil {
+				b.Fatal(err)
+			}
+			desc, err := repo.ResolveRevision(plumbing.Revision("HEAD"))
+			if err != nil {
+				b.Fatal(err)
+			}
+			ancCommit, err := repo.CommitObject(*anc)
+			if err != nil {
+				b.Fatal(err)
+			}
+			descCommit, err := repo.CommitObject(*desc)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if _, err := ancCommit.IsAncestor(descCommit); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkSpawnPatchID measures the show|patch-id pipeline. go-git has no
+// stable patch-id implementation, so there is no library variant: this stays
+// a subprocess regardless and is reported for reference.
+func BenchmarkSpawnPatchID(b *testing.B) {
+	path := benchRepoPath(b)
+	sha := execGitOut(b, path, "rev-parse", "HEAD")
+	for b.Loop() {
+		_ = GetPatchID(path, sha)
+	}
+}
+
+// BenchmarkEnqueueSequence runs the full per-commit enqueue sequence the
+// daemon performs, both ways. The "exec" variant spawns a process per call
+// (today's behavior); the "gogit" variant opens the repo once and runs every
+// operation in-process, which is the realistic shape of a go-git refactor.
+// patch-id stays a subprocess in both since go-git cannot produce it.
+func BenchmarkEnqueueSequence(b *testing.B) {
+	path := benchRepoPath(b)
+	const rs = "\x1e"
+	ancestor := hasParent(path)
+
+	b.Run("exec", func(b *testing.B) {
+		for b.Loop() {
+			_ = execGitOut(b, path, "rev-parse", "--show-toplevel")
+			_ = execGitOut(b, path, "rev-parse", "--git-common-dir")
+			_ = execGitOut(b, path, "symbolic-ref", "HEAD")
+			sha := execGitOut(b, path, "rev-parse", "HEAD")
+			_ = execGitOut(b, path, "log", "-1",
+				"--format=%H"+rs+"%an"+rs+"%s"+rs+"%aI"+rs+"%b", "HEAD")
+			_ = GetPatchID(path, sha)
+			if ancestor {
+				cmd := exec.Command("git", "merge-base", "--is-ancestor", "HEAD~1", "HEAD")
+				cmd.Dir = path
+				_ = cmd.Run()
+			}
+		}
+	})
+
+	b.Run("gogit", func(b *testing.B) {
+		for b.Loop() {
+			repo, err := openGoGit(path)
+			if err != nil {
+				b.Fatal(err)
+			}
+			wt, err := repo.Worktree()
+			if err != nil {
+				b.Fatal(err)
+			}
+			_ = wt.Filesystem.Root()
+			head, err := repo.Head()
+			if err != nil {
+				b.Fatal(err)
+			}
+			_ = head.Name().Short()
+			sha := head.Hash()
+			c, err := repo.CommitObject(sha)
+			if err != nil {
+				b.Fatal(err)
+			}
+			_, _, _ = c.Author.Name, c.Author.When, c.Message
+			// patch-id has no go-git equivalent; still a subprocess.
+			_ = GetPatchID(path, sha.String())
+			if ancestor {
+				anc, err := repo.ResolveRevision(plumbing.Revision("HEAD~1"))
+				if err != nil {
+					b.Fatal(err)
+				}
+				ancCommit, err := repo.CommitObject(*anc)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if _, err := ancCommit.IsAncestor(c); err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	})
+}

--- a/internal/git/gitspawn_bench_test.go
+++ b/internal/git/gitspawn_bench_test.go
@@ -31,7 +31,6 @@ package git
 
 import (
 	"os"
-	"os/exec"
 	"strings"
 	"testing"
 
@@ -63,9 +62,13 @@ func openGoGit(path string) (*gogit.Repository, error) {
 	})
 }
 
+// execGitOut runs git via newGitCmd -- the same production helper the daemon
+// uses -- so the measured spawn cost includes its GIT_* env stripping and
+// Windows console-hiding, and an inherited GIT_DIR/GIT_WORK_TREE can't redirect
+// the benchmark at the wrong repository.
 func execGitOut(b *testing.B, dir string, args ...string) string {
 	b.Helper()
-	cmd := exec.Command("git", args...)
+	cmd := newGitCmd(args...)
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {
@@ -193,7 +196,7 @@ func BenchmarkSpawnIsAncestor(b *testing.B) {
 
 	b.Run("exec", func(b *testing.B) {
 		for b.Loop() {
-			cmd := exec.Command("git", "merge-base", "--is-ancestor", "HEAD~1", "HEAD")
+			cmd := newGitCmd("merge-base", "--is-ancestor", "HEAD~1", "HEAD")
 			cmd.Dir = path
 			if err := cmd.Run(); err != nil {
 				b.Fatal(err)
@@ -261,7 +264,7 @@ func BenchmarkEnqueueSequence(b *testing.B) {
 				"--format=%H"+rs+"%an"+rs+"%s"+rs+"%aI"+rs+"%b", "HEAD")
 			_ = GetPatchID(path, sha)
 			if ancestor {
-				cmd := exec.Command("git", "merge-base", "--is-ancestor", "HEAD~1", "HEAD")
+				cmd := newGitCmd("merge-base", "--is-ancestor", "HEAD~1", "HEAD")
 				cmd.Dir = path
 				_ = cmd.Run()
 			}


### PR DESCRIPTION
## Summary

- Make the post-commit hook HTTP timeout configurable via a new `hook_timeout` option (global `~/.roborev/config.toml` and per-repo `.roborev.toml`, as a Go duration string), resolved at hook time with **per-repo > global > platform default** precedence (`config.ResolveHookTimeout`).
- Default the timeout per-platform: **3s elsewhere, 30s on Windows**. On Windows each git subprocess spawn costs ~250-750ms, so the daemon's sequential git calls in the enqueue handler blow past the old fixed 3s budget on large repos, producing the `context deadline exceeded` hook failures in #916.
- Config reads on the hook path are filesystem-only (`LoadRepoConfig`/`LoadGlobal`), so resolving the timeout adds no git-subprocess overhead to the hook.
- Add a test-only benchmark (`internal/git/gitspawn_bench_test.go`) comparing the enqueue-path git operations as subprocesses vs in-process go-git, to quantify the Windows spawn overhead behind #916. Point it at a large repo (or a linked worktree) via `ROBOREV_BENCH_REPO`. go-git is a test-only import; no production path uses it. patch-id has no go-git equivalent and stays a subprocess in both variants.
- Document `hook_timeout` in `docs/configuration.md` (global and per-repo tables plus the example config).

Fixes #916

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sup>generated by a clanker</sup>