### PR TITLE
Move enqueue metadata reads to go-git

### DIFF
--- a/internal/daemon/panel_enqueue.go
+++ b/internal/daemon/panel_enqueue.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	gitrepo "go.kenn.io/kit/git/repo"
 
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
@@ -71,6 +70,7 @@ type freezeInputs struct {
 	gitRef            string
 	checkoutRoot      string
 	repoRoot          string
+	metadata          git.EnqueueMetadataReader
 	worktreePath      string
 	normalizedMinSev  string
 	requestedModel    string
@@ -112,6 +112,9 @@ func classifyTarget(customPrompt, gitRef string) targetKind {
 func (s *Server) buildTargetDescriptor(
 	ctx context.Context, in freezeInputs,
 ) (targetDescriptor, *RawJSONOutput) {
+	if in.metadata == nil {
+		in.metadata = git.OpenEnqueueMetadataReader(ctx, in.checkoutRoot)
+	}
 	insightsPrompt, early := s.resolveInsightsPrompt(ctx, in)
 	if early != nil {
 		return targetDescriptor{}, early
@@ -223,10 +226,10 @@ func (s *Server) descriptorForDirty(
 		return targetDescriptor{}, out
 	}
 
-	targetSHA, _ := gitrepo.Resolve(ctx, in.checkoutRoot, "HEAD")
+	targetSHA, _ := in.metadata.Resolve("HEAD")
 	var commitID int64
 	if targetSHA != "" {
-		if info, err := git.GetCommitInfo(in.repoRoot, targetSHA); err == nil {
+		if info, err := in.metadata.CommitInfo(targetSHA); err == nil {
 			if commit, err := s.db.GetOrCreateCommit(
 				in.repo.ID, targetSHA, info.Author, info.Subject, info.Timestamp,
 			); err == nil {
@@ -257,12 +260,10 @@ func (s *Server) descriptorForRange(
 	ctx context.Context, in freezeInputs,
 ) (targetDescriptor, *RawJSONOutput) {
 	parts := strings.SplitN(in.gitRef, "..", 2)
-	startSHA, err := gitrepo.Resolve(ctx, in.checkoutRoot, parts[0])
+	startSHA, err := in.metadata.Resolve(parts[0])
 	if err != nil {
 		if before, ok := strings.CutSuffix(parts[0], "^"); ok {
-			if _, resolveErr := gitrepo.Resolve(
-				ctx, in.checkoutRoot, before+"^{commit}",
-			); resolveErr == nil {
+			if _, resolveErr := in.metadata.Resolve(before + "^{commit}"); resolveErr == nil {
 				startSHA = git.EmptyTreeSHA
 				err = nil
 			}
@@ -273,7 +274,7 @@ func (s *Server) descriptorForRange(
 			return targetDescriptor{}, out
 		}
 	}
-	endSHA, err := gitrepo.Resolve(ctx, in.checkoutRoot, parts[1])
+	endSHA, err := in.metadata.Resolve(parts[1])
 	if err != nil {
 		out, _ := rawJSONOutput(http.StatusBadRequest,
 			ErrorResponse{Error: fmt.Sprintf("invalid end commit: %v", err)})
@@ -281,7 +282,7 @@ func (s *Server) descriptorForRange(
 	}
 
 	fullRef := startSHA + ".." + endSHA
-	if skip := s.rangeExclusionSkip(in.repoRoot, in.checkoutRoot, fullRef); skip != nil {
+	if skip := s.rangeExclusionSkip(in.repoRoot, in.metadata, fullRef); skip != nil {
 		return targetDescriptor{}, skip
 	}
 
@@ -300,14 +301,16 @@ func (s *Server) descriptorForRange(
 // rangeExclusionSkip returns a skip 200 when every commit in the range matches an
 // excluded message pattern, mirroring the single-commit exclusion. It returns nil
 // when the range cannot be fully read or no commits match, so the review proceeds.
-func (s *Server) rangeExclusionSkip(repoRoot, checkoutRoot, fullRef string) *RawJSONOutput {
-	rangeCommits, rcErr := git.GetRangeCommits(checkoutRoot, fullRef)
+func (s *Server) rangeExclusionSkip(
+	repoRoot string, metadata git.EnqueueMetadataReader, fullRef string,
+) *RawJSONOutput {
+	rangeCommits, rcErr := metadata.RangeCommits(fullRef)
 	if rcErr != nil || len(rangeCommits) == 0 {
 		return nil
 	}
 	messages := make([]string, 0, len(rangeCommits))
 	for _, rc := range rangeCommits {
-		ci, ciErr := git.GetCommitInfo(repoRoot, rc)
+		ci, ciErr := metadata.CommitInfo(rc)
 		if ciErr != nil {
 			return nil
 		}
@@ -329,14 +332,14 @@ func (s *Server) rangeExclusionSkip(repoRoot, checkoutRoot, fullRef string) *Raw
 func (s *Server) descriptorForSingleCommit(
 	ctx context.Context, in freezeInputs,
 ) (targetDescriptor, *RawJSONOutput) {
-	sha, err := gitrepo.Resolve(ctx, in.checkoutRoot, in.gitRef)
+	sha, err := in.metadata.Resolve(in.gitRef)
 	if err != nil {
 		out, _ := rawJSONOutput(http.StatusBadRequest,
 			ErrorResponse{Error: fmt.Sprintf("invalid commit: %v", err)})
 		return targetDescriptor{}, out
 	}
 
-	info, err := git.GetCommitInfo(in.repoRoot, sha)
+	info, err := in.metadata.CommitInfo(sha)
 	if err != nil {
 		out, _ := rawJSONOutput(http.StatusBadRequest,
 			ErrorResponse{Error: fmt.Sprintf("get commit info: %v", err)})

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -1863,7 +1863,8 @@ func (s *Server) humaEnqueue(
 	}
 	req.ReviewType = canonical[0]
 
-	checkoutRoot, err := gitrepo.Root(ctx, req.RepoPath)
+	metadata := git.OpenEnqueueMetadataReader(ctx, req.RepoPath)
+	checkoutRoot, err := metadata.Root()
 	if err != nil {
 		return rawJSONOutput(
 			http.StatusBadRequest,
@@ -1884,7 +1885,7 @@ func (s *Server) humaEnqueue(
 		worktreePath = filepath.Clean(checkoutRoot)
 	}
 
-	currentBranch := gitrepo.CurrentBranch(ctx, checkoutRoot)
+	currentBranch := metadata.CurrentBranch()
 	branchToCheck := currentBranch
 	if req.JobType == storage.JobTypeInsights {
 		if req.Branch != "" {
@@ -1977,6 +1978,7 @@ func (s *Server) humaEnqueue(
 		gitRef:            gitRef,
 		checkoutRoot:      checkoutRoot,
 		repoRoot:          repoRoot,
+		metadata:          metadata,
 		worktreePath:      worktreePath,
 		normalizedMinSev:  normalizedMinSev,
 		requestedModel:    requestedModel,

--- a/internal/git/enqueue_metadata.go
+++ b/internal/git/enqueue_metadata.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -35,11 +36,32 @@ var openGoGitRepository = func(path string) (*gogit.Repository, error) {
 // read yet, such as reftable, SHA-256, or partial clones with missing objects.
 func OpenEnqueueMetadataReader(ctx context.Context, repoPath string) EnqueueMetadataReader {
 	fallback := subprocessEnqueueMetadataReader{ctx: ctx, repoPath: repoPath}
+	if hasDotGitFileAncestor(repoPath) {
+		return fallback
+	}
 	repo, err := openGoGitRepository(repoPath)
 	if err != nil {
 		return fallback
 	}
 	return &goGitEnqueueMetadataReader{repo: repo, fallback: fallback}
+}
+
+func hasDotGitFileAncestor(path string) bool {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		abs = path
+	}
+	for {
+		info, err := os.Stat(filepath.Join(abs, ".git"))
+		if err == nil {
+			return !info.IsDir()
+		}
+		parent := filepath.Dir(abs)
+		if parent == abs {
+			return false
+		}
+		abs = parent
+	}
 }
 
 type subprocessEnqueueMetadataReader struct {

--- a/internal/git/enqueue_metadata.go
+++ b/internal/git/enqueue_metadata.go
@@ -1,0 +1,168 @@
+package git
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+// EnqueueMetadataReader serves the cheap git metadata reads needed while
+// freezing an enqueue target. Implementations must not compute patch-id or
+// main-repo-root; those stay on their existing subprocess paths.
+type EnqueueMetadataReader interface {
+	Root() (string, error)
+	CurrentBranch() string
+	Resolve(ref string) (string, error)
+	CommitInfo(ref string) (*CommitInfo, error)
+	RangeCommits(rangeRef string) ([]string, error)
+}
+
+var openGoGitRepository = func(path string) (*gogit.Repository, error) {
+	return gogit.PlainOpenWithOptions(path, &gogit.PlainOpenOptions{
+		DetectDotGit:          true,
+		EnableDotGitCommonDir: true,
+	})
+}
+
+// OpenEnqueueMetadataReader uses go-git when it can open the repository, and
+// falls back to the existing subprocess helpers for repositories go-git cannot
+// read yet, such as reftable, SHA-256, or partial clones with missing objects.
+func OpenEnqueueMetadataReader(ctx context.Context, repoPath string) EnqueueMetadataReader {
+	fallback := subprocessEnqueueMetadataReader{ctx: ctx, repoPath: repoPath}
+	repo, err := openGoGitRepository(repoPath)
+	if err != nil {
+		return fallback
+	}
+	return &goGitEnqueueMetadataReader{repo: repo, fallback: fallback}
+}
+
+type subprocessEnqueueMetadataReader struct {
+	ctx      context.Context
+	repoPath string
+}
+
+func (r subprocessEnqueueMetadataReader) Root() (string, error) {
+	return GetRepoRoot(r.repoPath)
+}
+
+func (r subprocessEnqueueMetadataReader) CurrentBranch() string {
+	return GetCurrentBranch(r.repoPath)
+}
+
+func (r subprocessEnqueueMetadataReader) Resolve(ref string) (string, error) {
+	return ResolveSHACtx(r.ctx, r.repoPath, ref)
+}
+
+func (r subprocessEnqueueMetadataReader) CommitInfo(ref string) (*CommitInfo, error) {
+	return GetCommitInfoCtx(r.ctx, r.repoPath, ref)
+}
+
+func (r subprocessEnqueueMetadataReader) RangeCommits(rangeRef string) ([]string, error) {
+	return GetRangeCommitsCtx(r.ctx, r.repoPath, rangeRef)
+}
+
+type goGitEnqueueMetadataReader struct {
+	mu       sync.Mutex
+	repo     *gogit.Repository
+	fallback subprocessEnqueueMetadataReader
+	disabled bool
+}
+
+func (r *goGitEnqueueMetadataReader) fallbackDisabled() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.disabled
+}
+
+func (r *goGitEnqueueMetadataReader) disableGoGit() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.disabled = true
+}
+
+func (r *goGitEnqueueMetadataReader) Root() (string, error) {
+	if r.fallbackDisabled() {
+		return r.fallback.Root()
+	}
+	wt, err := r.repo.Worktree()
+	if err != nil {
+		r.disableGoGit()
+		return r.fallback.Root()
+	}
+	return filepath.Clean(wt.Filesystem.Root()), nil
+}
+
+func (r *goGitEnqueueMetadataReader) CurrentBranch() string {
+	if r.fallbackDisabled() {
+		return r.fallback.CurrentBranch()
+	}
+	head, err := r.repo.Head()
+	if err != nil || !head.Name().IsBranch() {
+		if err != nil {
+			r.disableGoGit()
+			return r.fallback.CurrentBranch()
+		}
+		return ""
+	}
+	return head.Name().Short()
+}
+
+func (r *goGitEnqueueMetadataReader) Resolve(ref string) (string, error) {
+	if r.fallbackDisabled() {
+		return r.fallback.Resolve(ref)
+	}
+	hash, err := r.repo.ResolveRevision(plumbing.Revision(ref))
+	if err != nil {
+		r.disableGoGit()
+		return r.fallback.Resolve(ref)
+	}
+	return hash.String(), nil
+}
+
+func (r *goGitEnqueueMetadataReader) CommitInfo(ref string) (*CommitInfo, error) {
+	if r.fallbackDisabled() {
+		return r.fallback.CommitInfo(ref)
+	}
+	hash, err := r.repo.ResolveRevision(plumbing.Revision(ref))
+	if err != nil {
+		r.disableGoGit()
+		return r.fallback.CommitInfo(ref)
+	}
+	commit, err := r.repo.CommitObject(*hash)
+	if err != nil {
+		r.disableGoGit()
+		return r.fallback.CommitInfo(ref)
+	}
+	return commitInfoFromGoGit(commit), nil
+}
+
+func commitInfoFromGoGit(commit *object.Commit) *CommitInfo {
+	subject, body := splitCommitMessage(commit.Message)
+	timestamp := commit.Author.When
+	if timestamp.IsZero() {
+		timestamp = time.Now()
+	}
+	return &CommitInfo{
+		SHA:       commit.Hash.String(),
+		Author:    commit.Author.Name,
+		Subject:   subject,
+		Body:      body,
+		Timestamp: timestamp,
+	}
+}
+
+func splitCommitMessage(message string) (string, string) {
+	message = strings.TrimRight(message, "\r\n")
+	subject, body, _ := strings.Cut(message, "\n")
+	return subject, strings.TrimSpace(body)
+}
+
+func (r *goGitEnqueueMetadataReader) RangeCommits(rangeRef string) ([]string, error) {
+	return r.fallback.RangeCommits(rangeRef)
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -860,6 +861,123 @@ func TestGetCommitInfo(t *testing.T) {
 		assert.Contains(t, info.Subject, "|", "expected subject to contain pipe, got '%s'", info.Subject)
 		assert.Contains(t, info.Body, "foo | bar", "expected body to contain 'foo | bar', got '%s'", info.Body)
 	})
+}
+
+func TestOpenEnqueueMetadataReaderGoGitMatchesGit(t *testing.T) {
+	assert := assert.New(t)
+	repo := NewTestRepo(t)
+	repo.CommitFile("base.txt", "base", "base")
+	repo.Run("checkout", "-b", "feature/enqueue")
+	repo.WriteFile("feature.txt", "feature")
+	repo.Run("add", ".")
+	repo.Run("commit", "-m", "Feature subject", "-m", "Feature body line 1\n\nFeature body line 2")
+
+	reader := OpenEnqueueMetadataReader(t.Context(), repo.Dir)
+
+	root, err := reader.Root()
+	require.NoError(t, err)
+	wantRoot, err := GetRepoRoot(repo.Dir)
+	require.NoError(t, err)
+	assert.Equal(wantRoot, root)
+
+	assert.Equal(GetCurrentBranch(repo.Dir), reader.CurrentBranch())
+
+	head, err := reader.Resolve("HEAD")
+	require.NoError(t, err)
+	wantHead, err := ResolveSHA(repo.Dir, "HEAD")
+	require.NoError(t, err)
+	assert.Equal(wantHead, head)
+
+	headParent, err := reader.Resolve("HEAD~1")
+	require.NoError(t, err)
+	wantParent, err := ResolveSHA(repo.Dir, "HEAD~1")
+	require.NoError(t, err)
+	assert.Equal(wantParent, headParent)
+
+	branchHead, err := reader.Resolve("feature/enqueue")
+	require.NoError(t, err)
+	assert.Equal(wantHead, branchHead)
+
+	commitSyntax, err := reader.Resolve("HEAD^{commit}")
+	require.NoError(t, err)
+	assert.Equal(wantHead, commitSyntax)
+
+	abbrev, err := reader.Resolve(wantHead[:12])
+	require.NoError(t, err)
+	assert.Equal(wantHead, abbrev)
+
+	gotInfo, err := reader.CommitInfo("HEAD")
+	require.NoError(t, err)
+	wantInfo, err := GetCommitInfo(repo.Dir, "HEAD")
+	require.NoError(t, err)
+	assert.Equal(wantInfo.SHA, gotInfo.SHA)
+	assert.Equal(wantInfo.Author, gotInfo.Author)
+	assert.Equal(wantInfo.Subject, gotInfo.Subject)
+	assert.Equal(wantInfo.Body, gotInfo.Body)
+	assert.True(wantInfo.Timestamp.Equal(gotInfo.Timestamp),
+		"timestamp mismatch: want %s got %s", wantInfo.Timestamp, gotInfo.Timestamp)
+
+	gotRange, err := reader.RangeCommits("HEAD~1..HEAD")
+	require.NoError(t, err)
+	wantRange, err := GetRangeCommits(repo.Dir, "HEAD~1..HEAD")
+	require.NoError(t, err)
+	assert.Equal(wantRange, gotRange)
+}
+
+func TestOpenEnqueueMetadataReaderRangeCommitsUsesCancellableGitLog(t *testing.T) {
+	repo := NewTestRepo(t)
+	repo.CommitFile("base.txt", "base", "base")
+	repo.CommitFile("feature.txt", "feature", "feature")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	reader := OpenEnqueueMetadataReader(ctx, repo.Dir)
+	cancel()
+
+	_, err := reader.RangeCommits("HEAD~1..HEAD")
+	require.Error(t, err)
+}
+
+func TestOpenEnqueueMetadataReaderGoGitUsesWorktreeRootAndBranch(t *testing.T) {
+	assert := assert.New(t)
+	repo := NewTestRepo(t)
+	repo.CommitFile("base.txt", "base", "base")
+	wt := repo.AddWorktree("feature/worktree")
+
+	reader := OpenEnqueueMetadataReader(t.Context(), wt.Dir)
+
+	root, err := reader.Root()
+	require.NoError(t, err)
+	assert.Equal(cleanEvalPath(wt.Dir), cleanEvalPath(root))
+	assert.Equal("feature/worktree", reader.CurrentBranch())
+
+	head, err := reader.Resolve("HEAD")
+	require.NoError(t, err)
+	assert.Equal(strings.TrimSpace(wt.Run("rev-parse", "HEAD")), head)
+}
+
+func TestOpenEnqueueMetadataReaderFallsBackWhenGoGitOpenFails(t *testing.T) {
+	repo := NewTestRepo(t)
+	repo.CommitFile("base.txt", "base", "base")
+
+	oldOpen := openGoGitRepository
+	openGoGitRepository = func(string) (*gogit.Repository, error) {
+		return nil, errors.New("forced go-git open failure")
+	}
+	t.Cleanup(func() { openGoGitRepository = oldOpen })
+
+	reader := OpenEnqueueMetadataReader(t.Context(), repo.Dir)
+
+	root, err := reader.Root()
+	require.NoError(t, err)
+	assert.Equal(t, cleanEvalPath(repo.Dir), cleanEvalPath(root))
+
+	sha, err := reader.Resolve("HEAD")
+	require.NoError(t, err)
+	assert.Equal(t, strings.TrimSpace(repo.Run("rev-parse", "HEAD")), sha)
+
+	info, err := reader.CommitInfo("HEAD")
+	require.NoError(t, err)
+	assert.Equal(t, "base", info.Subject)
 }
 
 func TestGetCommitParents(t *testing.T) {


### PR DESCRIPTION
Windows post-commit reviews still pay for several sequential git subprocess launches while the daemon freezes an enqueue target. That cost is high enough on large Windows repositories to eat into the hook timeout budget even after increasing the timeout default, so this moves the safe metadata reads to go-git after opening the checkout once.

The change deliberately keeps main-root discovery, patch-id generation, and session ancestry checks on their existing subprocess paths because those paths have compatibility or algorithm constraints that go-git does not cover cleanly. If go-git cannot open the repository, or if it later fails while reading metadata, the enqueue path falls back to the existing subprocess helpers so unsupported repository formats and partial-object cases keep working.

Local repo-wide tests completed successfully before opening this draft.

Fixes #923

<sup>generated by a clanker</sup>