### PR TITLE
Publish docs Markdown source files

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,8 +16,8 @@ clones do not pull large screenshots and PNGs into the main history.
 - `assets/update-static-assets-branch.sh`: updates curated static assets.
 - `screenshots/`: Docker/tmux/freeze screenshot generator and generated asset
   branch updater.
-- `scripts/check_built_site.py` and `scripts/check_vercel_redirects.py`:
-  post-build validation.
+- `scripts/check_built_site.py`, `scripts/check_public_markdown_sources.py`,
+  and `scripts/check_vercel_redirects.py`: post-build validation.
 
 `docs/assets/static/`, `docs/assets/generated/`, `docs/site/`, and `docs/.venv/`
 are ignored local outputs.
@@ -62,7 +62,8 @@ make docs-check
 ```
 
 `make docs-check` hydrates assets, runs a strict Zensical build, checks generated
-links/assets/metadata, and validates `vercel.json` redirects.
+links/assets/metadata, verifies public Markdown source files, and validates
+`vercel.json` redirects.
 
 Asset hydration force-fetches `origin/docs-assets` and
 `origin/docs-generated-assets` by default so force-pushed orphan branches do not
@@ -135,6 +136,11 @@ Vercel root directory:
 | Install command | `uv sync --frozen --no-dev` |
 | Build command | `uv run --frozen bash ./vercel-build.sh` |
 | Output directory | `site` |
+
+The build wrapper also copies `index.md` and every nav-listed Markdown document
+into `site/`. That keeps source-form docs available from the same deployment as
+the rendered page: for example, `/changelog.md` serves the Markdown source that
+generated `/changelog/`.
 
 Link the checkout once from the repository root:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -132,6 +132,11 @@ its root directory. Use these project settings:
 | Build command | `uv run --frozen bash ./vercel-build.sh` |
 | Output directory | `site` |
 
+The build wrapper also copies `index.md` and every nav-listed Markdown document
+into `site/`. That keeps source-form docs available from the same deployment as
+the rendered page: for example, `/changelog.md` serves the Markdown source that
+generated `/changelog/`.
+
 Deploy committed docs changes with:
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,13 @@ roborev tui           # Browse reviews in the terminal UI
 
 For Windows, see the [installation guide](/installation/#quick-install-recommended).
 
+## For LLMs
+
+This docs site publishes source Markdown next to each rendered page. Prefer the
+`.md` URL when reading or citing docs programmatically: `/changelog.md` for
+`/changelog/`, `/guides/reviewing-code.md` for `/guides/reviewing-code/`, and
+`/index.md` for this page.
+
 ## Why roborev?
 
 AI coding agents write code fast, but they make mistakes. Most review feedback comes too late. The agent has moved on and context is lost. roborev changes this:

--- a/docs/scripts/check_public_markdown_sources.py
+++ b/docs/scripts/check_public_markdown_sources.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import pathlib
+
+from public_markdown_sources import fail, public_markdown_sources
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CONFIG = ROOT / "zensical.toml"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Check generated docs include public Markdown source files.",
+    )
+    parser.add_argument(
+        "--site-dir",
+        default="site",
+        help="generated site directory relative to docs root",
+    )
+    args = parser.parse_args()
+
+    site_dir = ROOT / args.site_dir
+    if not site_dir.is_dir():
+        fail(f"missing generated site directory: {site_dir.relative_to(ROOT)}")
+
+    for path in public_markdown_sources(CONFIG):
+        source = ROOT / path
+        generated = site_dir / path
+        if not source.is_file():
+            fail(f"nav source is missing: {path}")
+        if not generated.is_file():
+            fail(f"generated site is missing Markdown source: {generated.relative_to(ROOT)}")
+        if generated.read_bytes() != source.read_bytes():
+            fail(
+                "generated Markdown source differs from docs source: "
+                f"{generated.relative_to(ROOT)}",
+            )
+
+    print("public Markdown source checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/scripts/check_vercel_redirects.py
+++ b/docs/scripts/check_vercel_redirects.py
@@ -282,6 +282,13 @@ def main() -> None:
         fail("vercel.json must set trailingSlash true")
 
     redirects = collect_redirects(data)
+    for source in redirects:
+        if source.endswith(".md"):
+            fail(
+                "Markdown source URL must be served as a static file, "
+                f"not redirected: {source}"
+            )
+
     for source, destination in PERMANENT.items():
         item = redirects.get(source)
         if not item:

--- a/docs/scripts/copy_public_markdown_sources.py
+++ b/docs/scripts/copy_public_markdown_sources.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import pathlib
+import shutil
+
+from public_markdown_sources import fail, public_markdown_sources
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Copy public docs Markdown sources into the generated site.",
+    )
+    parser.add_argument(
+        "--docs-dir",
+        required=True,
+        help="public docs source directory relative to docs root",
+    )
+    parser.add_argument(
+        "--site-dir",
+        default="site",
+        help="generated site directory relative to docs root",
+    )
+    parser.add_argument(
+        "--config",
+        default="zensical.toml",
+        help="Zensical config path relative to docs root",
+    )
+    args = parser.parse_args()
+
+    docs_dir = ROOT / args.docs_dir
+    site_dir = ROOT / args.site_dir
+    config = ROOT / args.config
+    if not docs_dir.is_dir():
+        fail(f"missing public docs source directory: {docs_dir.relative_to(ROOT)}")
+    if not site_dir.is_dir():
+        fail(f"missing generated site directory: {site_dir.relative_to(ROOT)}")
+
+    for path in public_markdown_sources(config):
+        source = docs_dir / path
+        destination = site_dir / path
+        if not source.is_file():
+            fail(f"nav source is missing from public docs tree: {source.relative_to(ROOT)}")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, destination)
+
+    print("public Markdown sources copied")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/scripts/public_markdown_sources.py
+++ b/docs/scripts/public_markdown_sources.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+import tomllib
+from collections.abc import Iterable
+from typing import Any
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def iter_nav_markdown(value: Any) -> Iterable[str]:
+    if isinstance(value, str):
+        if value.endswith(".md"):
+            yield value
+        return
+    if isinstance(value, list):
+        for item in value:
+            yield from iter_nav_markdown(item)
+        return
+    if isinstance(value, dict):
+        for item in value.values():
+            yield from iter_nav_markdown(item)
+
+
+def public_markdown_sources(config: pathlib.Path) -> list[str]:
+    try:
+        data = tomllib.loads(config.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        fail(f"missing {config.name}")
+    except tomllib.TOMLDecodeError as error:
+        fail(f"invalid {config.name}: {error}")
+
+    project = data.get("project")
+    if not isinstance(project, dict):
+        fail(f"{config.name} missing [project]")
+    nav = project.get("nav")
+    if not isinstance(nav, list):
+        fail(f"{config.name} missing project.nav")
+
+    seen: set[str] = set()
+    sources: list[str] = []
+    for path in ["index.md", *iter_nav_markdown(nav)]:
+        if path not in seen:
+            seen.add(path)
+            sources.append(path)
+    if not sources:
+        fail(f"{config.name} nav does not list any Markdown documents")
+    return sources

--- a/docs/zensical-docs.sh
+++ b/docs/zensical-docs.sh
@@ -94,6 +94,13 @@ awk -v docs_dir="$tmp_docs_name" -v site_dir="$site_dir" '
 case "$command_name" in
   build)
     (cd "$docs_root" && "$zensical_bin" build --strict --config-file "$tmp_config_name" "$@")
+    (
+      cd "$docs_root"
+      python3 scripts/copy_public_markdown_sources.py \
+        --docs-dir "$tmp_docs_name" \
+        --site-dir "$site_dir" \
+        --config "$tmp_config_name"
+    )
     ;;
   serve)
     (cd "$docs_root" && "$zensical_bin" serve --config-file "$tmp_config_name" "$@")

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -54,6 +54,7 @@ if command -v uv >/dev/null 2>&1; then
     cd docs
     uv run --frozen bash ./zensical-docs.sh build
     uv run --frozen python scripts/check_built_site.py
+    uv run --frozen python scripts/check_public_markdown_sources.py
     uv run --frozen python scripts/check_vercel_redirects.py
   )
 else


### PR DESCRIPTION
LLM and agent consumers get cleaner input from the source Markdown than from rendered HTML, but roborev.io only published the rendered Zensical routes. This mirrors the kata docs deployment pattern so public docs pages can be fetched from stable `.md` URLs, such as `/changelog.md` next to `/changelog/` and `/index.md` next to the landing page.

The landing page now tells programmatic readers to prefer those source-form URLs, and the docs build/check path verifies that generated deployments include matching Markdown files and do not redirect `.md` routes away from static source content.