### PR TITLE
Point refine docs readers to Agent Hook for in-agent automation

### DIFF
--- a/docs/guides/auto-fixing.md
+++ b/docs/guides/auto-fixing.md
@@ -10,6 +10,9 @@ For a one-shot fix without re-review, see [`roborev fix`](/guides/assisted-refac
 !!! tip "Run from an agent session"
     The `/roborev-refine` skill runs the same iterative loop from within a Claude Code or Codex session. See [Agent Skills](/guides/agent-skills/#refine-a-branch).
 
+!!! tip "Automation inside your coding agent"
+    If you want review fixes to happen automatically during your Codex or Claude Code sessions — without invoking a command yourself — see [Agent Hook](/agent-hook/), which watches the agent boundary and steers the agent to fix failed reviews as they appear.
+
 ```bash
 roborev refine                       # Fix failed reviews using default agent
 roborev refine --agent claude-code   # Use specific agent


### PR DESCRIPTION
## Summary

- The Auto-Fix with Refine page already tells readers they can run the refine loop from inside an agent session, but readers looking for hands-off automation had no pointer to Agent Hook, which is the feature actually built for that — fixes triggered automatically at the agent boundary without invoking a command.
- Adds a tip near the top of `docs/guides/auto-fixing.md` directing users who want automation within their coding agent to the Agent Hook docs, so they discover the right tool before wiring up manual refine invocations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)