### PR TITLE
Retry transient CI attempts on startup

### DIFF
--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -208,6 +208,12 @@ func (p *CIPoller) Start() error {
 	stopCh := p.stopCh
 	doneCh := p.doneCh
 
+	if woke, err := p.db.MakeTransientReviewAttemptsDue(time.Now()); err != nil {
+		log.Printf("CI poller: error making transient review attempts due on startup: %v", err)
+	} else if woke > 0 {
+		log.Printf("CI poller: made %d transient review attempt(s) due on startup", woke)
+	}
+
 	// Subscribe to events before starting poll to avoid missing early completions
 	if p.broadcaster != nil {
 		subID, eventCh := p.broadcaster.Subscribe("")

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -911,6 +911,30 @@ func TestCIPollerStartStopHealth(t *testing.T) {
 	}
 }
 
+func TestCIPollerStartMakesTransientAttemptsDue(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	now := time.Now()
+
+	created, err := db.ReserveReviewAttempt("acme/api", 42, "head-startup", now)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.NoError(t, db.DeferReviewAttempt("acme/api", 42, "head-startup", "transient", "quota", "run",
+		now.Add(time.Hour), false))
+
+	cfg := config.DefaultConfig()
+	cfg.CI.Enabled = true
+	cfg.CI.PollInterval = "5m"
+	p := NewCIPoller(db, NewStaticConfig(cfg), nil)
+
+	require.NoError(t, p.Start())
+	p.Stop()
+
+	due, err := db.GetDueReviewAttempts("acme/api", time.Now())
+	require.NoError(t, err)
+	require.Len(t, due, 1)
+	assert.Equal(t, "head-startup", due[0].HeadSHA)
+}
+
 func TestCIPollerFindLocalRepo_PartialIdentityFallback(t *testing.T) {
 	h := newCIPollerHarness(t, "ssh://git@github.com/acme/api.git")
 

--- a/internal/storage/review_attempts.go
+++ b/internal/storage/review_attempts.go
@@ -164,6 +164,31 @@ func (db *DB) DeferReviewAttempt(repo string, pr int, sha, errClass, excerpt, la
 	return nil
 }
 
+// MakeTransientReviewAttemptsDue clears startup-visible transient backoff by
+// moving future deferred transient attempts to now. Quota/cooldown failures are
+// recorded as transient at the CI-attempt layer, so a daemon restart after the
+// provider recovers should let the retry sweep run immediately. Genuine
+// deterministic failures keep their scheduled backoff.
+func (db *DB) MakeTransientReviewAttemptsDue(now time.Time) (int64, error) {
+	nowTS := now.Format(time.RFC3339)
+	res, err := db.Exec(`
+		UPDATE ci_pr_review_attempts
+		SET next_attempt_at = ?, updated_at = ?
+		WHERE state = 'deferred'
+		  AND last_error_class = 'transient'
+		  AND next_attempt_at IS NOT NULL
+		  AND datetime(next_attempt_at) > datetime(?)`,
+		nowTS, nowTS, nowTS)
+	if err != nil {
+		return 0, fmt.Errorf("make transient review attempts due: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("make transient review attempts due rows: %w", err)
+	}
+	return n, nil
+}
+
 // RearmStuckReviewAttempt re-defers a 'pending' attempt that the crash/stuck
 // reconcile found stranded — claimed by the retry sweep (state flipped to
 // 'pending', attempt bumped) but then CreateCIPanelRun failed or the daemon

--- a/internal/storage/review_attempts_test.go
+++ b/internal/storage/review_attempts_test.go
@@ -17,6 +17,14 @@ func openReviewAttemptsTestDB(t *testing.T) *DB {
 	return db
 }
 
+func attemptHeads(attempts []ReviewAttempt) []string {
+	heads := make([]string, 0, len(attempts))
+	for _, attempt := range attempts {
+		heads = append(heads, attempt.HeadSHA)
+	}
+	return heads
+}
+
 func TestReviewAttemptsTableExists(t *testing.T) {
 	db := openReviewAttemptsTestDB(t)
 	insert := `INSERT INTO ci_pr_review_attempts
@@ -121,6 +129,44 @@ func TestGetDueReviewAttempts(t *testing.T) {
 	assert.Len(due, 1)
 	assert.Equal("a", due[0].HeadSHA)
 	assert.Equal("deferred", due[0].State)
+}
+
+func TestMakeTransientReviewAttemptsDue(t *testing.T) {
+	assert := assert.New(t)
+	db := openReviewAttemptsTestDB(t)
+	now := time.Now()
+
+	created, err := db.ReserveReviewAttempt("o/r", 1, "transient-future", now)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.NoError(t, db.DeferReviewAttempt("o/r", 1, "transient-future", "transient", "quota", "u",
+		now.Add(time.Hour), false))
+
+	created, err = db.ReserveReviewAttempt("o/r", 2, "genuine-future", now)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.NoError(t, db.DeferReviewAttempt("o/r", 2, "genuine-future", "genuine", "bad config", "u",
+		now.Add(time.Hour), true))
+
+	created, err = db.ReserveReviewAttempt("o/r", 3, "transient-past", now)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.NoError(t, db.DeferReviewAttempt("o/r", 3, "transient-past", "transient", "outage", "u",
+		now.Add(-time.Minute), false))
+
+	updated, err := db.MakeTransientReviewAttemptsDue(now)
+	require.NoError(t, err)
+	assert.Equal(int64(1), updated)
+
+	due, err := db.GetDueReviewAttempts("o/r", now)
+	require.NoError(t, err)
+	assert.ElementsMatch([]string{"transient-future", "transient-past"}, attemptHeads(due))
+
+	genuine, err := db.GetReviewAttempt("o/r", 2, "genuine-future")
+	require.NoError(t, err)
+	require.NotNil(t, genuine)
+	require.NotNil(t, genuine.NextAttemptAt)
+	assert.True(genuine.NextAttemptAt.After(now), "genuine retry backoff should remain scheduled")
 }
 
 func TestGetNonTerminalAttemptPRs(t *testing.T) {


### PR DESCRIPTION
Deferred CI attempts caused by provider quota or availability failures can outlive the in-memory cooldown that originally blocked them. If the daemon restarts after the provider is available again, those attempts should become eligible for the first retry sweep instead of waiting for an old backoff timestamp.

This keeps startup recovery limited to transient attempt state. Genuine deterministic failures keep their scheduled backoff, so a restart does not turn repeatable configuration or agent errors into immediate retry loops.

The branch was validated with the repository Go test suite after rebasing on current main.