### PR TITLE
Add incremental review export cursors

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,12 +215,18 @@ local reporting or archival workflows:
 roborev export reviews
 roborev export reviews --profile metadata --since 2026-06-01 --until 2026-06-30
 roborev export reviews --closed-only --repo github.com/org/repo --limit 1000
+roborev export reviews --cursor "$NEXT_CURSOR" --until 2026-07-01
 ```
 
 The default `content` profile includes raw review output as stored. That output
 may contain sensitive repository details, so handle exported files carefully.
 Use `--profile metadata` when you only need identifiers, timestamps, verdicts,
 cost metadata, and related review metadata.
+
+Exports include a stable `database_id` for the local review database and, when
+at least one review is emitted, an opaque `next_cursor`. Pass
+`--cursor <next_cursor>` to resume after the previous page; `--cursor` cannot
+be combined with `--since`.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,10 @@ cost metadata, and related review metadata.
 Exports include a stable `database_id` for the local review database and, when
 at least one review is emitted, an opaque `next_cursor`. Pass
 `--cursor <next_cursor>` to resume after the previous page; `--cursor` cannot
-be combined with `--since`.
+be combined with `--since`. If a cursor belongs to a previous database
+generation, `roborev export reviews` exits with code `3`; discard the cursor
+and retry with a window backfill. Other cursor rejections also require
+discarding the cursor before backfilling.
 
 ## Configuration
 

--- a/cmd/roborev/export.go
+++ b/cmd/roborev/export.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,7 +17,12 @@ import (
 	"go.kenn.io/roborev/internal/storage"
 )
 
-const exportReviewsMaxPageSize = 5000
+const (
+	exportReviewsMaxPageSize         = 5000
+	exportReviewsCursorResetExitCode = 3
+)
+
+var errExportCursorDatabaseReset = errors.New("export cursor database reset")
 
 type exportReviewsOpts struct {
 	format     string
@@ -56,9 +62,11 @@ matching rows are available immediately.
 
 Cursor tokens are opaque and versioned for stability across invocations and
 roborev upgrades. Export documents include database_id; a cursor from a
-different database is rejected so callers can discard it and backfill. Reviews
-that complete late with completed_at before an already consumed cursor position
-are not returned by cursor resume; consumers that need convergence should use an
+different database is rejected with exit code 3 so callers can discard it and
+backfill. Other cursor rejections exit non-zero and should also be handled by
+discarding the cursor and retrying with a window backfill. Reviews that complete
+late with completed_at before an already consumed cursor position are not
+returned by cursor resume; consumers that need convergence should use an
 overlapping window separately.`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			limitSet := cmd.Flags().Changed("limit")
@@ -71,6 +79,9 @@ overlapping window separately.`),
 
 			doc, err := fetchAllExportReviews(getDaemonEndpoint(), opts, limitSet)
 			if err != nil {
+				if errors.Is(err, errExportCursorDatabaseReset) {
+					return &exitError{code: exportReviewsCursorResetExitCode, cause: err}
+				}
 				return err
 			}
 			enc := json.NewEncoder(cmd.OutOrStdout())
@@ -189,6 +200,10 @@ func fetchExportReviewsPage(ep daemon.DaemonEndpoint, opts exportReviewsOpts, cu
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusConflict {
+			return daemon.ExportReviewsDocument{}, fmt.Errorf("%w: daemon returned %s: %s",
+				errExportCursorDatabaseReset, resp.Status, strings.TrimSpace(string(body)))
+		}
 		return daemon.ExportReviewsDocument{}, fmt.Errorf("daemon returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
 	}
 	var doc daemon.ExportReviewsDocument

--- a/cmd/roborev/export.go
+++ b/cmd/roborev/export.go
@@ -171,7 +171,7 @@ func fetchExportReviewsPage(ep daemon.DaemonEndpoint, opts exportReviewsOpts, cu
 	params := url.Values{}
 	params.Set("format", opts.format)
 	params.Set("profile", opts.profile)
-	if opts.since != "" {
+	if opts.since != "" && cursor == "" {
 		params.Set("since", opts.since)
 	}
 	if opts.until != "" {

--- a/cmd/roborev/export.go
+++ b/cmd/roborev/export.go
@@ -23,6 +23,7 @@ type exportReviewsOpts struct {
 	profile    string
 	since      string
 	until      string
+	cursor     string
 	closedOnly bool
 	repo       string
 	project    string
@@ -44,6 +45,21 @@ func exportReviewsCmd() *cobra.Command {
 		Use:   "reviews",
 		Args:  cobra.NoArgs,
 		Short: "Export completed reviews as JSON",
+		Long: strings.TrimSpace(`
+Export completed reviews as a JSON document.
+
+Rows are ordered by completed_at, review_id ascending. Use --cursor with the
+next_cursor value from a previous export to resume strictly after that position.
+--cursor cannot be used with --since; --until, --limit, --profile, and filters
+still apply. Every non-empty export includes next_cursor; truncated means more
+matching rows are available immediately.
+
+Cursor tokens are opaque and versioned for stability across invocations and
+roborev upgrades. Export documents include database_id; a cursor from a
+different database is rejected so callers can discard it and backfill. Reviews
+that complete late with completed_at before an already consumed cursor position
+are not returned by cursor resume; consumers that need convergence should use an
+overlapping window separately.`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			limitSet := cmd.Flags().Changed("limit")
 			if err := validateExportReviewsOpts(opts, limitSet); err != nil {
@@ -66,6 +82,7 @@ func exportReviewsCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.profile, "profile", string(storage.ExportProfileContent), "export profile (content or metadata)")
 	cmd.Flags().StringVar(&opts.since, "since", "", "inclusive completed_at lower bound (RFC3339 or YYYY-MM-DD)")
 	cmd.Flags().StringVar(&opts.until, "until", "", "exclusive completed_at upper bound (RFC3339 or YYYY-MM-DD)")
+	cmd.Flags().StringVar(&opts.cursor, "cursor", "", "opaque next_cursor from a previous export; resumes after that cursor and cannot be used with --since")
 	cmd.Flags().BoolVar(&opts.closedOnly, "closed-only", false, "only include reviews marked closed")
 	cmd.Flags().StringVar(&opts.repo, "repo", "", "exact exported repo identifier filter")
 	cmd.Flags().StringVar(&opts.project, "project", "", "exact project display-name filter")
@@ -84,12 +101,15 @@ func validateExportReviewsOpts(opts exportReviewsOpts, limitSet bool) error {
 	if limitSet && opts.limit <= 0 {
 		return fmt.Errorf("--limit must be greater than 0")
 	}
+	if opts.cursor != "" && opts.since != "" {
+		return fmt.Errorf("--cursor cannot be used with --since; cursor already defines the resume position")
+	}
 	return nil
 }
 
 func fetchAllExportReviews(ep daemon.DaemonEndpoint, opts exportReviewsOpts, limitSet bool) (*daemon.ExportReviewsDocument, error) {
 	var out *daemon.ExportReviewsDocument
-	var cursor string
+	cursor := opts.cursor
 	remaining := opts.limit
 	for {
 		pageLimit := 0
@@ -116,8 +136,11 @@ func fetchAllExportReviews(ep daemon.DaemonEndpoint, opts exportReviewsOpts, lim
 				break
 			}
 		}
-		if page.NextCursor == nil || *page.NextCursor == "" {
+		if !page.Truncated {
 			break
+		}
+		if page.NextCursor == nil || *page.NextCursor == "" {
+			return nil, fmt.Errorf("daemon returned truncated export page without next cursor")
 		}
 		if len(page.Reviews) == 0 {
 			return nil, fmt.Errorf("daemon returned empty export page with next cursor")
@@ -129,7 +152,6 @@ func fetchAllExportReviews(ep daemon.DaemonEndpoint, opts exportReviewsOpts, lim
 	}
 	if !limitSet {
 		out.Truncated = false
-		out.NextCursor = nil
 	}
 	return out, nil
 }

--- a/cmd/roborev/export_test.go
+++ b/cmd/roborev/export_test.go
@@ -252,6 +252,30 @@ func TestExportReviewsCmdPropagatesCursorErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid export cursor")
 }
 
+func TestExportReviewsCmdUsesDistinctExitCodeForCursorDatabaseReset(t *testing.T) {
+	NewMockDaemon(t, MockRefineHooks{
+		OnUnhandled: func(w http.ResponseWriter, r *http.Request, state *mockRefineState) bool {
+			if r.URL.Path != "/api/export/reviews" {
+				return false
+			}
+			assert.Equal(t, "old-cursor", r.URL.Query().Get("cursor"))
+			http.Error(w, "export cursor database reset", http.StatusConflict)
+			return true
+		},
+	})
+
+	cmd := exportCmd()
+	cmd.SetArgs([]string{"reviews", "--cursor", "old-cursor"})
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	var exitErr *exitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, exportReviewsCursorResetExitCode, exitErr.code)
+	assert.Contains(t, err.Error(), "daemon returned 409 Conflict")
+	assert.Contains(t, err.Error(), "database reset")
+}
+
 func runExportCmd(t *testing.T, args ...string) string {
 	t.Helper()
 	var out bytes.Buffer

--- a/cmd/roborev/export_test.go
+++ b/cmd/roborev/export_test.go
@@ -37,7 +37,7 @@ func TestExportReviewsCmdFollowsCursors(t *testing.T) {
 				})
 			case 2:
 				assert.Equal("cursor-1", r.URL.Query().Get("cursor"))
-				writeExportTestPage(t, w, r.URL.Query().Get("profile"), false, nil, []map[string]any{
+				writeExportTestPage(t, w, r.URL.Query().Get("profile"), false, new("cursor-2"), []map[string]any{
 					{"review_id": "r2", "content": nil},
 				})
 			default:
@@ -67,7 +67,8 @@ func TestExportReviewsCmdFollowsCursors(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(output), &got))
 	assert.Equal("metadata", got.Profile)
 	assert.False(got.Truncated)
-	assert.Nil(got.NextCursor)
+	require.NotNil(t, got.NextCursor)
+	assert.Equal("cursor-2", *got.NextCursor)
 	require.Len(t, got.Reviews, 2)
 	assert.Equal("r1", got.Reviews[0]["review_id"])
 	assert.Equal("r2", got.Reviews[1]["review_id"])
@@ -106,6 +107,47 @@ func TestExportReviewsCmdLimitStopsAtCursor(t *testing.T) {
 	assert.Equal("next-page", *got.NextCursor)
 	require.Len(t, got.Reviews, 1)
 	assert.Equal("raw", got.Reviews[0]["content"])
+}
+
+func TestExportReviewsCmdStartsFromCursor(t *testing.T) {
+	assert := assert.New(t)
+	var calls []string
+	NewMockDaemon(t, MockRefineHooks{
+		OnUnhandled: func(w http.ResponseWriter, r *http.Request, state *mockRefineState) bool {
+			if r.URL.Path != "/api/export/reviews" {
+				return false
+			}
+			calls = append(calls, r.URL.RawQuery)
+			assert.Equal("opaque-cursor", r.URL.Query().Get("cursor"))
+			assert.Empty(r.URL.Query().Get("since"))
+			assert.Equal("2026-06-30", r.URL.Query().Get("until"))
+			assert.Equal("metadata", r.URL.Query().Get("profile"))
+			writeExportTestPage(t, w, r.URL.Query().Get("profile"), false, new("resume-r2"), []map[string]any{
+				{"review_id": "r2", "content": nil},
+			})
+			return true
+		},
+	})
+
+	output := runExportCmd(t,
+		"reviews",
+		"--profile", "metadata",
+		"--cursor", "opaque-cursor",
+		"--until", "2026-06-30",
+	)
+
+	require.Len(t, calls, 1)
+	var got struct {
+		DatabaseID string           `json:"database_id"`
+		NextCursor *string          `json:"next_cursor"`
+		Reviews    []map[string]any `json:"reviews"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(output), &got))
+	assert.Equal("test-database", got.DatabaseID)
+	require.NotNil(t, got.NextCursor)
+	assert.Equal("resume-r2", *got.NextCursor)
+	require.Len(t, got.Reviews, 1)
+	assert.Equal("r2", got.Reviews[0]["review_id"])
 }
 
 func TestExportReviewsCmdExplicitLargeLimitFollowsUntilLimit(t *testing.T) {
@@ -158,6 +200,7 @@ func TestExportReviewsCmdRejectsInvalidFlags(t *testing.T) {
 		{name: "format", args: []string{"reviews", "--format", "yaml"}},
 		{name: "profile", args: []string{"reviews", "--profile", "full"}},
 		{name: "limit", args: []string{"reviews", "--limit", "0"}},
+		{name: "cursor-since", args: []string{"reviews", "--cursor", "opaque", "--since", "2026-06-29"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -188,6 +231,27 @@ func TestRootExportReviewsCmdRejectsInvalidFlagsAsUsageError(t *testing.T) {
 	assert.False(t, executed.SilenceUsage)
 }
 
+func TestExportReviewsCmdPropagatesCursorErrors(t *testing.T) {
+	NewMockDaemon(t, MockRefineHooks{
+		OnUnhandled: func(w http.ResponseWriter, r *http.Request, state *mockRefineState) bool {
+			if r.URL.Path != "/api/export/reviews" {
+				return false
+			}
+			assert.Equal(t, "corrupt", r.URL.Query().Get("cursor"))
+			http.Error(w, "invalid export cursor: illegal base64 data", http.StatusBadRequest)
+			return true
+		},
+	})
+
+	cmd := exportCmd()
+	cmd.SetArgs([]string{"reviews", "--cursor", "corrupt"})
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "daemon returned 400 Bad Request")
+	assert.Contains(t, err.Error(), "invalid export cursor")
+}
+
 func runExportCmd(t *testing.T, args ...string) string {
 	t.Helper()
 	var out bytes.Buffer
@@ -209,6 +273,7 @@ func writeExportTestPage(t *testing.T, w http.ResponseWriter, profile string, tr
 		"tool":           "roborev",
 		"tool_version":   "dev",
 		"generated_at":   "2026-06-29T00:00:00Z",
+		"database_id":    "test-database",
 		"profile":        profile,
 		"window": map[string]any{
 			"field": "completed_at",

--- a/cmd/roborev/export_test.go
+++ b/cmd/roborev/export_test.go
@@ -24,18 +24,19 @@ func TestExportReviewsCmdFollowsCursors(t *testing.T) {
 			assert.Equal(http.MethodGet, r.Method)
 			assert.Equal("json", r.URL.Query().Get("format"))
 			assert.Equal("metadata", r.URL.Query().Get("profile"))
-			assert.Equal("2026-06-29", r.URL.Query().Get("since"))
 			assert.Equal("2026-06-30", r.URL.Query().Get("until"))
 			assert.Equal("true", r.URL.Query().Get("closed_only"))
 			assert.Equal("github.com/acme/widgets", r.URL.Query().Get("repo"))
 			assert.Equal("widgets", r.URL.Query().Get("project"))
 			switch len(calls) {
 			case 1:
+				assert.Equal("2026-06-29", r.URL.Query().Get("since"))
 				assert.Empty(r.URL.Query().Get("cursor"))
 				writeExportTestPage(t, w, r.URL.Query().Get("profile"), true, new("cursor-1"), []map[string]any{
 					{"review_id": "r1", "content": nil},
 				})
 			case 2:
+				assert.Empty(r.URL.Query().Get("since"))
 				assert.Equal("cursor-1", r.URL.Query().Get("cursor"))
 				writeExportTestPage(t, w, r.URL.Query().Get("profile"), false, new("cursor-2"), []map[string]any{
 					{"review_id": "r2", "content": nil},

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -137,6 +137,7 @@ roborev export reviews --profile metadata
 roborev export reviews --since 2026-06-01 --until 2026-06-30
 roborev export reviews --closed-only --repo github.com/org/repo
 roborev export reviews --project my-workspace --limit 1000
+roborev export reviews --cursor "$NEXT_CURSOR" --until 2026-07-01
 ```
 
 | Flag | Description |
@@ -145,6 +146,7 @@ roborev export reviews --project my-workspace --limit 1000
 | `--profile content\|metadata` | Export profile. `content` is the default |
 | `--since <time>` | Inclusive `completed_at` lower bound. Accepts RFC3339 or `YYYY-MM-DD` |
 | `--until <time>` | Exclusive `completed_at` upper bound. Accepts RFC3339 or `YYYY-MM-DD` |
+| `--cursor <opaque>` | Resume strictly after a previous `next_cursor`. Mutually exclusive with `--since` |
 | `--closed-only` | Include only reviews you have marked resolved |
 | `--repo <id>` | Exact exported repo identifier, usually `github.com/org/repo` |
 | `--project <name>` | Exact local project/workspace label |
@@ -166,6 +168,30 @@ the start of June 1 through the end of June 30 UTC. When `--limit` is omitted,
 the CLI follows daemon cursors until all matching rows are included in the one
 JSON document. With `--limit`, the CLI still pages through bounded daemon
 responses until the requested top-level count is reached or no more rows match.
+
+Export documents use `schema_version: 1` and include a stable `database_id`
+for the local review database. Adding `database_id` does not bump
+`schema_version` because it is an additive header field and existing consumers
+must continue to ignore unknown header keys.
+
+Rows are ordered by `(completed_at, review_id)` ascending. `next_cursor` is an
+opaque, internally versioned token containing that compound position and the
+`database_id`; version 1 cursors are stable across invocations and roborev
+upgrades, and future cursor encoding changes must keep old cursor versions
+resolvable or reject them clearly. Every non-empty export includes a
+`next_cursor`, even when `truncated` is `false`; `truncated` only means more
+matching rows are available immediately. `--cursor <opaque>` resumes strictly
+after the cursor position, cannot be combined with `--since`, and still honors
+`--until`, `--limit`, `--profile`, `--closed-only`, `--repo`, and `--project`.
+A malformed, corrupt, stale, or no-longer-resolvable cursor fails instead of
+silently producing a full or empty export. A cursor from a different
+`database_id` is rejected distinctly as a database reset so callers can discard
+the cursor and backfill.
+
+Cursor resume is not an overlap scan. A review that completes later with
+`completed_at` earlier than an already consumed cursor position will not be
+returned by cursor resume. Consumers that need convergence for late-completing
+reviews should run their own overlapping completed-at window separately.
 
 !!! warning "Review content may be sensitive"
     The `content` profile exports raw review output as stored. Review text can

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -184,9 +184,11 @@ matching rows are available immediately. `--cursor <opaque>` resumes strictly
 after the cursor position, cannot be combined with `--since`, and still honors
 `--until`, `--limit`, `--profile`, `--closed-only`, `--repo`, and `--project`.
 A malformed, corrupt, stale, or no-longer-resolvable cursor fails instead of
-silently producing a full or empty export. A cursor from a different
-`database_id` is rejected distinctly as a database reset so callers can discard
-the cursor and backfill.
+silently producing a full or empty export. Consumers should treat any cursor
+rejection as a signal to discard the cursor and retry with a completed-at window
+backfill. A cursor from a different `database_id` is rejected distinctly as a
+database reset, and the CLI exits with code `3` for that case so shell callers
+can branch without parsing stderr.
 
 Cursor resume is not an overlap scan. A review that completes later with
 `completed_at` earlier than an already consumed cursor position will not be

--- a/internal/daemon/routes.go
+++ b/internal/daemon/routes.go
@@ -48,6 +48,21 @@ func (s *Server) registerHumaAPI(mux *http.ServeMux) huma.API {
 			o.OperationID = "export-reviews"
 			o.Summary = "Export completed reviews"
 			o.Tags = []string{"reviews"}
+			if o.Responses == nil {
+				o.Responses = map[string]*huma.Response{}
+			}
+			o.Responses["409"] = &huma.Response{
+				Description: "Cursor database_id does not match this local database",
+				Content: map[string]*huma.MediaType{
+					"application/problem+json": {Schema: jsonSchema(api, huma.ErrorModel{})},
+				},
+			}
+			o.Responses["default"] = &huma.Response{
+				Description: "Error",
+				Content: map[string]*huma.MediaType{
+					"application/problem+json": {Schema: jsonSchema(api, huma.ErrorModel{})},
+				},
+			}
 		})
 
 	// /api/job/output is registered as a plain HandleFunc

--- a/internal/daemon/routes_test.go
+++ b/internal/daemon/routes_test.go
@@ -7,12 +7,16 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testutil"
 	"go.kenn.io/roborev/internal/tokens"
@@ -296,6 +300,66 @@ func TestHumaExportReviewsRejectsDifferentDatabaseCursorWithConflict(t *testing.
 	assert.Contains(t, rr.Body.String(), "database reset")
 }
 
+func TestHumaExportReviewsRejectsCursorAfterDatabaseRecreation(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "reviews.db")
+
+	firstDB, err := storage.Open(dbPath)
+	require.NoError(t, err)
+	firstServer := newServerWithLogs(firstDB, config.DefaultConfig(), "", newTestErrorLog(), newTestActivityLog())
+	firstRepo := testutil.CreateTestRepo(t, firstDB)
+	firstJob := testutil.CreateCompletedReview(
+		t, firstDB, firstRepo.ID, "export-before-reset", "test-agent", "No issues found.",
+	)
+	_, err = firstDB.Exec(`UPDATE reviews SET created_at = '2026-06-29 00:00:00' WHERE job_id = ?`, firstJob.ID)
+	require.NoError(t, err)
+
+	firstRR := serveHuma(t, firstServer, http.MethodGet, "/api/export/reviews?limit=10", nil)
+	require.Equal(t, http.StatusOK, firstRR.Code, firstRR.Body.String())
+	var firstExport struct {
+		DatabaseID string  `json:"database_id"`
+		NextCursor *string `json:"next_cursor"`
+	}
+	require.NoError(t, json.Unmarshal(firstRR.Body.Bytes(), &firstExport))
+	require.NotEmpty(t, firstExport.DatabaseID)
+	require.NotNil(t, firstExport.NextCursor)
+	require.NoError(t, firstServer.Close())
+	require.NoError(t, firstDB.Close())
+
+	removeSQLiteFiles(t, dbPath)
+
+	secondDB, err := storage.Open(dbPath)
+	require.NoError(t, err)
+	defer secondDB.Close()
+	secondServer := newServerWithLogs(secondDB, config.DefaultConfig(), "", newTestErrorLog(), newTestActivityLog())
+	defer secondServer.Close()
+	secondRepo := testutil.CreateTestRepo(t, secondDB)
+	secondJob := testutil.CreateCompletedReview(
+		t, secondDB, secondRepo.ID, "export-after-reset", "test-agent", "No issues found.",
+	)
+	_, err = secondDB.Exec(`UPDATE reviews SET created_at = '2026-06-29 00:00:00' WHERE job_id = ?`, secondJob.ID)
+	require.NoError(t, err)
+
+	resetRR := serveHuma(t, secondServer, http.MethodGet,
+		"/api/export/reviews?cursor="+url.QueryEscape(*firstExport.NextCursor), nil)
+	assert.Equal(t, http.StatusConflict, resetRR.Code, resetRR.Body.String())
+	assert.Contains(t, resetRR.Body.String(), "database reset")
+
+	backfillRR := serveHuma(t, secondServer, http.MethodGet, "/api/export/reviews?limit=10", nil)
+	require.Equal(t, http.StatusOK, backfillRR.Code, backfillRR.Body.String())
+	var backfill struct {
+		DatabaseID string                 `json:"database_id"`
+		NextCursor *string                `json:"next_cursor"`
+		Reviews    []storage.ExportReview `json:"reviews"`
+	}
+	require.NoError(t, json.Unmarshal(backfillRR.Body.Bytes(), &backfill))
+	assert.NotEmpty(t, backfill.DatabaseID)
+	assert.NotEqual(t, firstExport.DatabaseID, backfill.DatabaseID)
+	require.NotNil(t, backfill.NextCursor)
+	require.Len(t, backfill.Reviews, 1)
+	assert.Equal(t, "export-after-reset", *backfill.Reviews[0].CommitSHA)
+}
+
 func TestHumaExportReviewsRejectsCursorWithSince(t *testing.T) {
 	srv, _, _ := newTestServer(t)
 
@@ -371,6 +435,16 @@ func encodeExportCursorForRouteTest(t *testing.T, databaseID, completedAt, revie
 	})
 	require.NoError(t, err)
 	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+func removeSQLiteFiles(t *testing.T, dbPath string) {
+	t.Helper()
+	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		err := os.Remove(path)
+		if err != nil && !os.IsNotExist(err) {
+			require.NoError(t, err)
+		}
+	}
 }
 
 func TestHumaCancelJob(t *testing.T) {

--- a/internal/daemon/routes_test.go
+++ b/internal/daemon/routes_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -230,6 +231,7 @@ func TestHumaExportReviews(t *testing.T) {
 		Tool          string                 `json:"tool"`
 		ToolVersion   string                 `json:"tool_version"`
 		GeneratedAt   string                 `json:"generated_at"`
+		DatabaseID    string                 `json:"database_id"`
 		Profile       string                 `json:"profile"`
 		Window        map[string]*string     `json:"window"`
 		Truncated     bool                   `json:"truncated"`
@@ -241,6 +243,9 @@ func TestHumaExportReviews(t *testing.T) {
 	assert.Equal(t, "roborev", body.Tool)
 	assert.NotEmpty(t, body.ToolVersion)
 	assert.NotEmpty(t, body.GeneratedAt)
+	databaseID, err := db.GetDatabaseID()
+	require.NoError(t, err)
+	assert.Equal(t, databaseID, body.DatabaseID)
 	assert.Equal(t, "metadata", body.Profile)
 	require.NotNil(t, body.Window["field"])
 	assert.Equal(t, "completed_at", *body.Window["field"])
@@ -259,16 +264,46 @@ func TestHumaExportReviews(t *testing.T) {
 		"/api/export/reviews?profile=content&cursor="+*body.NextCursor+"&limit=10", nil)
 	require.Equal(t, http.StatusOK, rr2.Code, rr2.Body.String())
 	var page2 struct {
+		DatabaseID string                 `json:"database_id"`
 		Truncated  bool                   `json:"truncated"`
 		NextCursor *string                `json:"next_cursor"`
 		Reviews    []storage.ExportReview `json:"reviews"`
 	}
 	require.NoError(t, json.Unmarshal(rr2.Body.Bytes(), &page2))
+	assert.Equal(t, databaseID, page2.DatabaseID)
 	assert.False(t, page2.Truncated)
-	assert.Nil(t, page2.NextCursor)
+	assert.NotNil(t, page2.NextCursor)
 	require.Len(t, page2.Reviews, 1)
 	assert.Equal(t, "fail", page2.Reviews[0].Verdict)
 	assert.Equal(t, "- Medium — issue", *page2.Reviews[0].Content)
+}
+
+func TestHumaExportReviewsRejectsDifferentDatabaseCursorWithConflict(t *testing.T) {
+	srv, db, _ := newTestServer(t)
+	repo := testutil.CreateTestRepo(t, db)
+	job := testutil.CreateCompletedReview(
+		t, db, repo.ID, "export-reset", "test-agent", "No issues found.",
+	)
+	_, err := db.Exec(`UPDATE reviews SET created_at = '2026-06-29 00:00:00' WHERE job_id = ?`, job.ID)
+	require.NoError(t, err)
+	review, err := db.GetReviewByJobID(job.ID)
+	require.NoError(t, err)
+
+	cursor := encodeExportCursorForRouteTest(t, "00000000-0000-4000-8000-000000000000", "2026-06-29T00:00:00Z", review.UUID)
+	rr := serveHuma(t, srv, http.MethodGet, "/api/export/reviews?cursor="+cursor, nil)
+
+	assert.Equal(t, http.StatusConflict, rr.Code, rr.Body.String())
+	assert.Contains(t, rr.Body.String(), "database reset")
+}
+
+func TestHumaExportReviewsRejectsCursorWithSince(t *testing.T) {
+	srv, _, _ := newTestServer(t)
+
+	rr := serveHuma(t, srv, http.MethodGet,
+		"/api/export/reviews?cursor=opaque&since=2026-06-29", nil)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code, rr.Body.String())
+	assert.Contains(t, rr.Body.String(), "cursor cannot be used with since")
 }
 
 func TestHumaExportReviewsValidation(t *testing.T) {
@@ -278,6 +313,7 @@ func TestHumaExportReviewsValidation(t *testing.T) {
 		"/api/export/reviews?format=yaml",
 		"/api/export/reviews?profile=full",
 		"/api/export/reviews?since=not-a-time",
+		"/api/export/reviews?cursor=not-base64",
 	}
 	for _, path := range tests {
 		t.Run(path, func(t *testing.T) {
@@ -323,6 +359,18 @@ func TestHumaExportReviewsMaxLimitIsClamped(t *testing.T) {
 	assert.Len(t, body.Reviews, 5000)
 	assert.True(t, body.Truncated)
 	assert.NotNil(t, body.NextCursor)
+}
+
+func encodeExportCursorForRouteTest(t *testing.T, databaseID, completedAt, reviewID string) string {
+	t.Helper()
+	data, err := json.Marshal(map[string]any{
+		"version":      1,
+		"database_id":  databaseID,
+		"completed_at": completedAt,
+		"review_id":    reviewID,
+	})
+	require.NoError(t, err)
+	return base64.RawURLEncoding.EncodeToString(data)
 }
 
 func TestHumaCancelJob(t *testing.T) {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -1228,6 +1228,9 @@ func (s *Server) humaExportReviews(
 		profile != string(storage.ExportProfileMetadata) {
 		return nil, huma.Error400BadRequest("unsupported export profile")
 	}
+	if input.Cursor != "" && input.Since != "" {
+		return nil, huma.Error400BadRequest("cursor cannot be used with since")
+	}
 
 	since, sinceOut, err := parseExportTimeBound(input.Since, false)
 	if err != nil {
@@ -1257,7 +1260,14 @@ func (s *Server) humaExportReviews(
 		Limit:      limit,
 	})
 	if err != nil {
+		if errors.Is(err, storage.ErrExportCursorDatabaseMismatch) {
+			return nil, huma.Error409Conflict(err.Error())
+		}
 		return nil, huma.Error400BadRequest(err.Error())
+	}
+	databaseID, err := s.db.GetDatabaseID()
+	if err != nil {
+		return nil, fmt.Errorf("get database ID: %w", err)
 	}
 
 	var nextCursor *string
@@ -1270,6 +1280,7 @@ func (s *Server) humaExportReviews(
 		Tool:          "roborev",
 		ToolVersion:   version.Version,
 		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		DatabaseID:    databaseID,
 		Profile:       profile,
 		Window: ExportReviewsWindow{
 			Field: "completed_at",

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -127,7 +127,7 @@ type ExportReviewsInput struct {
 	Repo       string `query:"repo" doc:"Exact exported repo identifier filter"`
 	Project    string `query:"project" doc:"Exact project display-name filter"`
 	Limit      int    `query:"limit" default:"500" doc:"Maximum top-level reviews in this page"`
-	Cursor     string `query:"cursor" doc:"Opaque cursor from a previous page"`
+	Cursor     string `query:"cursor" doc:"Opaque next_cursor from a previous page. Resumes strictly after its (completed_at, review_id) position; mutually exclusive with since."`
 }
 
 type ExportReviewsWindow struct {
@@ -141,10 +141,11 @@ type ExportReviewsDocument struct {
 	Tool          string                 `json:"tool"`
 	ToolVersion   string                 `json:"tool_version"`
 	GeneratedAt   string                 `json:"generated_at"`
+	DatabaseID    string                 `json:"database_id" doc:"Stable identity for the local review database; changes when the database is recreated."`
 	Profile       string                 `json:"profile"`
 	Window        ExportReviewsWindow    `json:"window"`
-	Truncated     bool                   `json:"truncated"`
-	NextCursor    *string                `json:"next_cursor"`
+	Truncated     bool                   `json:"truncated" doc:"True when more matching rows are available immediately."`
+	NextCursor    *string                `json:"next_cursor" doc:"Opaque resume cursor emitted when reviews is non-empty; pass as cursor to resume after the last returned review."`
 	Reviews       []storage.ExportReview `json:"reviews"`
 }
 

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -198,6 +198,10 @@ func Open(dbPath string) (*DB, error) {
 		db.Close()
 		return nil, fmt.Errorf("migrate: %w", err)
 	}
+	if _, err := wrapped.GetDatabaseID(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("initialize database ID: %w", err)
+	}
 	if _, err := wrapped.BackfillVerdictBool(); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("backfill verdicts: %w", err)

--- a/internal/storage/export.go
+++ b/internal/storage/export.go
@@ -18,6 +18,7 @@ const (
 	ExportProfileContent  ExportProfile = "content"
 	ExportProfileMetadata ExportProfile = "metadata"
 
+	exportCursorVersion     = 1
 	exportContentMaxBytes   = 1 << 20
 	exportDefaultPageLimit  = 500
 	exportMaxPageLimit      = 5000
@@ -26,6 +27,11 @@ const (
 	exportReviewStatusDone  = "done"
 	exportReviewVerdictPass = "pass"
 	exportReviewVerdictFail = "fail"
+)
+
+var (
+	ErrExportCursorDatabaseMismatch = errors.New("export cursor database reset")
+	ErrExportCursorNotFound         = errors.New("export cursor no longer resolvable")
 )
 
 type ExportReviewsOptions struct {
@@ -85,6 +91,8 @@ type ExportReviewCost struct {
 }
 
 type exportCursor struct {
+	Version     int    `json:"version"`
+	DatabaseID  string `json:"database_id"`
 	CompletedAt string `json:"completed_at"`
 	ReviewID    string `json:"review_id"`
 }
@@ -130,7 +138,7 @@ func (db *DB) ExportReviews(opts ExportReviewsOptions) (ExportReviewsPage, error
 		opts.Limit = exportMaxPageLimit
 	}
 
-	cursor, err := decodeExportCursor(opts.Cursor)
+	cursor, err := db.resolveExportCursor(opts.Cursor)
 	if err != nil {
 		return ExportReviewsPage{}, err
 	}
@@ -164,9 +172,13 @@ func (db *DB) ExportReviews(opts ExportReviewsOptions) (ExportReviewsPage, error
 	if err := rows.Err(); err != nil {
 		return ExportReviewsPage{}, err
 	}
-	if page.Truncated && len(page.Reviews) > 0 {
+	if len(page.Reviews) > 0 {
 		last := page.Reviews[len(page.Reviews)-1]
-		nextCursor := encodeExportCursor(last.CompletedAt, last.ReviewID)
+		databaseID, err := db.GetDatabaseID()
+		if err != nil {
+			return ExportReviewsPage{}, err
+		}
+		nextCursor := encodeExportCursor(databaseID, last.CompletedAt, last.ReviewID)
 		if nextCursor != "" {
 			page.NextCursor = &nextCursor
 		}
@@ -548,16 +560,49 @@ func isSHALike(s string) bool {
 	return true
 }
 
-func encodeExportCursor(completedAt, reviewID string) string {
-	if completedAt == "" || reviewID == "" {
+func encodeExportCursor(databaseID, completedAt, reviewID string) string {
+	if databaseID == "" || completedAt == "" || reviewID == "" {
 		return ""
 	}
-	data, err := json.Marshal(exportCursor{CompletedAt: completedAt, ReviewID: reviewID})
+	data, err := json.Marshal(exportCursor{
+		Version:     exportCursorVersion,
+		DatabaseID:  databaseID,
+		CompletedAt: completedAt,
+		ReviewID:    reviewID,
+	})
 	if err != nil {
 		log.Printf("storage: warning: encode export cursor: %v", err)
 		return ""
 	}
 	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+func (db *DB) resolveExportCursor(cursor string) (*exportCursor, error) {
+	decoded, err := decodeExportCursor(cursor)
+	if err != nil || decoded == nil {
+		return decoded, err
+	}
+	databaseID, err := db.GetDatabaseID()
+	if err != nil {
+		return nil, err
+	}
+	if decoded.DatabaseID != databaseID {
+		return nil, fmt.Errorf(
+			"%w: cursor database_id %q does not match current database_id %q",
+			ErrExportCursorDatabaseMismatch, decoded.DatabaseID, databaseID,
+		)
+	}
+	found, err := db.exportCursorReviewExists(decoded)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf(
+			"%w: completed_at %q review_id %q",
+			ErrExportCursorNotFound, decoded.CompletedAt, decoded.ReviewID,
+		)
+	}
+	return decoded, nil
 }
 
 func decodeExportCursor(cursor string) (*exportCursor, error) {
@@ -572,7 +617,10 @@ func decodeExportCursor(cursor string) (*exportCursor, error) {
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		return nil, fmt.Errorf("invalid export cursor: %w", err)
 	}
-	if decoded.CompletedAt == "" || decoded.ReviewID == "" {
+	if decoded.Version != exportCursorVersion {
+		return nil, fmt.Errorf("invalid export cursor: unsupported version %d", decoded.Version)
+	}
+	if decoded.DatabaseID == "" || decoded.CompletedAt == "" || decoded.ReviewID == "" {
 		return nil, errors.New("invalid export cursor: missing fields")
 	}
 	t, err := time.Parse(time.RFC3339Nano, decoded.CompletedAt)
@@ -581,4 +629,24 @@ func decodeExportCursor(cursor string) (*exportCursor, error) {
 	}
 	decoded.CompletedAt = t.UTC().Format(time.RFC3339)
 	return &decoded, nil
+}
+
+func (db *DB) exportCursorReviewExists(cursor *exportCursor) (bool, error) {
+	completedExpr := sqliteNormalizedTimestampExpr("rv.created_at")
+	var count int
+	err := db.QueryRow(`
+		SELECT COUNT(1)
+		FROM reviews rv
+		JOIN review_jobs j ON j.id = rv.job_id
+		WHERE rv.uuid = ?
+		  AND `+completedExpr+` = datetime(?)
+		  AND j.status = 'done'
+		  AND COALESCE(j.job_type, 'review') IN ('review','range','dirty','synthesis')
+		  AND COALESCE(j.panel_role, '') != 'member'
+		  AND rv.verdict_bool IS NOT NULL
+	`, cursor.ReviewID, cursor.CompletedAt).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("validate export cursor: %w", err)
+	}
+	return count > 0, nil
 }

--- a/internal/storage/export_test.go
+++ b/internal/storage/export_test.go
@@ -190,8 +190,56 @@ func TestExportReviewsPagination(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, page2.Reviews, 1)
 	assert.False(page2.Truncated)
-	assert.Nil(page2.NextCursor)
+	require.NotNil(t, page2.NextCursor)
 	assert.Equal(third.UUID, page2.Reviews[0].ReviewID)
+
+	page3, err := db.ExportReviews(ExportReviewsOptions{Profile: ExportProfileContent, Cursor: *page2.NextCursor, Limit: 2})
+	require.NoError(t, err)
+	assert.Empty(page3.Reviews)
+	assert.False(page3.Truncated)
+	assert.Nil(page3.NextCursor)
+}
+
+func TestExportReviewsCursorRoundTripAcrossPagesMatchesUnpaginated(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
+	for i := range 5 {
+		seedCompletedExportReview(
+			t, db, repo.ID, fmt.Sprintf("%040x", i+1),
+			fmt.Sprintf("2026-06-29 00:00:%02d", i), false,
+		)
+	}
+
+	full, err := db.ExportReviews(ExportReviewsOptions{Profile: ExportProfileMetadata, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, full.Reviews, 5)
+
+	var cursor string
+	var pagedIDs []string
+	for {
+		page, err := db.ExportReviews(ExportReviewsOptions{
+			Profile: ExportProfileMetadata,
+			Cursor:  cursor,
+			Limit:   2,
+		})
+		require.NoError(t, err)
+		for _, review := range page.Reviews {
+			pagedIDs = append(pagedIDs, review.ReviewID)
+		}
+		if page.NextCursor == nil || len(page.Reviews) == 0 {
+			break
+		}
+		cursor = *page.NextCursor
+	}
+
+	fullIDs := make([]string, 0, len(full.Reviews))
+	for _, review := range full.Reviews {
+		fullIDs = append(fullIDs, review.ReviewID)
+	}
+	assert.Equal(t, fullIDs, pagedIDs)
+	assert.Len(t, uniqueStrings(pagedIDs), len(pagedIDs), "paged export must not duplicate reviews")
 }
 
 func TestExportReviewsCursorPaginatesSameCompletedTimestamp(t *testing.T) {
@@ -212,6 +260,43 @@ func TestExportReviewsCursorPaginatesSameCompletedTimestamp(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, page2.Reviews, 1)
 	assert.Equal(t, second.UUID, page2.Reviews[0].ReviewID)
+	assert.NotNil(t, page2.NextCursor)
+}
+
+func TestExportReviewsCursorPaginatesSameCompletedTimestampPileup(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
+	wantIDs := make([]string, 0, 5)
+	for i := range 5 {
+		review := seedCompletedExportReview(
+			t, db, repo.ID, fmt.Sprintf("%040x", i+1),
+			"2026-06-29 00:00:00", false,
+		)
+		wantIDs = append(wantIDs, review.UUID)
+	}
+
+	var cursor string
+	var gotIDs []string
+	for {
+		page, err := db.ExportReviews(ExportReviewsOptions{
+			Profile: ExportProfileContent,
+			Cursor:  cursor,
+			Limit:   2,
+		})
+		require.NoError(t, err)
+		for _, review := range page.Reviews {
+			gotIDs = append(gotIDs, review.ReviewID)
+		}
+		if page.NextCursor == nil || len(page.Reviews) == 0 {
+			break
+		}
+		cursor = *page.NextCursor
+	}
+
+	assert.Equal(t, wantIDs, gotIDs)
+	assert.Len(t, uniqueStrings(gotIDs), len(gotIDs), "same-timestamp pagination must not duplicate reviews")
 }
 
 func TestExportReviewsDefaultLimitIsBounded(t *testing.T) {
@@ -244,14 +329,83 @@ func TestExportReviewsEmptyPageUsesEmptyReviewsArray(t *testing.T) {
 	assert.NotContains(t, string(encoded), `"reviews":null`)
 }
 
-func TestExportReviewsRejectsInvalidCursorTimestamp(t *testing.T) {
-	cursor := base64.RawURLEncoding.EncodeToString([]byte(`{"completed_at":"not-a-time","review_id":"r1"}`))
+func TestExportReviewsNonTruncatedPageIncludesResumeCursor(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()
 
-	_, err := db.ExportReviews(ExportReviewsOptions{Profile: ExportProfileContent, Cursor: cursor, Limit: 10})
+	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
+	first := seedCompletedExportReview(t, db, repo.ID, "1111111111111111111111111111111111111111", "2026-06-29 00:00:00", false)
+
+	page, err := db.ExportReviews(ExportReviewsOptions{Profile: ExportProfileMetadata, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, page.Reviews, 1)
+	assert.False(t, page.Truncated)
+	require.NotNil(t, page.NextCursor)
+	assert.Equal(t, first.UUID, page.Reviews[0].ReviewID)
+
+	resumed, err := db.ExportReviews(ExportReviewsOptions{
+		Profile: ExportProfileMetadata,
+		Cursor:  *page.NextCursor,
+		Limit:   10,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resumed.Reviews)
+	assert.False(t, resumed.Truncated)
+	assert.Nil(t, resumed.NextCursor)
+}
+
+func TestExportReviewsRejectsInvalidCursorTimestamp(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	databaseID, err := db.GetDatabaseID()
+	require.NoError(t, err)
+	cursor := encodeExportCursorForTest(t, databaseID, "not-a-time", "r1")
+
+	_, err = db.ExportReviews(ExportReviewsOptions{Profile: ExportProfileContent, Cursor: cursor, Limit: 10})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid export cursor timestamp")
+}
+
+func TestExportReviewsRejectsCorruptCursor(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	_, err := db.ExportReviews(ExportReviewsOptions{
+		Profile: ExportProfileContent,
+		Cursor:  "not base64",
+		Limit:   10,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid export cursor")
+}
+
+func TestExportReviewsRejectsCursorFromDifferentDatabaseID(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
+	first := seedCompletedExportReview(t, db, repo.ID, "1111111111111111111111111111111111111111", "2026-06-29 00:00:00", false)
+	cursor := encodeExportCursorForTest(t, "00000000-0000-4000-8000-000000000000", formatExportTime(first.CreatedAt), first.UUID)
+
+	_, err := db.ExportReviews(ExportReviewsOptions{Profile: ExportProfileMetadata, Cursor: cursor, Limit: 10})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrExportCursorDatabaseMismatch)
+	assert.Contains(t, err.Error(), "database reset")
+}
+
+func TestExportReviewsRejectsNoLongerResolvableCursor(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	databaseID, err := db.GetDatabaseID()
+	require.NoError(t, err)
+	cursor := encodeExportCursorForTest(t, databaseID, "2026-06-29T00:00:00Z", "missing-review")
+
+	_, err = db.ExportReviews(ExportReviewsOptions{Profile: ExportProfileMetadata, Cursor: cursor, Limit: 10})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrExportCursorNotFound)
+	assert.Contains(t, err.Error(), "no longer resolvable")
 }
 
 func TestExportReviewsPanelSubagents(t *testing.T) {
@@ -535,4 +689,24 @@ func derefFloat64(v *float64) float64 {
 		return 0
 	}
 	return *v
+}
+
+func encodeExportCursorForTest(t *testing.T, databaseID, completedAt, reviewID string) string {
+	t.Helper()
+	data, err := json.Marshal(map[string]any{
+		"version":      1,
+		"database_id":  databaseID,
+		"completed_at": completedAt,
+		"review_id":    reviewID,
+	})
+	require.NoError(t, err)
+	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+func uniqueStrings(values []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		out[value] = struct{}{}
+	}
+	return out
 }

--- a/internal/storage/sync.go
+++ b/internal/storage/sync.go
@@ -17,6 +17,7 @@ const (
 	SyncStateLastReviewCursor = "last_review_cursor" // Composite cursor for reviews (updated_at,id)
 	SyncStateLastResponseID   = "last_response_id"   // inserted_at/id cursor of last synced response
 	SyncStateSyncTargetID     = "sync_target_id"     // Database ID of last synced Postgres
+	SyncStateDatabaseID       = "database_id"        // Stable identity of this local SQLite database
 )
 
 // GetSyncState retrieves a value from the sync_state table.
@@ -124,6 +125,18 @@ func (db *DB) GetMachineID() (string, error) {
 			return "", fmt.Errorf("update empty machine ID: %w", err)
 		}
 		return newID, nil
+	}
+	return id, nil
+}
+
+// GetDatabaseID returns this local database's unique identifier, creating one
+// if it doesn't exist. It changes only when the SQLite database is recreated.
+func (db *DB) GetDatabaseID() (string, error) {
+	id, err := db.GetOrCreateSyncStateValue(SyncStateDatabaseID, func() (string, error) {
+		return GenerateUUID(), nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("get database ID: %w", err)
 	}
 	return id, nil
 }

--- a/internal/storage/sync_state_test.go
+++ b/internal/storage/sync_state_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"os"
 	"path/filepath"
 	"regexp"
 	"testing"
@@ -103,6 +104,36 @@ func TestGetMachineID_EmptyValueRegeneration(t *testing.T) {
 	err = db.QueryRow(`SELECT value FROM sync_state WHERE key = ?`, SyncStateMachineID).Scan(&stored)
 	r.NoError(err, "Failed to query stored ID: %v", err)
 	a.Equal(id, stored, "Stored ID %q doesn't match returned ID %q", stored, id)
+}
+
+func TestGetDatabaseIDStableAcrossRestartAndChangesAfterRecreation(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "reviews.db")
+
+	db, err := Open(dbPath)
+	require.NoError(t, err)
+	first, err := db.GetDatabaseID()
+	require.NoError(t, err)
+	require.NotEmpty(t, first)
+	require.NoError(t, db.Close())
+
+	reopened, err := Open(dbPath)
+	require.NoError(t, err)
+	second, err := reopened.GetDatabaseID()
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+	require.NoError(t, reopened.Close())
+
+	require.NoError(t, os.Remove(dbPath))
+	_ = os.Remove(dbPath + "-wal")
+	_ = os.Remove(dbPath + "-shm")
+
+	recreated, err := Open(dbPath)
+	require.NoError(t, err)
+	third, err := recreated.GetDatabaseID()
+	require.NoError(t, err)
+	assert.NotEmpty(t, third)
+	assert.NotEqual(t, first, third)
+	require.NoError(t, recreated.Close())
 }
 
 func TestGetOrCreateSyncStateValue(t *testing.T) {

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -426,7 +426,21 @@ func (c *Client) ExportReviewsWithResponse(ctx context.Context, options *ExportR
 			}
 		}
 		return out, nil
-	case 500:
+	case 409:
+		out.ApplicationProblemPlusJSON409 = new(ExportReviewsErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.ApplicationProblemPlusJSON409); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ExportReviewsErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
 		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
 	default:
 		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -81,7 +81,7 @@ type ExportReviewsQuery struct {
 	// Limit Maximum top-level reviews in this page
 	Limit *int64 `json:"limit,omitempty"`
 
-	// Cursor Opaque cursor from a previous page
+	// Cursor Opaque next_cursor from a previous page. Resumes strictly after its (completed_at, review_id) position; mutually exclusive with since.
 	Cursor *string `json:"cursor,omitempty"`
 }
 

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -277,10 +277,11 @@ type EnqueueJobResp struct {
 }
 
 type ExportReviewsResp struct {
-	HTTPResponse *http.Response
-	Body         []byte
-	StatusCode   int
-	JSON200      *ExportReviewsResponse
+	HTTPResponse                  *http.Response
+	Body                          []byte
+	StatusCode                    int
+	JSON200                       *ExportReviewsResponse
+	ApplicationProblemPlusJSON409 *ExportReviewsErrorResponse
 }
 
 type GetHealthResp struct {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -453,20 +453,30 @@ type ExportReviewCost struct {
 
 type ExportReviewsDocument struct {
 	// Schema A URL to the JSON Schema for this object.
-	Schema        *string             `json:"$schema,omitempty"`
-	GeneratedAt   string              `json:"generated_at" validate:"required"`
-	NextCursor    *string             `json:"next_cursor,omitempty" validate:"required"`
-	Profile       string              `json:"profile" validate:"required"`
-	Reviews       []ExportReview      `json:"reviews,omitempty" validate:"required"`
-	SchemaVersion int64               `json:"schema_version"`
-	Tool          string              `json:"tool" validate:"required"`
-	ToolVersion   string              `json:"tool_version" validate:"required"`
-	Truncated     bool                `json:"truncated"`
-	Window        ExportReviewsWindow `json:"window"`
+	Schema *string `json:"$schema,omitempty"`
+
+	// DatabaseID Stable identity for the local review database; changes when the database is recreated.
+	DatabaseID  string `json:"database_id" validate:"required"`
+	GeneratedAt string `json:"generated_at" validate:"required"`
+
+	// NextCursor Opaque resume cursor emitted when reviews is non-empty; pass as cursor to resume after the last returned review.
+	NextCursor    *string        `json:"next_cursor,omitempty" validate:"required"`
+	Profile       string         `json:"profile" validate:"required"`
+	Reviews       []ExportReview `json:"reviews,omitempty" validate:"required"`
+	SchemaVersion int64          `json:"schema_version"`
+	Tool          string         `json:"tool" validate:"required"`
+	ToolVersion   string         `json:"tool_version" validate:"required"`
+
+	// Truncated True when more matching rows are available immediately.
+	Truncated bool                `json:"truncated"`
+	Window    ExportReviewsWindow `json:"window"`
 }
 
 func (e ExportReviewsDocument) Validate() error {
 	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(e.DatabaseID, "required"); err != nil {
+		errors = errors.Append("DatabaseID", err)
+	}
 	if err := typesValidator.Var(e.GeneratedAt, "required"); err != nil {
 		errors = errors.Append("GeneratedAt", err)
 	}

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -673,9 +673,13 @@ components:
           format: uri
           readOnly: true
           type: string
+        database_id:
+          description: Stable identity for the local review database; changes when the database is recreated.
+          type: string
         generated_at:
           type: string
         next_cursor:
+          description: Opaque resume cursor emitted when reviews is non-empty; pass as cursor to resume after the last returned review.
           type:
             - string
             - "null"
@@ -695,6 +699,7 @@ components:
         tool_version:
           type: string
         truncated:
+          description: True when more matching rows are available immediately.
           type: boolean
         window:
           $ref: "#/components/schemas/ExportReviewsWindow"
@@ -703,6 +708,7 @@ components:
         - tool
         - tool_version
         - generated_at
+        - database_id
         - profile
         - window
         - truncated
@@ -2137,12 +2143,12 @@ paths:
             description: Maximum top-level reviews in this page
             format: int64
             type: integer
-        - description: Opaque cursor from a previous page
+        - description: Opaque next_cursor from a previous page. Resumes strictly after its (completed_at, review_id) position; mutually exclusive with since.
           explode: false
           in: query
           name: cursor
           schema:
-            description: Opaque cursor from a previous page
+            description: Opaque next_cursor from a previous page. Resumes strictly after its (completed_at, review_id) position; mutually exclusive with since.
             type: string
       responses:
         "200":
@@ -2151,6 +2157,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ExportReviewsDocument"
           description: OK
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Cursor database_id does not match this local database
         default:
           content:
             application/problem+json:


### PR DESCRIPTION
Review exports are useful as a durable synchronization surface, but window-only polling forces consumers to repeatedly re-read the same completed reviews and push deduplication downstream. A stable cursor lets callers resume from a precise export position instead of treating every poll as a trailing backfill.

This ties cursors to a stable local database identity so callers can distinguish malformed or stale cursor failures from a database reset that requires discarding the old watermark and backfilling again. The CLI now exits with code 3 for that database-reset case so shell callers can branch programmatically instead of parsing stderr.

The export document keeps schema_version at 1 because database_id is an additive header field and existing consumers are expected to ignore unknown keys. Other cursor rejections, including anchors that are no longer resolvable, remain ordinary cursor rejection failures; the documented consumer contract is to discard the cursor and retry from a completed-at backfill window.

The important behavioral contract for reviewers is that cursor resume is ordered by (completed_at, review_id) and is not an overlap scan. Consumers that need convergence for late-completing reviews with earlier completed_at values still need their own overlap-window strategy.