### PR TITLE
Show panel wall-clock elapsed time

### DIFF
--- a/cmd/roborev/tui/queue_test.go
+++ b/cmd/roborev/tui/queue_test.go
@@ -599,6 +599,52 @@ func TestTUIJobCellsContent(t *testing.T) {
 		cells := m.jobCells(member)
 		assert.Empty(t, cells[8])
 	})
+
+	t.Run("panel parent elapsed uses panel wall clock when members are cached", func(t *testing.T) {
+		elapsedIdx := colElapsed - colRef
+		firstMemberStarted := time.Date(2026, time.March, 1, 12, 0, 0, 0, time.UTC)
+		synthesisStarted := firstMemberStarted.Add(9 * time.Minute)
+		synthesisFinished := firstMemberStarted.Add(11 * time.Minute)
+		parent := makeJob(10,
+			withSynthesis("R", storage.PanelSummary{MembersTotal: 2, MembersTerminal: 2}),
+			withStartedAt(synthesisStarted),
+			withFinishedAt(&synthesisFinished),
+		)
+		memberA := makeJob(11,
+			withPanelMember("R", "default", 0),
+			withStartedAt(firstMemberStarted),
+		)
+		memberB := makeJob(12,
+			withPanelMember("R", "security", 1),
+			withStartedAt(firstMemberStarted.Add(2*time.Minute)),
+		)
+		m.panelMembers = map[string][]storage.ReviewJob{"R": {memberA, memberB}}
+
+		cells := m.jobCells(parent)
+
+		assert.Equal(t, "11m0s", cells[elapsedIdx])
+	})
+
+	t.Run("panel parent elapsed uses panel summary before members are cached", func(t *testing.T) {
+		elapsedIdx := colElapsed - colRef
+		firstMemberStarted := time.Date(2026, time.March, 1, 12, 0, 0, 0, time.UTC)
+		synthesisStarted := firstMemberStarted.Add(9 * time.Minute)
+		synthesisFinished := firstMemberStarted.Add(11 * time.Minute)
+		parent := makeJob(10,
+			withSynthesis("R", storage.PanelSummary{
+				MembersTotal:    2,
+				MembersTerminal: 2,
+				FirstStartedAt:  &firstMemberStarted,
+			}),
+			withStartedAt(synthesisStarted),
+			withFinishedAt(&synthesisFinished),
+		)
+		m.panelMembers = nil
+
+		cells := m.jobCells(parent)
+
+		assert.Equal(t, "11m0s", cells[elapsedIdx])
+	})
 }
 
 func TestTUIJobCellsReviewTypeTag(t *testing.T) {
@@ -687,6 +733,35 @@ func TestTUIQueueShowsCostColumnByDefault(t *testing.T) {
 		"Cost header should be visible by default")
 	assert.Contains(t, out, "~$0.42",
 		"cost value should render in the row")
+}
+
+func TestTUIQueuePanelParentRendersPanelElapsedTime(t *testing.T) {
+	firstMemberStarted := time.Date(2026, time.March, 1, 12, 0, 0, 0, time.UTC)
+	synthesisStarted := firstMemberStarted.Add(9 * time.Minute)
+	synthesisFinished := firstMemberStarted.Add(11 * time.Minute)
+	parent := makeJob(10,
+		withRef("syn1234"),
+		withRepoName("repo"),
+		withAgent("test"),
+		withSynthesis("R", storage.PanelSummary{
+			MembersTotal:    2,
+			MembersTerminal: 2,
+			FirstStartedAt:  &firstMemberStarted,
+		}),
+		withStartedAt(synthesisStarted),
+		withFinishedAt(&synthesisFinished),
+	)
+
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.width = 200
+	m.height = 30
+	m.jobs = []storage.ReviewJob{parent}
+	m.selectedIdx = 0
+	m.selectedJobID = parent.ID
+
+	out := stripTestANSI(m.renderQueueView())
+	assert.Contains(t, out, "11m0s")
+	assert.NotContains(t, out, "2m0s")
 }
 
 func TestTUIQueueHeaderShowsPausedQueueState(t *testing.T) {

--- a/cmd/roborev/tui/render_queue.go
+++ b/cmd/roborev/tui/render_queue.go
@@ -930,14 +930,7 @@ func (m model) jobCells(job storage.ReviewJob) []string {
 
 	enqueued := job.EnqueuedAt.Local().Format("Jan 02 15:04")
 
-	elapsed := ""
-	if job.StartedAt != nil {
-		if job.FinishedAt != nil {
-			elapsed = job.FinishedAt.Sub(*job.StartedAt).Round(time.Second).String()
-		} else {
-			elapsed = time.Since(*job.StartedAt).Round(time.Second).String()
-		}
-	}
+	elapsed := m.jobElapsedCell(job)
 
 	status := statusLabel(job)
 
@@ -966,6 +959,45 @@ func (m model) jobCells(job storage.ReviewJob) []string {
 	cost := m.jobCostCell(job)
 
 	return []string{ref, branch, repo, agentName, enqueued, elapsed, status, verdict, handled, sessionID, requestedModel, requestedProvider, cost}
+}
+
+func (m model) jobElapsedCell(job storage.ReviewJob) string {
+	startedAt, ok := m.jobElapsedStart(job)
+	if !ok {
+		return ""
+	}
+	if job.FinishedAt != nil {
+		return job.FinishedAt.Sub(startedAt).Round(time.Second).String()
+	}
+	return time.Since(startedAt).Round(time.Second).String()
+}
+
+func (m model) jobElapsedStart(job storage.ReviewJob) (time.Time, bool) {
+	startedAt := time.Time{}
+	hasStartedAt := false
+	if job.StartedAt != nil {
+		startedAt = *job.StartedAt
+		hasStartedAt = true
+	}
+
+	if !job.IsSynthesisJob() || job.PanelRunUUID == "" {
+		return startedAt, hasStartedAt
+	}
+
+	if job.PanelSummary != nil && job.PanelSummary.FirstStartedAt != nil {
+		startedAt = *job.PanelSummary.FirstStartedAt
+		hasStartedAt = true
+	}
+	for _, member := range m.panelMembers[job.PanelRunUUID] {
+		if member.StartedAt == nil {
+			continue
+		}
+		if !hasStartedAt || member.StartedAt.Before(startedAt) {
+			startedAt = *member.StartedAt
+			hasStartedAt = true
+		}
+	}
+	return startedAt, hasStartedAt
 }
 
 // jobCostCell renders the stored priced estimate for a row. For a panel parent,

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -1866,16 +1866,17 @@ func (db *DB) GetPanelMemberReviews(panelRunUUID string) ([]BatchReviewResult, e
 // ambiguous — an all-failed panel is finished but has zero done members — so
 // the terminal set is broken out explicitly.
 type PanelSummary struct {
-	PanelRunUUID        string  `json:"panel_run_uuid"`
-	MembersTotal        int     `json:"members_total"`
-	MembersTerminal     int     `json:"members_terminal"`
-	MembersSucceeded    int     `json:"members_succeeded"`
-	MembersFailed       int     `json:"members_failed"`
-	MembersCanceled     int     `json:"members_canceled"`
-	MembersSkipped      int     `json:"members_skipped"`
-	MembersWithCost     int     `json:"members_with_cost,omitempty"`
-	MembersCostUSD      float64 `json:"members_cost_usd,omitempty"`
-	MembersCostComplete bool    `json:"members_cost_complete,omitempty"`
+	PanelRunUUID        string     `json:"panel_run_uuid"`
+	MembersTotal        int        `json:"members_total"`
+	MembersTerminal     int        `json:"members_terminal"`
+	MembersSucceeded    int        `json:"members_succeeded"`
+	MembersFailed       int        `json:"members_failed"`
+	MembersCanceled     int        `json:"members_canceled"`
+	MembersSkipped      int        `json:"members_skipped"`
+	MembersWithCost     int        `json:"members_with_cost,omitempty"`
+	MembersCostUSD      float64    `json:"members_cost_usd,omitempty"`
+	MembersCostComplete bool       `json:"members_cost_complete,omitempty"`
+	FirstStartedAt      *time.Time `json:"first_started_at,omitempty"`
 }
 
 // GetPanelSummaries computes the member breakdown for each given panel run in
@@ -1900,7 +1901,8 @@ func (db *DB) GetPanelSummaries(runUUIDs []string) (map[string]PanelSummary, err
 		       COALESCE(SUM(CASE WHEN status = 'canceled' THEN 1 ELSE 0 END), 0),
 		       COALESCE(SUM(CASE WHEN status = 'skipped' THEN 1 ELSE 0 END), 0),
 		       COALESCE(SUM(CASE WHEN json_valid(token_usage) AND json_extract(token_usage, '$.has_cost') THEN 1 ELSE 0 END), 0),
-		       COALESCE(SUM(CASE WHEN json_valid(token_usage) AND json_extract(token_usage, '$.has_cost') THEN json_extract(token_usage, '$.cost_usd') ELSE 0 END), 0)
+		       COALESCE(SUM(CASE WHEN json_valid(token_usage) AND json_extract(token_usage, '$.has_cost') THEN json_extract(token_usage, '$.cost_usd') ELSE 0 END), 0),
+		       MIN(started_at)
 		FROM review_jobs
 		WHERE panel_role = 'member' AND panel_run_uuid IN (%s)
 		GROUP BY panel_run_uuid
@@ -1916,13 +1918,18 @@ func (db *DB) GetPanelSummaries(runUUIDs []string) (map[string]PanelSummary, err
 	for rows.Next() {
 		var s PanelSummary
 		var membersWithCost int
+		var firstStartedAt sql.NullString
 		if err := rows.Scan(&s.PanelRunUUID, &s.MembersTotal, &s.MembersTerminal,
 			&s.MembersSucceeded, &s.MembersFailed, &s.MembersCanceled, &s.MembersSkipped,
-			&membersWithCost, &s.MembersCostUSD); err != nil {
+			&membersWithCost, &s.MembersCostUSD, &firstStartedAt); err != nil {
 			return nil, fmt.Errorf("scan panel summary: %w", err)
 		}
 		s.MembersWithCost = membersWithCost
 		s.MembersCostComplete = s.MembersTotal > 0 && membersWithCost == s.MembersTotal
+		if firstStartedAt.Valid {
+			t := parseSQLiteTime(firstStartedAt.String)
+			s.FirstStartedAt = &t
+		}
 		out[s.PanelRunUUID] = s
 	}
 	return out, rows.Err()

--- a/internal/storage/panels_test.go
+++ b/internal/storage/panels_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -192,6 +193,14 @@ func enqueuePanelRun(t *testing.T, db *DB, repoID int64, runUUID string, n int) 
 func setStatus(t *testing.T, db *DB, jobID int64, status JobStatus) {
 	t.Helper()
 	_, err := db.Exec(`UPDATE review_jobs SET status = ? WHERE id = ?`, string(status), jobID)
+	require.NoError(t, err)
+}
+
+func setStartedAt(t *testing.T, db *DB, jobID int64, startedAt time.Time) {
+	t.Helper()
+	_, err := db.Exec(
+		`UPDATE review_jobs SET started_at = ? WHERE id = ?`,
+		startedAt.UTC().Format(time.RFC3339), jobID)
 	require.NoError(t, err)
 }
 
@@ -431,6 +440,10 @@ func TestGetPanelSummaries(t *testing.T) {
 
 	// Run A: 3 members — done, failed, skipped (all terminal; 1 succeeded).
 	_, a := enqueuePanelRun(t, db, repo.ID, "run-A", 3)
+	firstAStarted := time.Date(2026, time.March, 1, 12, 0, 0, 0, time.UTC)
+	setStartedAt(t, db, a[0].ID, firstAStarted.Add(2*time.Minute))
+	setStartedAt(t, db, a[1].ID, firstAStarted)
+	setStartedAt(t, db, a[2].ID, firstAStarted.Add(time.Minute))
 	setStatus(t, db, a[0].ID, JobStatusDone)
 	setStatus(t, db, a[1].ID, JobStatusFailed)
 	setStatus(t, db, a[2].ID, JobStatusSkipped)
@@ -463,6 +476,11 @@ func TestGetPanelSummaries(t *testing.T) {
 	assert.Equal(3, sumA.MembersWithCost)
 	assert.True(sumA.MembersCostComplete)
 	assert.InDelta(0.40, sumA.MembersCostUSD, 0.000001)
+	sumAJSON, err := json.Marshal(sumA)
+	require.NoError(t, err)
+	var sumAMap map[string]any
+	require.NoError(t, json.Unmarshal(sumAJSON, &sumAMap))
+	assert.Equal(firstAStarted.Format(time.RFC3339), sumAMap["first_started_at"])
 
 	sumB := got["run-B"]
 	assert.Equal(2, sumB.MembersTotal)

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -798,16 +798,17 @@ type OverviewStats struct {
 }
 
 type PanelSummary struct {
-	MembersCanceled     int64    `json:"members_canceled"`
-	MembersCostComplete *bool    `json:"members_cost_complete,omitempty"`
-	MembersCostUsd      *float64 `json:"members_cost_usd,omitempty"`
-	MembersFailed       int64    `json:"members_failed"`
-	MembersSkipped      int64    `json:"members_skipped"`
-	MembersSucceeded    int64    `json:"members_succeeded"`
-	MembersTerminal     int64    `json:"members_terminal"`
-	MembersTotal        int64    `json:"members_total"`
-	MembersWithCost     *int64   `json:"members_with_cost,omitempty"`
-	PanelRunUUID        string   `json:"panel_run_uuid" validate:"required"`
+	FirstStartedAt      *time.Time `json:"first_started_at,omitempty"`
+	MembersCanceled     int64      `json:"members_canceled"`
+	MembersCostComplete *bool      `json:"members_cost_complete,omitempty"`
+	MembersCostUsd      *float64   `json:"members_cost_usd,omitempty"`
+	MembersFailed       int64      `json:"members_failed"`
+	MembersSkipped      int64      `json:"members_skipped"`
+	MembersSucceeded    int64      `json:"members_succeeded"`
+	MembersTerminal     int64      `json:"members_terminal"`
+	MembersTotal        int64      `json:"members_total"`
+	MembersWithCost     *int64     `json:"members_with_cost,omitempty"`
+	PanelRunUUID        string     `json:"panel_run_uuid" validate:"required"`
 }
 
 func (p PanelSummary) Validate() error {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -1067,6 +1067,9 @@ components:
     PanelSummary:
       additionalProperties: false
       properties:
+        first_started_at:
+          format: date-time
+          type: string
         members_canceled:
           format: int64
           type: integer


### PR DESCRIPTION
Panel rows currently show the synthesis worker runtime, which understates the actual time a user waits for a panel review. This PR makes the elapsed column reflect the wall-clock panel window from the first reviewer start through synthesis completion, while preserving the existing synthesis timestamps as a fallback for older or incomplete responses.

The change exposes the first member start in the existing panel summary aggregate so collapsed panel parents have enough data without fetching members. Reviewers should treat this as an additive API field: existing consumers can ignore it, and the public client has been regenerated to include it.