### PR TITLE
Honor CLAUDE_CONFIG_DIR and CODEX_HOME when installing skills

### DIFF
--- a/cmd/roborev/skills.go
+++ b/cmd/roborev/skills.go
@@ -112,8 +112,8 @@ func skillsCmd() *cobra.Command {
 		Long: `Install roborev skills to your AI agent configuration directories.
 
 Skills are installed for agents whose config directories exist:
-  - Claude Code: ~/.claude/skills/
-  - Codex: ~/.codex/skills/
+  - Claude Code: ~/.claude/skills/ (or $CLAUDE_CONFIG_DIR/skills/ if set)
+  - Codex: ~/.codex/skills/ (or $CODEX_HOME/skills/ if set)
   - Factory Droid: ~/.factory/skills/
 
 This command is idempotent - running it multiple times is safe.`,
@@ -141,7 +141,7 @@ This command is idempotent - running it multiple times is safe.`,
 			var installedAgents []skills.Agent
 			for _, result := range results {
 				if result.Skipped {
-					fmt.Printf("%s: skipped (no ~/.%s directory)\n", result.Agent, result.Agent)
+					fmt.Printf("%s: skipped (no %s directory)\n", result.Agent, result.ConfigDir)
 					continue
 				}
 

--- a/internal/agenthook/install.go
+++ b/internal/agenthook/install.go
@@ -691,6 +691,9 @@ func DefaultCodexHooksPath() string {
 }
 
 func DefaultClaudeSettingsPath() string {
+	if dir := os.Getenv("CLAUDE_CONFIG_DIR"); dir != "" {
+		return filepath.Join(dir, "settings.json")
+	}
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
 		return ""

--- a/internal/agenthook/install_test.go
+++ b/internal/agenthook/install_test.go
@@ -651,6 +651,24 @@ func TestDefaultDroidHooksPath(t *testing.T) {
 	assert.Empty(t, DefaultDroidHooksPath("project"))
 }
 
+func TestDefaultClaudeSettingsPathHonorsClaudeConfigDir(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", configDir)
+
+	assert.Equal(t, filepath.Join(configDir, "settings.json"), DefaultClaudeSettingsPath())
+}
+
+func TestDefaultClaudeSettingsPathDefaultsToHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+
+	assert.Equal(t, filepath.Join(home, ".claude", "settings.json"), DefaultClaudeSettingsPath())
+}
+
 func TestUpsertCommandHookCollapsesDuplicatesAndKeepsOthers(t *testing.T) {
 	assert := assert.New(t)
 	spec := InstallSpec{

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -38,6 +38,7 @@ const (
 type agentSpec struct {
 	agent         Agent
 	configDirName string
+	configDirEnv  string
 	embedFS       fs.FS
 	embedDir      string
 }
@@ -50,8 +51,8 @@ type embeddedSkill struct {
 }
 
 var supportedAgents = []agentSpec{
-	{agent: AgentClaude, configDirName: ".claude", embedFS: claudeSkills, embedDir: "claude"},
-	{agent: AgentCodex, configDirName: ".codex", embedFS: codexSkills, embedDir: "codex"},
+	{agent: AgentClaude, configDirName: ".claude", configDirEnv: "CLAUDE_CONFIG_DIR", embedFS: claudeSkills, embedDir: "claude"},
+	{agent: AgentCodex, configDirName: ".codex", configDirEnv: "CODEX_HOME", embedFS: codexSkills, embedDir: "codex"},
 	{agent: AgentDroid, configDirName: ".factory", embedFS: droidSkills, embedDir: "droid"},
 }
 
@@ -60,6 +61,7 @@ var userHomeDir = os.UserHomeDir
 // InstallResult contains the result of a skill installation
 type InstallResult struct {
 	Agent     Agent
+	ConfigDir string // Resolved agent config directory
 	Installed []string
 	Updated   []string
 	Skipped   bool // True if agent config dir doesn't exist
@@ -121,6 +123,11 @@ func lookupAgent(agent Agent) (agentSpec, bool) {
 }
 
 func agentConfigDir(home string, spec agentSpec) string {
+	if spec.configDirEnv != "" {
+		if dir := os.Getenv(spec.configDirEnv); dir != "" {
+			return dir
+		}
+	}
 	return filepath.Join(home, spec.configDirName)
 }
 
@@ -276,6 +283,7 @@ func installAgent(spec agentSpec) (InstallResult, error) {
 	}
 
 	configDir := agentConfigDir(home, spec)
+	result.ConfigDir = configDir
 	if _, err := os.Stat(configDir); os.IsNotExist(err) {
 		result.Skipped = true
 		return result, nil

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -33,6 +33,10 @@ func setupTestEnv(t *testing.T) string {
 	t.Setenv("HOMEDRIVE", "")
 	t.Setenv("HOMEPATH", "")
 
+	// Clear config-dir overrides so tests never touch a real agent config.
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	t.Setenv("CODEX_HOME", "")
+
 	return tmpHome
 }
 
@@ -119,6 +123,75 @@ func TestInstallWhenDirExists(t *testing.T) {
 			assertSkillsInstalled(t, tmpHome, tc)
 		})
 	}
+}
+
+func TestInstallHonorsConfigDirEnvOverride(t *testing.T) {
+	tests := []struct {
+		agent  Agent
+		envVar string
+	}{
+		{agent: AgentClaude, envVar: "CLAUDE_CONFIG_DIR"},
+		{agent: AgentCodex, envVar: "CODEX_HOME"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.envVar, func(t *testing.T) {
+			expectedSkills := expectedSkillDirNamesForAgent(t, tt.agent)
+			tmpHome := setupTestEnv(t)
+			configDir := t.TempDir()
+			t.Setenv(tt.envVar, configDir)
+
+			results, err := Install()
+			require.NoError(t, err, "Install failed")
+
+			res := findResultByAgent(t, results, tt.agent)
+			assert.False(t, res.Skipped, "expected not to be skipped")
+			assert.Equal(t, configDir, res.ConfigDir)
+			assert.Len(t, res.Installed, len(expectedSkills))
+
+			for _, skill := range expectedSkills {
+				path := filepath.Join(configDir, "skills", skill, "SKILL.md")
+				_, err := os.Stat(path)
+				require.NoError(t, err, "expected %s to exist", path)
+			}
+
+			spec, ok := lookupAgent(tt.agent)
+			require.True(t, ok)
+			_, err = os.Stat(filepath.Join(tmpHome, spec.configDirName))
+			assert.True(t, os.IsNotExist(err), "expected nothing under the home config dir")
+
+			assert.True(t, IsInstalled(tt.agent), "expected IsInstalled to honor the override")
+
+			for _, status := range Status() {
+				if status.Agent != tt.agent {
+					continue
+				}
+				assert.True(t, status.Available, "expected Status to honor the override")
+				for _, skill := range expectedSkills {
+					assert.Equal(t, SkillCurrent, status.Skills[skill])
+				}
+			}
+		})
+	}
+}
+
+func TestInstallSkipsWhenConfigDirEnvOverrideMissing(t *testing.T) {
+	tmpHome := setupTestEnv(t)
+
+	// The home config dir exists, but the override takes precedence.
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpHome, ".claude"), 0o755))
+	missing := filepath.Join(t.TempDir(), "missing")
+	t.Setenv("CLAUDE_CONFIG_DIR", missing)
+
+	results, err := Install()
+	require.NoError(t, err, "Install failed")
+
+	claudeResult := findResultByAgent(t, results, AgentClaude)
+	assert.True(t, claudeResult.Skipped, "expected Claude to be skipped when the override dir doesn't exist")
+	assert.Equal(t, missing, claudeResult.ConfigDir)
+
+	_, err = os.Stat(filepath.Join(tmpHome, ".claude", "skills"))
+	assert.True(t, os.IsNotExist(err), "expected no skills under the home config dir")
 }
 
 func TestInstallIdempotent(t *testing.T) {

--- a/internal/testenv/testenv.go
+++ b/internal/testenv/testenv.go
@@ -34,6 +34,9 @@ func RunIsolatedMain(m *testing.M) int {
 	restoreDataDir := setDataDirEnv(tmpDir)
 	defer restoreDataDir()
 
+	restoreAgentConfigEnv := unsetAgentConfigDirEnv()
+	defer restoreAgentConfigEnv()
+
 	code := m.Run()
 
 	// Hard barrier: fail if tests polluted production logs.
@@ -83,6 +86,29 @@ func setDataDirEnv(dir string) func() {
 			return
 		}
 		_ = os.Unsetenv("ROBOREV_DATA_DIR")
+	}
+}
+
+// unsetAgentConfigDirEnv clears agent config-dir overrides (e.g.
+// CLAUDE_CONFIG_DIR replacing ~/.claude) so tests that redirect HOME never
+// resolve paths into a developer's real agent configuration.
+func unsetAgentConfigDirEnv() func() {
+	keys := []string{"CLAUDE_CONFIG_DIR", "CODEX_HOME"}
+	restores := make([]func(), 0, len(keys))
+	for _, key := range keys {
+		orig, has := os.LookupEnv(key)
+		if !has {
+			continue
+		}
+		_ = os.Unsetenv(key)
+		restores = append(restores, func() {
+			_ = os.Setenv(key, orig)
+		})
+	}
+	return func() {
+		for _, restore := range restores {
+			restore()
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Resolve the Claude Code config directory from `CLAUDE_CONFIG_DIR` (and the Codex one from `CODEX_HOME`) when installing, updating, and reporting skills, falling back to `~/.claude` / `~/.codex` when unset
- Honor `CLAUDE_CONFIG_DIR` in `DefaultClaudeSettingsPath` for agent-hook installs, mirroring the existing `CODEX_HOME` handling in `DefaultCodexHooksPath`
- Print the resolved config directory in the skills install skip message, which also fixes the previous `~/.droid` rendering for Factory Droid
- Clear both env vars in `RunIsolatedMain` and the skills test setup so test suites never resolve paths into a developer's real agent configuration

Fixes #947

🤖 Generated with [Claude Code](https://claude.com/claude-code)
