### PR TITLE
docs: require explicit roborev requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,6 +234,11 @@ Test conventions:
 
 ## Review / Refine Guidance
 
+- Never manually invoke `roborev review` in any form unless the user explicitly
+  asks for it. Never invoke a roborev skill (including `roborev-fix` or
+  `roborev-design-review-branch`) unless the user explicitly asks for that
+  skill.
+
 When reviewing or fixing issues:
 
 - Focus on correctness, concurrency safety, and error handling in daemon/worker code.


### PR DESCRIPTION
Automated review runs can consume resources and create persistent review state even when review was not part of the requested task. Make both direct `roborev review` invocation and roborev skill activation explicitly user-directed so agents do not treat either as an automatic completion step.