### PR TITLE
fix(agent): version-gate the Antigravity (agy) print-mode invocation

### DIFF
--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -7,8 +7,11 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os/exec"
 	"path"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // errNoStreamJSON indicates no valid stream-json events were parsed.
@@ -166,7 +169,11 @@ func commandBaseName(command string) string {
 }
 
 func (a *GeminiAgent) buildAntigravityArgs(agenticMode bool) []string {
-	args := []string{"--print", "--print-timeout", "30m"}
+	// These are the flags common to both print-mode contracts. runAntigravity
+	// adds the prompt-carrying flag (a bare --print for old agy that reads
+	// stdin, or --prompt <text> for agy >= 1.1.1) after detecting the version,
+	// so no --print is emitted here where it would swallow --print-timeout.
+	args := []string{"--print-timeout", "30m"}
 
 	if agenticMode {
 		args = append(args, "--dangerously-skip-permissions")
@@ -219,13 +226,45 @@ func (a *GeminiAgent) runGemini(ctx context.Context, repoPath, prompt string, ar
 	return "No review output generated", runResult.Stderr, nil
 }
 
+// antigravityPromptFlagVersion is the agy release where print mode began taking
+// the prompt as the value of --prompt (an alias of --print/-p) and stopped
+// reading it from stdin. Older agy builds read the prompt from stdin with a
+// bare --print. agy is an unstable CLI target, so the invocation is gated on
+// the reported version rather than assuming one contract.
+const (
+	antigravityPromptFlagVersion   = "1.1.1"
+	antigravityVersionProbeTimeout = 10 * time.Second
+)
+
 func (a *GeminiAgent) runAntigravity(ctx context.Context, repoPath, prompt string, args []string, output io.Writer) (string, string, error) {
+	// Choose the prompt-carrying flag by agy version: >= 1.1.1 takes the prompt
+	// as the value of --prompt (stdin is ignored); older agy reads it from
+	// stdin with a bare --print. A bare --print on new agy would swallow the
+	// following --print-timeout token as the prompt, so the two forms must not
+	// be mixed.
+	trimmedPrompt := strings.TrimRight(prompt, "\n")
+	var finalArgs []string
+	var stdin io.Reader
+	if antigravityPromptViaFlag(ctx, a.Command) {
+		// This contract carries the prompt in argv (agy has no stdin/file
+		// prompt input here), so bound its length to fail with a clear error
+		// rather than an opaque exec failure (E2BIG, or Windows' ~32KB
+		// CreateProcess limit). Mirrors kiro's maxPromptArgLen guard.
+		if len(trimmedPrompt) > maxPromptArgLen {
+			return "", "", fmt.Errorf("prompt too large for antigravity argv (%d bytes, max %d)", len(trimmedPrompt), maxPromptArgLen)
+		}
+		finalArgs = append(append([]string(nil), args...), "--prompt", trimmedPrompt)
+	} else {
+		finalArgs = append([]string{"--print"}, args...)
+		stdin = strings.NewReader(trimmedPrompt + "\n")
+	}
+
 	runResult, runErr := runStreamingCLI(ctx, streamingCLISpec{
 		Name:         "antigravity",
 		Command:      a.Command,
-		Args:         args,
+		Args:         finalArgs,
 		Dir:          repoPath,
-		Stdin:        strings.NewReader(strings.TrimRight(prompt, "\n") + "\n"),
+		Stdin:        stdin,
 		Output:       output,
 		StreamStderr: true,
 		Parse: func(r io.Reader, sw *syncWriter) (string, error) {
@@ -249,6 +288,88 @@ func (a *GeminiAgent) runAntigravity(ctx context.Context, repoPath, prompt strin
 	}
 
 	return "No review output generated", runResult.Stderr, nil
+}
+
+// antigravityPromptViaFlag reports whether the installed agy expects the prompt
+// as a --prompt flag value (agy >= 1.1.1) rather than on stdin (agy <= 1.1.0).
+// It shells out to `agy --version`; the `agy version` subcommand needs a TTY
+// and fails in pipes/subprocesses. Any detection failure (missing binary,
+// timeout, unparseable output) defaults to the current flag contract, since the
+// stdin form only exists in old agy builds.
+func antigravityPromptViaFlag(ctx context.Context, command string) bool {
+	// Cap the probe: `agy --version` returns instantly, but agy's sibling
+	// `agy version` subcommand hangs without a TTY, so don't let a wedged probe
+	// consume the whole review timeout.
+	vctx, cancel := context.WithTimeout(ctx, antigravityVersionProbeTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(vctx, command, "--version").Output()
+	if err != nil {
+		log.Printf("antigravity: could not read agy version (%v); assuming the --prompt flag contract", err)
+		return true
+	}
+	return antigravityVersionUsesPromptFlag(string(out))
+}
+
+// antigravityVersionUsesPromptFlag reports whether agy's `--version` output
+// indicates the --prompt flag contract (>= 1.1.1). It scans for the first
+// dotted version token, so decorated output ("agy version 1.1.0", a trailing
+// build hash) still resolves. Output with no parseable version defaults to
+// true, the current contract.
+func antigravityVersionUsesPromptFlag(versionOutput string) bool {
+	for _, tok := range strings.Fields(versionOutput) {
+		if !strings.Contains(tok, ".") {
+			continue
+		}
+		if cmp, ok := compareDotVersion(tok, antigravityPromptFlagVersion); ok {
+			return cmp >= 0
+		}
+	}
+	return true
+}
+
+// compareDotVersion compares two dotted numeric versions (major.minor.patch,
+// with an optional leading 'v' and any -prerelease/+build suffix ignored). It
+// returns -1, 0, or 1, and ok=false if either side has no parseable version.
+func compareDotVersion(a, b string) (int, bool) {
+	av, aok := parseDotVersion(a)
+	bv, bok := parseDotVersion(b)
+	if !aok || !bok {
+		return 0, false
+	}
+	for i := range av {
+		switch {
+		case av[i] < bv[i]:
+			return -1, true
+		case av[i] > bv[i]:
+			return 1, true
+		}
+	}
+	return 0, true
+}
+
+// parseDotVersion parses a single major[.minor[.patch]] numeric version token,
+// tolerating a 'v' prefix and dropping any -prerelease/+build metadata.
+func parseDotVersion(v string) ([3]int, bool) {
+	var out [3]int
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		v = v[:i]
+	}
+	if v == "" {
+		return out, false
+	}
+	parts := strings.Split(v, ".")
+	if len(parts) > 3 {
+		return out, false
+	}
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 {
+			return out, false
+		}
+		out[i] = n
+	}
+	return out, true
 }
 
 func parseAntigravityOutput(r io.Reader, sw *syncWriter) (string, error) {

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os/exec"
 	"path"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -248,10 +249,10 @@ func (a *GeminiAgent) runAntigravity(ctx context.Context, repoPath, prompt strin
 	if antigravityPromptViaFlag(ctx, a.Command) {
 		// This contract carries the prompt in argv (agy has no stdin/file
 		// prompt input here), so bound its length to fail with a clear error
-		// rather than an opaque exec failure (E2BIG, or Windows' ~32KB
-		// CreateProcess limit). Mirrors kiro's maxPromptArgLen guard.
-		if len(trimmedPrompt) > maxPromptArgLen {
-			return "", "", fmt.Errorf("prompt too large for antigravity argv (%d bytes, max %d)", len(trimmedPrompt), maxPromptArgLen)
+		// rather than an opaque exec failure. The ceiling is platform-specific
+		// (see antigravityMaxPromptArgLen).
+		if limit := antigravityMaxPromptArgLen(); len(trimmedPrompt) > limit {
+			return "", "", fmt.Errorf("prompt too large for antigravity argv (%d bytes, max %d on %s)", len(trimmedPrompt), limit, runtime.GOOS)
 		}
 		finalArgs = append(append([]string(nil), args...), "--prompt", trimmedPrompt)
 	} else {
@@ -302,12 +303,35 @@ func antigravityPromptViaFlag(ctx context.Context, command string) bool {
 	// consume the whole review timeout.
 	vctx, cancel := context.WithTimeout(ctx, antigravityVersionProbeTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(vctx, command, "--version").Output()
+	cmd := exec.CommandContext(vctx, command, "--version")
+	// Run the probe from a stable cwd and without a console window, and avoid
+	// inheriting a deleted daemon working directory (a bad cwd otherwise makes
+	// the probe fail and mis-default a legacy agy to the --prompt contract).
+	configureCapabilityProbe(cmd)
+	out, err := cmd.Output()
 	if err != nil {
 		log.Printf("antigravity: could not read agy version (%v); assuming the --prompt flag contract", err)
 		return true
 	}
 	return antigravityVersionUsesPromptFlag(string(out))
+}
+
+// antigravityMaxPromptArgLen bounds the prompt when it is passed in argv, the
+// only channel agy print mode offers. The ceiling is platform-specific because
+// the OS limits differ sharply: Windows caps the whole command line near 32K
+// UTF-16 units, Linux caps a single argument at MAX_ARG_STRLEN (128 KiB), and
+// macOS only bounds total argv+env (~1 MiB). The default prompt cap (200 KiB)
+// exceeds the Linux and Windows limits, so a large diff would otherwise fail
+// with an opaque exec error instead of a clear one.
+func antigravityMaxPromptArgLen() int {
+	switch runtime.GOOS {
+	case "windows":
+		return 30 * 1000 // headroom under the ~32K UTF-16 command-line cap
+	case "linux":
+		return 120 * 1024 // under MAX_ARG_STRLEN (128 KiB) per argument
+	default:
+		return maxPromptArgLen // macOS/other: bounded by total ARG_MAX
+	}
 }
 
 // antigravityVersionUsesPromptFlag reports whether agy's `--version` output

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -251,8 +251,8 @@ func (a *GeminiAgent) runAntigravity(ctx context.Context, repoPath, prompt strin
 		// prompt input here), so bound its length to fail with a clear error
 		// rather than an opaque exec failure. The ceiling is platform-specific
 		// (see antigravityMaxPromptArgLen).
-		if limit := antigravityMaxPromptArgLen(); len(trimmedPrompt) > limit {
-			return "", "", fmt.Errorf("prompt too large for antigravity argv (%d bytes, max %d on %s)", len(trimmedPrompt), limit, runtime.GOOS)
+		if size, limit := antigravityPromptArgSize(trimmedPrompt), antigravityMaxPromptArgLen(); size > limit {
+			return "", "", fmt.Errorf("prompt too large for antigravity argv (size %d, max %d on %s)", size, limit, runtime.GOOS)
 		}
 		finalArgs = append(append([]string(nil), args...), "--prompt", trimmedPrompt)
 	} else {
@@ -316,17 +316,44 @@ func antigravityPromptViaFlag(ctx context.Context, command string) bool {
 	return antigravityVersionUsesPromptFlag(string(out))
 }
 
-// antigravityMaxPromptArgLen bounds the prompt when it is passed in argv, the
-// only channel agy print mode offers. The ceiling is platform-specific because
-// the OS limits differ sharply: Windows caps the whole command line near 32K
+// antigravityPromptArgSize measures the prompt against the platform's
+// command-line limit: UTF-16 code units on Windows (what CreateProcess counts,
+// counting supplementary-plane runes as a surrogate pair), bytes elsewhere.
+func antigravityPromptArgSize(prompt string) int {
+	if runtime.GOOS != "windows" {
+		return len(prompt)
+	}
+	return utf16CodeUnits(prompt)
+}
+
+// utf16CodeUnits counts the UTF-16 code units in s, counting supplementary-plane
+// runes (> U+FFFF) as a surrogate pair.
+func utf16CodeUnits(s string) int {
+	units := 0
+	for _, r := range s {
+		if r > 0xFFFF {
+			units += 2
+		} else {
+			units++
+		}
+	}
+	return units
+}
+
+// antigravityMaxPromptArgLen is the ceiling for antigravityPromptArgSize when
+// the prompt is passed in argv, the only channel agy print mode offers. The
+// limits differ sharply by OS: Windows caps the whole command line at 32767
 // UTF-16 units, Linux caps a single argument at MAX_ARG_STRLEN (128 KiB), and
 // macOS only bounds total argv+env (~1 MiB). The default prompt cap (200 KiB)
-// exceeds the Linux and Windows limits, so a large diff would otherwise fail
-// with an opaque exec error instead of a clear one.
+// exceeds the Linux and Windows ceilings, so a large diff fails with a clear
+// error instead of an opaque one.
 func antigravityMaxPromptArgLen() int {
 	switch runtime.GOOS {
 	case "windows":
-		return 30 * 1000 // headroom under the ~32K UTF-16 command-line cap
+		// Half of the 32767-unit command-line cap, which survives worst-case
+		// quote/backslash escaping (it can nearly double a quoted argument) and
+		// reserves room for the executable path and the other flags.
+		return 15000
 	case "linux":
 		return 120 * 1024 // under MAX_ARG_STRLEN (128 KiB) per argument
 	default:

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -367,7 +367,7 @@ func antigravityMaxPromptArgLen() int {
 // build hash) still resolves. Output with no parseable version defaults to
 // true, the current contract.
 func antigravityVersionUsesPromptFlag(versionOutput string) bool {
-	for _, tok := range strings.Fields(versionOutput) {
+	for tok := range strings.FieldsSeq(versionOutput) {
 		if !strings.Contains(tok, ".") {
 			continue
 		}

--- a/internal/agent/gemini_test.go
+++ b/internal/agent/gemini_test.go
@@ -380,6 +380,15 @@ echo "No issues found."
 	assert.NotContains(t, argsOut, "--prompt\n")
 }
 
+func TestUTF16CodeUnits(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal(0, utf16CodeUnits(""))
+	assert.Equal(3, utf16CodeUnits("abc"))
+	assert.Equal(1, utf16CodeUnits("é"))          // é, BMP, 2 UTF-8 bytes but 1 UTF-16 unit
+	assert.Equal(2, utf16CodeUnits("\U0001D11E")) // musical symbol, surrogate pair
+	assert.Equal(4, utf16CodeUnits("a\U0001D11Eb"))
+}
+
 func TestGeminiAntigravityPromptTooLargeForArgv(t *testing.T) {
 	skipIfWindows(t)
 

--- a/internal/agent/gemini_test.go
+++ b/internal/agent/gemini_test.go
@@ -380,6 +380,25 @@ echo "No issues found."
 	assert.NotContains(t, argsOut, "--prompt\n")
 }
 
+func TestGeminiAntigravityPromptTooLargeForArgv(t *testing.T) {
+	skipIfWindows(t)
+
+	// New-contract (flag) path bounds the argv-passed prompt with a clear error.
+	scriptPath := writeTempCommand(t, `#!/bin/sh
+if [ "$1" = "--version" ]; then echo "1.1.1"; exit 0; fi
+echo "should not run the review"
+`)
+	a := NewGeminiAgent(scriptPath)
+	a.Command = filepath.Join(filepath.Dir(scriptPath), "agy")
+	require.NoError(t, os.Rename(scriptPath, a.Command))
+
+	big := strings.Repeat("x", antigravityMaxPromptArgLen()+1)
+	_, err := a.Review(context.Background(), t.TempDir(), "sha", big, &bytes.Buffer{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too large for antigravity argv")
+}
+
 func TestGeminiAntigravityVersionProbeFailureDefaultsToPromptFlag(t *testing.T) {
 	skipIfWindows(t)
 

--- a/internal/agent/gemini_test.go
+++ b/internal/agent/gemini_test.go
@@ -105,6 +105,9 @@ func TestGeminiAntigravityBuildArgs(t *testing.T) {
 				"--approval-mode",
 				"-m",
 				"--dangerously-skip-permissions",
+				// A bare --print would swallow --print-timeout as the
+				// prompt; the prompt is passed via --prompt at run time.
+				"--print",
 			},
 		},
 		{
@@ -116,6 +119,7 @@ func TestGeminiAntigravityBuildArgs(t *testing.T) {
 				"--approval-mode",
 				"-m",
 				"--sandbox",
+				"--print",
 			},
 		},
 	}
@@ -125,7 +129,6 @@ func TestGeminiAntigravityBuildArgs(t *testing.T) {
 			a := NewGeminiAgent("agy").WithModel("gemini-1.5-pro").(*GeminiAgent)
 			args := a.buildArgs(tc.agentic)
 
-			assert.Contains(t, args, "--print")
 			assertFlagValue(t, args, "--print-timeout", "30m")
 			assert.Contains(t, args, tc.wantFlag)
 			for _, unwanted := range tc.unwantedArgs {
@@ -305,13 +308,17 @@ func TestGeminiAntigravityReviewPlainText(t *testing.T) {
 	skipIfWindows(t)
 
 	scriptPath := writeTempCommand(t, `#!/bin/sh
+if [ "$1" = "--version" ]; then echo "1.1.1"; exit 0; fi
 cat > "$STDIN_FILE"
+printf '%s\n' "$@" > "$ARGS_FILE"
 echo "Plain text review output"
 echo "No issues found."
 `)
 
 	stdinFile := filepath.Join(t.TempDir(), "stdin")
+	argsFile := filepath.Join(t.TempDir(), "args")
 	t.Setenv("STDIN_FILE", stdinFile)
+	t.Setenv("ARGS_FILE", argsFile)
 	a := NewGeminiAgent(scriptPath)
 	a.Command = filepath.Join(filepath.Dir(scriptPath), "agy")
 	require.NoError(t, os.Rename(scriptPath, a.Command))
@@ -322,9 +329,113 @@ echo "No issues found."
 	require.NoError(t, err)
 	assert.Equal(t, "Plain text review output\nNo issues found.", res)
 	assert.Contains(t, output.String(), "Plain text review output")
+
+	// agy >= 1.1.1 takes the prompt as the value of --prompt, not from stdin.
+	stdinBytes, readErr := os.ReadFile(stdinFile)
+	require.NoError(t, readErr)
+	assert.Empty(t, string(stdinBytes))
+
+	argsBytes, readErr := os.ReadFile(argsFile)
+	require.NoError(t, readErr)
+	argsOut := string(argsBytes)
+	assert.Contains(t, argsOut, "--prompt\nprompt\n")
+	assert.NotContains(t, argsOut, "--print\n")
+}
+
+func TestGeminiAntigravityLegacyStdinContract(t *testing.T) {
+	skipIfWindows(t)
+
+	// Old agy (<= 1.1.0) read the prompt from stdin with a bare --print.
+	scriptPath := writeTempCommand(t, `#!/bin/sh
+if [ "$1" = "--version" ]; then echo "1.1.0"; exit 0; fi
+cat > "$STDIN_FILE"
+printf '%s\n' "$@" > "$ARGS_FILE"
+echo "Legacy review output"
+echo "No issues found."
+`)
+
+	stdinFile := filepath.Join(t.TempDir(), "stdin")
+	argsFile := filepath.Join(t.TempDir(), "args")
+	t.Setenv("STDIN_FILE", stdinFile)
+	t.Setenv("ARGS_FILE", argsFile)
+	a := NewGeminiAgent(scriptPath)
+	a.Command = filepath.Join(filepath.Dir(scriptPath), "agy")
+	require.NoError(t, os.Rename(scriptPath, a.Command))
+
+	var output bytes.Buffer
+	res, err := a.Review(context.Background(), t.TempDir(), "sha", "prompt", &output)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Legacy review output\nNo issues found.", res)
+
+	// Prompt arrives on stdin; args carry a bare --print and no --prompt.
 	stdinBytes, readErr := os.ReadFile(stdinFile)
 	require.NoError(t, readErr)
 	assert.Equal(t, "prompt\n", string(stdinBytes))
+
+	argsBytes, readErr := os.ReadFile(argsFile)
+	require.NoError(t, readErr)
+	argsOut := string(argsBytes)
+	assert.Contains(t, argsOut, "--print\n")
+	assert.NotContains(t, argsOut, "--prompt\n")
+}
+
+func TestGeminiAntigravityVersionProbeFailureDefaultsToPromptFlag(t *testing.T) {
+	skipIfWindows(t)
+
+	// If `agy --version` fails, detection defaults to the current (flag) contract.
+	scriptPath := writeTempCommand(t, `#!/bin/sh
+if [ "$1" = "--version" ]; then echo "boom" >&2; exit 1; fi
+cat > "$STDIN_FILE"
+printf '%s\n' "$@" > "$ARGS_FILE"
+echo "Review output"
+echo "No issues found."
+`)
+
+	stdinFile := filepath.Join(t.TempDir(), "stdin")
+	argsFile := filepath.Join(t.TempDir(), "args")
+	t.Setenv("STDIN_FILE", stdinFile)
+	t.Setenv("ARGS_FILE", argsFile)
+	a := NewGeminiAgent(scriptPath)
+	a.Command = filepath.Join(filepath.Dir(scriptPath), "agy")
+	require.NoError(t, os.Rename(scriptPath, a.Command))
+
+	res, err := a.Review(context.Background(), t.TempDir(), "sha", "prompt", &bytes.Buffer{})
+
+	require.NoError(t, err)
+	assert.Equal(t, "Review output\nNo issues found.", res)
+
+	// Defaulted to the flag contract: prompt via --prompt, stdin empty.
+	stdinBytes, readErr := os.ReadFile(stdinFile)
+	require.NoError(t, readErr)
+	assert.Empty(t, string(stdinBytes))
+
+	argsBytes, readErr := os.ReadFile(argsFile)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(argsBytes), "--prompt\nprompt\n")
+}
+
+func TestAntigravityVersionUsesPromptFlag(t *testing.T) {
+	assert := assert.New(t)
+	// New contract (>= 1.1.1).
+	assert.True(antigravityVersionUsesPromptFlag("1.1.1"))
+	assert.True(antigravityVersionUsesPromptFlag("1.1.2"))
+	assert.True(antigravityVersionUsesPromptFlag("1.2.0"))
+	assert.True(antigravityVersionUsesPromptFlag("2.0.0"))
+	assert.True(antigravityVersionUsesPromptFlag("v1.1.1"))
+	assert.True(antigravityVersionUsesPromptFlag("1.1.1-beta"))
+	// Old stdin contract (<= 1.1.0).
+	assert.False(antigravityVersionUsesPromptFlag("1.1.0"))
+	assert.False(antigravityVersionUsesPromptFlag("1.0.16"))
+	assert.False(antigravityVersionUsesPromptFlag("1.1")) // 1.1.0
+	// Decorated / multi-token output resolves the first dotted version token.
+	assert.True(antigravityVersionUsesPromptFlag("1.1.1 (abc123)"))
+	assert.True(antigravityVersionUsesPromptFlag("agy 2.0.0\n"))
+	assert.False(antigravityVersionUsesPromptFlag("agy version 1.1.0"))
+	// Unparseable, empty, or dot-less output defaults to the current (flag) contract.
+	assert.True(antigravityVersionUsesPromptFlag(""))
+	assert.True(antigravityVersionUsesPromptFlag("unknown"))
+	assert.True(antigravityVersionUsesPromptFlag("12345"))
 }
 
 func TestGeminiAntigravityExplicitModelFailsClearly(t *testing.T) {


### PR DESCRIPTION
Fixes #951.

## The problem

The Gemini agent, when it's backed by the Antigravity CLI (`agy`), stops reviewing the diff. It answers a question about agy's own `--print-timeout` flag instead. agy 1.1.1 changed print mode: `--print` / `-p` / `--prompt` now takes the prompt as its value and no longer reads stdin. roborev was passing a bare `--print` followed by `--print-timeout 30m` with the prompt on stdin, so agy consumed the literal `--print-timeout` token as the prompt and ignored the diff. #951 has the full repro and timeline (the Antigravity path in #730 was validated against an older agy that still read stdin).

## The fix

agy is an unstable CLI target, so rather than assume one contract this gates the invocation on the reported version:

- agy >= 1.1.1: pass the prompt as the value of `--prompt`, no stdin.
- agy <= 1.1.0: keep the original bare `--print` with the prompt on stdin.

Detection runs `agy --version` and compares against 1.1.1, the release where the changelog says print mode stopped reading stdin. A few notes on the detection, since agy has some sharp edges here:

- It uses `agy --version`, not the `agy version` subcommand. The subcommand wants a TTY and fails in a pipe or subprocess with "could not open TTY", so it's unusable for a probe.
- The version parse scans for the first dotted token, so decorated output still resolves, and any detection failure (missing binary, unparseable output, timeout) defaults to the current `--prompt` contract, since the stdin form only exists in old agy builds.
- The probe runs under a short timeout so a wedged `agy --version` can't eat the whole review budget.

## Hardening

A couple of robustness items came out of review:

- The new contract carries the prompt in argv (agy has no stdin or file prompt input there), so it's length-bounded with a clear error, reusing the existing `maxPromptArgLen` guard from the kiro agent rather than letting a huge diff fail with an opaque exec error.
- Two things I deliberately left as possible follow-ups: a GOOS-aware limit (the flat 512KB won't catch Windows' ~32KB `CreateProcess` limit, same as kiro today), and `CommandLine()` no longer rendering a prompt-carrying flag (it never showed the stdin prompt for legacy gemini either, and the contract isn't known at display time).

## Tests

New coverage for both contracts (flag value vs stdin), the version-threshold table (including decorated and unparseable output), and the probe-failure default. `go test ./internal/agent/`, `go vet`, and `gofmt` all pass.

I've been running this locally against agy 1.1.1 and reviews are back to reviewing the diff.