### PR TITLE
Add roborev cancel command for a single job

### DIFF
--- a/cmd/roborev/cancel.go
+++ b/cmd/roborev/cancel.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+func cancelCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cancel <job_id>",
+		Short: "Cancel a queued or running review job",
+		Long: `Cancel a review job by ID.
+
+Only jobs that are still queued or running can be canceled; jobs that have
+already finished (done, failed, canceled, etc.) cannot.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := ensureDaemon(); err != nil {
+				return fmt.Errorf("daemon not running: %w", err)
+			}
+
+			jobID, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil || jobID <= 0 {
+				return fmt.Errorf("invalid job_id: %s", args[0])
+			}
+
+			ep := getDaemonEndpoint()
+			if err := cancelJob(ep.BaseURL(), jobID); err != nil {
+				return err
+			}
+
+			fmt.Printf("Job %d canceled\n", jobID)
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/roborev/cancel_test.go
+++ b/cmd/roborev/cancel_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mockCancelHandler(t *testing.T, receivedJobID *int64, statusCode int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/job/cancel" && r.Method == "POST" {
+			var req struct {
+				JobID int64 `json:"job_id"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				assert.NoError(t, err, "failed to decode request body: %v", err)
+				return
+			}
+			if receivedJobID != nil {
+				*receivedJobID = req.JobID
+			}
+			w.WriteHeader(statusCode)
+			if statusCode != http.StatusOK {
+				_, _ = w.Write([]byte("job not found or not cancellable"))
+			}
+			return
+		}
+	}
+}
+
+func TestCancelCmd(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		statusCode    int
+		wantJobID     int64
+		wantErr       bool
+		wantErrSubstr string
+	}{
+		{
+			name:       "cancels queued job",
+			args:       []string{"42"},
+			statusCode: http.StatusOK,
+			wantJobID:  42,
+		},
+		{
+			name:          "rejects non-numeric job id",
+			args:          []string{"abc"},
+			wantErr:       true,
+			wantErrSubstr: "invalid job_id",
+		},
+		{
+			name:          "rejects non-positive job id",
+			args:          []string{"0"},
+			wantErr:       true,
+			wantErrSubstr: "invalid job_id",
+		},
+		{
+			name:          "surfaces not-cancellable error",
+			args:          []string{"42"},
+			statusCode:    http.StatusNotFound,
+			wantErr:       true,
+			wantErrSubstr: "not cancellable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var receivedJobID int64
+			daemonFromHandler(t, mockCancelHandler(t, &receivedJobID, tt.statusCode))
+
+			cmd := cancelCmd()
+			cmd.SetArgs(tt.args)
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+
+			err := cmd.Execute()
+
+			if tt.wantErr {
+				require.Error(t, err, "expected error, got nil")
+				assert.ErrorContains(t, err, tt.wantErrSubstr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantJobID, receivedJobID, "expected job_id %d, got %d", tt.wantJobID, receivedJobID)
+			}
+		})
+	}
+}

--- a/cmd/roborev/main.go
+++ b/cmd/roborev/main.go
@@ -49,6 +49,7 @@ func main() {
 	rootCmd.AddCommand(commentCmd())
 	rootCmd.AddCommand(respondCmd()) // hidden alias for backward compatibility
 	rootCmd.AddCommand(closeCmd())
+	rootCmd.AddCommand(cancelCmd())
 	rootCmd.AddCommand(installHookCmd())
 	rootCmd.AddCommand(uninstallHookCmd())
 	rootCmd.AddCommand(daemonCmd())


### PR DESCRIPTION
## Summary

- Adds a `roborev cancel <job_id>` CLI command that cancels a queued or running review job by ID.
- Previously cancellation was reachable only via the TUI (`x` key) or the raw `/api/job/cancel` endpoint; there was no CLI surface for it.
- Mirrors the `close` command's structure and reuses the existing `cancelJob` helper, so no new API or DB code is introduced.
- Only `queued`/`running` jobs are cancellable; terminal jobs (done, failed, etc.) surface a clear "not cancellable" error instead of a silent no-op.
- Adds a table-driven test covering success, invalid job IDs, and the not-cancellable error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)