### PR TITLE
Fix workflow models leaking to ACP agents over the paired [acp].model

### DIFF
--- a/internal/agent/model_resolution.go
+++ b/internal/agent/model_resolution.go
@@ -176,23 +176,52 @@ func ResolveWorkflowModelForAgentFromConfig(
 		// [acp].model rather than handing a foreign model to the ACP agent,
 		// which its model validation would reject. Scope guard: this only
 		// affects ACP-selected agents; non-ACP agents keep legacy behavior.
-		if isConfiguredACPAgentNameFromConfig(selectedAgent, globalCfg, repoCfg) {
-			workflowAgent := config.ResolveAgentForWorkflowFromConfig(
-				"", repoCfg, globalCfg, workflow, level,
-			)
-			if workflowModelComparableAgentNameFromConfig(workflowAgent, repoCfg, globalCfg) !=
-				workflowModelComparableAgentNameFromConfig(selectedAgent, repoCfg, globalCfg) {
-				return ""
-			}
+		if acpSelectedWithUnpairedWorkflowAgent(
+			selectedAgent, repoCfg, globalCfg, workflow, level,
+		) {
+			return ""
 		}
 		return config.ResolveWorkflowModelFromConfig(
 			repoCfg, globalCfg, workflow, level,
 		)
 	}
 
+	// Selected agent IS the default agent. The generic model (repo model /
+	// global default_model) pairs with the default agent and still applies,
+	// but a workflow model pairs with the workflow-configured agent: when
+	// the selected ACP agent is the default yet the workflow agent resolves
+	// to a different agent, skip the workflow model and resolve only the
+	// generic chain. If that is empty, the ACP-config-model fallback in
+	// ModelForSelectedAgent supplies [acp].model.
+	if acpSelectedWithUnpairedWorkflowAgent(
+		selectedAgent, repoCfg, globalCfg, workflow, level,
+	) {
+		return config.ResolveModelFromConfig("", repoCfg, globalCfg)
+	}
+
 	return config.ResolveModelForWorkflowFromConfig(
 		"", repoCfg, globalCfg, workflow, level,
 	)
+}
+
+// acpSelectedWithUnpairedWorkflowAgent reports whether the selected agent is
+// the configured ACP agent while the workflow-configured agent for this
+// workflow+level resolves to a different agent. In that case workflow models
+// are paired with that other agent and must not be handed to the ACP agent.
+func acpSelectedWithUnpairedWorkflowAgent(
+	selectedAgent string,
+	repoCfg *config.RepoConfig,
+	globalCfg *config.Config,
+	workflow, level string,
+) bool {
+	if !isConfiguredACPAgentNameFromConfig(selectedAgent, globalCfg, repoCfg) {
+		return false
+	}
+	workflowAgent := config.ResolveAgentForWorkflowFromConfig(
+		"", repoCfg, globalCfg, workflow, level,
+	)
+	return workflowModelComparableAgentNameFromConfig(workflowAgent, repoCfg, globalCfg) !=
+		workflowModelComparableAgentNameFromConfig(selectedAgent, repoCfg, globalCfg)
 }
 
 func workflowModelComparableAgentName(name string, repoPath string, cfg *config.Config) string {

--- a/internal/agent/model_resolution.go
+++ b/internal/agent/model_resolution.go
@@ -167,6 +167,24 @@ func ResolveWorkflowModelForAgentFromConfig(
 	defaultAgent := config.ResolveAgentFromConfig("", repoCfg, globalCfg)
 	if workflowModelComparableAgentNameFromConfig(selectedAgent, repoCfg, globalCfg) !=
 		workflowModelComparableAgentNameFromConfig(defaultAgent, repoCfg, globalCfg) {
+		// Workflow models follow their paired workflow agent. When the
+		// selected agent is the configured ACP agent but the workflow's
+		// configured agent for this workflow+level is NOT that ACP agent, the
+		// workflow model (e.g. a global review_model meant for the default
+		// reviewer) is paired with a different agent. Returning "" lets the
+		// ACP-config-model fallback in ModelForSelectedAgent supply
+		// [acp].model rather than handing a foreign model to the ACP agent,
+		// which its model validation would reject. Scope guard: this only
+		// affects ACP-selected agents; non-ACP agents keep legacy behavior.
+		if isConfiguredACPAgentNameFromConfig(selectedAgent, globalCfg, repoCfg) {
+			workflowAgent := config.ResolveAgentForWorkflowFromConfig(
+				"", repoCfg, globalCfg, workflow, level,
+			)
+			if workflowModelComparableAgentNameFromConfig(workflowAgent, repoCfg, globalCfg) !=
+				workflowModelComparableAgentNameFromConfig(selectedAgent, repoCfg, globalCfg) {
+				return ""
+			}
+		}
 		return config.ResolveWorkflowModelFromConfig(
 			repoCfg, globalCfg, workflow, level,
 		)

--- a/internal/agent/model_resolution_test.go
+++ b/internal/agent/model_resolution_test.go
@@ -5,10 +5,144 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/roborev/internal/config"
 )
+
+// TestModelForSelectedAgentACPWorkflowModelPrecedence pins the semantic that
+// workflow models (review_model, leveled variants) follow their paired
+// workflow agent. A workflow model configured for the default reviewer must
+// NOT be handed to a CLI-selected configured ACP agent; the [acp].model must
+// win in that case. When the workflow agent IS the ACP agent, the paired
+// workflow model applies as before.
+func TestModelForSelectedAgentACPWorkflowModelPrecedence(t *testing.T) {
+	t.Parallel()
+
+	const acpName = "agy-sdk"
+	const acpModel = "gemini-3.5-flash"
+
+	tests := []struct {
+		name          string
+		cfg           *config.Config
+		workflow      string
+		level         string
+		selectedAgent string
+		cliModel      string
+		want          string
+	}{
+		{
+			// THE BUG: global review_model paired with the default reviewer
+			// must not leak to the CLI-selected ACP agent.
+			name: "acp selected, workflow model but no workflow agent -> acp model",
+			cfg: &config.Config{
+				DefaultAgent: "codex",
+				ReviewModel:  "gpt-5.4",
+				ACP:          &config.ACPAgentConfig{Name: acpName, Model: acpModel},
+			},
+			workflow:      "review",
+			level:         "standard",
+			selectedAgent: acpName,
+			want:          acpModel,
+		},
+		{
+			// Workflow agent IS the ACP agent: paired workflow model applies.
+			name: "acp selected and review_agent is acp -> workflow model",
+			cfg: &config.Config{
+				DefaultAgent: "codex",
+				ReviewAgent:  acpName,
+				ReviewModel:  "gpt-5.4",
+				ACP:          &config.ACPAgentConfig{Name: acpName, Model: acpModel},
+			},
+			workflow:      "review",
+			level:         "standard",
+			selectedAgent: acpName,
+			want:          "gpt-5.4",
+		},
+		{
+			// Explicit CLI --model always wins.
+			name: "acp selected with explicit cli model -> cli model",
+			cfg: &config.Config{
+				DefaultAgent: "codex",
+				ReviewModel:  "gpt-5.4",
+				ACP:          &config.ACPAgentConfig{Name: acpName, Model: acpModel},
+			},
+			workflow:      "review",
+			level:         "standard",
+			selectedAgent: acpName,
+			cliModel:      "gpt-5.4-custom",
+			want:          "gpt-5.4-custom",
+		},
+		{
+			// Scope guard: non-ACP selected agent keeps legacy behavior
+			// (workflow model still applies).
+			name: "non-acp selected differing from default -> workflow model",
+			cfg: &config.Config{
+				DefaultAgent: "codex",
+				ReviewModel:  "gpt-5.4",
+				ACP:          &config.ACPAgentConfig{Name: acpName, Model: acpModel},
+			},
+			workflow:      "review",
+			level:         "standard",
+			selectedAgent: "gemini",
+			want:          "gpt-5.4",
+		},
+		{
+			// Existing fallback: no workflow model anywhere -> acp model.
+			name: "acp selected, no workflow model -> acp model",
+			cfg: &config.Config{
+				DefaultAgent: "codex",
+				ACP:          &config.ACPAgentConfig{Name: acpName, Model: acpModel},
+			},
+			workflow:      "review",
+			level:         "standard",
+			selectedAgent: acpName,
+			want:          acpModel,
+		},
+		{
+			// Leveled variant, no leveled workflow agent -> acp model.
+			name: "acp selected, thorough model but no thorough agent -> acp model",
+			cfg: &config.Config{
+				DefaultAgent:        "codex",
+				ReviewModelThorough: "gpt-5.4-thorough",
+				ACP:                 &config.ACPAgentConfig{Name: acpName, Model: acpModel},
+			},
+			workflow:      "review",
+			level:         "thorough",
+			selectedAgent: acpName,
+			want:          acpModel,
+		},
+		{
+			// Leveled variant with leveled workflow agent -> leveled model.
+			name: "acp selected, thorough agent is acp -> thorough model",
+			cfg: &config.Config{
+				DefaultAgent:        "codex",
+				ReviewAgentThorough: acpName,
+				ReviewModelThorough: "gpt-5.4-thorough",
+				ACP:                 &config.ACPAgentConfig{Name: acpName, Model: acpModel},
+			},
+			workflow:      "review",
+			level:         "thorough",
+			selectedAgent: acpName,
+			want:          "gpt-5.4-thorough",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			resolution, err := ResolveWorkflowConfigFromConfig(
+				tt.selectedAgent, nil, tt.cfg, tt.workflow, tt.level,
+			)
+			require.NoError(t, err)
+			got := resolution.ModelForSelectedAgent(tt.selectedAgent, tt.cliModel)
+			assert.Equal(tt.want, got,
+				"ModelForSelectedAgent(%q, %q) = %q, want %q",
+				tt.selectedAgent, tt.cliModel, got, tt.want)
+		})
+	}
+}
 
 func TestResolveWorkflowModelForAgentSkipsGenericDefaultModel(t *testing.T) {
 	t.Parallel()

--- a/internal/agent/model_resolution_test.go
+++ b/internal/agent/model_resolution_test.go
@@ -114,6 +114,55 @@ func TestModelForSelectedAgentACPWorkflowModelPrecedence(t *testing.T) {
 			want:          acpModel,
 		},
 		{
+			// Default agent IS the ACP agent, but the workflow agent is a
+			// different agent: the workflow model pairs with that workflow
+			// agent and must not leak to the selected ACP agent. With no
+			// generic model, the ACP fallback supplies [acp].model.
+			name: "acp is default, workflow agent differs -> acp model",
+			cfg: &config.Config{
+				DefaultAgent: acpName,
+				ReviewAgent:  "codex",
+				ReviewModel:  "gpt-5.4",
+				ACP:          &config.ACPAgentConfig{Name: acpName, Model: acpModel},
+			},
+			workflow:      "review",
+			level:         "standard",
+			selectedAgent: acpName,
+			want:          acpModel,
+		},
+		{
+			// Same, but a generic model is configured: the generic model
+			// pairs with the default agent, which IS the selected ACP agent,
+			// so it applies (and beats the [acp].model fallback).
+			name: "acp is default, workflow agent differs, generic model -> generic model",
+			cfg: &config.Config{
+				DefaultAgent: acpName,
+				DefaultModel: "gemini-custom",
+				ReviewAgent:  "codex",
+				ReviewModel:  "gpt-5.4",
+				ACP:          &config.ACPAgentConfig{Name: acpName, Model: acpModel},
+			},
+			workflow:      "review",
+			level:         "standard",
+			selectedAgent: acpName,
+			want:          "gemini-custom",
+		},
+		{
+			// No workflow agent configured: the workflow model pairs with
+			// the default agent, which IS the selected ACP agent, so the
+			// workflow model still applies.
+			name: "acp is default, no workflow agent, workflow model -> workflow model",
+			cfg: &config.Config{
+				DefaultAgent: acpName,
+				ReviewModel:  "gemini-paired",
+				ACP:          &config.ACPAgentConfig{Name: acpName, Model: acpModel},
+			},
+			workflow:      "review",
+			level:         "standard",
+			selectedAgent: acpName,
+			want:          "gemini-paired",
+		},
+		{
 			// Leveled variant with leveled workflow agent -> leveled model.
 			name: "acp selected, thorough agent is acp -> thorough model",
 			cfg: &config.Config{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1124,8 +1124,19 @@ func GetDisplayName(repoPath string) string {
 // 3. Global config (default_model in config.toml)
 // 4. Default (empty string, agent uses its default)
 func ResolveModel(explicit string, repoPath string, globalCfg *Config) string {
+	repoCfg, err := LoadRepoConfig(repoPath)
+	if err != nil {
+		repoCfg = nil
+	}
+	return ResolveModelFromConfig(explicit, repoCfg, globalCfg)
+}
+
+// ResolveModelFromConfig is the config-taking core of ResolveModel: it
+// resolves entirely from the passed repoCfg and globalCfg, never reading the
+// working tree.
+func ResolveModelFromConfig(explicit string, repoCfg *RepoConfig, globalCfg *Config) string {
 	var repoVal string
-	if repoCfg, err := LoadRepoConfig(repoPath); err == nil && repoCfg != nil {
+	if repoCfg != nil {
 		repoVal = strings.TrimSpace(repoCfg.Model)
 	}
 	var globalVal string


### PR DESCRIPTION
## Summary

- Workflow models (`review_model`, `fix_model`, leveled variants) were applied agent-agnostically, so selecting a configured ACP agent handed it the workflow model meant for the default reviewer (e.g. `review_model = "gpt-5.4"` reaching a Gemini-only ACP agent). The agent's model validation rejected the foreign model, the job burned 3 retries, and then silently failed over to the backup agent — `[acp].model` never applied. Observed live with an antigravity-SDK ACP bridge.
- Make models follow their paired agent: when the selected agent is the configured ACP agent and the workflow-configured agent for that workflow+level does not resolve to it, the workflow model is skipped — falling through to the existing `[acp].model` fallback (or the generic `model` key when the ACP agent is the default agent, since the generic model pairs with the default agent).
- Scoped strictly to ACP-selected agents; non-ACP agents keep today's behavior exactly.
- Extracted `config.ResolveModelFromConfig` as the generic-only core of `ResolveModel` (delegation, no behavior change) rather than re-implementing generic precedence at the call site.
- Adds a 10-case table-driven test pinning the precedence: the two leak scenarios, paired workflow-agent routing (leveled and unleveled), explicit `--model` override, non-ACP scope guard, and the fallback chain.

## Why the guard is ACP-scoped

The obvious maintainer question is why workflow-model pairing is corrected only for ACP-selected agents and left unchanged for native CLIs. The answer is that the failure mode is destructive only for ACP:

- **Native CLIs (codex, claude, gemini, …) tolerate an unknown model.** A foreign `-m`/`--model` is either ignored or surfaces as an ordinary, visible error; the review still runs (or fails loudly) with no silent agent swap. Changing precedence for them would be a behavior change with no bug to fix, so their handling is intentionally left exactly as-is.
- **ACP hard-validates exact model membership, then fails over silently.** The ACP agent validates the model string against the list the agent advertises at session start (`configuredModelIsAvailable` / `validateConfiguredModel`); a non-member value is a hard error. That error burns 3 retries and then silently fails the job over to the backup agent, so a mispaired model doesn't just get ignored — it swaps out the reviewer with no signal. ACP is the only place the leak is actually harmful, so the guard is scoped to it.

## Backup-path investigation (step 1 of `ModelForSelectedAgent`)

A review comment asked whether the `BackupModel()` shortcut (taken before the pairing guard) can hand a mispaired model to an ACP backup agent. It cannot leak a generic or workflow model:

- `BackupModel()` resolves **only** backup_model-family fields (workflow/repo/global `backup_model`), never `default_model` or a workflow `review_model`. So a generic/workflow model can never reach an ACP backup agent through this path.
- When `BackupModel()` is empty, the ACP backup agent keeps its own baked-in `[acp].model` — callers apply the resolved model as `if model != "" { WithModel }`, and the configured ACP agent is constructed with `[acp].model` already set.
- A non-empty `backup_model` is an explicit backup-config pair with `backup_agent`. If a user pairs an ACP backup agent with a foreign `backup_model` (e.g. a cross-layer `default_backup_model`), ACP session-time validation is the backstop. A code guard suppressing that would regress the legitimate case of a global `default_backup_agent` + `default_backup_model` configured together as an ACP pair.

This behavior is now documented at the backup early-return and pinned by a backup-pairing table test (explicit workflow-specific `backup_model` used; no `backup_model` → empty, `[acp].model` kept; cross-layer `default_backup_model` honored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HwTz3BHkFuESb3BauS7F9r
