### PR TITLE
Make Claude Code roborev skills explicit-only

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,7 @@ All notable changes to roborev, grouped by minor release.
 **Bug fixes**
 
 - Bundled Codex roborev skills now require explicit personal, plugin-namespaced, or structured selection. Machine-readable activation policy and invocation-only descriptions keep ordinary review and fix requests in Codex's native workflow. See [Agent Skills](/guides/agent-skills/#agent-specific-syntax).
+- Bundled Claude Code roborev skills are now explicit-only as well. Skills set `disable-model-invocation: true` and state only their invocation contract in the description, so Claude Code never auto-selects a roborev skill for an ordinary review or fix request; invoke skills with their slash commands. `roborev-fix` stays model-invocable so the agent-hook instruction keeps working. See [Agent Skills](/guides/agent-skills/#agent-specific-syntax).
 
 **Acknowledgements**
 

--- a/docs/guides/agent-skills.md
+++ b/docs/guides/agent-skills.md
@@ -30,12 +30,21 @@ roborev skills install
 
 ## Usage
 
-!!! note "Codex users"
-    All bundled Codex roborev skills are **explicit-only**. An ordinary request
-    such as "Review the changes in this branch" uses Codex's native behavior; it
-    must not activate a roborev skill or run roborev.
+!!! note "Explicit invocation"
+    All bundled roborev skills are **explicit-only**. An ordinary request such
+    as "Review the changes in this branch" uses your agent's native behavior;
+    it must not activate a roborev skill or run roborev.
 
-    Explicit invocation has three supported forms:
+    **Claude Code** enforces this in skill metadata: the bundled skills set
+    `disable-model-invocation: true`, so the model never selects a roborev
+    skill on its own. Invoke a skill by typing its slash command
+    (`/roborev-review-branch`) or picking it from the `/` menu. Plugin-managed
+    skills use the plugin namespace: `/roborev:roborev-review-branch`. The one
+    exception is `/roborev-fix`, which stays model-invocable so
+    [`roborev agent-hook`](../agent-hook.md) can instruct a session to run it;
+    its description still permits only explicit invocation.
+
+    **Codex** explicit invocation has three supported forms:
 
     - For skills installed by `roborev skills install`, replace the leading `/`
       in the examples below with `$`: `$roborev-review-branch`.
@@ -181,7 +190,8 @@ Unlike `roborev refine` on the CLI, the skill performs the full workflow inside 
 
 | Agent | Syntax |
 |-------|--------|
-| Claude Code | `/roborev-review`, `/roborev-review-branch`, `/roborev-design-review`, `/roborev-design-review-branch`, `/roborev-lookahead-review`, `/roborev-lookahead-review-branch`, `/roborev-fix`, `/roborev-refine`, `/roborev-respond` |
+| Claude Code, personal install | `/roborev-review`, `/roborev-review-branch`, `/roborev-design-review`, `/roborev-design-review-branch`, `/roborev-lookahead-review`, `/roborev-lookahead-review-branch`, `/roborev-fix`, `/roborev-refine`, `/roborev-respond` |
+| Claude Code, plugin install | `/roborev:roborev-review`, `/roborev:roborev-review-branch`, `/roborev:roborev-design-review`, `/roborev:roborev-design-review-branch`, `/roborev:roborev-lookahead-review`, `/roborev:roborev-lookahead-review-branch`, `/roborev:roborev-fix`, `/roborev:roborev-refine`, `/roborev:roborev-respond` |
 | Factory Droid | `/roborev-review`, `/roborev-review-branch`, `/roborev-design-review`, `/roborev-design-review-branch`, `/roborev-lookahead-review`, `/roborev-lookahead-review-branch`, `/roborev-fix`, `/roborev-refine`, `/roborev-respond` |
 | Codex, personal install | `$roborev-review`, `$roborev-review-branch`, `$roborev-design-review`, `$roborev-design-review-branch`, `$roborev-lookahead-review`, `$roborev-lookahead-review-branch`, `$roborev-fix`, `$roborev-refine`, `$roborev-respond` |
 | Codex, plugin install | `$roborev:roborev-review`, `$roborev:roborev-review-branch`, `$roborev:roborev-design-review`, `$roborev:roborev-design-review-branch`, `$roborev:roborev-lookahead-review`, `$roborev:roborev-lookahead-review-branch`, `$roborev:roborev-fix`, `$roborev:roborev-refine`, `$roborev:roborev-respond` |
@@ -189,7 +199,11 @@ Unlike `roborev refine` on the CLI, the skill performs the full workflow inside 
 Codex can also invoke either installation by selecting the skill in its
 structured skill picker. Skill descriptions intentionally state only the
 explicit invocation requirement; workflow details live in the skill body so
-ordinary prose cannot semantically match a capability summary.
+ordinary prose cannot semantically match a capability summary. Claude Code
+skills additionally set `disable-model-invocation: true` in their frontmatter
+(except `roborev-fix`, which the agent-hook instruction invokes), so Claude
+Code never auto-selects a roborev skill — only user invocation via the slash
+command or `/` menu loads it.
 
 ## Checking Skill Status
 
@@ -245,6 +259,15 @@ example, `$roborev:roborev-fix`); invoke a personal skill installed by roborev
 as `$roborev-<workflow>` (for example, `$roborev-fix`). Both forms are explicit
 invocations. General requests such as "fix the issues in this branch" remain
 native Codex tasks and do not select roborev.
+
+Claude Code likewise namespaces plugin-managed skills: invoke them as
+`/roborev:roborev-<workflow>` (for example, `/roborev:roborev-fix`). Personal
+skills installed by `roborev skills install` keep the plain `/roborev-<workflow>`
+form. Either way, the bundled `disable-model-invocation: true` policy means
+only you can invoke them; Claude never selects a roborev skill for an
+ordinary request. `roborev-fix` alone omits the policy so the
+[agent-hook](../agent-hook.md) instruction can invoke it, and relies on its
+explicit-only description instead.
 
 ## Waiting for Hook-Triggered Reviews
 

--- a/internal/skills/claude/roborev-design-review-branch/SKILL.md
+++ b/internal/skills/claude/roborev-design-review-branch/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: roborev-design-review-branch
-description: Request a design review for all commits on the current branch and present the results
+description: Use only when the user explicitly invokes /roborev-design-review-branch
+disable-model-invocation: true
 ---
 
 # roborev-design-review-branch
@@ -12,6 +13,13 @@ Request a design review for all commits on the current branch and present the re
 ```
 /roborev-design-review-branch [--base <branch>] [--panel <name>|none]
 ```
+
+## Explicit invocation only
+
+Invocation must be explicit: literal personal `/roborev-design-review-branch`, or structured
+Claude Code skill selection.
+Requests such as “review this branch's design” without one of these
+explicit mechanisms must use native behavior and must not run roborev.
 
 ## When NOT to invoke this skill
 

--- a/internal/skills/claude/roborev-design-review/SKILL.md
+++ b/internal/skills/claude/roborev-design-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: roborev-design-review
-description: Request a design review for a commit and present the results
+description: Use only when the user explicitly invokes /roborev-design-review
+disable-model-invocation: true
 ---
 
 # roborev-design-review
@@ -12,6 +13,13 @@ Request a design review for a commit and present the results.
 ```
 /roborev-design-review [commit] [--panel <name>|none]
 ```
+
+## Explicit invocation only
+
+Invocation must be explicit: literal personal `/roborev-design-review`, or structured
+Claude Code skill selection.
+Requests such as “review this commit's design” without one of these explicit mechanisms
+must use native behavior and must not run roborev.
 
 ## When NOT to invoke this skill
 

--- a/internal/skills/claude/roborev-lookahead-review-branch/SKILL.md
+++ b/internal/skills/claude/roborev-lookahead-review-branch/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: roborev-lookahead-review-branch
-description: Request a time-series look-ahead (a.k.a. peekahead / future-data leakage) review for all commits on the current branch and present the results
+description: Use only when the user explicitly invokes /roborev-lookahead-review-branch
+disable-model-invocation: true
 ---
 
 # roborev-lookahead-review-branch
@@ -15,6 +16,13 @@ also called peekahead, future leakage, or temporal leakage.
 ```
 /roborev-lookahead-review-branch [--base <branch>] [--panel <name>|none]
 ```
+
+## Explicit invocation only
+
+Invocation must be explicit: literal personal `/roborev-lookahead-review-branch`, or structured
+Claude Code skill selection.
+Requests such as “check this branch for future leakage” without one of these
+explicit mechanisms must use native behavior and must not run roborev.
 
 ## When NOT to invoke this skill
 

--- a/internal/skills/claude/roborev-lookahead-review/SKILL.md
+++ b/internal/skills/claude/roborev-lookahead-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: roborev-lookahead-review
-description: Request a time-series look-ahead (a.k.a. peekahead / future-data leakage) review for a commit and present the results
+description: Use only when the user explicitly invokes /roborev-lookahead-review
+disable-model-invocation: true
 ---
 
 # roborev-lookahead-review
@@ -15,6 +16,13 @@ leakage, or temporal leakage.
 ```
 /roborev-lookahead-review [commit] [--panel <name>|none]
 ```
+
+## Explicit invocation only
+
+Invocation must be explicit: literal personal `/roborev-lookahead-review`, or structured
+Claude Code skill selection.
+Requests such as “check this commit for peekahead” without one of these explicit
+mechanisms must use native behavior and must not run roborev.
 
 ## When NOT to invoke this skill
 

--- a/internal/skills/claude/roborev-refine/SKILL.md
+++ b/internal/skills/claude/roborev-refine/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: roborev-refine
 description: Use only when the user explicitly invokes /roborev-refine
+disable-model-invocation: true
 ---
 
 # roborev-refine

--- a/internal/skills/claude/roborev-respond/SKILL.md
+++ b/internal/skills/claude/roborev-respond/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: roborev-respond
 description: Use only when the user explicitly invokes /roborev-respond
+disable-model-invocation: true
 ---
 
 # roborev-respond

--- a/internal/skills/claude/roborev-review-branch/SKILL.md
+++ b/internal/skills/claude/roborev-review-branch/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: roborev-review-branch
-description: Request a code review for all commits on the current branch and present the results
+description: Use only when the user explicitly invokes /roborev-review-branch
+disable-model-invocation: true
 ---
 
 # roborev-review-branch
@@ -12,6 +13,13 @@ Request a code review for all commits on the current branch and present the resu
 ```
 /roborev-review-branch [--base <branch>] [--type security|design] [--panel <name>|none]
 ```
+
+## Explicit invocation only
+
+Invocation must be explicit: literal personal `/roborev-review-branch`, or structured
+Claude Code skill selection.
+Requests such as “review this branch” without one of these explicit mechanisms must use
+native behavior and must not run roborev.
 
 ## When NOT to invoke this skill
 

--- a/internal/skills/claude/roborev-review/SKILL.md
+++ b/internal/skills/claude/roborev-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: roborev-review
-description: Request a code review for a commit and present the results
+description: Use only when the user explicitly invokes /roborev-review
+disable-model-invocation: true
 ---
 
 # roborev-review
@@ -12,6 +13,13 @@ Request a code review for a commit and present the results.
 ```
 /roborev-review [commit] [--type security|design] [--panel <name>|none]
 ```
+
+## Explicit invocation only
+
+Invocation must be explicit: literal personal `/roborev-review`, or structured
+Claude Code skill selection.
+Requests such as “review this commit” without one of these explicit mechanisms must use native
+behavior and must not run roborev.
 
 ## When NOT to invoke this skill
 

--- a/internal/skills/derive.go
+++ b/internal/skills/derive.go
@@ -56,16 +56,28 @@ func skillDerivations() []skillDerivation {
 		})
 	}
 	for _, skillName := range derivedClaudeSkills {
-		derivations = append(derivations, skillDerivation{
-			TargetAgent: AgentClaude,
-			SkillName:   skillName,
-			Replacements: []stringReplacement{
-				{
-					Old: ", plugin\n`$roborev:" + skillName + "`, or structured Codex skill selection",
-					New: ", or structured\nClaude Code skill selection",
-				},
-				{Old: "$roborev", New: "/roborev"},
+		replacements := []stringReplacement{
+			{
+				Old: ", plugin\n`$roborev:" + skillName + "`, or structured Codex skill selection",
+				New: ", or structured\nClaude Code skill selection",
 			},
+			{Old: "$roborev", New: "/roborev"},
+		}
+		// roborev-fix must stay model-invocable: the agent-hook Stop hook
+		// instructs the Claude Code model to invoke it, and
+		// disable-model-invocation would block that path. Its explicit-only
+		// description and body section remain the guard against implicit
+		// selection.
+		if skillName != "roborev-fix" {
+			replacements = append([]stringReplacement{{
+				Old: "invokes $" + skillName + "\n---",
+				New: "invokes /" + skillName + "\ndisable-model-invocation: true\n---",
+			}}, replacements...)
+		}
+		derivations = append(derivations, skillDerivation{
+			TargetAgent:  AgentClaude,
+			SkillName:    skillName,
+			Replacements: replacements,
 		})
 	}
 	return derivations

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -125,6 +125,75 @@ func TestCodexSkillBodiesAcceptEveryExplicitInvocationPath(t *testing.T) {
 	}
 }
 
+func TestClaudeSkillDescriptionsRequireExplicitInvocation(t *testing.T) {
+	spec, ok := lookupAgent(AgentClaude)
+	require.True(t, ok)
+	skills, err := embeddedSkillsForAgent(spec)
+	require.NoError(t, err)
+	require.Len(t, skills, 9)
+
+	for _, skill := range skills {
+		wantDescription := "Use only when the user explicitly invokes /" + skill.DirName
+		assert.Equal(t, wantDescription, skill.Description,
+			"%s description must contain only the explicit invocation contract", skill.DirName)
+	}
+}
+
+func TestClaudeSkillsEmbedExplicitInvocationPolicy(t *testing.T) {
+	// disable-model-invocation is Claude Code's machine-readable equivalent of
+	// the Codex agents/openai.yaml policy: the model can never auto-select the
+	// skill; the user invokes it with /<name> or structured skill selection.
+	// roborev-fix is the one exception: the agent-hook Stop hook instructs the
+	// model to invoke it, so it must remain model-invocable and relies on its
+	// explicit-only description and body section instead.
+	spec, ok := lookupAgent(AgentClaude)
+	require.True(t, ok)
+	skills, err := embeddedSkillsForAgent(spec)
+	require.NoError(t, err)
+	require.Len(t, skills, 9)
+
+	for _, skill := range skills {
+		content := strings.ReplaceAll(string(skill.Content), "\r\n", "\n")
+		require.True(t, strings.HasPrefix(content, "---\n"), "%s missing frontmatter", skill.DirName)
+		frontmatterEnd := strings.Index(content[len("---\n"):], "\n---\n")
+		require.NotEqual(t, -1, frontmatterEnd, "%s missing frontmatter close", skill.DirName)
+		frontmatterLines := strings.Split(content[len("---\n"):len("---\n")+frontmatterEnd], "\n")
+		if skill.DirName == "roborev-fix" {
+			assert.NotContains(t, frontmatterLines, "disable-model-invocation: true",
+				"roborev-fix must stay model-invocable for the agent-hook instruction")
+		} else {
+			assert.Contains(t, frontmatterLines, "disable-model-invocation: true",
+				"%s frontmatter must disable implicit model invocation", skill.DirName)
+		}
+	}
+}
+
+func TestClaudeSkillBodiesAcceptEveryExplicitInvocationPath(t *testing.T) {
+	spec, ok := lookupAgent(AgentClaude)
+	require.True(t, ok)
+	skills, err := embeddedSkillsForAgent(spec)
+	require.NoError(t, err)
+	require.Len(t, skills, 9)
+
+	for _, skill := range skills {
+		content := string(skill.Content)
+		sectionStart := strings.Index(content, "## Explicit invocation only\n")
+		require.NotEqual(t, -1, sectionStart, "%s missing explicit-invocation section", skill.DirName)
+		section := content[sectionStart:]
+		if sectionEnd := strings.Index(section[len("## Explicit invocation only\n"):], "\n## "); sectionEnd >= 0 {
+			section = section[:len("## Explicit invocation only\n")+sectionEnd]
+		}
+		section = strings.Join(strings.Fields(section), " ")
+
+		assert.Contains(t, section, "`/"+skill.DirName+"`", "%s missing personal invocation", skill.DirName)
+		assert.Contains(t, section, "structured Claude Code skill selection", "%s missing structured selection", skill.DirName)
+		assert.Contains(t, section, "Requests such as", "%s missing ordinary prose example", skill.DirName)
+		assert.Contains(t, section, "without one of these explicit mechanisms", "%s must distinguish ordinary prose", skill.DirName)
+		assert.Contains(t, section, "must use native behavior", "%s missing native fallback", skill.DirName)
+		assert.Contains(t, section, "must not run roborev", "%s missing no-roborev instruction", skill.DirName)
+	}
+}
+
 func TestPluginDefaultPromptsExplicitlyInvokeNamespacedSkills(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join("..", "..", ".codex-plugin", "plugin.json"))
 	require.NoError(t, err)
@@ -751,8 +820,15 @@ func TestDerivedExplicitInvocationWordingUsesTargetAgent(t *testing.T) {
 		assert.NotContains(t, text, "roborev:", "%s retains Codex plugin namespace", relPath)
 		if strings.HasPrefix(relPath, "droid/") {
 			assert.Contains(t, text, "`/"+skillName+"`, or structured Factory skill selection", relPath)
+			assert.NotContains(t, text, "disable-model-invocation", "%s must not carry the Claude-only frontmatter policy", relPath)
 		} else {
 			assert.Contains(t, text, "`/"+skillName+"`, or structured Claude Code skill selection", relPath)
+			if skillName == "roborev-fix" {
+				assert.NotContains(t, text, "disable-model-invocation",
+					"roborev-fix must stay model-invocable for the agent-hook instruction")
+			} else {
+				assert.Contains(t, text, "disable-model-invocation: true", "%s missing Claude frontmatter policy", relPath)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Follows up #956: Claude models can select installed skills from their metadata when responding to ordinary requests, so descriptions like "Request a code review for a commit and present the results" let a prompt such as "review this branch" create roborev jobs that were meant to be opt-in.
- Rewrites the six hand-maintained Claude review skill descriptions (`roborev-review`, `roborev-review-branch`, `roborev-design-review`, `roborev-design-review-branch`, `roborev-lookahead-review`, `roborev-lookahead-review-branch`) to state only the explicit invocation contract, and adds the same "Explicit invocation only" body section the Codex skills carry.
- Sets `disable-model-invocation: true` in the skill frontmatter — Claude Code's machine-readable equivalent of the Codex `agents/openai.yaml` policy. The model can never auto-select the skill; typing the slash command, picking it from the `/` menu, and the `/roborev:` plugin namespace all keep working. The three Codex-derived skills (`roborev-refine`, `roborev-respond`, `roborev-fix`) get their updates through a new derivation replacement in `derive.go`.
- Excepts `roborev-fix` from the frontmatter policy: the `roborev agent-hook` Stop hook instructs the Claude Code model to invoke that skill, and `disable-model-invocation` blocks all model-side invocation. It keeps the explicit-only description and body section from #956 as its guard, matching how Codex allows hook-instructed explicit invocation.
- Adds unit tests mirroring the Codex conformance checks (descriptions, body sections, frontmatter policy, and no policy leakage into Droid derivations), and updates the Agent Skills guide and changelog.

No Claude analog of the model-backed Codex conformance eval is included: `disable-model-invocation` is enforced by the Claude Code harness itself (the description is never loaded into model context), so there is no model behavior to evaluate for the eight policy-covered skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)