### PR TITLE
Avoid auto-fixing during pre-commit lint

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -15,7 +15,7 @@ always_run = true
 id = "golangci-lint"
 name = "golangci-lint"
 language = "system"
-entry = "make lint"
+entry = "make lint-ci"
 pass_filenames = false
 always_run = true
 


### PR DESCRIPTION
The pre-commit lint hook currently invokes the auto-fixing target. That is unsafe in commit and release workflows because it can mutate the working tree and contend with another linter process, preventing release bookkeeping commits.

Use the read-only lint target for hook validation while retaining `make lint` as the explicit opt-in auto-fix command.