### PR TITLE
Document the 0.62.0 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,8 +149,8 @@ Use `testify` (`github.com/stretchr/testify`) for all test assertions. Use `requ
   Use command wrapper timeouts of at least 10 minutes for `go test ./...` and
   at least 5 minutes for `go test ./internal/daemon` or `go test ./cmd/roborev`.
 - Pre-commit hooks in this repo are managed with `prek`; run `prek install` after cloning or `make install-hooks` as a wrapper.
-- The local pre-commit hook is a `prek` system hook that runs `make lint` with `always_run`, so it executes on every commit and may auto-fix files before the commit succeeds.
-- If the hook rewrites files, re-stage them and rerun the commit. Use `prek run --all-files` to execute the hook manually and `make lint-ci` for a non-mutating lint check.
+- The local pre-commit hook is a `prek` system hook that runs the non-mutating `make lint-ci` target with `always_run`, so it executes on every commit without rewriting files.
+- Use `prek run --all-files` to execute the hooks manually. Run `make lint` only when you explicitly want golangci-lint to apply fixes.
 - Useful build/lint checks: `go build ./...`, `make lint`, `make lint-ci`, `prek run --all-files`
 
 Test conventions:

--- a/README.md
+++ b/README.md
@@ -165,9 +165,9 @@ go install go.kenn.io/roborev/cmd/roborev@latest
 
 This repo uses [`prek`](https://prek.j178.dev/) for local pre-commit checks.
 The hooks are local system hooks. They run a fast Git-test isolation guard and
-`make lint`, so pre-commit can apply `golangci-lint --fix` automatically
-instead of using the upstream `golangci-lint` pre-commit repository. The hooks
-for the Git-test isolation guard and `make lint` are configured with
+`make lint-ci`, the non-mutating golangci-lint target, instead of using the
+upstream `golangci-lint` pre-commit repository. The hooks for the Git-test
+isolation guard and `make lint-ci` are configured with
 `always_run = true`, so they run on every commit, not just commits that touch Go
 files. The Renovate config validator runs when `renovate.json` changes.
 
@@ -178,8 +178,7 @@ prek install          # install the local git hook
 prek run --all-files  # run the configured checks manually
 ```
 
-If the hook rewrites files, re-stage them and re-run `git commit`. Use
-`make lint-ci` when you want a non-mutating lint check. Use
+Use `make lint` when you explicitly want golangci-lint to apply fixes. Use
 `make check-renovate-config` to validate `renovate.json` directly.
 
 ## Commands

--- a/docs/advanced/acp.md
+++ b/docs/advanced/acp.md
@@ -172,17 +172,19 @@ The agent doesn't support the requested session mode. Check which modes the agen
 
 The agent doesn't support the requested model. Remove the `model` field from your `[acp]` config, or check the agent's documentation for supported model names.
 
-### Reviews run with a different model (or agent) than configured
+### Which model wins for an ACP agent?
 
-Workflow model settings (`review_model`, `fix_model`, and their leveled
-variants) take precedence over the `[acp]` `model` field. If a global workflow
-model names a model your ACP agent does not advertise (say `review_model =
-"gpt-5.4"` with a Gemini-only agent), the model check fails, the job retries,
-and after retries it silently fails over to the backup agent — the review
-completes, but a different agent served it. Pass `--model` explicitly, or
-align the workflow model with the ACP agent. To see which agent actually
-served a job: `roborev show --job <id> --json` and check `job.agent` /
-`job.model`.
+Workflow models follow their paired workflow agent. If `review_agent =
+"codex"` and `review_model = "gpt-5.4"`, selecting a Gemini ACP agent with
+`--agent agy-sdk` does not pass `gpt-5.4` to that agent; the ACP agent keeps its
+`[acp].model` instead. This also applies when the workflow agent is inherited
+from the default agent.
+
+A workflow model does apply when its workflow agent resolves to the selected
+ACP agent. An explicit `--model` always wins, and a generic `model` or
+`default_model` still applies when the selected ACP agent is also the matching
+default agent. To confirm which agent and model served a job, run `roborev show
+--job <id> --json` and inspect `job.agent` and `job.model`.
 
 ### `--agent` is ignored and a panel runs instead
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,34 @@ description: Release history for roborev
 
 All notable changes to roborev, grouped by minor release.
 
+## 0.62.0
+<small>2026-07-11</small>
+
+**New features**
+
+- `roborev cancel <job_id>` cancels one queued or running job from the command line. Terminal jobs cannot be canceled. See [Canceling a Job](/commands/#canceling-a-job).
+
+**Improvements**
+
+- Bundled Codex and Claude Code roborev skills now require explicit user invocation. Personal, plugin-namespaced, and structured Codex selection remain available, as do Claude Code slash commands and menu selection; ordinary review or fix requests stay in the agent's native workflow. See [Agent Skills](/guides/agent-skills/#usage).
+- `roborev skills install`, skill status checks, updates, and agent-hook installation now honor `CLAUDE_CONFIG_DIR` and `CODEX_HOME`, falling back to `~/.claude` and `~/.codex` when the variables are unset. See [Agent Skills](/guides/agent-skills/#how-it-works).
+- ACP documentation now includes model-selectable Gemini setup through an Antigravity SDK bridge, thinking-level model suffixes, daemon environment injection, and troubleshooting for agent and model selection. See [Model-Selectable Gemini via a Bridge](/advanced/acp/#example-model-selectable-gemini-via-a-bridge).
+
+**Bug fixes**
+
+- Workflow-specific models no longer leak into a selected ACP agent when the model is paired with a different workflow agent. The selected ACP agent instead keeps its `[acp].model`; explicit `--model` values and models paired with that ACP agent still take precedence.
+- The Antigravity adapter now selects the prompt transport supported by the installed `agy` version: stdin-based `--print` through 1.1.0 and `--prompt` starting with 1.1.1.
+- Pre-commit lint checks now use the non-mutating `make lint-ci` target, preventing commits from unexpectedly rewriting files. `make lint` remains the explicit auto-fix command.
+
+**Acknowledgements**
+
+- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for `roborev cancel`, the model-selectable Gemini ACP documentation, and ACP model-pairing fixes.
+- Thanks to [Yo Iida](https://github.com/y011d4) for honoring custom Claude Code and Codex configuration directories during skill installation.
+- Thanks to [Graham Taylor](https://github.com/gwtaylor) for Antigravity version compatibility.
+- Thanks to [Wes McKinney](https://github.com/wesm) for explicit-only Codex and Claude Code skills and non-mutating pre-commit lint checks.
+
+---
+
 ## 0.61.2
 <small>2026-07-04</small>
 
@@ -15,11 +43,6 @@ All notable changes to roborev, grouped by minor release.
 **Improvements**
 
 - Metadata-only job listings can omit prompt and diff payloads, reducing daemon and agent-hook response sizes while avoiding unnecessary prompt exposure in callers that only need job state.
-
-**Bug fixes**
-
-- Bundled Codex roborev skills now require explicit personal, plugin-namespaced, or structured selection. Machine-readable activation policy and invocation-only descriptions keep ordinary review and fix requests in Codex's native workflow. See [Agent Skills](/guides/agent-skills/#agent-specific-syntax).
-- Bundled Claude Code roborev skills are now explicit-only as well. Skills set `disable-model-invocation: true` and state only their invocation contract in the description, so Claude Code never auto-selects a roborev skill for an ordinary review or fix request; invoke skills with their slash commands. `roborev-fix` stays model-invocable so the agent-hook instruction keeps working. See [Agent Skills](/guides/agent-skills/#agent-specific-syntax).
 
 **Acknowledgements**
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -17,6 +17,7 @@ roborev fix                      # Fix open reviews
 roborev status                   # Check daemon and queue
 roborev pause                    # Pause queue processing
 roborev unpause                  # Resume queue processing
+roborev cancel <job_id>          # Cancel one queued or running job
 roborev summary                  # Aggregate review statistics
 roborev cost                     # Approximate aggregate review cost
 roborev insights                 # Analyze review patterns
@@ -128,6 +129,17 @@ See: [Terminal UI](/integrations/tui/)
 
 !!! tip
     Press `l` in the TUI to open the log viewer for any job (running or completed).
+
+## Canceling a Job
+
+```bash
+roborev cancel 42                # Cancel job 42 if it is queued or running
+```
+
+`roborev cancel` accepts one positive numeric job ID. It asks the daemon to
+cancel that job and prints `Job 42 canceled` when successful. Jobs that have
+already reached a terminal state, including done, failed, or canceled jobs,
+cannot be canceled and return an error.
 
 ## Exporting Reviews
 
@@ -605,6 +617,7 @@ roborev daemon restart           # Restart daemon
 roborev daemon run               # Run in foreground
 roborev pause                    # Pause queue processing
 roborev unpause                  # Resume queue processing
+roborev cancel <job_id>          # Cancel one queued or running job
 
 roborev status                   # Show daemon and queue status
 roborev status --json            # Structured status for scripting
@@ -620,7 +633,7 @@ roborev uninstall-hook           # Remove hook
 | `--json` | Emit daemon and queue status as JSON. Includes the active daemon endpoint as `network`, `address`, and `port` fields alongside queue counters and version fields |
 | `--force` | Overwrite an existing post-commit hook with a fresh one |
 
-`pause` and `unpause` are daemon-wide queue controls. Pausing prevents workers from starting new queued jobs, but running jobs continue to completion. A paused queue survives daemon restarts and is shown in `roborev status` and the TUI.
+`pause` and `unpause` are daemon-wide queue controls. Pausing prevents workers from starting new queued jobs, but running jobs continue to completion. A paused queue survives daemon restarts and is shown in `roborev status` and the TUI. Use `cancel` when you need to stop one queued or running job instead of pausing the whole queue.
 
 !!! tip "Broken post-commit hook?"
     If your post-commit hook was corrupted during a previous upgrade (e.g. a stray `fi` or missing lines), run:

--- a/docs/guides/agent-skills.md
+++ b/docs/guides/agent-skills.md
@@ -239,8 +239,16 @@ roborev update
 
 Skills are installed as agent-specific configuration:
 
-- **Claude Code**: Custom slash commands in `~/.claude/`
-- **Codex**: Custom agent skills directory
+- **Claude Code**: Custom slash commands under
+  `$CLAUDE_CONFIG_DIR/skills/` when `CLAUDE_CONFIG_DIR` is set, otherwise
+  `~/.claude/skills/`
+- **Codex**: Custom agent skills under `$CODEX_HOME/skills/` when `CODEX_HOME`
+  is set, otherwise `~/.codex/skills/`
+- **Factory Droid**: Custom skills under `~/.factory/skills/`
+
+The same resolved directories are used when installing, updating, and checking
+skill status. Claude Code agent-hook installation also honors
+`CLAUDE_CONFIG_DIR`; Codex agent-hook installation honors `CODEX_HOME`.
 
 The review skills use `--wait` internally so the agent can present results inline. The fix skills call `roborev show --job <id> --json` to fetch review data, then parse and present findings to the agent in a structured format. All reviews (whether requested via skills or the post-commit hook) appear in the TUI queue.
 


### PR DESCRIPTION
0.62.0 shipped a new job-control command plus several agent, ACP, and contributor-workflow changes, but the public docs did not yet present them as one release and the ACP guide still described behavior that this release fixed. This update grounds the changelog in the tagged source, credits each contributor, documents the new command and configuration semantics, and corrects the developer guidance that changed with the release.

The generated docs asset branch was refreshed as well, so the published CLI help includes `roborev cancel` and the remaining captures match the released command and TUI surfaces.