### PR TITLE
ACP Gemini follow-ups: backup-path model pairing guard, plus docs

### DIFF
--- a/docs/advanced/acp.md
+++ b/docs/advanced/acp.md
@@ -88,11 +88,19 @@ Then select it anywhere agents are routable: `--agent agy-sdk`, per-workflow
 agents, backup agents, or panel members. Bridge model IDs accept an optional
 thinking suffix (`gemini-3.5-flash:high`), which is how a reasoning level
 reaches the model — roborev's ACP client transmits only mode and model, not
-reasoning.
+reasoning. The suffixed IDs work only because the bridge advertises the
+suffixed strings verbatim in its model list: roborev validates the configured
+model against exact membership of what the agent advertises (for agy-acp, the
+set in `AGY_ACP_MODELS`), so a suffix the bridge does not advertise is
+rejected just like any unknown model.
 
 If the agent process needs environment variables (API keys, cloud project
-settings), remember it is spawned by the **daemon**, which does not inherit
-your shell environment. Inject them with an `env` wrapper:
+settings), remember that daemon-run reviews spawn it from the **daemon**,
+which carries the environment the daemon was started with — not your current
+shell. Exports added to your shell after the daemon started are invisible to
+it until a daemon restart (foreground flows like `roborev review --local` do
+use your shell environment). To make the values explicit regardless of how
+the agent is launched, inject them with an `env` wrapper:
 
 ```toml
 [acp]
@@ -101,6 +109,48 @@ command = "env"
 args = ["AGY_ACP_VERTEX=1", "AGY_ACP_PROJECT=my-gcp-project", "agy-acp"]
 model = "gemini-3.5-flash"
 ```
+
+The `env` args pattern is for **non-secret** values only. Everything in `args`
+is committed to your TOML config and is visible in the process table
+(`/proc/<pid>/cmdline`) while the agent runs, so never put API keys or tokens
+there. For credentials, point `command` at a protected wrapper script (e.g.
+`chmod 700`, stored outside any repo) that exports the secrets before
+`exec`-ing the bridge:
+
+```toml
+[acp]
+name = "agy-sdk"
+command = "/home/you/.config/roborev/agy-acp-wrapper.sh"
+model = "gemini-3.5-flash"
+```
+
+```bash
+#!/usr/bin/env bash
+# ~/.config/roborev/agy-acp-wrapper.sh  (chmod 700, outside any repo)
+export GEMINI_API_KEY="$(cat "$HOME/.secrets/gemini_api_key")"
+exec agy-acp "$@"
+```
+
+### Which Gemini path should I use?
+
+Pick by how you authenticate to Gemini:
+
+- **Consumer Antigravity / Gemini subscription (OAuth login):** use the
+  built-in `gemini` agent via the `agy` CLI. No model selection is possible
+  on this path: an explicit model errors whenever the agent resolves to
+  `agy` — even with the legacy `gemini` CLI also installed — unless you pin
+  `gemini_cmd = "gemini"` (see [Supported Agents](/agents/)). The underlying
+  SDK has no OAuth path, so an ACP bridge cannot restore model selection
+  either.
+- **`GEMINI_API_KEY` (AI Studio key):** use the agy-acp bridge above. Full
+  model and thinking-suffix selection.
+- **GCP Vertex (application-default credentials):** use the agy-acp bridge
+  with `AGY_ACP_VERTEX=1` and `AGY_ACP_PROJECT=<project>` (location `global`),
+  or the legacy `gemini` CLI `-m` flag if you are an enterprise user who still
+  has it.
+- **Avoid** routing Gemini through an Anthropic-compat proxy (LiteLLM + the
+  `claude-code` agent) for reviews: reasoning arrives as ordinary text and
+  contaminates the review output.
 
 ## Configuration Reference
 
@@ -181,10 +231,12 @@ Workflow models follow their paired workflow agent. If `review_agent =
 from the default agent.
 
 A workflow model does apply when its workflow agent resolves to the selected
-ACP agent. An explicit `--model` always wins, and a generic `model` or
-`default_model` still applies when the selected ACP agent is also the matching
-default agent. To confirm which agent and model served a job, run `roborev show
---job <id> --json` and inspect `job.agent` and `job.model`.
+ACP agent. An explicit `--model` wins on the single-agent path (if
+`default_panel` is configured, panel member jobs choose their own models —
+add `--panel none`; see below), and a generic `model` or `default_model`
+still applies when the selected ACP agent is also the matching default agent.
+To confirm which agent and model served a job, run `roborev show --job <id>
+--json` and inspect `job.agent` and `job.model`.
 
 ### `--agent` is ignored and a panel runs instead
 

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -148,14 +148,11 @@ curl -fsSL https://antigravity.google/cli/install.sh | bash
 npm install -g @google/gemini-cli
 ```
 
-Antigravity runs in `--print` mode with the prompt piped over stdin. Review jobs get `--sandbox`; agentic jobs get `--dangerously-skip-permissions`.
+Antigravity runs in print mode — the prompt is passed via `--prompt` on `agy` >= 1.1.1 and piped over stdin with a bare `--print` on older versions (roborev probes `agy --version` to pick the contract). Review jobs get `--sandbox`; agentic jobs get `--dangerously-skip-permissions`.
 
-Antigravity does not currently accept a `--model` flag, so:
+Antigravity does not currently accept a `--model` flag, so an explicit `--model` returns an error whenever the Gemini agent resolves to `agy` — even when the legacy `gemini` CLI is also installed — rather than silently ignoring the override.
 
-- If both `agy` and `gemini` are installed, any `--model` override automatically reroutes to `gemini`.
-- If only `agy` is installed, an explicit `--model` returns an error so the override is not silently ignored.
-
-If you rely on model selection and want to keep using `gemini` exclusively, install only the legacy CLI or shadow `agy` on your `PATH` with a wrapper that exec's `gemini`.
+If you rely on model selection, pin the legacy CLI with `gemini_cmd = "gemini"` in your config, install only the legacy CLI, or shadow `agy` on your `PATH` with a wrapper that exec's `gemini`.
 
 ## Pi Structured Output
 

--- a/internal/agent/model_resolution.go
+++ b/internal/agent/model_resolution.go
@@ -102,6 +102,19 @@ func (w WorkflowConfig) ModelForSelectedAgent(
 ) string {
 	if w.UsesBackupAgent(selectedAgent) &&
 		strings.TrimSpace(cliModel) == "" {
+		// Backup path is intentionally NOT wrapped in the ACP pairing guard
+		// applied to workflow models below. BackupModel() resolves only
+		// backup_model-family fields (workflow/repo/global backup_model), never
+		// generic default_model or a workflow review_model, so a generic or
+		// workflow model can never leak onto an ACP backup agent here. When
+		// BackupModel() is empty the ACP backup agent keeps its own [acp].model
+		// (callers apply the resolved model as `if model != "" { WithModel }`,
+		// and the configured ACP agent is constructed with [acp].model baked
+		// in), so the empty case is already correct. A non-empty backup_model is
+		// an explicit backup-config pair with backup_agent; if a user pairs an
+		// ACP backup agent with a foreign backup_model (e.g. a cross-layer
+		// default_backup_model), ACP session-time validation is the backstop.
+		// See model_resolution_test.go (backup-pairing cases) for the pins.
 		return w.BackupModel()
 	}
 	var model string

--- a/internal/agent/model_resolution.go
+++ b/internal/agent/model_resolution.go
@@ -93,6 +93,40 @@ func (w WorkflowConfig) BackupModel() string {
 	)
 }
 
+// acpBackupModelMispaired reports whether the backup model resolved for this
+// workflow was inherited from the global default_backup_model while the
+// selected ACP backup agent is not paired with it at that layer.
+// default_backup_model pairs with default_backup_agent; when the ACP backup
+// agent came from a more specific layer (or no default_backup_agent is set),
+// the inherited model belongs to a different agent and must not be handed to
+// the ACP agent, whose exact-membership model validation would reject it and
+// break the backup handoff. Workflow-scoped backup models pair with the
+// workflow's resolved backup agent — the selected agent on this path — and
+// are never mispaired here.
+func (w WorkflowConfig) acpBackupModelMispaired(selectedAgent string) bool {
+	if !w.isConfiguredACPAgentName(selectedAgent) {
+		return false
+	}
+	repoCfg := w.RepoConfig
+	if repoCfg == nil {
+		repoCfg, _ = config.LoadRepoConfig(w.RepoPath)
+	}
+	if config.ResolveWorkflowScopedBackupModelFromConfig(
+		repoCfg, w.GlobalConfig, w.Workflow,
+	) != "" {
+		// The resolved backup model is workflow-scoped: paired with the
+		// selected backup agent by construction.
+		return false
+	}
+	// The model was inherited from global default_backup_model, which pairs
+	// with default_backup_agent only.
+	if w.GlobalConfig == nil {
+		return false
+	}
+	pairedAgent := strings.TrimSpace(w.GlobalConfig.DefaultBackupAgent)
+	return pairedAgent == "" || !w.AgentMatches(selectedAgent, pairedAgent)
+}
+
 // ModelForSelectedAgent resolves the model for the actual selected
 // agent. Backup agents use the workflow backup model when no explicit
 // CLI model was provided; otherwise the workflow/default precedence used
@@ -102,20 +136,26 @@ func (w WorkflowConfig) ModelForSelectedAgent(
 ) string {
 	if w.UsesBackupAgent(selectedAgent) &&
 		strings.TrimSpace(cliModel) == "" {
-		// Backup path is intentionally NOT wrapped in the ACP pairing guard
-		// applied to workflow models below. BackupModel() resolves only
-		// backup_model-family fields (workflow/repo/global backup_model), never
-		// generic default_model or a workflow review_model, so a generic or
-		// workflow model can never leak onto an ACP backup agent here. When
-		// BackupModel() is empty the ACP backup agent keeps its own [acp].model
-		// (callers apply the resolved model as `if model != "" { WithModel }`,
-		// and the configured ACP agent is constructed with [acp].model baked
-		// in), so the empty case is already correct. A non-empty backup_model is
-		// an explicit backup-config pair with backup_agent; if a user pairs an
-		// ACP backup agent with a foreign backup_model (e.g. a cross-layer
-		// default_backup_model), ACP session-time validation is the backstop.
-		// See model_resolution_test.go (backup-pairing cases) for the pins.
-		return w.BackupModel()
+		// Backup models pair with backup agents layer by layer, mirroring the
+		// workflow-model pairing guard below. Workflow-scoped backup models
+		// (repo {workflow}_backup_model, repo backup_model, global
+		// {workflow}_backup_model) pair with the workflow's resolved backup
+		// agent — which is the selected agent on this path — so they always
+		// apply. A model inherited from the trailing global
+		// default_backup_model fallback pairs with default_backup_agent only:
+		// when the selected ACP backup agent was configured at a more specific
+		// layer (e.g. review_backup_agent), handing it the inherited model
+		// would fail ACP exact-membership validation and break the backup
+		// handoff — the last line of defense. Return "" instead so the agent
+		// keeps its own [acp].model (callers apply the resolved model as
+		// `if model != "" { WithModel }`, and the configured ACP agent is
+		// constructed with [acp].model baked in). Non-ACP backup agents keep
+		// legacy behavior: native CLIs tolerate a foreign model value.
+		model := w.BackupModel()
+		if model != "" && w.acpBackupModelMispaired(selectedAgent) {
+			return ""
+		}
+		return model
 	}
 	var model string
 	if w.RepoConfig != nil {

--- a/internal/agent/model_resolution.go
+++ b/internal/agent/model_resolution.go
@@ -146,13 +146,16 @@ func (w WorkflowConfig) ModelForSelectedAgent(
 		// when the selected ACP backup agent was configured at a more specific
 		// layer (e.g. review_backup_agent), handing it the inherited model
 		// would fail ACP exact-membership validation and break the backup
-		// handoff — the last line of defense. Return "" instead so the agent
-		// keeps its own [acp].model (callers apply the resolved model as
-		// `if model != "" { WithModel }`, and the configured ACP agent is
-		// constructed with [acp].model baked in). Non-ACP backup agents keep
-		// legacy behavior: native CLIs tolerate a foreign model value.
+		// handoff — the last line of defense. Skip the foreign model and
+		// surface the agent's own [acp].model instead (when set) so persisted
+		// job metadata matches the model the ACP agent actually runs. Non-ACP
+		// backup agents keep legacy behavior: native CLIs tolerate a foreign
+		// model value.
 		model := w.BackupModel()
 		if model != "" && w.acpBackupModelMispaired(selectedAgent) {
+			if acpCfg := w.resolveACPAgentConfig(); acpCfg != nil && acpCfg.Model != "" {
+				return acpCfg.Model
+			}
 			return ""
 		}
 		return model

--- a/internal/agent/model_resolution.go
+++ b/internal/agent/model_resolution.go
@@ -93,16 +93,28 @@ func (w WorkflowConfig) BackupModel() string {
 	)
 }
 
-// acpBackupModelMispaired reports whether the backup model resolved for this
-// workflow was inherited from the global default_backup_model while the
-// selected ACP backup agent is not paired with it at that layer.
-// default_backup_model pairs with default_backup_agent; when the ACP backup
-// agent came from a more specific layer (or no default_backup_agent is set),
-// the inherited model belongs to a different agent and must not be handed to
-// the ACP agent, whose exact-membership model validation would reject it and
-// break the backup handoff. Workflow-scoped backup models pair with the
-// workflow's resolved backup agent — the selected agent on this path — and
-// are never mispaired here.
+// acpBackupModelMispaired reports whether the resolved backup model is
+// paired with a different agent than the selected ACP backup agent. Backup
+// agent and model precedence resolve independently, so a model must be
+// applied only when the backup agent resolvable AT THE MODEL'S OWN LAYER is
+// the selected ACP agent:
+//
+//   - Repo-layer models (repo {workflow}_backup_model, repo backup_model)
+//     pair with the normally-resolved backup agent: the repo author wrote
+//     the model against whatever full resolution yields (an inherited global
+//     agent included), which is the selected agent on this path. Never
+//     mispaired.
+//   - A global {workflow}_backup_model pairs with the backup agent
+//     resolvable from global-layer fields only (global
+//     {workflow}_backup_agent, else default_backup_agent). A more specific
+//     repo-layer agent override must not capture the global model.
+//   - A global default_backup_model pairs with default_backup_agent only. A
+//     more specific workflow- or repo-layer agent must not capture the
+//     generic model.
+//
+// A mispaired model would fail the ACP agent's exact-membership model
+// validation and break the backup handoff, which is why this is guarded for
+// ACP-selected backup agents only.
 func (w WorkflowConfig) acpBackupModelMispaired(selectedAgent string) bool {
 	if !w.isConfiguredACPAgentName(selectedAgent) {
 		return false
@@ -111,19 +123,31 @@ func (w WorkflowConfig) acpBackupModelMispaired(selectedAgent string) bool {
 	if repoCfg == nil {
 		repoCfg, _ = config.LoadRepoConfig(w.RepoPath)
 	}
+	// Repo-layer model: pairs with the fully-resolved backup agent (the
+	// selected agent). Passing a nil global config scopes resolution to the
+	// repo-layer fields.
 	if config.ResolveWorkflowScopedBackupModelFromConfig(
-		repoCfg, w.GlobalConfig, w.Workflow,
+		repoCfg, nil, w.Workflow,
 	) != "" {
-		// The resolved backup model is workflow-scoped: paired with the
-		// selected backup agent by construction.
 		return false
 	}
-	// The model was inherited from global default_backup_model, which pairs
-	// with default_backup_agent only.
 	if w.GlobalConfig == nil {
 		return false
 	}
-	pairedAgent := strings.TrimSpace(w.GlobalConfig.DefaultBackupAgent)
+	var pairedAgent string
+	if config.ResolveWorkflowScopedBackupModelFromConfig(
+		nil, w.GlobalConfig, w.Workflow,
+	) != "" {
+		// Global {workflow}_backup_model: pairs with the global-layer
+		// workflow backup agent resolution (global {workflow}_backup_agent,
+		// else default_backup_agent).
+		pairedAgent = config.ResolveBackupAgentForWorkflowFromConfig(
+			nil, w.GlobalConfig, w.Workflow,
+		)
+	} else {
+		// Global default_backup_model: pairs with default_backup_agent only.
+		pairedAgent = strings.TrimSpace(w.GlobalConfig.DefaultBackupAgent)
+	}
 	return pairedAgent == "" || !w.AgentMatches(selectedAgent, pairedAgent)
 }
 

--- a/internal/agent/model_resolution.go
+++ b/internal/agent/model_resolution.go
@@ -149,8 +149,11 @@ func (w WorkflowConfig) ModelForSelectedAgent(
 		// handoff — the last line of defense. Skip the foreign model and
 		// surface the agent's own [acp].model instead (when set) so persisted
 		// job metadata matches the model the ACP agent actually runs. Non-ACP
-		// backup agents keep legacy behavior: native CLIs tolerate a foreign
-		// model value.
+		// backup agents keep legacy behavior: a foreign model on a native CLI
+		// surfaces as a visible agent-layer error or is ignored, never a
+		// silent failover break. (Gemini resolved to the agy CLI rejects any
+		// explicit model with a loud, actionable error — pre-existing
+		// behavior enforced at the agent layer, see gemini.go.)
 		model := w.BackupModel()
 		if model != "" && w.acpBackupModelMispaired(selectedAgent) {
 			if acpCfg := w.resolveACPAgentConfig(); acpCfg != nil && acpCfg.Model != "" {

--- a/internal/agent/model_resolution_test.go
+++ b/internal/agent/model_resolution_test.go
@@ -646,8 +646,10 @@ func TestModelForSelectedAgentACPBackupPairing(t *testing.T) {
 		{
 			// Scope guard: a non-ACP backup agent keeps legacy behavior — the
 			// inherited default_backup_model still applies even though no
-			// default_backup_agent pairs with it (native CLIs tolerate a
-			// foreign model value).
+			// default_backup_agent pairs with it. Any incompatibility
+			// surfaces at the agent layer as a visible error (e.g. gemini
+			// via agy rejects explicit models loudly), never as ACP's
+			// silent failover break.
 			name: "non-acp backup, inherited default_backup_model -> honored (legacy)",
 			cfg: &config.Config{
 				DefaultAgent:       "codex",

--- a/internal/agent/model_resolution_test.go
+++ b/internal/agent/model_resolution_test.go
@@ -502,7 +502,7 @@ func TestResolveWorkflowConfigModelForSelectedAgent_BackupWithoutModelKeepsDefau
 // path — while a model inherited from the trailing global
 // default_backup_model fallback pairs with default_backup_agent only. An
 // inherited model whose paired agent is not the selected ACP backup agent is
-// skipped (""), leaving the agent's own [acp].model in effect, because ACP
+// skipped in favor of the agent's own [acp].model, because ACP
 // exact-membership validation would otherwise reject the foreign value and
 // break the backup handoff. Non-ACP backup agents keep legacy behavior.
 func TestModelForSelectedAgentACPBackupPairing(t *testing.T) {
@@ -557,9 +557,10 @@ func TestModelForSelectedAgentACPBackupPairing(t *testing.T) {
 			// model is the inherited global default_backup_model, which pairs
 			// with default_backup_agent (unset here). Handing the inherited
 			// model to the ACP agent would fail its exact-membership
-			// validation and break the backup handoff, so it is skipped and
-			// the agent keeps its own [acp].model.
-			name: "acp backup, inherited default_backup_model, no default_backup_agent -> skipped",
+			// validation and break the backup handoff, so the agent's own
+			// [acp].model is surfaced instead (keeping persisted job metadata
+			// accurate).
+			name: "acp backup, inherited default_backup_model, no default_backup_agent -> acp model",
 			cfg: &config.Config{
 				DefaultAgent:       "codex",
 				ReviewAgent:        "gemini",
@@ -569,14 +570,14 @@ func TestModelForSelectedAgentACPBackupPairing(t *testing.T) {
 			},
 			workflow:      "review",
 			selectedAgent: acpName,
-			want:          "",
-			note:          "inherited default_backup_model is unpaired -> keeps [acp].model",
+			want:          acpModel,
+			note:          "inherited default_backup_model is unpaired -> [acp].model",
 		},
 		{
 			// Same mispair with default_backup_agent set to a DIFFERENT
 			// agent: default_backup_model pairs with that agent, not the
 			// workflow-selected ACP backup agent.
-			name: "acp backup, default_backup_model paired with other default_backup_agent -> skipped",
+			name: "acp backup, default_backup_model paired with other default_backup_agent -> acp model",
 			cfg: &config.Config{
 				DefaultAgent:       "codex",
 				ReviewAgent:        "gemini",
@@ -587,8 +588,25 @@ func TestModelForSelectedAgentACPBackupPairing(t *testing.T) {
 			},
 			workflow:      "review",
 			selectedAgent: acpName,
-			want:          "",
+			want:          acpModel,
 			note:          "default_backup_model belongs to claude, not the ACP agent",
+		},
+		{
+			// Mispair with no [acp].model configured either: nothing safe to
+			// hand the agent, so resolve to "" (the agent runs its own
+			// default).
+			name: "acp backup, mispaired inherited model, no [acp].model -> empty",
+			cfg: &config.Config{
+				DefaultAgent:       "codex",
+				ReviewAgent:        "gemini",
+				ReviewBackupAgent:  acpName,
+				DefaultBackupModel: "gpt-5.4-mini",
+				ACP:                &config.ACPAgentConfig{Name: acpName},
+			},
+			workflow:      "review",
+			selectedAgent: acpName,
+			want:          "",
+			note:          "mispaired inherited model with no [acp].model resolves empty",
 		},
 		{
 			// Legit same-layer global pair: default_backup_agent IS the ACP

--- a/internal/agent/model_resolution_test.go
+++ b/internal/agent/model_resolution_test.go
@@ -494,12 +494,17 @@ func TestResolveWorkflowConfigModelForSelectedAgent_BackupWithoutModelKeepsDefau
 	require.Empty(t, resolution.ModelForSelectedAgent("claude-code", ""))
 }
 
-// TestModelForSelectedAgentACPBackupPairing pins the backup-path semantics for
-// a configured ACP backup agent. The backup path deliberately bypasses the
-// workflow-model ACP pairing guard because BackupModel() only ever resolves
-// backup_model-family fields (never a generic default_model or workflow
-// review_model), so no generic/workflow model can leak onto an ACP backup
-// agent. These cases pin the resulting behavior across the layers that matter.
+// TestModelForSelectedAgentACPBackupPairing pins the backup-path pairing
+// semantics for a configured ACP backup agent. Backup models pair with backup
+// agents layer by layer: workflow-scoped backup models (repo
+// {workflow}_backup_model, repo backup_model, global {workflow}_backup_model)
+// pair with the workflow's resolved backup agent — the selected agent on this
+// path — while a model inherited from the trailing global
+// default_backup_model fallback pairs with default_backup_agent only. An
+// inherited model whose paired agent is not the selected ACP backup agent is
+// skipped (""), leaving the agent's own [acp].model in effect, because ACP
+// exact-membership validation would otherwise reject the foreign value and
+// break the backup handoff. Non-ACP backup agents keep legacy behavior.
 func TestModelForSelectedAgentACPBackupPairing(t *testing.T) {
 	t.Parallel()
 
@@ -547,23 +552,96 @@ func TestModelForSelectedAgentACPBackupPairing(t *testing.T) {
 			note:          "empty backup_model leaves [acp].model intact",
 		},
 		{
-			// Cross-layer: only a global default_backup_model is set while the
-			// ACP backup agent is workflow-specific. BackupModel() honors the
-			// explicit backup config (it is still a backup_model, not a generic
-			// or workflow model), and ACP session validation is the backstop if
-			// the value is foreign. Pinned to document the deliberate scope.
-			name: "acp backup, only global default_backup_model -> honored",
+			// THE LEAK (cross-layer mispair): the ACP backup agent is
+			// workflow-specific (review_backup_agent), but the only backup
+			// model is the inherited global default_backup_model, which pairs
+			// with default_backup_agent (unset here). Handing the inherited
+			// model to the ACP agent would fail its exact-membership
+			// validation and break the backup handoff, so it is skipped and
+			// the agent keeps its own [acp].model.
+			name: "acp backup, inherited default_backup_model, no default_backup_agent -> skipped",
 			cfg: &config.Config{
 				DefaultAgent:       "codex",
 				ReviewAgent:        "gemini",
 				ReviewBackupAgent:  acpName,
+				DefaultBackupModel: "gpt-5.4-mini",
+				ACP:                &config.ACPAgentConfig{Name: acpName, Model: acpModel},
+			},
+			workflow:      "review",
+			selectedAgent: acpName,
+			want:          "",
+			note:          "inherited default_backup_model is unpaired -> keeps [acp].model",
+		},
+		{
+			// Same mispair with default_backup_agent set to a DIFFERENT
+			// agent: default_backup_model pairs with that agent, not the
+			// workflow-selected ACP backup agent.
+			name: "acp backup, default_backup_model paired with other default_backup_agent -> skipped",
+			cfg: &config.Config{
+				DefaultAgent:       "codex",
+				ReviewAgent:        "gemini",
+				ReviewBackupAgent:  acpName,
+				DefaultBackupAgent: "claude",
+				DefaultBackupModel: "claude-sonnet",
+				ACP:                &config.ACPAgentConfig{Name: acpName, Model: acpModel},
+			},
+			workflow:      "review",
+			selectedAgent: acpName,
+			want:          "",
+			note:          "default_backup_model belongs to claude, not the ACP agent",
+		},
+		{
+			// Legit same-layer global pair: default_backup_agent IS the ACP
+			// agent and default_backup_model was configured alongside it.
+			name: "acp backup via default_backup_agent, default_backup_model -> that model",
+			cfg: &config.Config{
+				DefaultAgent:       "codex",
+				ReviewAgent:        "gemini",
+				DefaultBackupAgent: acpName,
 				DefaultBackupModel: "gemini-3.0-pro",
 				ACP:                &config.ACPAgentConfig{Name: acpName, Model: acpModel},
 			},
 			workflow:      "review",
 			selectedAgent: acpName,
 			want:          "gemini-3.0-pro",
-			note:          "explicit backup_model honored across layers",
+			note:          "same-layer default_backup_agent+default_backup_model pair holds",
+		},
+		{
+			// Legit inheritance: the backup agent inherits from
+			// default_backup_agent=ACP while the model is workflow-scoped
+			// (global review_backup_model). Workflow-scoped models pair with
+			// the resolved backup agent, so the pair holds — thinking
+			// suffixes included.
+			name: "acp backup inherited from default_backup_agent, workflow backup_model -> that model",
+			cfg: &config.Config{
+				DefaultAgent:       "codex",
+				ReviewAgent:        "gemini",
+				DefaultBackupAgent: acpName,
+				ReviewBackupModel:  "gemini-3.5-flash:high",
+				ACP:                &config.ACPAgentConfig{Name: acpName, Model: acpModel},
+			},
+			workflow:      "review",
+			selectedAgent: acpName,
+			want:          "gemini-3.5-flash:high",
+			note:          "workflow-scoped backup_model pairs with the resolved backup agent",
+		},
+		{
+			// Scope guard: a non-ACP backup agent keeps legacy behavior — the
+			// inherited default_backup_model still applies even though no
+			// default_backup_agent pairs with it (native CLIs tolerate a
+			// foreign model value).
+			name: "non-acp backup, inherited default_backup_model -> honored (legacy)",
+			cfg: &config.Config{
+				DefaultAgent:       "codex",
+				ReviewAgent:        "gemini",
+				ReviewBackupAgent:  "claude",
+				DefaultBackupModel: "claude-sonnet",
+				ACP:                &config.ACPAgentConfig{Name: acpName, Model: acpModel},
+			},
+			workflow:      "review",
+			selectedAgent: "claude-code",
+			want:          "claude-sonnet",
+			note:          "non-ACP backup agents are unaffected by the guard",
 		},
 	}
 

--- a/internal/agent/model_resolution_test.go
+++ b/internal/agent/model_resolution_test.go
@@ -494,6 +494,93 @@ func TestResolveWorkflowConfigModelForSelectedAgent_BackupWithoutModelKeepsDefau
 	require.Empty(t, resolution.ModelForSelectedAgent("claude-code", ""))
 }
 
+// TestModelForSelectedAgentACPBackupPairing pins the backup-path semantics for
+// a configured ACP backup agent. The backup path deliberately bypasses the
+// workflow-model ACP pairing guard because BackupModel() only ever resolves
+// backup_model-family fields (never a generic default_model or workflow
+// review_model), so no generic/workflow model can leak onto an ACP backup
+// agent. These cases pin the resulting behavior across the layers that matter.
+func TestModelForSelectedAgentACPBackupPairing(t *testing.T) {
+	t.Parallel()
+
+	const acpName = "agy-acp"
+	const acpModel = "gemini-3.5-flash"
+
+	tests := []struct {
+		name          string
+		cfg           *config.Config
+		workflow      string
+		selectedAgent string
+		want          string
+		note          string
+	}{
+		{
+			// Explicit workflow-specific backup_model paired with the ACP
+			// backup agent: it is used verbatim (thinking suffixes included).
+			name: "acp backup, workflow-specific backup_model -> that model",
+			cfg: &config.Config{
+				DefaultAgent:      "codex",
+				ReviewAgent:       "gemini",
+				ReviewBackupAgent: acpName,
+				ReviewBackupModel: "gemini-3.5-flash:high",
+				ACP:               &config.ACPAgentConfig{Name: acpName, Model: acpModel},
+			},
+			workflow:      "review",
+			selectedAgent: acpName,
+			want:          "gemini-3.5-flash:high",
+			note:          "explicit paired backup_model wins",
+		},
+		{
+			// No backup_model anywhere: returns "" so the ACP backup agent
+			// keeps its own baked-in [acp].model (callers only override when
+			// the resolved model is non-empty). This is the safe empty case.
+			name: "acp backup, no backup_model -> empty (keeps [acp].model)",
+			cfg: &config.Config{
+				DefaultAgent:      "codex",
+				ReviewAgent:       "gemini",
+				ReviewBackupAgent: acpName,
+				ACP:               &config.ACPAgentConfig{Name: acpName, Model: acpModel},
+			},
+			workflow:      "review",
+			selectedAgent: acpName,
+			want:          "",
+			note:          "empty backup_model leaves [acp].model intact",
+		},
+		{
+			// Cross-layer: only a global default_backup_model is set while the
+			// ACP backup agent is workflow-specific. BackupModel() honors the
+			// explicit backup config (it is still a backup_model, not a generic
+			// or workflow model), and ACP session validation is the backstop if
+			// the value is foreign. Pinned to document the deliberate scope.
+			name: "acp backup, only global default_backup_model -> honored",
+			cfg: &config.Config{
+				DefaultAgent:       "codex",
+				ReviewAgent:        "gemini",
+				ReviewBackupAgent:  acpName,
+				DefaultBackupModel: "gemini-3.0-pro",
+				ACP:                &config.ACPAgentConfig{Name: acpName, Model: acpModel},
+			},
+			workflow:      "review",
+			selectedAgent: acpName,
+			want:          "gemini-3.0-pro",
+			note:          "explicit backup_model honored across layers",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolution, err := ResolveWorkflowConfig(
+				"", t.TempDir(), tt.cfg, tt.workflow, "standard",
+			)
+			require.NoError(t, err)
+			require.True(t, resolution.UsesBackupAgent(tt.selectedAgent),
+				"expected %q to be resolved via the backup path", tt.selectedAgent)
+			got := resolution.ModelForSelectedAgent(tt.selectedAgent, "")
+			require.Equal(t, tt.want, got, tt.note)
+		})
+	}
+}
+
 func TestResolveWorkflowConfigIgnoresMalformedRepoConfig(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/model_resolution_test.go
+++ b/internal/agent/model_resolution_test.go
@@ -495,16 +495,18 @@ func TestResolveWorkflowConfigModelForSelectedAgent_BackupWithoutModelKeepsDefau
 }
 
 // TestModelForSelectedAgentACPBackupPairing pins the backup-path pairing
-// semantics for a configured ACP backup agent. Backup models pair with backup
-// agents layer by layer: workflow-scoped backup models (repo
-// {workflow}_backup_model, repo backup_model, global {workflow}_backup_model)
-// pair with the workflow's resolved backup agent — the selected agent on this
-// path — while a model inherited from the trailing global
-// default_backup_model fallback pairs with default_backup_agent only. An
-// inherited model whose paired agent is not the selected ACP backup agent is
-// skipped in favor of the agent's own [acp].model, because ACP
-// exact-membership validation would otherwise reject the foreign value and
-// break the backup handoff. Non-ACP backup agents keep legacy behavior.
+// semantics for a configured ACP backup agent. Backup agent and model
+// precedence resolve independently, so a backup model pairs with the backup
+// agent resolvable AT THE MODEL'S OWN LAYER: repo-layer models (repo
+// {workflow}_backup_model, repo backup_model) pair with the normally-resolved
+// backup agent — the selected agent on this path — and always apply; a global
+// {workflow}_backup_model pairs with the agent resolvable from global-layer
+// fields only (global {workflow}_backup_agent, else default_backup_agent); a
+// global default_backup_model pairs with default_backup_agent only. A model
+// whose paired agent is not the selected ACP backup agent is skipped in favor
+// of the agent's own [acp].model, because ACP exact-membership validation
+// would otherwise reject the foreign value and break the backup handoff.
+// Non-ACP backup agents keep legacy behavior.
 func TestModelForSelectedAgentACPBackupPairing(t *testing.T) {
 	t.Parallel()
 
@@ -513,6 +515,7 @@ func TestModelForSelectedAgentACPBackupPairing(t *testing.T) {
 
 	tests := []struct {
 		name          string
+		repoCfg       *config.RepoConfig
 		cfg           *config.Config
 		workflow      string
 		selectedAgent string
@@ -663,12 +666,109 @@ func TestModelForSelectedAgentACPBackupPairing(t *testing.T) {
 			want:          "claude-sonnet",
 			note:          "non-ACP backup agents are unaffected by the guard",
 		},
+		{
+			// Cross-file mispair: a repo-layer review_backup_agent selects
+			// the ACP agent, but the only backup model is a global
+			// review_backup_model written against the global backup agent
+			// resolution (empty here). The repo agent override must not
+			// capture the global model.
+			name: "repo acp backup agent, global review_backup_model -> acp model",
+			repoCfg: &config.RepoConfig{
+				ReviewBackupAgent: acpName,
+			},
+			cfg: &config.Config{
+				DefaultAgent:      "codex",
+				ReviewAgent:       "gemini",
+				ReviewBackupModel: "gpt-5.4",
+				ACP:               &config.ACPAgentConfig{Name: acpName, Model: acpModel},
+			},
+			workflow:      "review",
+			selectedAgent: acpName,
+			want:          acpModel,
+			note:          "repo agent override must not capture a global workflow model",
+		},
+		{
+			// Cross-file pair that holds: the global review_backup_model is
+			// paired with the global review_backup_agent, which IS the ACP
+			// agent the repo override also selects.
+			name: "repo acp backup agent, global pair also acp -> global model",
+			repoCfg: &config.RepoConfig{
+				ReviewBackupAgent: acpName,
+			},
+			cfg: &config.Config{
+				DefaultAgent:      "codex",
+				ReviewAgent:       "gemini",
+				ReviewBackupAgent: acpName,
+				ReviewBackupModel: "gemini-3.0-pro",
+				ACP:               &config.ACPAgentConfig{Name: acpName, Model: acpModel},
+			},
+			workflow:      "review",
+			selectedAgent: acpName,
+			want:          "gemini-3.0-pro",
+			note:          "global model paired with a matching global agent applies",
+		},
+		{
+			// Repo-layer model with the backup agent inherited from the
+			// global layer: the repo author wrote the model against the
+			// inherited agent, so the pair holds (suffixes included).
+			name: "repo review_backup_model, global acp backup agent -> repo model",
+			repoCfg: &config.RepoConfig{
+				ReviewBackupModel: "gemini-3.5-flash:high",
+			},
+			cfg: &config.Config{
+				DefaultAgent:      "codex",
+				ReviewAgent:       "gemini",
+				ReviewBackupAgent: acpName,
+				ACP:               &config.ACPAgentConfig{Name: acpName, Model: acpModel},
+			},
+			workflow:      "review",
+			selectedAgent: acpName,
+			want:          "gemini-3.5-flash:high",
+			note:          "repo model pairs with the normally-resolved backup agent",
+		},
+		{
+			// Both repo-layer: agent and model configured together in the
+			// repo file.
+			name: "repo acp backup agent and repo backup model -> repo model",
+			repoCfg: &config.RepoConfig{
+				ReviewBackupAgent: acpName,
+				ReviewBackupModel: "gemini-3.0-pro",
+			},
+			cfg: &config.Config{
+				DefaultAgent: "codex",
+				ReviewAgent:  "gemini",
+				ACP:          &config.ACPAgentConfig{Name: acpName, Model: acpModel},
+			},
+			workflow:      "review",
+			selectedAgent: acpName,
+			want:          "gemini-3.0-pro",
+			note:          "same-file repo pair applies",
+		},
+		{
+			// Scope guard for the cross-file case: a non-ACP repo backup
+			// agent still receives the global workflow model (legacy
+			// behavior).
+			name: "repo non-acp backup agent, global review_backup_model -> honored (legacy)",
+			repoCfg: &config.RepoConfig{
+				ReviewBackupAgent: "claude",
+			},
+			cfg: &config.Config{
+				DefaultAgent:      "codex",
+				ReviewAgent:       "gemini",
+				ReviewBackupModel: "gpt-5.4",
+				ACP:               &config.ACPAgentConfig{Name: acpName, Model: acpModel},
+			},
+			workflow:      "review",
+			selectedAgent: "claude-code",
+			want:          "gpt-5.4",
+			note:          "non-ACP backup agents are unaffected by the layer rule",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resolution, err := ResolveWorkflowConfig(
-				"", t.TempDir(), tt.cfg, tt.workflow, "standard",
+			resolution, err := ResolveWorkflowConfigFromConfig(
+				"", tt.repoCfg, tt.cfg, tt.workflow, "standard",
 			)
 			require.NoError(t, err)
 			require.True(t, resolution.UsesBackupAgent(tt.selectedAgent),

--- a/internal/config/workflow.go
+++ b/internal/config/workflow.go
@@ -622,6 +622,29 @@ func ResolveBackupModelForWorkflow(repoPath string, globalCfg *Config, workflow 
 // ResolveBackupModelForWorkflow: it resolves entirely from the passed repoCfg
 // and globalCfg, never reading the working tree.
 func ResolveBackupModelForWorkflowFromConfig(repoCfg *RepoConfig, globalCfg *Config, workflow string) string {
+	if s := ResolveWorkflowScopedBackupModelFromConfig(repoCfg, globalCfg, workflow); s != "" {
+		return s
+	}
+
+	// Global default layer.
+	if globalCfg != nil {
+		if s := strings.TrimSpace(globalCfg.DefaultBackupModel); s != "" {
+			return s
+		}
+	}
+
+	return ""
+}
+
+// ResolveWorkflowScopedBackupModelFromConfig resolves only the
+// workflow-scoped backup model fields — repo {workflow}_backup_model, repo
+// backup_model, global {workflow}_backup_model — excluding the trailing
+// global default_backup_model fallback of
+// ResolveBackupModelForWorkflowFromConfig. Workflow-scoped fields pair with
+// the workflow's resolved backup agent, whereas default_backup_model pairs
+// with default_backup_agent; the ACP backup pairing guard relies on this
+// distinction.
+func ResolveWorkflowScopedBackupModelFromConfig(repoCfg *RepoConfig, globalCfg *Config, workflow string) string {
 	// Repo layer: workflow-specific > generic
 	if repoCfg != nil {
 		if s := lookupFieldByTag(reflect.ValueOf(*repoCfg), workflow+"_backup_model"); s != "" {
@@ -632,12 +655,9 @@ func ResolveBackupModelForWorkflowFromConfig(repoCfg *RepoConfig, globalCfg *Con
 		}
 	}
 
-	// Global layer: workflow-specific > default
+	// Global layer: workflow-specific only
 	if globalCfg != nil {
 		if s := lookupFieldByTag(reflect.ValueOf(*globalCfg), workflow+"_backup_model"); s != "" {
-			return s
-		}
-		if s := strings.TrimSpace(globalCfg.DefaultBackupModel); s != "" {
 			return s
 		}
 	}

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -1258,7 +1258,16 @@ func (wp *WorkerPool) resolveBackupModel(job *storage.ReviewJob) string {
 	if err != nil {
 		return ""
 	}
-	return resolution.BackupModel()
+	backup := strings.TrimSpace(resolution.BackupAgent)
+	if backup == "" {
+		return ""
+	}
+	// Resolve the model for the concrete backup agent through the same
+	// chokepoint the enqueue paths use so the ACP backup pairing guard
+	// applies: an inherited global default_backup_model must not be
+	// persisted for a mispaired ACP backup agent, or the failover attempt
+	// would hand ACP a model it never advertised and fail again.
+	return resolution.ModelForSelectedAgent(backup, "")
 }
 
 // broadcastFailed sends a review.failed event for a job

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -2073,6 +2073,44 @@ func TestResolveBackupPrefersStoredJobBackup(t *testing.T) {
 	assert.Equal("opus", pool.resolveBackupModel(synthesisStored))
 }
 
+// TestResolveBackupModelSkipsMispairedACPInheritedDefault verifies the
+// failover path applies the ACP backup pairing guard: a global
+// default_backup_model inherited by a workflow-selected ACP backup agent
+// pairs with default_backup_agent (unset here), so persisting it would hand
+// the ACP agent a model it never advertised and the failover attempt would
+// fail again. The guard surfaces [acp].model instead. Non-ACP backups keep
+// legacy inheritance.
+func TestResolveBackupModelSkipsMispairedACPInheritedDefault(t *testing.T) {
+	assert := assert.New(t)
+	repoPath := t.TempDir()
+	job := &storage.ReviewJob{Agent: "codex", RepoPath: repoPath}
+
+	// Mispaired: ACP backup agent from review_backup_agent, model inherited
+	// from default_backup_model -> [acp].model wins.
+	cfg := config.DefaultConfig()
+	cfg.ACP = &config.ACPAgentConfig{Name: "agy-acp", Model: "gemini-3.5-flash"}
+	cfg.ReviewBackupAgent = "agy-acp"
+	cfg.DefaultBackupModel = "gpt-5.4-mini"
+	pool := NewWorkerPool(nil, NewStaticConfig(cfg), 1, NewBroadcaster(), nil, nil)
+	assert.Equal("gemini-3.5-flash", pool.resolveBackupModel(job))
+
+	// Same-layer pair: default_backup_agent IS the ACP agent, so the
+	// default_backup_model configured alongside it is honored.
+	cfgPaired := config.DefaultConfig()
+	cfgPaired.ACP = &config.ACPAgentConfig{Name: "agy-acp", Model: "gemini-3.5-flash"}
+	cfgPaired.DefaultBackupAgent = "agy-acp"
+	cfgPaired.DefaultBackupModel = "gemini-3.0-pro"
+	poolPaired := NewWorkerPool(nil, NewStaticConfig(cfgPaired), 1, NewBroadcaster(), nil, nil)
+	assert.Equal("gemini-3.0-pro", poolPaired.resolveBackupModel(job))
+
+	// Non-ACP backup: inherited default_backup_model keeps legacy behavior.
+	cfgLegacy := config.DefaultConfig()
+	cfgLegacy.ReviewBackupAgent = "claude"
+	cfgLegacy.DefaultBackupModel = "claude-sonnet"
+	poolLegacy := NewWorkerPool(nil, NewStaticConfig(cfgLegacy), 1, NewBroadcaster(), nil, nil)
+	assert.Equal("claude-sonnet", poolLegacy.resolveBackupModel(job))
+}
+
 func TestResolveBackupAgentUsesConfiguredCommandOverride(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell fake command uses POSIX permissions")

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -2109,6 +2109,24 @@ func TestResolveBackupModelSkipsMispairedACPInheritedDefault(t *testing.T) {
 	cfgLegacy.DefaultBackupModel = "claude-sonnet"
 	poolLegacy := NewWorkerPool(nil, NewStaticConfig(cfgLegacy), 1, NewBroadcaster(), nil, nil)
 	assert.Equal("claude-sonnet", poolLegacy.resolveBackupModel(job))
+
+	// Cross-file mispair: a repo-layer review_backup_agent selects the ACP
+	// agent while the only backup model is a global review_backup_model
+	// written against the global backup agent resolution (empty here). The
+	// repo agent override must not capture the global model on failover
+	// either.
+	repoOverridePath := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoOverridePath, ".roborev.toml"),
+		[]byte("review_backup_agent = \"agy-acp\"\n"),
+		0o644,
+	))
+	cfgCross := config.DefaultConfig()
+	cfgCross.ACP = &config.ACPAgentConfig{Name: "agy-acp", Model: "gemini-3.5-flash"}
+	cfgCross.ReviewBackupModel = "gpt-5.4"
+	poolCross := NewWorkerPool(nil, NewStaticConfig(cfgCross), 1, NewBroadcaster(), nil, nil)
+	crossJob := &storage.ReviewJob{Agent: "codex", RepoPath: repoOverridePath}
+	assert.Equal("gemini-3.5-flash", poolCross.resolveBackupModel(crossJob))
 }
 
 func TestResolveBackupAgentUsesConfiguredCommandOverride(t *testing.T) {


### PR DESCRIPTION
## Summary

Completes the Gemini-via-ACP story from #954/#955 (these follow-ups were pushed to those branches moments after the squash-merges, so they're re-landed here on top of #961).

**Code:** #955 established that a configured model only applies to the agent it's paired with. This PR extends that same principle to the one path it didn't cover: backup/failover. Previously, a global `default_backup_model` could be inherited by a workflow-selected ACP backup agent it was never paired with — and because ACP agents validate models by exact membership, the mismatch doesn't degrade, it breaks the failover itself. The guard now applies same-layer pairing on both the resolution and daemon-failover paths, keeps `[acp].model` in place on a mismatch (and reflects it in `job.model`), and leaves non-ACP agents and all legitimately-paired backup configs untouched. Pinned by a table-driven test across the pairing layers plus a failover-path test.

**Docs:** rounds out the Gemini guidance in `docs/advanced/acp.md` — a "Which Gemini path should I use?" decision tree keyed on how you authenticate (subscription OAuth vs `GEMINI_API_KEY` vs Vertex), a credentials-safe pattern for passing env to daemon-spawned ACP agents, and precision notes on model validation and `--model`/panel interaction — and aligns `docs/agents/index.md` with the current Antigravity behavior (explicit-model handling, the #952 version-gated prompt contract).

<img width="792" height="596" alt="snippy_1783849307483" src="https://github.com/user-attachments/assets/a79eb214-cfec-47d0-894e-b851dc2e24f7" />
