### PR TITLE
Add stable JSON version contract

### DIFF
--- a/cmd/roborev/version.go
+++ b/cmd/roborev/version.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -9,11 +10,27 @@ import (
 )
 
 func versionCmd() *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Show roborev version",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("roborev %s\n", version.Version)
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if jsonOutput {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(struct {
+					Name    string `json:"name"`
+					Version string `json:"version"`
+				}{
+					Name:    "roborev",
+					Version: version.Version,
+				})
+			}
+
+			_, err := fmt.Fprintf(cmd.OutOrStdout(), "roborev %s\n", version.Version)
+			return err
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output version information as JSON")
+	return cmd
 }

--- a/cmd/roborev/version_test.go
+++ b/cmd/roborev/version_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/version"
+)
+
+func TestVersionCmdHumanOutput(t *testing.T) {
+	var output bytes.Buffer
+	cmd := versionCmd()
+	cmd.SetOut(&output)
+
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, fmt.Sprintf("roborev %s\n", version.Version), output.String())
+}
+
+func TestVersionCmdJSONOutput(t *testing.T) {
+	var output bytes.Buffer
+	cmd := versionCmd()
+	cmd.SetOut(&output)
+	cmd.SetArgs([]string{"--json"})
+
+	require.NoError(t, cmd.Execute())
+
+	var got struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	}
+	require.NoError(t, json.Unmarshal(output.Bytes(), &got))
+	assert.Equal(t, "roborev", got.Name)
+	assert.Equal(t, version.Version, got.Version)
+}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -27,7 +27,26 @@ roborev tui                      # Interactive terminal UI
                                  # --no-quit: suppress keyboard quit
                                  # --control-socket: custom socket path
 roborev version                  # Show version
+roborev version --json           # Show stable machine-readable version data
 ```
+
+### Version JSON contract
+
+`roborev version --json` prints one JSON object and exits successfully without
+requiring a repository or a running daemon:
+
+```json
+{"name":"roborev","version":"v0.62.0"}
+```
+
+The stable fields are:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Canonical tool name; always `roborev` |
+| `version` | string | Build version, using the release semantic version for release builds |
+
+Consumers should ignore additional fields so the contract can grow compatibly.
 
 ## Reviewing Code
 


### PR DESCRIPTION
This adds an additive machine-readable contract with the canonical tool name and build version while preserving the existing plaintext behavior. Consumers can adopt the JSON form now and safely ignore future fields as the contract grows.

The command behavior and both output modes are covered by focused tests, and the schema is documented for integration authors.

<sup>generated by a clanker</sup>