### PR TITLE
Persist CI panel terminal metrics and add ci-metrics export

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,11 @@ the same cursor contract as `roborev export reviews`, ordered by
 `posted_at`, and exits with code `3` when a cursor's `database_id` no
 longer matches so callers can discard the cursor and backfill.
 
+Pass `--legacy` to export the frozen pre-panel CI era instead (rows with
+outcome `legacy_review`, one per reviewed PR head, from before panel runs
+existed) as a one-time backfill; legacy and panel cursors are namespaced
+and cannot be resumed against each other's export.
+
 ## Configuration
 
 Create `.roborev.toml` in your repo:

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Use `make lint` when you explicitly want golangci-lint to apply fixes. Use
 | `roborev compact` | Verify and consolidate open review findings |
 | `roborev show [sha]` | Display review for commit |
 | `roborev export reviews` | Export completed reviews as JSON |
+| `roborev export ci-metrics` | Export finalized CI panel metrics as JSON |
 | `roborev run "<task>"` | Execute a task with an AI agent |
 | `roborev close <id>` | Close a review |
 | `roborev skills install` | Install agent skills for Claude/Codex |
@@ -229,6 +230,15 @@ be combined with `--since`. If a cursor belongs to a previous database
 generation, `roborev export reviews` exits with code `3`; discard the cursor
 and retry with a window backfill. Other cursor rejections also require
 discarding the cursor before backfilling.
+
+Use `roborev export ci-metrics` to emit finalized CI panel runs — terminal
+outcome (`review_posted`, `no_review_posted`, `giveup_posted`, `abandoned`,
+or `unknown` for panels finalized before outcomes were recorded),
+first-attempt and posting timestamps, attempt count, and each panel's
+member/synthesis jobs — for external review turnaround tracking. It follows
+the same cursor contract as `roborev export reviews`, ordered by
+`posted_at`, and exits with code `3` when a cursor's `database_id` no
+longer matches so callers can discard the cursor and backfill.
 
 ## Configuration
 

--- a/cmd/roborev/export.go
+++ b/cmd/roborev/export.go
@@ -42,6 +42,7 @@ func exportCmd() *cobra.Command {
 		Short: "Export roborev data",
 	}
 	cmd.AddCommand(exportReviewsCmd())
+	cmd.AddCommand(exportCIMetricsCmd())
 	return cmd
 }
 

--- a/cmd/roborev/export_ci.go
+++ b/cmd/roborev/export_ci.go
@@ -23,6 +23,7 @@ type exportCIMetricsOpts struct {
 	until  string
 	cursor string
 	limit  int
+	legacy bool
 }
 
 func exportCIMetricsCmd() *cobra.Command {
@@ -45,7 +46,14 @@ Cursor tokens are opaque and versioned. Export documents include
 database_id; a cursor from a different database is rejected with exit code
 3 so callers can discard it and backfill. Panels finalized before outcome
 persistence existed export with outcome "unknown" and null
-first_attempt_at.`),
+first_attempt_at.
+
+Use --legacy to export the frozen pre-panel CI era instead: rows from the
+retired ci_pr_reviews table (roughly 2026-02 through 2026-06), one per
+reviewed PR head, with outcome "legacy_review". This is a one-time backfill
+source, not an ongoing feed — legacy first_attempt_at is job enqueue time,
+not comparable to panel-era first_attempt_at. Legacy cursors cannot be
+resumed against a non-legacy export, or vice versa.`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			limitSet := cmd.Flags().Changed("limit")
 			if err := validateExportCIMetricsOpts(opts, limitSet); err != nil {
@@ -72,6 +80,8 @@ first_attempt_at.`),
 	cmd.Flags().StringVar(&opts.until, "until", "", "exclusive posted_at upper bound (RFC3339 or YYYY-MM-DD)")
 	cmd.Flags().StringVar(&opts.cursor, "cursor", "", "opaque next_cursor from a previous export; cannot be used with --since")
 	cmd.Flags().IntVar(&opts.limit, "limit", 0, "maximum number of panels to emit")
+	cmd.Flags().BoolVar(&opts.legacy, "legacy", false,
+		"export the frozen pre-panel CI era (ci_pr_reviews) instead of panel runs; for one-time backfill")
 	return cmd
 }
 
@@ -151,6 +161,9 @@ func fetchExportCIMetricsPage(ep daemon.DaemonEndpoint, opts exportCIMetricsOpts
 	}
 	if cursor != "" {
 		params.Set("cursor", cursor)
+	}
+	if opts.legacy {
+		params.Set("legacy", "true")
 	}
 
 	resp, err := ep.HTTPClient(30 * time.Second).Get(ep.BaseURL() + "/api/export/ci-metrics?" + params.Encode())

--- a/cmd/roborev/export_ci.go
+++ b/cmd/roborev/export_ci.go
@@ -45,15 +45,18 @@ apply.
 Cursor tokens are opaque and versioned. Export documents include
 database_id; a cursor from a different database is rejected with exit code
 3 so callers can discard it and backfill. Panels finalized before outcome
-persistence existed export with outcome "unknown" and null
+persistence existed are backfilled at startup from their retained jobs;
+rows whose jobs were deleted export with outcome "unknown" and null
 first_attempt_at.
 
-Use --legacy to export the frozen pre-panel CI era instead: rows from the
-retired ci_pr_reviews table (roughly 2026-02 through 2026-06), one per
-reviewed PR head, with outcome "legacy_review". This is a one-time backfill
-source, not an ongoing feed — legacy first_attempt_at is job enqueue time,
-not comparable to panel-era first_attempt_at. Legacy cursors cannot be
-resumed against a non-legacy export, or vice versa.`),
+Use --legacy to export the frozen pre-panel CI era instead (roughly
+2026-02 through 2026-06): completed CI review jobs grouped per
+(repo, git_ref) into one wall-clock "pseudopanel" unit — first_attempt_at
+is the group's earliest enqueue, posted_at its latest finish, outcome
+"legacy_review", pr_number 0 (the PR linkage did not survive). This is a
+one-time backfill source, not an ongoing feed; legacy turnaround excludes
+comment-posting latency, unlike panel-era turnaround. Legacy cursors
+cannot be resumed against a non-legacy export, or vice versa.`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			limitSet := cmd.Flags().Changed("limit")
 			if err := validateExportCIMetricsOpts(opts, limitSet); err != nil {
@@ -81,7 +84,7 @@ resumed against a non-legacy export, or vice versa.`),
 	cmd.Flags().StringVar(&opts.cursor, "cursor", "", "opaque next_cursor from a previous export; cannot be used with --since")
 	cmd.Flags().IntVar(&opts.limit, "limit", 0, "maximum number of panels to emit")
 	cmd.Flags().BoolVar(&opts.legacy, "legacy", false,
-		"export the frozen pre-panel CI era (ci_pr_reviews) instead of panel runs; for one-time backfill")
+		"export the frozen pre-panel CI era (grouped review jobs) instead of panel runs; for one-time backfill")
 	return cmd
 }
 

--- a/cmd/roborev/export_ci.go
+++ b/cmd/roborev/export_ci.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"go.kenn.io/roborev/internal/daemon"
+	"go.kenn.io/roborev/internal/storage"
+)
+
+type exportCIMetricsOpts struct {
+	format string
+	since  string
+	until  string
+	cursor string
+	limit  int
+}
+
+func exportCIMetricsCmd() *cobra.Command {
+	var opts exportCIMetricsOpts
+	cmd := &cobra.Command{
+		Use:   "ci-metrics",
+		Args:  cobra.NoArgs,
+		Short: "Export finalized CI panel metrics as JSON",
+		Long: strings.TrimSpace(`
+Export finalized CI panel runs (terminal outcome, first-attempt and posting
+timestamps, attempt count, and per-panel member/synthesis jobs) as a JSON
+document, for external turnaround-time tracking.
+
+Rows are ordered by posted_at, panel_id ascending. Use --cursor with the
+next_cursor value from a previous export to resume strictly after that
+position. --cursor cannot be used with --since; --until and --limit still
+apply.
+
+Cursor tokens are opaque and versioned. Export documents include
+database_id; a cursor from a different database is rejected with exit code
+3 so callers can discard it and backfill. Panels finalized before outcome
+persistence existed export with outcome "unknown" and null
+first_attempt_at.`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			limitSet := cmd.Flags().Changed("limit")
+			if err := validateExportCIMetricsOpts(opts, limitSet); err != nil {
+				return usageErr(cmd, err)
+			}
+			if err := ensureDaemon(); err != nil {
+				return fmt.Errorf("daemon not running: %w", err)
+			}
+
+			doc, err := fetchAllExportCIMetrics(getDaemonEndpoint(), opts, limitSet)
+			if err != nil {
+				if errors.Is(err, errExportCursorDatabaseReset) {
+					return &exitError{code: exportReviewsCursorResetExitCode, cause: err}
+				}
+				return err
+			}
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(doc)
+		},
+	}
+	cmd.Flags().StringVar(&opts.format, "format", "json", "output format")
+	cmd.Flags().StringVar(&opts.since, "since", "", "inclusive posted_at lower bound (RFC3339 or YYYY-MM-DD)")
+	cmd.Flags().StringVar(&opts.until, "until", "", "exclusive posted_at upper bound (RFC3339 or YYYY-MM-DD)")
+	cmd.Flags().StringVar(&opts.cursor, "cursor", "", "opaque next_cursor from a previous export; cannot be used with --since")
+	cmd.Flags().IntVar(&opts.limit, "limit", 0, "maximum number of panels to emit")
+	return cmd
+}
+
+func validateExportCIMetricsOpts(opts exportCIMetricsOpts, limitSet bool) error {
+	if opts.format != "json" {
+		return fmt.Errorf("unsupported export format %q", opts.format)
+	}
+	if limitSet && opts.limit <= 0 {
+		return fmt.Errorf("--limit must be greater than 0")
+	}
+	if opts.cursor != "" && opts.since != "" {
+		return fmt.Errorf("--cursor cannot be used with --since; cursor already defines the resume position")
+	}
+	return nil
+}
+
+func fetchAllExportCIMetrics(ep daemon.DaemonEndpoint, opts exportCIMetricsOpts, limitSet bool) (*daemon.ExportCIMetricsDocument, error) {
+	var out *daemon.ExportCIMetricsDocument
+	cursor := opts.cursor
+	remaining := opts.limit
+	for {
+		pageLimit := 0
+		if limitSet {
+			pageLimit = min(remaining, exportReviewsMaxPageSize)
+		}
+		page, err := fetchExportCIMetricsPage(ep, opts, cursor, pageLimit)
+		if err != nil {
+			return nil, err
+		}
+		if out == nil {
+			copy := page
+			copy.Panels = append([]storage.ExportCIPanel{}, page.Panels...)
+			out = &copy
+		} else {
+			out.Panels = append(out.Panels, page.Panels...)
+			out.Truncated = page.Truncated
+			out.NextCursor = page.NextCursor
+		}
+
+		if limitSet {
+			remaining -= len(page.Panels)
+			if remaining <= 0 {
+				break
+			}
+		}
+		if !page.Truncated {
+			break
+		}
+		if page.NextCursor == nil || *page.NextCursor == "" {
+			return nil, fmt.Errorf("daemon returned truncated export page without next cursor")
+		}
+		if len(page.Panels) == 0 {
+			return nil, fmt.Errorf("daemon returned empty export page with next cursor")
+		}
+		cursor = *page.NextCursor
+	}
+	if out == nil {
+		return nil, fmt.Errorf("daemon returned no export page")
+	}
+	if !limitSet {
+		out.Truncated = false
+	}
+	return out, nil
+}
+
+func fetchExportCIMetricsPage(ep daemon.DaemonEndpoint, opts exportCIMetricsOpts, cursor string, limit int) (daemon.ExportCIMetricsDocument, error) {
+	params := url.Values{}
+	params.Set("format", opts.format)
+	if opts.since != "" && cursor == "" {
+		params.Set("since", opts.since)
+	}
+	if opts.until != "" {
+		params.Set("until", opts.until)
+	}
+	if limit > 0 {
+		params.Set("limit", strconv.Itoa(limit))
+	}
+	if cursor != "" {
+		params.Set("cursor", cursor)
+	}
+
+	resp, err := ep.HTTPClient(30 * time.Second).Get(ep.BaseURL() + "/api/export/ci-metrics?" + params.Encode())
+	if err != nil {
+		return daemon.ExportCIMetricsDocument{}, fmt.Errorf("failed to connect to daemon: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusConflict {
+			return daemon.ExportCIMetricsDocument{}, fmt.Errorf("%w: daemon returned %s: %s",
+				errExportCursorDatabaseReset, resp.Status, strings.TrimSpace(string(body)))
+		}
+		return daemon.ExportCIMetricsDocument{}, fmt.Errorf("daemon returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	var doc daemon.ExportCIMetricsDocument
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		return daemon.ExportCIMetricsDocument{}, fmt.Errorf("failed to parse export response: %w", err)
+	}
+	return doc, nil
+}

--- a/cmd/roborev/export_ci.go
+++ b/cmd/roborev/export_ci.go
@@ -49,14 +49,12 @@ persistence existed are backfilled at startup from their retained jobs;
 rows whose jobs were deleted export with outcome "unknown" and null
 first_attempt_at.
 
-Use --legacy to export the frozen pre-panel CI era instead (roughly
-2026-02 through 2026-06): completed CI review jobs grouped per
-(repo, git_ref) into one wall-clock "pseudopanel" unit — first_attempt_at
-is the group's earliest enqueue, posted_at its latest finish, outcome
-"legacy_review", pr_number 0 (the PR linkage did not survive). This is a
-one-time backfill source, not an ongoing feed; legacy turnaround excludes
-comment-posting latency, unlike panel-era turnaround. Legacy cursors
-cannot be resumed against a non-legacy export, or vice versa.`),
+Use --legacy to export the frozen pre-panel CI era instead: review jobs
+from before the database's first panel activity, grouped per
+(repo, git_ref) into one wall-clock "pseudopanel" unit with outcome
+"legacy_review" and pr_number 0. This is a one-time backfill source, not
+an ongoing feed. Legacy cursors cannot be resumed against a non-legacy
+export, or vice versa.`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			limitSet := cmd.Flags().Changed("limit")
 			if err := validateExportCIMetricsOpts(opts, limitSet); err != nil {

--- a/cmd/roborev/export_ci_test.go
+++ b/cmd/roborev/export_ci_test.go
@@ -65,3 +65,48 @@ func TestExportCIMetricsCmdFollowsCursors(t *testing.T) {
 	assert.Len(panels, 2)
 	assert.Equal(false, doc["truncated"])
 }
+
+func TestExportCIMetricsCmdLegacyFlagSetsQueryParam(t *testing.T) {
+	assert := assert.New(t)
+	var sawLegacy string
+	NewMockDaemon(t, MockRefineHooks{
+		OnUnhandled: func(w http.ResponseWriter, r *http.Request, state *mockRefineState) bool {
+			if r.URL.Path != "/api/export/ci-metrics" {
+				return false
+			}
+			sawLegacy = r.URL.Query().Get("legacy")
+			writeCIMetricsTestPage(t, w, false, nil, []map[string]any{
+				{"github_repo": "o/r", "pr_number": 1, "head_sha": "a", "outcome": "legacy_review", "jobs": []any{}},
+			})
+			return true
+		},
+	})
+
+	runExportCmd(t, "ci-metrics", "--legacy")
+
+	assert.Equal("true", sawLegacy)
+}
+
+func TestExportCIMetricsCmdWithoutLegacyFlagOmitsQueryParam(t *testing.T) {
+	assert := assert.New(t)
+	var sawLegacy string
+	sawParam := false
+	NewMockDaemon(t, MockRefineHooks{
+		OnUnhandled: func(w http.ResponseWriter, r *http.Request, state *mockRefineState) bool {
+			if r.URL.Path != "/api/export/ci-metrics" {
+				return false
+			}
+			sawParam = r.URL.Query().Has("legacy")
+			sawLegacy = r.URL.Query().Get("legacy")
+			writeCIMetricsTestPage(t, w, false, nil, []map[string]any{
+				{"github_repo": "o/r", "pr_number": 1, "head_sha": "a", "outcome": "review_posted", "jobs": []any{}},
+			})
+			return true
+		},
+	})
+
+	runExportCmd(t, "ci-metrics")
+
+	assert.False(sawParam, "legacy query param must be omitted when --legacy is not set")
+	assert.Empty(sawLegacy)
+}

--- a/cmd/roborev/export_ci_test.go
+++ b/cmd/roborev/export_ci_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeCIMetricsTestPage(t *testing.T, w http.ResponseWriter, truncated bool, next *string, panels []map[string]any) {
+	t.Helper()
+	doc := map[string]any{
+		"schema_version": 1,
+		"tool":           "roborev",
+		"tool_version":   "test",
+		"generated_at":   "2026-07-12T00:00:00Z",
+		"database_id":    "db-1",
+		"window":         map[string]any{"field": "posted_at", "since": nil, "until": nil},
+		"truncated":      truncated,
+		"next_cursor":    next,
+		"panels":         panels,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	require.NoError(t, json.NewEncoder(w).Encode(doc))
+}
+
+func TestExportCIMetricsCmdFollowsCursors(t *testing.T) {
+	assert := assert.New(t)
+	var calls []string
+	NewMockDaemon(t, MockRefineHooks{
+		OnUnhandled: func(w http.ResponseWriter, r *http.Request, state *mockRefineState) bool {
+			if r.URL.Path != "/api/export/ci-metrics" {
+				return false
+			}
+			calls = append(calls, r.URL.RawQuery)
+			assert.Equal(http.MethodGet, r.Method)
+			switch len(calls) {
+			case 1:
+				assert.Equal("2026-07-01", r.URL.Query().Get("since"))
+				assert.Empty(r.URL.Query().Get("cursor"))
+				writeCIMetricsTestPage(t, w, true, new("cursor-1"), []map[string]any{
+					{"github_repo": "o/r", "pr_number": 1, "head_sha": "a", "outcome": "review_posted", "jobs": []any{}},
+				})
+			case 2:
+				assert.Empty(r.URL.Query().Get("since"))
+				assert.Equal("cursor-1", r.URL.Query().Get("cursor"))
+				writeCIMetricsTestPage(t, w, false, new("cursor-2"), []map[string]any{
+					{"github_repo": "o/r", "pr_number": 2, "head_sha": "b", "outcome": "giveup_posted", "jobs": []any{}},
+				})
+			default:
+				http.Error(w, "too many calls", http.StatusInternalServerError)
+			}
+			return true
+		},
+	})
+
+	output := runExportCmd(t, "ci-metrics", "--since", "2026-07-01")
+
+	require.Len(t, calls, 2)
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal([]byte(output), &doc))
+	panels := doc["panels"].([]any)
+	assert.Len(panels, 2)
+	assert.Equal(false, doc["truncated"])
+}

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -1845,8 +1845,12 @@ func (p *CIPoller) finalizePanelRun(row *storage.CIPanel, members []storage.Batc
 
 	out := classifyPanelOutcome(results, p.synthesisFailureResult(row), consecutiveGenuine)
 	switch out.Kind {
-	case OutcomePost, OutcomeAllSkip:
-		p.postPanelComment(row, members)
+	case OutcomePost:
+		p.postPanelComment(row, members, storage.PanelOutcomeReviewPosted)
+	case OutcomeAllSkip:
+		// The all-skipped summary is a posted comment but not a review;
+		// terminal metrics must not count it as one.
+		p.postPanelComment(row, members, storage.PanelOutcomeNoReviewPosted)
 	case OutcomeGenuineGiveUp:
 		p.postPanelGiveUp(row,
 			reviewpkg.FormatGenuineSoftNoteComment(row.HeadSHA, out.LastErrorExcerpt),
@@ -1912,7 +1916,7 @@ func (p *CIPoller) ensureReviewAttempt(row *storage.CIPanel) (*storage.ReviewAtt
 // summary, both via panelCommentBody), sets the commit status, marks the
 // attempt done, and finalizes the panel row. This is the pre-existing posting
 // path, now invoked only for OutcomePost/OutcomeAllSkip.
-func (p *CIPoller) postPanelComment(row *storage.CIPanel, members []storage.BatchReviewResult) {
+func (p *CIPoller) postPanelComment(row *storage.CIPanel, members []storage.BatchReviewResult, outcome string) {
 	body := p.panelCommentBody(row, members)
 	if err := p.callPostPRComment(row.GithubRepo, row.PRNumber, body); err != nil {
 		p.handlePanelPostError(row, err)
@@ -1926,7 +1930,7 @@ func (p *CIPoller) postPanelComment(row *storage.CIPanel, members []storage.Batc
 			state, row.GithubRepo, row.HeadSHA, err)
 	}
 	p.markAttemptDone(row)
-	if err := p.db.MarkPanelPosted(row.ID); err != nil {
+	if err := p.db.MarkPanelPosted(row.ID, outcome); err != nil {
 		log.Printf("CI poller: warning: failed to finalize panel %d: %v", row.ID, err)
 	}
 	log.Printf("CI poller: posted panel comment on %s#%d (panel %d, %d members)",
@@ -1948,7 +1952,7 @@ func (p *CIPoller) postPanelGiveUp(row *storage.CIPanel, body, statusState, stat
 			row.GithubRepo, gitpkg.ShortSHA(row.HeadSHA), err)
 	}
 	p.markAttemptDone(row)
-	if err := p.db.MarkPanelPosted(row.ID); err != nil {
+	if err := p.db.MarkPanelPosted(row.ID, storage.PanelOutcomeGiveupPosted); err != nil {
 		log.Printf("CI poller: warning: failed to finalize give-up panel %d: %v", row.ID, err)
 	}
 	log.Printf("CI poller: posted give-up note on %s#%d (panel %d)",
@@ -2071,7 +2075,7 @@ func (p *CIPoller) abandonPanelPost(row *storage.CIPanel, statusDesc, reason str
 	p.markAttemptDone(row)
 	log.Printf("CI poller: abandoning panel %d for %s %s#%d",
 		row.ID, reason, row.GithubRepo, row.PRNumber)
-	if err := p.db.MarkPanelPosted(row.ID); err != nil {
+	if err := p.db.MarkPanelPosted(row.ID, storage.PanelOutcomeAbandoned); err != nil {
 		log.Printf("CI poller: error finalizing abandoned panel %d: %v", row.ID, err)
 	}
 }

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -1913,9 +1913,10 @@ func (p *CIPoller) ensureReviewAttempt(row *storage.CIPanel) (*storage.ReviewAtt
 }
 
 // postPanelComment posts the combined/synthesis comment (or the all-skipped
-// summary, both via panelCommentBody), sets the commit status, marks the
-// attempt done, and finalizes the panel row. This is the pre-existing posting
-// path, now invoked only for OutcomePost/OutcomeAllSkip.
+// summary, both via panelCommentBody), sets the commit status, and finalizes
+// the panel row (which also marks the attempt done, in the same transaction).
+// This is the pre-existing posting path, now invoked only for
+// OutcomePost/OutcomeAllSkip.
 func (p *CIPoller) postPanelComment(row *storage.CIPanel, members []storage.BatchReviewResult, outcome string) {
 	body := p.panelCommentBody(row, members)
 	if err := p.callPostPRComment(row.GithubRepo, row.PRNumber, body); err != nil {
@@ -1929,7 +1930,6 @@ func (p *CIPoller) postPanelComment(row *storage.CIPanel, members []storage.Batc
 		log.Printf("CI poller: failed to set %s status for %s@%s: %v",
 			state, row.GithubRepo, row.HeadSHA, err)
 	}
-	p.markAttemptDone(row)
 	if err := p.db.MarkPanelPosted(row.ID, outcome); err != nil {
 		log.Printf("CI poller: warning: failed to finalize panel %d: %v", row.ID, err)
 	}
@@ -1937,11 +1937,11 @@ func (p *CIPoller) postPanelComment(row *storage.CIPanel, members []storage.Batc
 		row.GithubRepo, row.PRNumber, row.ID, len(members))
 }
 
-// postPanelGiveUp posts a give-up note, sets the requested commit status, marks
-// the attempt done, and finalizes the panel row. Transient/provider-unavailable
-// give-up remains non-blocking; deterministic genuine give-up is blocking. A
-// comment-post failure routes through the same permanent/transient handling as a
-// normal post.
+// postPanelGiveUp posts a give-up note, sets the requested commit status, and
+// finalizes the panel row (which also marks the attempt done, in the same
+// transaction). Transient/provider-unavailable give-up remains non-blocking;
+// deterministic genuine give-up is blocking. A comment-post failure routes
+// through the same permanent/transient handling as a normal post.
 func (p *CIPoller) postPanelGiveUp(row *storage.CIPanel, body, statusState, statusDesc string) {
 	if err := p.callPostPRComment(row.GithubRepo, row.PRNumber, body); err != nil {
 		p.handlePanelPostError(row, err)
@@ -1951,7 +1951,6 @@ func (p *CIPoller) postPanelGiveUp(row *storage.CIPanel, body, statusState, stat
 		log.Printf("CI poller: failed to set give-up status for %s@%s: %v",
 			row.GithubRepo, gitpkg.ShortSHA(row.HeadSHA), err)
 	}
-	p.markAttemptDone(row)
 	if err := p.db.MarkPanelPosted(row.ID, storage.PanelOutcomeGiveupPosted); err != nil {
 		log.Printf("CI poller: warning: failed to finalize give-up panel %d: %v", row.ID, err)
 	}
@@ -2010,16 +2009,6 @@ func (p *CIPoller) recordDeferral(
 		attempt.Attempt, nextAt.Format(time.RFC3339), logExcerpt(excerpt))
 }
 
-// markAttemptDone marks the HEAD's attempt terminal. finalizePanelRun guarantees
-// a reserved attempt row before any path that reaches here, so the row always
-// exists.
-func (p *CIPoller) markAttemptDone(row *storage.CIPanel) {
-	if err := p.db.MarkReviewAttemptDone(row.GithubRepo, row.PRNumber, row.HeadSHA); err != nil {
-		log.Printf("CI poller: error marking review attempt done for %s#%d@%s: %v",
-			row.GithubRepo, row.PRNumber, gitpkg.ShortSHA(row.HeadSHA), err)
-	}
-}
-
 // panelCommentBody picks the PR comment body from the synthesis job status,
 // applying the F11 wrapper rule. Synthesis done -> the persisted review (wrapped
 // with a verdict header only when it lacks a `## roborev:` one, but always with
@@ -2072,7 +2061,6 @@ func (p *CIPoller) abandonPanelPost(row *storage.CIPanel, statusDesc, reason str
 		log.Printf("CI poller: failed to set error status for %s@%s: %v",
 			row.GithubRepo, row.HeadSHA, statusErr)
 	}
-	p.markAttemptDone(row)
 	log.Printf("CI poller: abandoning panel %d for %s %s#%d",
 		row.ID, reason, row.GithubRepo, row.PRNumber)
 	if err := p.db.MarkPanelPosted(row.ID, storage.PanelOutcomeAbandoned); err != nil {

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -2834,7 +2834,7 @@ func TestCIPollerProcessPR_PostedSameHeadIsAlreadyReviewed(t *testing.T) {
 	require.NoError(t, err, "first processPR")
 	panel, err := h.DB.GetCIPanelByPRSHA("acme/api", 72, "same-sha")
 	require.NoError(t, err)
-	require.NoError(t, h.DB.MarkPanelPosted(panel.ID))
+	require.NoError(t, h.DB.MarkPanelPosted(panel.ID, storage.PanelOutcomeReviewPosted))
 
 	captured := h.CaptureCommitStatuses()
 	err = h.Poller.processPR(

--- a/internal/daemon/panel_posting_test.go
+++ b/internal/daemon/panel_posting_test.go
@@ -211,6 +211,11 @@ func TestSynthesisCompletedPostsOnce(t *testing.T) {
 	assert.Len(*comments, 1, "exactly one PR comment despite duplicate delivery")
 	assert.True(h.panelPostedAt(t, panel.ID), "panel finalized (posted_at set)")
 	assert.NotEmpty(*statuses, "commit status set")
+
+	got, err := h.DB.GetCIPanelByPRSHA("acme/api", 5, "headsha111")
+	require.NoError(t, err)
+	require.NotNil(t, got.Outcome)
+	assert.Equal(storage.PanelOutcomeReviewPosted, *got.Outcome)
 }
 
 // TestSynthesisFailedPostsRawFallback covers F4: when the synthesis agent fails
@@ -234,6 +239,11 @@ func TestSynthesisFailedPostsRawFallback(t *testing.T) {
 		"## roborev: Combined Review", "Member finding X")
 	assert.True(h.panelPostedAt(t, panel.ID), "panel finalized")
 	assert.NotEmpty(*statuses, "commit status set")
+
+	got, err := h.DB.GetCIPanelByPRSHA("acme/api", 6, "headsha222")
+	require.NoError(t, err)
+	require.NotNil(t, got.Outcome)
+	assert.Equal(storage.PanelOutcomeReviewPosted, *got.Outcome)
 }
 
 // TestSynthesisQuotaFailureDefersInsteadOfRawFallback covers the quota-exhausted
@@ -401,6 +411,11 @@ func TestPanelPermanentPostErrorAbandons(t *testing.T) {
 	require.NotNil(t, attempt)
 	assert.Equal("done", attempt.State, "permanent error marks attempt terminal")
 
+	got, err := h.DB.GetCIPanelByPRSHA("acme/api", 8, "headsha444")
+	require.NoError(t, err)
+	require.NotNil(t, got.Outcome)
+	assert.Equal(storage.PanelOutcomeAbandoned, *got.Outcome)
+
 	// posted_at is set, so the CAS (posted_at IS NULL) bars any retry even though
 	// the claim is intentionally left in place.
 	won, err := h.DB.ClaimPanelForPosting(panel.ID, panelPostingStaleWindow)
@@ -439,6 +454,11 @@ func TestPanelPermanentPreflightErrorAbandons(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, attempt)
 	assert.Equal("done", attempt.State, "permanent preflight error marks attempt terminal")
+
+	got, err := h.DB.GetCIPanelByPRSHA("acme/api", 20, headSHA)
+	require.NoError(t, err)
+	require.NotNil(t, got.Outcome)
+	assert.Equal(storage.PanelOutcomeAbandoned, *got.Outcome)
 
 	won, err := h.DB.ClaimPanelForPosting(panel.ID, panelPostingStaleWindow)
 	require.NoError(t, err)
@@ -935,6 +955,11 @@ func TestPostPanelRunGenuineGiveUp(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, attempt)
 	assert.Equal("done", attempt.State, "give-up marks the attempt done")
+
+	got, err := h.DB.GetCIPanelByPRSHA("acme/api", 82, headSHA)
+	require.NoError(t, err)
+	require.NotNil(t, got.Outcome)
+	assert.Equal(storage.PanelOutcomeGiveupPosted, *got.Outcome)
 }
 
 // TestPostPanelRunTransientGiveUp covers the transient give-up: an all-transient
@@ -987,6 +1012,11 @@ func TestPostPanelRunTransientGiveUp(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, attempt)
 	assert.Equal("done", attempt.State, "transient give-up marks the attempt done")
+
+	got, err := h.DB.GetCIPanelByPRSHA("acme/api", 85, headSHA)
+	require.NoError(t, err)
+	require.NotNil(t, got.Outcome)
+	assert.Equal(storage.PanelOutcomeGiveupPosted, *got.Outcome)
 }
 
 // TestFinalizePanelRunBackfillsMissingAttemptRow covers upgrade-boundary panel

--- a/internal/daemon/panel_posting_test.go
+++ b/internal/daemon/panel_posting_test.go
@@ -1019,6 +1019,37 @@ func TestPostPanelRunTransientGiveUp(t *testing.T) {
 	assert.Equal(storage.PanelOutcomeGiveupPosted, *got.Outcome)
 }
 
+// TestPostPanelRunAllSkipPersistsNoReviewOutcome covers the all-skip finalize
+// arm: every member is a timeout skip (classifyPanelOutcome falls through to
+// OutcomeAllSkip), so finalizePanelRun still posts the all-skipped summary but
+// must persist storage.PanelOutcomeNoReviewPosted, not the OutcomePost arm's
+// PanelOutcomeReviewPosted — the two arms only differ in which outcome they
+// pass to postPanelComment, so a regression re-merging them would pass every
+// other test in this file.
+func TestPostPanelRunAllSkipPersistsNoReviewOutcome(t *testing.T) {
+	assert := assert.New(t)
+	h := newCIPollerHarness(t, "https://github.com/acme/api.git")
+	comments := h.CaptureComments()
+	statuses := h.CaptureCommitStatuses()
+
+	timeoutErr := reviewpkg.TimeoutErrorPrefix + "posted early"
+	panel, synth, _ := h.seedCIPanelRun(t, "acme/api", 87, "allskip1234567", "base..allskip1234567",
+		[]jobSpec{{Agent: "test", ReviewType: "review", Status: "canceled", Error: timeoutErr}})
+	h.markJobFailed(t, synth.ID, "synthesis released after all members skipped")
+
+	h.Poller.handleReviewFailed(ciEvent(synth.ID, "review.failed"))
+
+	require.Len(t, *comments, 1, "all-skip still posts the all-skipped summary")
+	assert.Contains((*comments)[0].Body, "## roborev: Combined Review", "all-skipped summary header")
+	assert.NotEmpty(*statuses, "commit status set on all-skip")
+	assert.True(h.panelPostedAt(t, panel.ID), "all-skip finalizes the panel (posted_at set)")
+
+	got, err := h.DB.GetCIPanelByPRSHA("acme/api", 87, "allskip1234567")
+	require.NoError(t, err)
+	require.NotNil(t, got.Outcome)
+	assert.Equal(storage.PanelOutcomeNoReviewPosted, *got.Outcome, "all-skip persists the no-review outcome")
+}
+
 // TestFinalizePanelRunBackfillsMissingAttemptRow covers upgrade-boundary panel
 // rows that predate reserve-on-enqueue. A terminal panel with no attempt row
 // must self-heal and still post instead of remaining active/unposted forever.

--- a/internal/daemon/panel_reconcile_test.go
+++ b/internal/daemon/panel_reconcile_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/storage"
 )
 
 // backdatePanelPostClaim forces a panel row's posting_claimed_at older than the
@@ -100,7 +102,7 @@ func TestReconcilePanelPostingNoop(t *testing.T) {
 	panel, synth, _ := h.seedCIPanelRun(t, "acme/api", 22, "headrec333", "base..headrec333",
 		[]jobSpec{{Agent: "test", ReviewType: "review", Status: "done", Output: "Finding T"}})
 	h.completeSynthesisWithReview(t, synth.ID, "## Combined\nVerified finding T.")
-	require.NoError(t, h.DB.MarkPanelPosted(panel.ID))
+	require.NoError(t, h.DB.MarkPanelPosted(panel.ID, storage.PanelOutcomeReviewPosted))
 
 	h.Poller.reconcilePanelPosting(context.Background(), "acme/api")
 

--- a/internal/daemon/routes.go
+++ b/internal/daemon/routes.go
@@ -74,6 +74,28 @@ func (s *Server) registerHumaAPI(mux *http.ServeMux) huma.API {
 			}
 		})
 
+	huma.Get(api, "/api/export/ci-metrics", s.humaExportCIMetrics,
+		func(o *huma.Operation) {
+			o.OperationID = "export-ci-metrics"
+			o.Summary = "Export finalized CI panel metrics"
+			o.Tags = []string{"reviews"}
+			if o.Responses == nil {
+				o.Responses = map[string]*huma.Response{}
+			}
+			o.Responses["409"] = &huma.Response{
+				Description: "Cursor database_id does not match this local database",
+				Content: map[string]*huma.MediaType{
+					"application/problem+json": {Schema: jsonSchema(api, huma.ErrorModel{})},
+				},
+			}
+			o.Responses["default"] = &huma.Response{
+				Description: "Error",
+				Content: map[string]*huma.MediaType{
+					"application/problem+json": {Schema: jsonSchema(api, huma.ErrorModel{})},
+				},
+			}
+		})
+
 	// /api/job/output is registered as a plain HandleFunc
 	// (not Huma) because its stream=1 mode uses NDJSON
 	// streaming which doesn't fit Huma's typed response model.

--- a/internal/daemon/routes_test.go
+++ b/internal/daemon/routes_test.go
@@ -472,14 +472,18 @@ func TestHumaExportCIMetricsLegacy(t *testing.T) {
 	srv, db, _ := newTestServer(t)
 	repo := testutil.CreateTestRepo(t, db)
 
-	// Seed a frozen pre-panel ci_pr_reviews row directly: no production
-	// writer remains for this table, panels replaced it.
+	// Seed one completed pre-panel CI review job: source='ci', no panel
+	// run. The legacy export groups such jobs per (repo, git_ref) into
+	// pseudopanel units.
 	job, err := db.EnqueueJob(storage.EnqueueOpts{
 		RepoID: repo.ID, GitRef: "legacy-sha", Agent: "legacy-agent", Model: "legacy-model",
+		Source: storage.JobSourceCI,
 	})
 	require.NoError(t, err)
-	_, err = db.Exec(`INSERT INTO ci_pr_reviews (github_repo, pr_number, head_sha, job_id, created_at)
-		VALUES (?, ?, ?, ?, ?)`, "o/r", 9, "legacy-sha", job.ID, "2026-03-01 10:00:00")
+	_, err = db.Exec(`UPDATE review_jobs
+		SET status = 'done', enqueued_at = ?, started_at = ?, finished_at = ?
+		WHERE id = ?`,
+		"2026-03-01 10:00:00", "2026-03-01 10:00:00", "2026-03-01 10:05:00", job.ID)
 	require.NoError(t, err)
 
 	rr := serveHuma(t, srv, http.MethodGet, "/api/export/ci-metrics?legacy=true", nil)
@@ -488,7 +492,7 @@ func TestHumaExportCIMetricsLegacy(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &doc))
 	require.Len(t, doc.Panels, 1)
 	assert.Equal(t, storage.PanelOutcomeLegacyReview, doc.Panels[0].Outcome)
-	assert.Equal(t, "o/r", doc.Panels[0].GithubRepo)
+	assert.Equal(t, repo.Name, doc.Panels[0].GithubRepo)
 	assert.Equal(t, "legacy-sha", doc.Panels[0].HeadSHA)
 	require.Len(t, doc.Panels[0].Jobs, 1)
 	assert.Equal(t, "review", doc.Panels[0].Jobs[0].Role)

--- a/internal/daemon/routes_test.go
+++ b/internal/daemon/routes_test.go
@@ -468,6 +468,38 @@ func TestHumaExportCIMetrics(t *testing.T) {
 	assert.Equal(t, http.StatusConflict, rr.Code, rr.Body.String())
 }
 
+func TestHumaExportCIMetricsLegacy(t *testing.T) {
+	srv, db, _ := newTestServer(t)
+	repo := testutil.CreateTestRepo(t, db)
+
+	// Seed a frozen pre-panel ci_pr_reviews row directly: no production
+	// writer remains for this table, panels replaced it.
+	job, err := db.EnqueueJob(storage.EnqueueOpts{
+		RepoID: repo.ID, GitRef: "legacy-sha", Agent: "legacy-agent", Model: "legacy-model",
+	})
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO ci_pr_reviews (github_repo, pr_number, head_sha, job_id, created_at)
+		VALUES (?, ?, ?, ?, ?)`, "o/r", 9, "legacy-sha", job.ID, "2026-03-01 10:00:00")
+	require.NoError(t, err)
+
+	rr := serveHuma(t, srv, http.MethodGet, "/api/export/ci-metrics?legacy=true", nil)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	var doc ExportCIMetricsDocument
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &doc))
+	require.Len(t, doc.Panels, 1)
+	assert.Equal(t, storage.PanelOutcomeLegacyReview, doc.Panels[0].Outcome)
+	assert.Equal(t, "o/r", doc.Panels[0].GithubRepo)
+	assert.Equal(t, "legacy-sha", doc.Panels[0].HeadSHA)
+	require.Len(t, doc.Panels[0].Jobs, 1)
+	assert.Equal(t, "review", doc.Panels[0].Jobs[0].Role)
+
+	// A non-legacy export must not see the legacy row.
+	rr = serveHuma(t, srv, http.MethodGet, "/api/export/ci-metrics", nil)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &doc))
+	assert.Empty(t, doc.Panels)
+}
+
 func encodeExportCursorForRouteTest(t *testing.T, databaseID, completedAt, reviewID string) string {
 	t.Helper()
 	data, err := json.Marshal(map[string]any{

--- a/internal/daemon/routes_test.go
+++ b/internal/daemon/routes_test.go
@@ -472,6 +472,13 @@ func TestHumaExportCIMetricsLegacy(t *testing.T) {
 	srv, db, _ := newTestServer(t)
 	repo := testutil.CreateTestRepo(t, db)
 
+	// Panel activity starting 2026-06-01 bounds the pre-panel era; the
+	// seeded jobs below predate it.
+	_, err := db.Exec(`INSERT INTO ci_pr_panels
+		(github_repo, pr_number, head_sha, panel_run_uuid, created_at)
+		VALUES ('era/marker', 999999, 'sha-era', 'era-uuid', '2026-06-01 00:00:00')`)
+	require.NoError(t, err)
+
 	// Seed one pre-panel pseudopanel: two completed review jobs sharing a
 	// (repo, git_ref), no panel run, no CI tagging (rows from that era
 	// predate it). The legacy export groups them into one unit.

--- a/internal/daemon/routes_test.go
+++ b/internal/daemon/routes_test.go
@@ -472,19 +472,21 @@ func TestHumaExportCIMetricsLegacy(t *testing.T) {
 	srv, db, _ := newTestServer(t)
 	repo := testutil.CreateTestRepo(t, db)
 
-	// Seed one completed pre-panel CI review job: source='ci', no panel
-	// run. The legacy export groups such jobs per (repo, git_ref) into
-	// pseudopanel units.
-	job, err := db.EnqueueJob(storage.EnqueueOpts{
-		RepoID: repo.ID, GitRef: "legacy-sha", Agent: "legacy-agent", Model: "legacy-model",
-		Source: storage.JobSourceCI,
-	})
-	require.NoError(t, err)
-	_, err = db.Exec(`UPDATE review_jobs
-		SET status = 'done', enqueued_at = ?, started_at = ?, finished_at = ?
-		WHERE id = ?`,
-		"2026-03-01 10:00:00", "2026-03-01 10:00:00", "2026-03-01 10:05:00", job.ID)
-	require.NoError(t, err)
+	// Seed one pre-panel pseudopanel: two completed review jobs sharing a
+	// (repo, git_ref), no panel run, no CI tagging (rows from that era
+	// predate it). The legacy export groups them into one unit.
+	for i, agent := range []string{"legacy-agent", "legacy-agent-2"} {
+		job, err := db.EnqueueJob(storage.EnqueueOpts{
+			RepoID: repo.ID, GitRef: "legacy-sha", Agent: agent, Model: "legacy-model",
+		})
+		require.NoError(t, err)
+		_, err = db.Exec(`UPDATE review_jobs
+			SET status = 'done', enqueued_at = ?, started_at = ?, finished_at = ?
+			WHERE id = ?`,
+			"2026-03-01 10:00:00", "2026-03-01 10:00:00",
+			fmt.Sprintf("2026-03-01 10:0%d:00", 5+i), job.ID)
+		require.NoError(t, err)
+	}
 
 	rr := serveHuma(t, srv, http.MethodGet, "/api/export/ci-metrics?legacy=true", nil)
 	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
@@ -494,7 +496,7 @@ func TestHumaExportCIMetricsLegacy(t *testing.T) {
 	assert.Equal(t, storage.PanelOutcomeLegacyReview, doc.Panels[0].Outcome)
 	assert.Equal(t, repo.Name, doc.Panels[0].GithubRepo)
 	assert.Equal(t, "legacy-sha", doc.Panels[0].HeadSHA)
-	require.Len(t, doc.Panels[0].Jobs, 1)
+	require.Len(t, doc.Panels[0].Jobs, 2)
 	assert.Equal(t, "review", doc.Panels[0].Jobs[0].Role)
 
 	// A non-legacy export must not see the legacy row.

--- a/internal/daemon/routes_test.go
+++ b/internal/daemon/routes_test.go
@@ -425,6 +425,49 @@ func TestHumaExportReviewsMaxLimitIsClamped(t *testing.T) {
 	assert.NotNil(t, body.NextCursor)
 }
 
+func TestHumaExportCIMetrics(t *testing.T) {
+	srv, db, _ := newTestServer(t)
+	repo := testutil.CreateTestRepo(t, db)
+
+	// Seed one finalized panel exactly as the storage tests do.
+	created, err := db.ReserveReviewAttempt("o/r", 5, "headsha5",
+		time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	require.True(t, created)
+	members := []storage.EnqueueOpts{
+		{RepoID: repo.ID, GitRef: "b..headsha5", Agent: "test", PanelMemberIndex: 0},
+	}
+	synthesis := storage.EnqueueOpts{RepoID: repo.ID, GitRef: "b..headsha5", Agent: "test"}
+	ok, _, _, err := db.CreateCIPanelRun("o/r", 5, "headsha5", members, synthesis)
+	require.NoError(t, err)
+	require.True(t, ok)
+	panel, err := db.GetCIPanelByPRSHA("o/r", 5, "headsha5")
+	require.NoError(t, err)
+	require.NoError(t, db.MarkPanelPosted(panel.ID, storage.PanelOutcomeReviewPosted))
+
+	rr := serveHuma(t, srv, http.MethodGet, "/api/export/ci-metrics", nil)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	var doc ExportCIMetricsDocument
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &doc))
+	assert.Equal(t, 1, doc.SchemaVersion)
+	assert.Equal(t, "roborev", doc.Tool)
+	assert.NotEmpty(t, doc.DatabaseID)
+	assert.Equal(t, "posted_at", doc.Window.Field)
+	require.Len(t, doc.Panels, 1)
+	assert.Equal(t, storage.PanelOutcomeReviewPosted, doc.Panels[0].Outcome)
+
+	// Cursor from a different database → 409.
+	foreign, err := json.Marshal(map[string]any{
+		"version": 1, "database_id": "other",
+		"posted_at": "2026-07-01T00:00:00Z", "panel_id": 1,
+	})
+	require.NoError(t, err)
+	cursor := base64.RawURLEncoding.EncodeToString(foreign)
+	rr = serveHuma(t, srv, http.MethodGet,
+		"/api/export/ci-metrics?cursor="+url.QueryEscape(cursor), nil)
+	assert.Equal(t, http.StatusConflict, rr.Code, rr.Body.String())
+}
+
 func encodeExportCursorForRouteTest(t *testing.T, databaseID, completedAt, reviewID string) string {
 	t.Helper()
 	data, err := json.Marshal(map[string]any{
@@ -695,6 +738,7 @@ func TestHumaOpenAPISpec(t *testing.T) {
 		"/api/jobs":              "get",
 		"/api/review":            "get",
 		"/api/export/reviews":    "get",
+		"/api/export/ci-metrics": "get",
 		"/api/comments":          "get",
 		"/api/repos":             "get",
 		"/api/repos/resolve":     "get",

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -1302,6 +1302,60 @@ func (s *Server) humaExportReviews(
 	return resp, nil
 }
 
+func (s *Server) humaExportCIMetrics(
+	ctx context.Context, input *ExportCIMetricsInput,
+) (*ExportCIMetricsOutput, error) {
+	if input.Format != "" && input.Format != "json" {
+		return nil, huma.Error400BadRequest("unsupported export format")
+	}
+	if input.Cursor != "" && input.Since != "" {
+		return nil, huma.Error400BadRequest("cursor cannot be used with since")
+	}
+	since, sinceOut, err := parseExportTimeBound(input.Since, false)
+	if err != nil {
+		return nil, huma.Error400BadRequest("invalid since")
+	}
+	until, untilOut, err := parseExportTimeBound(input.Until, true)
+	if err != nil {
+		return nil, huma.Error400BadRequest("invalid until")
+	}
+
+	page, err := s.db.ExportCIMetrics(storage.ExportCIMetricsOptions{
+		Since:  since,
+		Until:  until,
+		Cursor: input.Cursor,
+		Limit:  input.Limit,
+	})
+	if err != nil {
+		if errors.Is(err, storage.ErrExportCursorDatabaseMismatch) {
+			return nil, huma.Error409Conflict(err.Error())
+		}
+		return nil, huma.Error400BadRequest(err.Error())
+	}
+	databaseID, err := s.db.GetDatabaseID()
+	if err != nil {
+		return nil, fmt.Errorf("get database ID: %w", err)
+	}
+
+	resp := &ExportCIMetricsOutput{}
+	resp.Body = ExportCIMetricsDocument{
+		SchemaVersion: 1,
+		Tool:          "roborev",
+		ToolVersion:   version.Version,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		DatabaseID:    databaseID,
+		Window: ExportReviewsWindow{
+			Field: "posted_at",
+			Since: sinceOut,
+			Until: untilOut,
+		},
+		Truncated:  page.Truncated,
+		NextCursor: page.NextCursor,
+		Panels:     page.Panels,
+	}
+	return resp, nil
+}
+
 func parseExportTimeBound(raw string, upper bool) (time.Time, *string, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -1325,6 +1325,7 @@ func (s *Server) humaExportCIMetrics(
 		Until:  until,
 		Cursor: input.Cursor,
 		Limit:  input.Limit,
+		Legacy: input.Legacy,
 	})
 	if err != nil {
 		if errors.Is(err, storage.ErrExportCursorDatabaseMismatch) {

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -155,6 +155,36 @@ type ExportReviewsOutput struct {
 	Body ExportReviewsDocument
 }
 
+// -- GET /api/export/ci-metrics --
+
+// ExportCIMetricsInput holds query parameters for exporting finalized CI
+// panel metrics.
+type ExportCIMetricsInput struct {
+	Format string `query:"format" default:"json" doc:"Output format; only json is supported"`
+	Since  string `query:"since" doc:"Inclusive posted_at lower bound (RFC3339 or YYYY-MM-DD)"`
+	Until  string `query:"until" doc:"Exclusive posted_at upper bound (RFC3339 or YYYY-MM-DD; date-only means through that UTC day)"`
+	Limit  int    `query:"limit" default:"500" doc:"Maximum panels in this page"`
+	Cursor string `query:"cursor" doc:"Opaque next_cursor from a previous page. Resumes strictly after its (posted_at, panel_id) position; mutually exclusive with since."`
+}
+
+// ExportCIMetricsDocument is the response body for GET /api/export/ci-metrics.
+type ExportCIMetricsDocument struct {
+	SchemaVersion int                     `json:"schema_version"`
+	Tool          string                  `json:"tool"`
+	ToolVersion   string                  `json:"tool_version"`
+	GeneratedAt   string                  `json:"generated_at"`
+	DatabaseID    string                  `json:"database_id" doc:"Stable identity for the local review database; changes when the database is recreated."`
+	Window        ExportReviewsWindow     `json:"window"`
+	Truncated     bool                    `json:"truncated" doc:"True when more matching rows are available immediately."`
+	NextCursor    *string                 `json:"next_cursor" doc:"Opaque resume cursor emitted when panels is non-empty."`
+	Panels        []storage.ExportCIPanel `json:"panels"`
+}
+
+// ExportCIMetricsOutput is the response for GET /api/export/ci-metrics.
+type ExportCIMetricsOutput struct {
+	Body ExportCIMetricsDocument
+}
+
 // -- Shared request/response types (used by Huma handlers) --
 
 // CancelJobRequest is the JSON body for POST /api/job/cancel.

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -165,6 +165,7 @@ type ExportCIMetricsInput struct {
 	Until  string `query:"until" doc:"Exclusive posted_at upper bound (RFC3339 or YYYY-MM-DD; date-only means through that UTC day)"`
 	Limit  int    `query:"limit" default:"500" doc:"Maximum panels in this page"`
 	Cursor string `query:"cursor" doc:"Opaque next_cursor from a previous page. Resumes strictly after its (posted_at, panel_id) position; mutually exclusive with since."`
+	Legacy bool   `query:"legacy" doc:"Export the frozen pre-panel ci_pr_reviews era instead of panel runs. Cursors are namespaced to this mode and cannot be reused across modes."`
 }
 
 // ExportCIMetricsDocument is the response body for GET /api/export/ci-metrics.

--- a/internal/storage/ci_panels.go
+++ b/internal/storage/ci_panels.go
@@ -17,6 +17,12 @@ const (
 	PanelOutcomeGiveupPosted   = "giveup_posted"
 	PanelOutcomeAbandoned      = "abandoned"
 	PanelOutcomeUnknown        = "unknown"
+
+	// PanelOutcomeLegacyReview marks rows exported from the frozen pre-panel
+	// ci_pr_reviews table (ExportCIMetricsOptions.Legacy). It is never
+	// persisted to ci_pr_panels; ExportCIMetrics stamps it onto legacy rows
+	// at export time.
+	PanelOutcomeLegacyReview = "legacy_review"
 )
 
 // CIPanel maps a PR HEAD (github_repo, pr_number, head_sha) to the subagent

--- a/internal/storage/ci_panels.go
+++ b/internal/storage/ci_panels.go
@@ -269,10 +269,27 @@ func (db *DB) ReleasePanelPostClaim(id int64) error {
 	return err
 }
 
-// MarkPanelPosted records that the PR comment for this run has been posted,
-// permanently barring further posting claims for the row.
-func (db *DB) MarkPanelPosted(id int64) error {
-	_, err := db.Exec(`UPDATE ci_pr_panels SET posted_at = datetime('now') WHERE id = ? AND retired_at IS NULL`, id)
+// MarkPanelPosted finalizes the run: it permanently bars further posting
+// claims and atomically stamps the terminal outcome plus a snapshot of
+// first_attempt_at/attempt from the operational attempt row. The snapshot
+// matters because closed-PR cleanup later deletes attempt rows; the panel
+// row is the durable record of terminal metrics.
+func (db *DB) MarkPanelPosted(id int64, outcome string) error {
+	_, err := db.Exec(`
+		UPDATE ci_pr_panels
+		SET posted_at = datetime('now'),
+		    outcome = ?,
+		    first_attempt_at = (
+		        SELECT a.first_attempt_at FROM ci_pr_review_attempts a
+		        WHERE a.github_repo = ci_pr_panels.github_repo
+		          AND a.pr_number = ci_pr_panels.pr_number
+		          AND a.head_sha = ci_pr_panels.head_sha),
+		    attempt_count = (
+		        SELECT a.attempt FROM ci_pr_review_attempts a
+		        WHERE a.github_repo = ci_pr_panels.github_repo
+		          AND a.pr_number = ci_pr_panels.pr_number
+		          AND a.head_sha = ci_pr_panels.head_sha)
+		WHERE id = ? AND retired_at IS NULL`, outcome, id)
 	return err
 }
 

--- a/internal/storage/ci_panels.go
+++ b/internal/storage/ci_panels.go
@@ -8,6 +8,17 @@ import (
 	"time"
 )
 
+// Panel terminal outcomes, persisted once at finalization. A NULL outcome
+// means the row was finalized before outcome persistence existed; exports
+// surface it as PanelOutcomeUnknown.
+const (
+	PanelOutcomeReviewPosted   = "review_posted"
+	PanelOutcomeNoReviewPosted = "no_review_posted"
+	PanelOutcomeGiveupPosted   = "giveup_posted"
+	PanelOutcomeAbandoned      = "abandoned"
+	PanelOutcomeUnknown        = "unknown"
+)
+
 // CIPanel maps a PR HEAD (github_repo, pr_number, head_sha) to the subagent
 // panel run that reviews it and to that run's synthesis job. It is the
 // panel-based successor to CIPRBatch: instead of tracking a matrix of jobs
@@ -25,12 +36,16 @@ type CIPanel struct {
 	PostingClaimedAt *time.Time `json:"posting_claimed_at,omitempty"`
 	PostedAt         *time.Time `json:"posted_at,omitempty"`
 	RetiredAt        *time.Time `json:"retired_at,omitempty"`
+	Outcome          *string    `json:"outcome,omitempty"`
+	FirstAttemptAt   *time.Time `json:"first_attempt_at,omitempty"`
+	AttemptCount     *int64     `json:"attempt_count,omitempty"`
 }
 
 // ciPanelColumns is the canonical SELECT column list for scanCIPanel. Kept in
 // one place so every Get* query and the scanner stay in lockstep.
 const ciPanelColumns = `id, github_repo, pr_number, head_sha, panel_run_uuid,
-	synthesis_job_id, created_at, posting_claimed_at, posted_at, retired_at`
+	synthesis_job_id, created_at, posting_claimed_at, posted_at, retired_at,
+	outcome, first_attempt_at, attempt_count`
 
 // scanCIPanel hydrates a CIPanel from a row selecting ciPanelColumns. Nullable
 // columns are scanned through sql.Null* and the timestamps parsed with
@@ -43,9 +58,13 @@ func scanCIPanel(row sqlScanner) (*CIPanel, error) {
 	var postingClaimedAt sql.NullString
 	var postedAt sql.NullString
 	var retiredAt sql.NullString
+	var outcome sql.NullString
+	var firstAttemptAt sql.NullString
+	var attemptCount sql.NullInt64
 	if err := row.Scan(
 		&p.ID, &p.GithubRepo, &p.PRNumber, &p.HeadSHA, &p.PanelRunUUID,
 		&synthesisJobID, &createdAt, &postingClaimedAt, &postedAt, &retiredAt,
+		&outcome, &firstAttemptAt, &attemptCount,
 	); err != nil {
 		return nil, err
 	}
@@ -66,6 +85,16 @@ func scanCIPanel(row sqlScanner) (*CIPanel, error) {
 	if retiredAt.Valid {
 		t := parseSQLiteTime(retiredAt.String)
 		p.RetiredAt = &t
+	}
+	if outcome.Valid {
+		p.Outcome = &outcome.String
+	}
+	if firstAttemptAt.Valid {
+		t := parseSQLiteTime(firstAttemptAt.String)
+		p.FirstAttemptAt = &t
+	}
+	if attemptCount.Valid {
+		p.AttemptCount = &attemptCount.Int64
 	}
 	return &p, nil
 }

--- a/internal/storage/ci_panels.go
+++ b/internal/storage/ci_panels.go
@@ -269,13 +269,35 @@ func (db *DB) ReleasePanelPostClaim(id int64) error {
 	return err
 }
 
-// MarkPanelPosted finalizes the run: it permanently bars further posting
-// claims and atomically stamps the terminal outcome plus a snapshot of
-// first_attempt_at/attempt from the operational attempt row. The snapshot
-// matters because closed-PR cleanup later deletes attempt rows; the panel
-// row is the durable record of terminal metrics.
+// MarkPanelPosted finalizes the run: in one atomic transaction it marks the
+// HEAD's review attempt terminal (state='done', mirroring
+// MarkReviewAttemptDone) and finalizes the panel row — permanently barring
+// further posting claims and stamping the terminal outcome plus a snapshot of
+// first_attempt_at/attempt from the operational attempt row. Doing both in one
+// transaction prevents a split where the panel is terminal but the attempt
+// stays pending: the stuck-attempt reconcile would otherwise rearm it and
+// enqueue a duplicate review. The snapshot matters because closed-PR cleanup
+// later deletes attempt rows; the panel row is the durable record of terminal
+// metrics. The attempt row may already be gone (deleted by closed-PR
+// cleanup); zero rows affected there is not an error.
 func (db *DB) MarkPanelPosted(id int64, outcome string) error {
-	_, err := db.Exec(`
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("mark panel posted: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	now := time.Now().Format(time.RFC3339)
+	if _, err := tx.Exec(`
+		UPDATE ci_pr_review_attempts
+		SET state = 'done', next_attempt_at = NULL, updated_at = ?
+		WHERE (github_repo, pr_number, head_sha) = (
+		    SELECT github_repo, pr_number, head_sha FROM ci_pr_panels WHERE id = ?)`,
+		now, id); err != nil {
+		return fmt.Errorf("mark panel posted: mark attempt done: %w", err)
+	}
+
+	if _, err := tx.Exec(`
 		UPDATE ci_pr_panels
 		SET posted_at = datetime('now'),
 		    outcome = ?,
@@ -289,8 +311,14 @@ func (db *DB) MarkPanelPosted(id int64, outcome string) error {
 		        WHERE a.github_repo = ci_pr_panels.github_repo
 		          AND a.pr_number = ci_pr_panels.pr_number
 		          AND a.head_sha = ci_pr_panels.head_sha)
-		WHERE id = ? AND retired_at IS NULL`, outcome, id)
-	return err
+		WHERE id = ? AND retired_at IS NULL`, outcome, id); err != nil {
+		return fmt.Errorf("mark panel posted: finalize panel: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("mark panel posted: commit: %w", err)
+	}
+	return nil
 }
 
 // MarkPanelRetired makes an abandoned panel row non-postable while retaining its

--- a/internal/storage/ci_panels.go
+++ b/internal/storage/ci_panels.go
@@ -269,17 +269,20 @@ func (db *DB) ReleasePanelPostClaim(id int64) error {
 	return err
 }
 
-// MarkPanelPosted finalizes the run: in one atomic transaction it marks the
-// HEAD's review attempt terminal (state='done', mirroring
-// MarkReviewAttemptDone) and finalizes the panel row — permanently barring
-// further posting claims and stamping the terminal outcome plus a snapshot of
-// first_attempt_at/attempt from the operational attempt row. Doing both in one
-// transaction prevents a split where the panel is terminal but the attempt
-// stays pending: the stuck-attempt reconcile would otherwise rearm it and
-// enqueue a duplicate review. The snapshot matters because closed-PR cleanup
-// later deletes attempt rows; the panel row is the durable record of terminal
-// metrics. The attempt row may already be gone (deleted by closed-PR
-// cleanup); zero rows affected there is not an error.
+// MarkPanelPosted finalizes the run: in one atomic transaction it finalizes
+// the panel row — permanently barring further posting claims and stamping the
+// terminal outcome plus a snapshot of first_attempt_at/attempt from the
+// operational attempt row — then marks the HEAD's review attempt terminal
+// (state='done', mirroring MarkReviewAttemptDone). The panel UPDATE is
+// guarded with posted_at IS NULL AND retired_at IS NULL and its RowsAffected
+// is checked: a stale posting lease that races a previous MarkPanelPosted
+// call (or a concurrent retire) must not double-finalize the row or overwrite
+// an already-stamped outcome, so the whole transaction is rolled back and an
+// error returned instead of also marking the attempt done. The snapshot
+// matters because closed-PR cleanup later deletes attempt rows; the panel row
+// is the durable record of terminal metrics. The attempt row may already be
+// gone (deleted by closed-PR cleanup); zero rows affected there is not an
+// error.
 func (db *DB) MarkPanelPosted(id int64, outcome string) error {
 	tx, err := db.Begin()
 	if err != nil {
@@ -287,17 +290,7 @@ func (db *DB) MarkPanelPosted(id int64, outcome string) error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	now := time.Now().Format(time.RFC3339)
-	if _, err := tx.Exec(`
-		UPDATE ci_pr_review_attempts
-		SET state = 'done', next_attempt_at = NULL, updated_at = ?
-		WHERE (github_repo, pr_number, head_sha) = (
-		    SELECT github_repo, pr_number, head_sha FROM ci_pr_panels WHERE id = ?)`,
-		now, id); err != nil {
-		return fmt.Errorf("mark panel posted: mark attempt done: %w", err)
-	}
-
-	if _, err := tx.Exec(`
+	res, err := tx.Exec(`
 		UPDATE ci_pr_panels
 		SET posted_at = datetime('now'),
 		    outcome = ?,
@@ -311,8 +304,26 @@ func (db *DB) MarkPanelPosted(id int64, outcome string) error {
 		        WHERE a.github_repo = ci_pr_panels.github_repo
 		          AND a.pr_number = ci_pr_panels.pr_number
 		          AND a.head_sha = ci_pr_panels.head_sha)
-		WHERE id = ? AND retired_at IS NULL`, outcome, id); err != nil {
+		WHERE id = ? AND posted_at IS NULL AND retired_at IS NULL`, outcome, id)
+	if err != nil {
 		return fmt.Errorf("mark panel posted: finalize panel: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("mark panel posted: rows affected: %w", err)
+	}
+	if n != 1 {
+		return fmt.Errorf("panel %d not finalizable: already posted, retired, or missing", id)
+	}
+
+	now := time.Now().Format(time.RFC3339)
+	if _, err := tx.Exec(`
+		UPDATE ci_pr_review_attempts
+		SET state = 'done', next_attempt_at = NULL, updated_at = ?
+		WHERE (github_repo, pr_number, head_sha) = (
+		    SELECT github_repo, pr_number, head_sha FROM ci_pr_panels WHERE id = ?)`,
+		now, id); err != nil {
+		return fmt.Errorf("mark panel posted: mark attempt done: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/internal/storage/ci_panels.go
+++ b/internal/storage/ci_panels.go
@@ -39,13 +39,15 @@ type CIPanel struct {
 	Outcome          *string    `json:"outcome,omitempty"`
 	FirstAttemptAt   *time.Time `json:"first_attempt_at,omitempty"`
 	AttemptCount     *int64     `json:"attempt_count,omitempty"`
+	SynthesisAgent   *string    `json:"synthesis_agent,omitempty"`
+	SynthesisModel   *string    `json:"synthesis_model,omitempty"`
 }
 
 // ciPanelColumns is the canonical SELECT column list for scanCIPanel. Kept in
 // one place so every Get* query and the scanner stay in lockstep.
 const ciPanelColumns = `id, github_repo, pr_number, head_sha, panel_run_uuid,
 	synthesis_job_id, created_at, posting_claimed_at, posted_at, retired_at,
-	outcome, first_attempt_at, attempt_count`
+	outcome, first_attempt_at, attempt_count, synthesis_agent, synthesis_model`
 
 // scanCIPanel hydrates a CIPanel from a row selecting ciPanelColumns. Nullable
 // columns are scanned through sql.Null* and the timestamps parsed with
@@ -61,10 +63,12 @@ func scanCIPanel(row sqlScanner) (*CIPanel, error) {
 	var outcome sql.NullString
 	var firstAttemptAt sql.NullString
 	var attemptCount sql.NullInt64
+	var synthesisAgent sql.NullString
+	var synthesisModel sql.NullString
 	if err := row.Scan(
 		&p.ID, &p.GithubRepo, &p.PRNumber, &p.HeadSHA, &p.PanelRunUUID,
 		&synthesisJobID, &createdAt, &postingClaimedAt, &postedAt, &retiredAt,
-		&outcome, &firstAttemptAt, &attemptCount,
+		&outcome, &firstAttemptAt, &attemptCount, &synthesisAgent, &synthesisModel,
 	); err != nil {
 		return nil, err
 	}
@@ -95,6 +99,12 @@ func scanCIPanel(row sqlScanner) (*CIPanel, error) {
 	}
 	if attemptCount.Valid {
 		p.AttemptCount = &attemptCount.Int64
+	}
+	if synthesisAgent.Valid {
+		p.SynthesisAgent = &synthesisAgent.String
+	}
+	if synthesisModel.Valid {
+		p.SynthesisModel = &synthesisModel.String
 	}
 	return &p, nil
 }
@@ -271,18 +281,19 @@ func (db *DB) ReleasePanelPostClaim(id int64) error {
 
 // MarkPanelPosted finalizes the run: in one atomic transaction it finalizes
 // the panel row — permanently barring further posting claims and stamping the
-// terminal outcome plus a snapshot of first_attempt_at/attempt from the
-// operational attempt row — then marks the HEAD's review attempt terminal
-// (state='done', mirroring MarkReviewAttemptDone). The panel UPDATE is
-// guarded with posted_at IS NULL AND retired_at IS NULL and its RowsAffected
-// is checked: a stale posting lease that races a previous MarkPanelPosted
-// call (or a concurrent retire) must not double-finalize the row or overwrite
-// an already-stamped outcome, so the whole transaction is rolled back and an
-// error returned instead of also marking the attempt done. The snapshot
-// matters because closed-PR cleanup later deletes attempt rows; the panel row
-// is the durable record of terminal metrics. The attempt row may already be
-// gone (deleted by closed-PR cleanup); zero rows affected there is not an
-// error.
+// terminal outcome, a snapshot of first_attempt_at/attempt from the
+// operational attempt row, and a snapshot of the synthesis job's agent/model —
+// then marks the HEAD's review attempt terminal (state='done', mirroring
+// MarkReviewAttemptDone). The panel UPDATE is guarded with
+// posted_at IS NULL AND retired_at IS NULL and its RowsAffected is checked: a
+// stale posting lease that races a previous MarkPanelPosted call (or a
+// concurrent retire) must not double-finalize the row or overwrite an
+// already-stamped outcome, so the whole transaction is rolled back and an
+// error returned instead of also marking the attempt done. Both snapshots
+// matter because closed-PR cleanup later deletes attempt rows and cascade
+// repo deletion deletes review_jobs rows; the panel row is the durable record
+// of terminal metrics. The attempt row may already be gone (deleted by
+// closed-PR cleanup); zero rows affected there is not an error.
 func (db *DB) MarkPanelPosted(id int64, outcome string) error {
 	tx, err := db.Begin()
 	if err != nil {
@@ -303,7 +314,11 @@ func (db *DB) MarkPanelPosted(id int64, outcome string) error {
 		        SELECT a.attempt FROM ci_pr_review_attempts a
 		        WHERE a.github_repo = ci_pr_panels.github_repo
 		          AND a.pr_number = ci_pr_panels.pr_number
-		          AND a.head_sha = ci_pr_panels.head_sha)
+		          AND a.head_sha = ci_pr_panels.head_sha),
+		    synthesis_agent = (
+		        SELECT j.agent FROM review_jobs j WHERE j.id = ci_pr_panels.synthesis_job_id),
+		    synthesis_model = (
+		        SELECT j.model FROM review_jobs j WHERE j.id = ci_pr_panels.synthesis_job_id)
 		WHERE id = ? AND posted_at IS NULL AND retired_at IS NULL`, outcome, id)
 	if err != nil {
 		return fmt.Errorf("mark panel posted: finalize panel: %w", err)

--- a/internal/storage/ci_panels_test.go
+++ b/internal/storage/ci_panels_test.go
@@ -712,6 +712,13 @@ func TestMarkPanelPostedSnapshotsAttemptMetrics(t *testing.T) {
 	id := seedPanelRow(t, db, "o/r", 7, "headsha7")
 	require.NoError(t, db.MarkPanelPosted(id, PanelOutcomeReviewPosted))
 
+	// MarkPanelPosted finalizes the attempt row and the panel row in the same
+	// transaction; the attempt must be terminal before it is ever deleted.
+	attempt, err := db.GetReviewAttempt("o/r", 7, "headsha7")
+	require.NoError(t, err)
+	require.NotNil(t, attempt)
+	assert.Equal(t, "done", attempt.State)
+
 	// Closed-PR cleanup deletes attempt rows; the snapshot must survive it.
 	_, err = db.DeleteReviewAttemptsForPR("o/r", 7)
 	require.NoError(t, err)

--- a/internal/storage/ci_panels_test.go
+++ b/internal/storage/ci_panels_test.go
@@ -748,3 +748,80 @@ func TestMarkPanelPostedWithoutAttemptRow(t *testing.T) {
 	assert.Nil(t, p.FirstAttemptAt)
 	assert.Nil(t, p.AttemptCount)
 }
+
+// TestMarkPanelPostedTwiceErrorsAndPreservesFirstResult covers a stale
+// posting lease (or any other double call) racing a prior successful
+// MarkPanelPosted: the guarded panel UPDATE must not match a second time, so
+// the second call errors instead of overwriting the already-stamped outcome/
+// first_attempt_at/attempt_count/posted_at, and the attempt row set 'done' by
+// the first call must stay 'done' rather than being touched again.
+func TestMarkPanelPostedTwiceErrorsAndPreservesFirstResult(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	created, err := db.ReserveReviewAttempt("o/r", 9, "headsha9", now)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	id := seedPanelRow(t, db, "o/r", 9, "headsha9")
+	require.NoError(t, db.MarkPanelPosted(id, PanelOutcomeReviewPosted))
+
+	first, err := db.GetCIPanelByPRSHA("o/r", 9, "headsha9")
+	require.NoError(t, err)
+
+	err = db.MarkPanelPosted(id, PanelOutcomeAbandoned)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "not finalizable")
+
+	second, err := db.GetCIPanelByPRSHA("o/r", 9, "headsha9")
+	require.NoError(t, err)
+	require.NotNil(t, second.Outcome)
+	assert.Equal(t, PanelOutcomeReviewPosted, *second.Outcome, "outcome from first call survives")
+	require.NotNil(t, second.FirstAttemptAt)
+	require.NotNil(t, first.FirstAttemptAt)
+	assert.True(t, second.FirstAttemptAt.Equal(*first.FirstAttemptAt))
+	require.NotNil(t, second.AttemptCount)
+	require.NotNil(t, first.AttemptCount)
+	assert.Equal(t, *first.AttemptCount, *second.AttemptCount)
+	require.NotNil(t, second.PostedAt)
+	require.NotNil(t, first.PostedAt)
+	assert.True(t, second.PostedAt.Equal(*first.PostedAt), "posted_at must not be overwritten")
+
+	attempt, err := db.GetReviewAttempt("o/r", 9, "headsha9")
+	require.NoError(t, err)
+	require.NotNil(t, attempt)
+	assert.Equal(t, "done", attempt.State, "attempt row stays done from the first call")
+}
+
+// TestMarkPanelPostedRetiredPanelErrors covers a concurrently retired panel: a
+// posting lease that finishes after MarkPanelRetired must not finalize the
+// row (it has no outcome to protect its own metrics from a stale caller) and
+// must not mark the attempt row done, since the panel run was abandoned by
+// the retire, not completed.
+func TestMarkPanelPostedRetiredPanelErrors(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	created, err := db.ReserveReviewAttempt("o/r", 10, "headsha10", now)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	id := seedPanelRow(t, db, "o/r", 10, "headsha10")
+	require.NoError(t, db.MarkPanelRetired(id))
+
+	err = db.MarkPanelPosted(id, PanelOutcomeReviewPosted)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "not finalizable")
+
+	panel, err := db.GetCIPanelByPRSHA("o/r", 10, "headsha10")
+	require.NoError(t, err)
+	assert.Nil(t, panel.Outcome, "retired panel must not be finalized")
+	assert.NotNil(t, panel.RetiredAt)
+
+	attempt, err := db.GetReviewAttempt("o/r", 10, "headsha10")
+	require.NoError(t, err)
+	require.NotNil(t, attempt)
+	assert.NotEqual(t, "done", attempt.State, "attempt must not be marked done for a retired panel")
+}

--- a/internal/storage/ci_panels_test.go
+++ b/internal/storage/ci_panels_test.go
@@ -614,6 +614,38 @@ func TestCreateCIPanelRunRace(t *testing.T) {
 	assert.Equal(1, countCIPanels(t, db, "o/r", 9), "single mapping row")
 }
 
+func TestCIPanelTerminalMetricsRoundTrip(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	id := seedPanelRow(t, db, "o/r", 42, "headsha42")
+	_, err := db.Exec(`UPDATE ci_pr_panels
+		SET outcome = ?, first_attempt_at = '2026-07-01T00:00:00Z', attempt_count = 3
+		WHERE id = ?`, PanelOutcomeReviewPosted, id)
+	require.NoError(t, err)
+
+	p, err := db.GetCIPanelByPRSHA("o/r", 42, "headsha42")
+	require.NoError(t, err)
+	require.NotNil(t, p.Outcome)
+	assert.Equal(t, PanelOutcomeReviewPosted, *p.Outcome)
+	require.NotNil(t, p.FirstAttemptAt)
+	assert.True(t, p.FirstAttemptAt.Equal(time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)))
+	require.NotNil(t, p.AttemptCount)
+	assert.Equal(t, int64(3), *p.AttemptCount)
+}
+
+func TestCIPanelTerminalMetricsNullForLegacyRows(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	seedPanelRow(t, db, "o/r", 43, "headsha43")
+	p, err := db.GetCIPanelByPRSHA("o/r", 43, "headsha43")
+	require.NoError(t, err)
+	assert.Nil(t, p.Outcome)
+	assert.Nil(t, p.FirstAttemptAt)
+	assert.Nil(t, p.AttemptCount)
+}
+
 // TestCreateCIPanelRunAtomicity covers F2: a failure inside createCIPanelRunTx
 // (after the mapping INSERT) rolls back fully — no orphan mapping, no orphan
 // jobs. The failure is injected with failingExecer rather than a foreign-key

--- a/internal/storage/ci_panels_test.go
+++ b/internal/storage/ci_panels_test.go
@@ -88,7 +88,7 @@ func TestClaimPanelForPosting(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, got3, "re-claimable after release")
 
-	require.NoError(t, db.MarkPanelPosted(id))
+	require.NoError(t, db.MarkPanelPosted(id, PanelOutcomeReviewPosted))
 	got4, err := db.ClaimPanelForPosting(id, staleWindow)
 	require.NoError(t, err)
 	assert.False(t, got4, "posted row never claims again")
@@ -163,7 +163,7 @@ func TestGetPendingPanelPRsAndDelete(t *testing.T) {
 	// PR 1 posted (excluded), PR 2 + PR 3 pending (included). A row under a
 	// different repo proves the github_repo filter excludes it.
 	postedID := seedPanelRow(t, db, "o/r", 1, "sha1")
-	require.NoError(t, db.MarkPanelPosted(postedID))
+	require.NoError(t, db.MarkPanelPosted(postedID, PanelOutcomeReviewPosted))
 	pendingID2 := seedPanelRow(t, db, "o/r", 2, "sha2")
 	seedPanelRow(t, db, "o/r", 3, "sha3")
 	seedPanelRow(t, db, "x/y", 9, "sha9")
@@ -202,7 +202,7 @@ func TestGetActivePanelsForPR(t *testing.T) {
 	// Two rows for PR 7: one posted (excluded), one pending (included). Rows for
 	// a different PR and a different repo prove the filters.
 	postedID := seedPanelRow(t, db, "o/r", 7, "posted")
-	require.NoError(t, db.MarkPanelPosted(postedID))
+	require.NoError(t, db.MarkPanelPosted(postedID, PanelOutcomeReviewPosted))
 	seedPanelRow(t, db, "o/r", 7, "pending")
 	seedPanelRow(t, db, "o/r", 8, "other-pr")
 	seedPanelRow(t, db, "x/y", 7, "other-repo")
@@ -250,7 +250,7 @@ func TestGetTimedOutPanels(t *testing.T) {
 	queuedOld, queuedMember := seedRun(4, "queued-old", time.Now().Add(-1*time.Hour).Format(time.RFC3339))
 	_, err := db.Exec(`UPDATE review_jobs SET status = 'queued', started_at = NULL WHERE id = ?`, queuedMember.ID)
 	require.NoError(t, err)
-	require.NoError(t, db.MarkPanelPosted(oldPosted.ID))
+	require.NoError(t, db.MarkPanelPosted(oldPosted.ID, PanelOutcomeReviewPosted))
 	_ = recentUnposted
 	_ = queuedOld
 
@@ -469,7 +469,7 @@ func TestGetUnpostedTerminalPanels(t *testing.T) {
 	// (c) synthesis failed, posted_at SET -> EXCLUDED (already posted).
 	cPanel, cSynth := seedPanelRunForRepo(t, db, repo.ID, "o/r", 3, "failed-posted")
 	setStatus(t, db, cSynth.ID, JobStatusFailed)
-	require.NoError(t, db.MarkPanelPosted(cPanel.ID))
+	require.NoError(t, db.MarkPanelPosted(cPanel.ID, PanelOutcomeReviewPosted))
 	// (d) synthesis failed, posted_at NULL -> INCLUDED (raw-fallback must post).
 	dPanel, dSynth := seedPanelRunForRepo(t, db, repo.ID, "o/r", 4, "failed-unposted")
 	setStatus(t, db, dSynth.ID, JobStatusFailed)
@@ -561,7 +561,7 @@ func TestMarkPanelRetiredDoesNotRetirePostedPanel(t *testing.T) {
 	t.Cleanup(func() { db.Close() })
 
 	id := seedPanelRow(t, db, "o/r", 6, "posted-head")
-	require.NoError(t, db.MarkPanelPosted(id))
+	require.NoError(t, db.MarkPanelPosted(id, PanelOutcomeReviewPosted))
 	require.NoError(t, db.MarkPanelRetired(id))
 
 	panel, err := db.GetActiveCIPanelByPRSHA("o/r", 6, "posted-head")
@@ -698,4 +698,46 @@ func TestCreateCIPanelRunAtomicity(t *testing.T) {
 	attempt, err := db.GetReviewAttempt("o/r", 11, "atomicsha")
 	require.NoError(t, err)
 	assert.Nil(attempt, "reserved attempt row rolls back with the failed run")
+}
+
+func TestMarkPanelPostedSnapshotsAttemptMetrics(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	created, err := db.ReserveReviewAttempt("o/r", 7, "headsha7", now)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	id := seedPanelRow(t, db, "o/r", 7, "headsha7")
+	require.NoError(t, db.MarkPanelPosted(id, PanelOutcomeReviewPosted))
+
+	// Closed-PR cleanup deletes attempt rows; the snapshot must survive it.
+	_, err = db.DeleteReviewAttemptsForPR("o/r", 7)
+	require.NoError(t, err)
+
+	p, err := db.GetCIPanelByPRSHA("o/r", 7, "headsha7")
+	require.NoError(t, err)
+	require.NotNil(t, p.PostedAt)
+	require.NotNil(t, p.Outcome)
+	assert.Equal(t, PanelOutcomeReviewPosted, *p.Outcome)
+	require.NotNil(t, p.FirstAttemptAt)
+	assert.True(t, p.FirstAttemptAt.Equal(now), "got %v want %v", p.FirstAttemptAt, now)
+	require.NotNil(t, p.AttemptCount)
+	assert.Equal(t, int64(1), *p.AttemptCount)
+}
+
+func TestMarkPanelPostedWithoutAttemptRow(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	id := seedPanelRow(t, db, "o/r", 8, "headsha8")
+	require.NoError(t, db.MarkPanelPosted(id, PanelOutcomeAbandoned))
+
+	p, err := db.GetCIPanelByPRSHA("o/r", 8, "headsha8")
+	require.NoError(t, err)
+	require.NotNil(t, p.Outcome)
+	assert.Equal(t, PanelOutcomeAbandoned, *p.Outcome)
+	assert.Nil(t, p.FirstAttemptAt)
+	assert.Nil(t, p.AttemptCount)
 }

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -1039,17 +1039,37 @@ func (db *DB) migrate() error {
 	// reads review_jobs.panel_run_uuid/panel_role, which that migration
 	// adds.
 	//
-	// Outcome is reconstructed from the retained MEMBER results, mirroring
-	// the posting decision (classifyPanelOutcome), NOT from the synthesis
-	// job's status: a genuinely failed synthesis still posted successful
-	// member output via the raw fallback. A member with retained non-empty
-	// review output means the review was posted; otherwise a failed member
-	// means the give-up note was; otherwise the all-skip notice was. Runs
-	// abandoned on a permanent posting failure are indistinguishable
+	// Outcome is reconstructed from the retained jobs, mirroring the live
+	// posting decision (classifyPanelOutcome) in precedence order:
+	//
+	//  1. A synthesis job that FAILED transiently (a provider outage or a
+	//     quota/session exhaustion) took precedence over member output in
+	//     the live path: the run deferred rather than post the degraded raw
+	//     fallback, and a posted row in that state is the terminal give-up
+	//     after the transient retry wall exhausted -> 'giveup_posted'. The
+	//     transient/quota distinction is an error-prefix match, matching
+	//     review.IsTransientFailure / IsQuotaFailure (OutageErrorPrefix
+	//     "outage: ", QuotaErrorPrefix "quota: "); storage cannot import
+	//     review (review imports storage), so the prefixes are inlined and
+	//     must track those constants. A GENUINE (deterministic) synthesis
+	//     failure is deliberately NOT caught here: it still posted the raw
+	//     member fallback, so it falls through to rule 2.
+	//  2. A member with retained non-empty review output means the review
+	//     (or the raw fallback) was posted -> 'review_posted'.
+	//  3. Otherwise a failed member means the give-up note was posted ->
+	//     'giveup_posted'.
+	//  4. Otherwise the all-skip notice was posted -> 'no_review_posted'.
+	//
+	// Runs abandoned on a permanent posting failure are indistinguishable
 	// (posting state was not persisted then) and stay approximate. Rows
 	// with no surviving member rows keep NULL and export as "unknown".
 	if _, err = db.Exec(`UPDATE ci_pr_panels SET outcome =
 		CASE
+			WHEN EXISTS (SELECT 1 FROM review_jobs sj
+			             WHERE sj.id = ci_pr_panels.synthesis_job_id
+			               AND sj.status = 'failed'
+			               AND (sj.error LIKE 'outage: %' OR sj.error LIKE 'quota: %'))
+			     THEN 'giveup_posted'
 			WHEN EXISTS (SELECT 1 FROM review_jobs j
 			             JOIN reviews rv ON rv.job_id = j.id
 			             WHERE j.panel_run_uuid = ci_pr_panels.panel_run_uuid

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -114,6 +114,9 @@ CREATE TABLE IF NOT EXISTS ci_pr_panels (
   posting_claimed_at TIMESTAMP,
   posted_at TIMESTAMP,
   retired_at TIMESTAMP,
+  outcome TEXT,
+  first_attempt_at TEXT,
+  attempt_count INTEGER,
   UNIQUE(github_repo, pr_number, head_sha)
 );
 
@@ -999,6 +1002,25 @@ func (db *DB) migrate() error {
 		_, err = db.Exec(`ALTER TABLE ci_pr_panels ADD COLUMN retired_at TIMESTAMP`)
 		if err != nil {
 			return fmt.Errorf("add retired_at column: %w", err)
+		}
+	}
+
+	// Migration: add terminal-metrics columns to ci_pr_panels if missing.
+	// Written once at finalization so the terminal outcome and retry timing
+	// survive later attempt-row cleanup.
+	for _, col := range []struct{ name, ddl string }{
+		{"outcome", `ALTER TABLE ci_pr_panels ADD COLUMN outcome TEXT`},
+		{"first_attempt_at", `ALTER TABLE ci_pr_panels ADD COLUMN first_attempt_at TEXT`},
+		{"attempt_count", `ALTER TABLE ci_pr_panels ADD COLUMN attempt_count INTEGER`},
+	} {
+		err = db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('ci_pr_panels') WHERE name = ?`, col.name).Scan(&count)
+		if err != nil {
+			return fmt.Errorf("check %s column: %w", col.name, err)
+		}
+		if count == 0 {
+			if _, err = db.Exec(col.ddl); err != nil {
+				return fmt.Errorf("add %s column: %w", col.name, err)
+			}
 		}
 	}
 

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -117,6 +117,8 @@ CREATE TABLE IF NOT EXISTS ci_pr_panels (
   outcome TEXT,
   first_attempt_at TEXT,
   attempt_count INTEGER,
+  synthesis_agent TEXT,
+  synthesis_model TEXT,
   UNIQUE(github_repo, pr_number, head_sha)
 );
 
@@ -1006,12 +1008,15 @@ func (db *DB) migrate() error {
 	}
 
 	// Migration: add terminal-metrics columns to ci_pr_panels if missing.
-	// Written once at finalization so the terminal outcome and retry timing
-	// survive later attempt-row cleanup.
+	// Written once at finalization so the terminal outcome, retry timing, and
+	// synthesis agent/model survive later attempt-row cleanup and cascade repo
+	// deletion (review_jobs rows for the panel's synthesis job may be gone).
 	for _, col := range []struct{ name, ddl string }{
 		{"outcome", `ALTER TABLE ci_pr_panels ADD COLUMN outcome TEXT`},
 		{"first_attempt_at", `ALTER TABLE ci_pr_panels ADD COLUMN first_attempt_at TEXT`},
 		{"attempt_count", `ALTER TABLE ci_pr_panels ADD COLUMN attempt_count INTEGER`},
+		{"synthesis_agent", `ALTER TABLE ci_pr_panels ADD COLUMN synthesis_agent TEXT`},
+		{"synthesis_model", `ALTER TABLE ci_pr_panels ADD COLUMN synthesis_model TEXT`},
 	} {
 		err = db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('ci_pr_panels') WHERE name = ?`, col.name).Scan(&count)
 		if err != nil {

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -1035,42 +1035,69 @@ func (db *DB) migrate() error {
 	}
 
 	// Backfill terminal metrics for panels finalized before the terminal-
-	// metrics columns existed, from their still-retained review_jobs rows.
-	// Runs after migrateSyncColumns because it reads
-	// review_jobs.panel_run_uuid, which that migration adds. The poster
-	// only set posted_at after posting a comment, and the synthesis job's
-	// terminal status pins down which comment that was: done posted the
-	// synthesized review, skipped posted the all-skip notice, and
-	// failed/canceled posted the give-up comment. first_attempt_at is
-	// approximated by the panel run's earliest job enqueue: the attempt
-	// rows are gone, so deferred attempts before the executed one are
-	// unrecoverable and this floor slightly undercounts turnaround for
-	// throttled PRs; attempt_count stays NULL for the same reason. Rows
-	// whose jobs were cascade-deleted keep NULLs and export as "unknown".
-	// Both statements only touch rows the finalizer never wrote, so re-runs
-	// are no-ops.
-	if _, err = db.Exec(`UPDATE ci_pr_panels SET outcome = (
-			SELECT CASE j.status
-				WHEN 'done' THEN 'review_posted'
-				WHEN 'skipped' THEN 'no_review_posted'
-				ELSE 'giveup_posted'
-			END FROM review_jobs j WHERE j.id = ci_pr_panels.synthesis_job_id
-		)
+	// metrics columns existed. Runs after migrateSyncColumns because it
+	// reads review_jobs.panel_run_uuid/panel_role, which that migration
+	// adds.
+	//
+	// Outcome is reconstructed from the retained MEMBER results, mirroring
+	// the posting decision (classifyPanelOutcome), NOT from the synthesis
+	// job's status: a genuinely failed synthesis still posted successful
+	// member output via the raw fallback. A member with retained non-empty
+	// review output means the review was posted; otherwise a failed member
+	// means the give-up note was; otherwise the all-skip notice was. Runs
+	// abandoned on a permanent posting failure are indistinguishable
+	// (posting state was not persisted then) and stay approximate. Rows
+	// with no surviving member rows keep NULL and export as "unknown".
+	if _, err = db.Exec(`UPDATE ci_pr_panels SET outcome =
+		CASE
+			WHEN EXISTS (SELECT 1 FROM review_jobs j
+			             JOIN reviews rv ON rv.job_id = j.id
+			             WHERE j.panel_run_uuid = ci_pr_panels.panel_run_uuid
+			               AND j.panel_role = 'member' AND j.status = 'done'
+			               AND TRIM(rv.output) != '') THEN 'review_posted'
+			WHEN EXISTS (SELECT 1 FROM review_jobs j
+			             WHERE j.panel_run_uuid = ci_pr_panels.panel_run_uuid
+			               AND j.panel_role = 'member'
+			               AND j.status = 'failed') THEN 'giveup_posted'
+			ELSE 'no_review_posted'
+		END
 		WHERE posted_at IS NOT NULL AND outcome IS NULL
-		  AND synthesis_job_id IS NOT NULL
-		  AND (SELECT j.status FROM review_jobs j WHERE j.id = ci_pr_panels.synthesis_job_id)
-		      IN ('done', 'skipped', 'failed', 'canceled')`); err != nil {
-		return fmt.Errorf("backfill ci_pr_panels outcome: %w", err)
-	}
-	if _, err = db.Exec(`UPDATE ci_pr_panels SET first_attempt_at = (
-			SELECT MIN(strftime('%Y-%m-%dT%H:%M:%SZ', j.enqueued_at))
-			FROM review_jobs j WHERE j.panel_run_uuid = ci_pr_panels.panel_run_uuid
-		)
-		WHERE posted_at IS NOT NULL AND first_attempt_at IS NULL
 		  AND panel_run_uuid != ''
 		  AND EXISTS (SELECT 1 FROM review_jobs j
 		              WHERE j.panel_run_uuid = ci_pr_panels.panel_run_uuid
-		                AND j.enqueued_at IS NOT NULL)`); err != nil {
+		                AND j.panel_role = 'member')`); err != nil {
+		return fmt.Errorf("backfill ci_pr_panels outcome: %w", err)
+	}
+	// first_attempt_at/attempt_count prefer the surviving
+	// ci_pr_review_attempts row — the exact source MarkPanelPosted
+	// snapshots at finalization — so deferred retries before the executed
+	// run are counted. Only when closed-PR cleanup already deleted the
+	// attempt row does first_attempt_at fall back to the final run's
+	// earliest job enqueue (a floor that undercounts throttled PRs), with
+	// attempt_count left NULL as unrecoverable. Both statements only touch
+	// rows the finalizer never wrote, so re-runs are no-ops.
+	if _, err = db.Exec(`UPDATE ci_pr_panels SET
+		first_attempt_at = COALESCE(
+			(SELECT a.first_attempt_at FROM ci_pr_review_attempts a
+			 WHERE a.github_repo = ci_pr_panels.github_repo
+			   AND a.pr_number = ci_pr_panels.pr_number
+			   AND a.head_sha = ci_pr_panels.head_sha),
+			(SELECT MIN(strftime('%Y-%m-%dT%H:%M:%SZ', j.enqueued_at))
+			 FROM review_jobs j WHERE j.panel_run_uuid = ci_pr_panels.panel_run_uuid)),
+		attempt_count =
+			(SELECT a.attempt FROM ci_pr_review_attempts a
+			 WHERE a.github_repo = ci_pr_panels.github_repo
+			   AND a.pr_number = ci_pr_panels.pr_number
+			   AND a.head_sha = ci_pr_panels.head_sha)
+		WHERE posted_at IS NOT NULL AND first_attempt_at IS NULL
+		  AND (EXISTS (SELECT 1 FROM ci_pr_review_attempts a
+		               WHERE a.github_repo = ci_pr_panels.github_repo
+		                 AND a.pr_number = ci_pr_panels.pr_number
+		                 AND a.head_sha = ci_pr_panels.head_sha)
+		       OR (panel_run_uuid != ''
+		           AND EXISTS (SELECT 1 FROM review_jobs j
+		                       WHERE j.panel_run_uuid = ci_pr_panels.panel_run_uuid
+		                         AND j.enqueued_at IS NOT NULL)))`); err != nil {
 		return fmt.Errorf("backfill ci_pr_panels first_attempt_at: %w", err)
 	}
 

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -1100,6 +1100,26 @@ func (db *DB) migrate() error {
 		                         AND j.enqueued_at IS NOT NULL)))`); err != nil {
 		return fmt.Errorf("backfill ci_pr_panels first_attempt_at: %w", err)
 	}
+	// Snapshot synthesis_agent/synthesis_model from the synthesis job for
+	// panels finalized before these columns existed, exactly as
+	// MarkPanelPosted now does at finalization. Without this the export
+	// falls back to the live review_jobs join, so a later cascade repo
+	// deletion (which deletes the synthesis job) permanently loses the
+	// model attribution for these historical rows. Only rows whose
+	// synthesis job still exists can be recovered; the pair is written
+	// together and guarded on synthesis_agent IS NULL, so re-runs and rows
+	// already snapshotted by the finalizer are untouched.
+	if _, err = db.Exec(`UPDATE ci_pr_panels SET
+		synthesis_agent = (SELECT j.agent FROM review_jobs j
+		                   WHERE j.id = ci_pr_panels.synthesis_job_id),
+		synthesis_model = (SELECT j.model FROM review_jobs j
+		                   WHERE j.id = ci_pr_panels.synthesis_job_id)
+		WHERE posted_at IS NOT NULL AND synthesis_agent IS NULL
+		  AND synthesis_job_id IS NOT NULL
+		  AND EXISTS (SELECT 1 FROM review_jobs j
+		              WHERE j.id = ci_pr_panels.synthesis_job_id)`); err != nil {
+		return fmt.Errorf("backfill ci_pr_panels synthesis snapshot: %w", err)
+	}
 
 	// Auto design review support: extends status CHECK constraint,
 	// adds skip_reason column. (job_type has no CHECK constraint;

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -1034,6 +1034,46 @@ func (db *DB) migrate() error {
 		return err
 	}
 
+	// Backfill terminal metrics for panels finalized before the terminal-
+	// metrics columns existed, from their still-retained review_jobs rows.
+	// Runs after migrateSyncColumns because it reads
+	// review_jobs.panel_run_uuid, which that migration adds. The poster
+	// only set posted_at after posting a comment, and the synthesis job's
+	// terminal status pins down which comment that was: done posted the
+	// synthesized review, skipped posted the all-skip notice, and
+	// failed/canceled posted the give-up comment. first_attempt_at is
+	// approximated by the panel run's earliest job enqueue: the attempt
+	// rows are gone, so deferred attempts before the executed one are
+	// unrecoverable and this floor slightly undercounts turnaround for
+	// throttled PRs; attempt_count stays NULL for the same reason. Rows
+	// whose jobs were cascade-deleted keep NULLs and export as "unknown".
+	// Both statements only touch rows the finalizer never wrote, so re-runs
+	// are no-ops.
+	if _, err = db.Exec(`UPDATE ci_pr_panels SET outcome = (
+			SELECT CASE j.status
+				WHEN 'done' THEN 'review_posted'
+				WHEN 'skipped' THEN 'no_review_posted'
+				ELSE 'giveup_posted'
+			END FROM review_jobs j WHERE j.id = ci_pr_panels.synthesis_job_id
+		)
+		WHERE posted_at IS NOT NULL AND outcome IS NULL
+		  AND synthesis_job_id IS NOT NULL
+		  AND (SELECT j.status FROM review_jobs j WHERE j.id = ci_pr_panels.synthesis_job_id)
+		      IN ('done', 'skipped', 'failed', 'canceled')`); err != nil {
+		return fmt.Errorf("backfill ci_pr_panels outcome: %w", err)
+	}
+	if _, err = db.Exec(`UPDATE ci_pr_panels SET first_attempt_at = (
+			SELECT MIN(strftime('%Y-%m-%dT%H:%M:%SZ', j.enqueued_at))
+			FROM review_jobs j WHERE j.panel_run_uuid = ci_pr_panels.panel_run_uuid
+		)
+		WHERE posted_at IS NOT NULL AND first_attempt_at IS NULL
+		  AND panel_run_uuid != ''
+		  AND EXISTS (SELECT 1 FROM review_jobs j
+		              WHERE j.panel_run_uuid = ci_pr_panels.panel_run_uuid
+		                AND j.enqueued_at IS NOT NULL)`); err != nil {
+		return fmt.Errorf("backfill ci_pr_panels first_attempt_at: %w", err)
+	}
+
 	// Auto design review support: extends status CHECK constraint,
 	// adds skip_reason column. (job_type has no CHECK constraint;
 	// 'classify' is accepted as-is.)

--- a/internal/storage/export_ci.go
+++ b/internal/storage/export_ci.go
@@ -364,7 +364,7 @@ const legacyUnitJobConditions = `(j.panel_run_uuid IS NULL OR j.panel_run_uuid =
 // wall clock (observed in production: one ref re-reviewed 12 days later
 // inflated its turnaround to 290 hours). Pseudopanel members enqueue within
 // seconds of each other, so the hour window is generous for real units.
-const legacyUnitWindowCTE = `unit_windows AS (
+const legacyUnitWindowCTE = `unit_windows AS MATERIALIZED (
 			SELECT j.repo_id, j.git_ref,
 			       strftime('%Y-%m-%dT%H:%M:%SZ',
 			                datetime(MIN(` + legacyUnitTimeExprConst + `), '+1 hour')) AS window_end

--- a/internal/storage/export_ci.go
+++ b/internal/storage/export_ci.go
@@ -24,8 +24,10 @@ type ExportCIMetricsOptions struct {
 	Cursor string
 	Limit  int
 	// Legacy switches the export to the pre-panel CI era (~2026-02 to
-	// ~2026-06): completed source='ci' review_jobs rows with no panel run,
-	// grouped per (repo, git_ref) into one wall-clock unit ("pseudopanel").
+	// ~2026-06): completed CI review_jobs rows with no panel run — tagged
+	// source='ci' or, for rows predating that tag, a non-empty
+	// ci_base_branch (the same markers ReviewJob.IsCI checks) — grouped
+	// per (repo, git_ref) into one wall-clock unit ("pseudopanel").
 	// Legacy turnaround (first_attempt_at -> posted_at) measures earliest
 	// job enqueue -> latest job finish and excludes comment-posting
 	// latency, so it slightly undercounts the panel-era PR-perceived
@@ -273,7 +275,8 @@ func (db *DB) exportCIMetricsLegacy(opts ExportCIMetricsOptions, cursor *ciMetri
 		       ` + postedExpr + `
 		FROM review_jobs j
 		JOIN repos r ON r.id = j.repo_id
-		WHERE j.source = ? AND (j.panel_run_uuid IS NULL OR j.panel_run_uuid = '')
+		WHERE (j.source = ? OR COALESCE(j.ci_base_branch, '') != '')
+		  AND (j.panel_run_uuid IS NULL OR j.panel_run_uuid = '')
 		  AND j.status = ? AND j.finished_at IS NOT NULL
 		GROUP BY j.repo_id, j.git_ref
 		` + havingClause + `
@@ -354,7 +357,8 @@ func (db *DB) legacyUnitJobs(repoID int64, gitRef string) ([]ExportCIPanelJob, e
 		       `+legacyUnitTimeExpr("j.finished_at")+`
 		FROM review_jobs j
 		WHERE j.repo_id = ? AND j.git_ref = ?
-		  AND j.source = ? AND (j.panel_run_uuid IS NULL OR j.panel_run_uuid = '')
+		  AND (j.source = ? OR COALESCE(j.ci_base_branch, '') != '')
+		  AND (j.panel_run_uuid IS NULL OR j.panel_run_uuid = '')
 		  AND j.status = ? AND j.finished_at IS NOT NULL
 		ORDER BY j.id ASC`,
 		repoID, gitRef, JobSourceCI, string(JobStatusDone))
@@ -556,13 +560,14 @@ func (db *DB) resolveCIMetricsCursor(cursor string, legacy bool) (*ciMetricsCurs
 		// check both still hold.
 		existsQuery = `
 			SELECT COUNT(1) FROM review_jobs a
-			WHERE a.id = ? AND a.source = '` + JobSourceCI + `'
+			WHERE a.id = ?
+			  AND (a.source = '` + JobSourceCI + `' OR COALESCE(a.ci_base_branch, '') != '')
 			  AND (a.panel_run_uuid IS NULL OR a.panel_run_uuid = '')
 			  AND a.status = 'done' AND a.finished_at IS NOT NULL
 			  AND (SELECT MAX(` + legacyUnitTimeExpr("j.finished_at") + `)
 			       FROM review_jobs j
 			       WHERE j.repo_id = a.repo_id AND j.git_ref = a.git_ref
-			         AND j.source = '` + JobSourceCI + `'
+			         AND (j.source = '` + JobSourceCI + `' OR COALESCE(j.ci_base_branch, '') != '')
 			         AND (j.panel_run_uuid IS NULL OR j.panel_run_uuid = '')
 			         AND j.status = 'done' AND j.finished_at IS NOT NULL) = ?`
 	}

--- a/internal/storage/export_ci.go
+++ b/internal/storage/export_ci.go
@@ -361,11 +361,11 @@ func (db *DB) exportCIMetricsLegacy(opts ExportCIMetricsOptions, cursor *ciMetri
 
 // legacyPanelEraEnd returns the timestamp of the database's first panel
 // activity (earliest panel-tagged job enqueue or ci_pr_panels row) in
-// normalized RFC 3339 UTC, or "" when there is none. It is the immutable
-// upper bound of the pre-panel era: only jobs enqueued strictly before it
-// can belong to a legacy pseudopanel, so post-panel reviews can never form
-// new legacy units or destabilize legacy cursors. Computed once per export
-// call and passed as a bound parameter.
+// normalized RFC 3339 UTC, or "" when there is none. It is the upper bound
+// of the pre-panel era: only jobs enqueued strictly before it can belong to
+// a legacy pseudopanel, so post-panel reviews do not form new legacy units.
+// Recomputed per export call; the --legacy export is a one-time backfill, so
+// this runs against complete data and is never a live, drifting feed.
 func (db *DB) legacyPanelEraEnd() (string, error) {
 	var end sql.NullString
 	err := db.QueryRow(`

--- a/internal/storage/export_ci.go
+++ b/internal/storage/export_ci.go
@@ -23,18 +23,17 @@ type ExportCIMetricsOptions struct {
 	Until  time.Time
 	Cursor string
 	Limit  int
-	// Legacy switches the export to the pre-panel CI era (~2026-02 to
-	// ~2026-06): completed review/range jobs with no panel run, grouped
-	// per (repo, git_ref) into one wall-clock unit ("pseudopanel") when
-	// two or more reviews share the ref. Rows from that era predate all
-	// CI tagging, so membership is structural, and singleton reviews are
-	// excluded as manual one-offs.
-	// Legacy turnaround (first_attempt_at -> posted_at) measures earliest
-	// job enqueue -> latest job finish and excludes comment-posting
-	// latency, so it slightly undercounts the panel-era PR-perceived
-	// turnaround (first poller attempt -> panel posted). Legacy cursors
-	// are namespaced and are rejected if replayed with Legacy unset, and
-	// vice versa.
+	// Legacy switches the export to the frozen pre-panel CI era: terminal
+	// (done or failed) review/range jobs with no panel run, enqueued
+	// before the database's first panel activity, grouped per
+	// (repo, git_ref) into one wall-clock unit ("pseudopanel") when two or
+	// more terminal jobs share the ref and at least one succeeded (the
+	// batch flow posted whatever output was available). Singleton reviews
+	// are excluded as manual one-offs; a database with no panel activity
+	// exports no legacy rows. Legacy turnaround (earliest enqueue ->
+	// latest finish) excludes comment-posting latency, unlike panel-era
+	// turnaround. Legacy cursors are namespaced and rejected if replayed
+	// with Legacy unset, and vice versa.
 	Legacy bool
 }
 
@@ -211,19 +210,20 @@ func legacyUnitTimeExpr(col string) string {
 	return "strftime('%Y-%m-%dT%H:%M:%SZ', " + col + ")"
 }
 
-// legacyGithubRepo maps a repos.name value (CI clones store the remote URL)
-// to the owner/repo form used by panel-era github_repo, passing through
-// values that are not GitHub remotes.
-func legacyGithubRepo(name string) string {
+// legacyGithubRepo maps a repo's remote identity (repos.identity, a GitHub
+// remote URL for CI clones; the export falls back to repos.name only when
+// identity is unset) to the owner/repo form used by panel-era github_repo,
+// passing through values that are not GitHub remotes.
+func legacyGithubRepo(identity string) string {
 	for _, prefix := range []string{
 		"https://github.com/", "http://github.com/",
 		"git@github.com:", "ssh://git@github.com/",
 	} {
-		if rest, ok := strings.CutPrefix(name, prefix); ok {
+		if rest, ok := strings.CutPrefix(identity, prefix); ok {
 			return strings.TrimSuffix(rest, ".git")
 		}
 	}
-	return name
+	return identity
 }
 
 // legacyHeadSHA extracts the head of a git_ref: the part after ".." (or
@@ -237,24 +237,30 @@ func legacyHeadSHA(gitRef string) string {
 
 // exportCIMetricsLegacy is the review_jobs-backed page builder used by
 // ExportCIMetrics when Legacy is set. The pre-panel CI era enqueued
-// independent reviews of the same range — typically two agents x two review
-// types per PR head ("pseudopanels") — before any CI tagging existed
-// (source='ci' and ci_base_branch both postdate those rows), and the tables
-// that linked them to PRs (ci_pr_batches, then ci_pr_reviews) have no
-// surviving production rows. A pseudopanel is therefore identified
-// structurally: two or more completed review/range jobs sharing
-// (repo, git_ref) with no panel run. Each such group collapses into one
-// wall-clock unit: panel_created_at/first_attempt_at is the group's
-// earliest enqueue, posted_at its latest finish, outcome is always
-// PanelOutcomeLegacyReview, pr_number is 0 (the PR linkage is
-// unrecoverable), and head_sha is the range head. Jobs lists the group's
-// completed jobs tagged role "review"; synthesis_agent/synthesis_model stay
-// nil (pseudopanels had no synthesis). Singleton reviews are excluded: a
-// lone job on a ref is a manual one-off, not a pseudopanel.
+// independent reviews of the same range before any CI tagging existed, and
+// the tables that linked them to PRs have no surviving production rows, so
+// a pseudopanel is identified structurally per the Legacy option doc. Each
+// group collapses into one wall-clock unit: panel_created_at/
+// first_attempt_at is the group's earliest enqueue, posted_at its latest
+// finish (the batch posted only after every member was terminal, so a
+// failed sibling's finish counts), outcome is PanelOutcomeLegacyReview,
+// pr_number is 0 (the PR linkage is unrecoverable), and head_sha is the
+// range head. Jobs lists the group's terminal jobs tagged role "review";
+// synthesis fields stay nil.
 func (db *DB) exportCIMetricsLegacy(opts ExportCIMetricsOptions, cursor *ciMetricsCursor) (ExportCIMetricsPage, error) {
+	eraEnd, err := db.legacyPanelEraEnd()
+	if err != nil {
+		return ExportCIMetricsPage{}, err
+	}
+	if eraEnd == "" {
+		// No panel activity ever: there is no bounded pre-panel era to
+		// export from.
+		return ExportCIMetricsPage{Panels: []ExportCIPanel{}}, nil
+	}
+
 	postedExpr := "MAX(" + legacyUnitTimeExpr("j.finished_at") + ")"
 	having := []string{}
-	args := make([]any, 0)
+	args := []any{eraEnd, eraEnd}
 	if !opts.Since.IsZero() {
 		having = append(having, postedExpr+" >= ?")
 		args = append(args, opts.Since.UTC().Format(time.RFC3339))
@@ -268,12 +274,14 @@ func (db *DB) exportCIMetricsLegacy(opts ExportCIMetricsOptions, cursor *ciMetri
 			"("+postedExpr+" > ? OR ("+postedExpr+" = ? AND MIN(j.id) > ?))")
 		args = append(args, cursor.PostedAt, cursor.PostedAt, cursor.PanelID)
 	}
-	having = append(having, "COUNT(*) >= 2")
+	having = append(having, "COUNT(*) >= 2",
+		"SUM(CASE WHEN j.status = 'done' THEN 1 ELSE 0 END) >= 1")
 	args = append(args, opts.Limit+1)
 
 	query := `
 		WITH ` + legacyUnitWindowCTE + `
-		SELECT MIN(j.id), j.repo_id, r.name, j.git_ref,
+		SELECT MIN(j.id), j.repo_id,
+		       COALESCE(NULLIF(TRIM(r.identity), ''), r.name), j.git_ref,
 		       MIN(` + legacyUnitTimeExpr("j.enqueued_at") + `),
 		       ` + postedExpr + `
 		FROM review_jobs j
@@ -300,20 +308,20 @@ func (db *DB) exportCIMetricsLegacy(opts ExportCIMetricsOptions, cursor *ciMetri
 	truncated := false
 	for rows.Next() {
 		var (
-			u        legacyUnit
-			repoName string
-			gitRef   string
-			first    sql.NullString
-			posted   sql.NullString
+			u            legacyUnit
+			repoIdentity string
+			gitRef       string
+			first        sql.NullString
+			posted       sql.NullString
 		)
-		if err := rows.Scan(&u.unitID, &u.repoID, &repoName, &gitRef, &first, &posted); err != nil {
+		if err := rows.Scan(&u.unitID, &u.repoID, &repoIdentity, &gitRef, &first, &posted); err != nil {
 			return ExportCIMetricsPage{}, fmt.Errorf("scan legacy ci metrics unit: %w", err)
 		}
 		if len(units) == opts.Limit {
 			truncated = true
 			break
 		}
-		u.panel.GithubRepo = legacyGithubRepo(repoName)
+		u.panel.GithubRepo = legacyGithubRepo(repoIdentity)
 		u.panel.HeadSHA = legacyHeadSHA(gitRef)
 		u.panel.Outcome = PanelOutcomeLegacyReview
 		u.panel.PostedAt = posted.String
@@ -322,7 +330,7 @@ func (db *DB) exportCIMetricsLegacy(opts ExportCIMetricsOptions, cursor *ciMetri
 			u.panel.FirstAttemptAt = &v
 			u.panel.PanelCreatedAt = v
 		}
-		u.panel.Jobs, err = db.legacyUnitJobs(u.repoID, gitRef)
+		u.panel.Jobs, err = db.legacyUnitJobs(u.repoID, gitRef, eraEnd)
 		if err != nil {
 			return ExportCIMetricsPage{}, err
 		}
@@ -350,13 +358,49 @@ func (db *DB) exportCIMetricsLegacy(opts ExportCIMetricsOptions, cursor *ciMetri
 	return page, nil
 }
 
-// legacyUnitJobConditions is the shared WHERE fragment selecting jobs that
-// can belong to a legacy pseudopanel unit: completed review/range jobs with
-// no panel run. Pre-panel rows carry no CI tagging, so membership is
-// structural (the unit query additionally requires groups of two or more).
-const legacyUnitJobConditions = `(j.panel_run_uuid IS NULL OR j.panel_run_uuid = '')
-		  AND j.job_type IN ('review', 'range')
-		  AND j.status = 'done' AND j.finished_at IS NOT NULL`
+// legacyPanelEraEnd returns the timestamp of the database's first panel
+// activity (earliest panel-tagged job enqueue or ci_pr_panels row) in
+// normalized RFC 3339 UTC, or "" when there is none. It is the immutable
+// upper bound of the pre-panel era: only jobs enqueued strictly before it
+// can belong to a legacy pseudopanel, so post-panel reviews can never form
+// new legacy units or destabilize legacy cursors. Computed once per export
+// call and passed as a bound parameter.
+func (db *DB) legacyPanelEraEnd() (string, error) {
+	var end sql.NullString
+	err := db.QueryRow(`
+		SELECT MIN(t) FROM (
+			SELECT MIN(strftime('%Y-%m-%dT%H:%M:%SZ', j.enqueued_at)) AS t
+			FROM review_jobs j
+			WHERE j.panel_run_uuid IS NOT NULL AND j.panel_run_uuid != ''
+			UNION ALL
+			SELECT MIN(strftime('%Y-%m-%dT%H:%M:%SZ', cp.created_at))
+			FROM ci_pr_panels cp
+		) WHERE t IS NOT NULL`).Scan(&end)
+	if err != nil {
+		return "", fmt.Errorf("query legacy panel era end: %w", err)
+	}
+	return end.String, nil
+}
+
+// legacyUnitJobConditionsFor builds the shared WHERE fragment selecting jobs
+// that can belong to a legacy pseudopanel unit under the given table alias:
+// terminal (done or failed) review/range jobs with no panel run, enqueued
+// before the pre-panel era end (one bound parameter, see
+// legacyPanelEraEnd). Failed jobs count as members because the batch flow
+// posted whatever output was available; the unit query separately requires
+// at least one done job per group. Pre-panel rows carry no CI tagging, so
+// membership is structural (the unit query additionally requires groups of
+// two or more).
+func legacyUnitJobConditionsFor(alias string) string {
+	return `(` + alias + `.panel_run_uuid IS NULL OR ` + alias + `.panel_run_uuid = '')
+		  AND ` + alias + `.job_type IN ('review', 'range')
+		  AND ` + alias + `.status IN ('done', 'failed') AND ` + alias + `.finished_at IS NOT NULL
+		  AND ` + legacyUnitTimeExpr(alias+".enqueued_at") + ` < ?`
+}
+
+// legacyUnitJobConditions is legacyUnitJobConditionsFor for the default
+// alias "j". Binds one parameter: the pre-panel era end.
+var legacyUnitJobConditions = legacyUnitJobConditionsFor("j")
 
 // legacyUnitWindowCTE bounds a unit to ADJACENT jobs: only jobs enqueued
 // within an hour of the ref's first enqueue belong to the pseudopanel, so a
@@ -364,7 +408,8 @@ const legacyUnitJobConditions = `(j.panel_run_uuid IS NULL OR j.panel_run_uuid =
 // wall clock (observed in production: one ref re-reviewed 12 days later
 // inflated its turnaround to 290 hours). Pseudopanel members enqueue within
 // seconds of each other, so the hour window is generous for real units.
-const legacyUnitWindowCTE = `unit_windows AS MATERIALIZED (
+// Binds one parameter: the pre-panel era end.
+var legacyUnitWindowCTE = `unit_windows AS MATERIALIZED (
 			SELECT j.repo_id, j.git_ref,
 			       strftime('%Y-%m-%dT%H:%M:%SZ',
 			                datetime(MIN(` + legacyUnitTimeExprConst + `), '+1 hour')) AS window_end
@@ -378,23 +423,22 @@ const legacyUnitWindowCTE = `unit_windows AS MATERIALIZED (
 const legacyUnitTimeExprConst = `strftime('%Y-%m-%dT%H:%M:%SZ', j.enqueued_at)`
 
 // legacyUnitWindowEndSubquery computes one (repo, git_ref) unit's adjacency
-// window end (first enqueue + 1 hour) as a scalar subquery over two bound
-// parameters. Per-unit callers use this instead of legacyUnitWindowCTE: the
-// CTE aggregates every unit in the table, which is fine once per page but
-// pathological when repeated for each of the page's units.
-const legacyUnitWindowEndSubquery = `(
+// window end (first enqueue + 1 hour) as a scalar subquery over three bound
+// parameters (repo_id, git_ref, era end). Per-unit callers use this instead
+// of legacyUnitWindowCTE: the CTE aggregates every unit in the table, which
+// is fine once per page but pathological when repeated for each of the
+// page's units.
+var legacyUnitWindowEndSubquery = `(
 		SELECT strftime('%Y-%m-%dT%H:%M:%SZ',
 		                datetime(MIN(strftime('%Y-%m-%dT%H:%M:%SZ', jj.enqueued_at)), '+1 hour'))
 		FROM review_jobs jj
 		WHERE jj.repo_id = ? AND jj.git_ref = ?
-		  AND (jj.panel_run_uuid IS NULL OR jj.panel_run_uuid = '')
-		  AND jj.job_type IN ('review', 'range')
-		  AND jj.status = 'done' AND jj.finished_at IS NOT NULL)`
+		  AND ` + legacyUnitJobConditionsFor("jj") + `)`
 
-// legacyUnitJobs returns the completed jobs of one legacy (repo, git_ref)
-// unit in id order — bounded to the adjacency window like the unit query —
-// shaped as ExportCIPanelJob rows tagged role "review".
-func (db *DB) legacyUnitJobs(repoID int64, gitRef string) ([]ExportCIPanelJob, error) {
+// legacyUnitJobs returns the terminal jobs of one legacy (repo, git_ref)
+// unit in id order — bounded to the adjacency window and pre-panel era like
+// the unit query — shaped as ExportCIPanelJob rows tagged role "review".
+func (db *DB) legacyUnitJobs(repoID int64, gitRef, eraEnd string) ([]ExportCIPanelJob, error) {
 	rows, err := db.Query(`
 		SELECT j.uuid, j.agent, j.model, j.provider, j.status,
 		       `+legacyUnitTimeExpr("j.started_at")+`,
@@ -404,7 +448,7 @@ func (db *DB) legacyUnitJobs(repoID int64, gitRef string) ([]ExportCIPanelJob, e
 		  AND `+legacyUnitJobConditions+`
 		  AND `+legacyUnitTimeExpr("j.enqueued_at")+` <= `+legacyUnitWindowEndSubquery+`
 		ORDER BY j.id ASC`,
-		repoID, gitRef, repoID, gitRef)
+		repoID, gitRef, eraEnd, repoID, gitRef, eraEnd)
 	if err != nil {
 		return nil, fmt.Errorf("query legacy ci unit jobs: %w", err)
 	}
@@ -597,16 +641,21 @@ func (db *DB) resolveCIMetricsCursor(cursor string, legacy bool) (*ciMetricsCurs
 		SELECT COUNT(1) FROM ci_pr_panels cp
 		WHERE cp.id = ? AND cp.posted_at IS NOT NULL
 		  AND ` + sqliteNormalizedTimestampExpr("cp.posted_at") + ` = datetime(?)`
+	existsArgs := []any{decoded.PanelID, decoded.PostedAt}
 	if legacy {
 		// A legacy cursor names a pseudopanel unit by its MIN(j.id) anchor
 		// job and the unit's latest finish; re-derive that unit's group and
-		// check both still hold.
+		// check both still hold. The era end bounds all three membership
+		// fragments; when the database has no panel activity ("" era end),
+		// nothing matches and the cursor is rejected as not found.
+		eraEnd, err := db.legacyPanelEraEnd()
+		if err != nil {
+			return nil, err
+		}
 		existsQuery = `
 			SELECT COUNT(1) FROM review_jobs a
 			WHERE a.id = ?
-			  AND (a.panel_run_uuid IS NULL OR a.panel_run_uuid = '')
-			  AND a.job_type IN ('review', 'range')
-			  AND a.status = 'done' AND a.finished_at IS NOT NULL
+			  AND ` + legacyUnitJobConditionsFor("a") + `
 			  AND (SELECT MAX(` + legacyUnitTimeExpr("j.finished_at") + `)
 			       FROM review_jobs j
 			       WHERE j.repo_id = a.repo_id AND j.git_ref = a.git_ref
@@ -616,12 +665,11 @@ func (db *DB) resolveCIMetricsCursor(cursor string, legacy bool) (*ciMetricsCurs
 			                    datetime(MIN(strftime('%Y-%m-%dT%H:%M:%SZ', jj.enqueued_at)), '+1 hour'))
 			           FROM review_jobs jj
 			           WHERE jj.repo_id = a.repo_id AND jj.git_ref = a.git_ref
-			             AND (jj.panel_run_uuid IS NULL OR jj.panel_run_uuid = '')
-			             AND jj.job_type IN ('review', 'range')
-			             AND jj.status = 'done' AND jj.finished_at IS NOT NULL)) = ?`
+			             AND ` + legacyUnitJobConditionsFor("jj") + `)) = ?`
+		existsArgs = []any{decoded.PanelID, eraEnd, eraEnd, eraEnd, decoded.PostedAt}
 	}
 	var count int
-	if err := db.QueryRow(existsQuery, decoded.PanelID, decoded.PostedAt).Scan(&count); err != nil {
+	if err := db.QueryRow(existsQuery, existsArgs...).Scan(&count); err != nil {
 		return nil, fmt.Errorf("validate ci metrics cursor: %w", err)
 	}
 	if count == 0 {

--- a/internal/storage/export_ci.go
+++ b/internal/storage/export_ci.go
@@ -23,14 +23,15 @@ type ExportCIMetricsOptions struct {
 	Until  time.Time
 	Cursor string
 	Limit  int
-	// Legacy switches the export to the frozen pre-panel ci_pr_reviews era
-	// (~2026-02 to ~2026-06), one row per reviewed PR head, before panels
-	// existed. Legacy turnaround (first_attempt_at -> posted_at) measures
-	// job enqueue time -> ci_pr_reviews record time; it is NOT comparable
-	// to panel-era turnaround (first poller attempt -> panel posted), so
-	// callers must not mix the two eras in one turnaround-time analysis.
-	// Legacy cursors are namespaced and are rejected if replayed with
-	// Legacy unset, and vice versa.
+	// Legacy switches the export to the pre-panel CI era (~2026-02 to
+	// ~2026-06): completed source='ci' review_jobs rows with no panel run,
+	// grouped per (repo, git_ref) into one wall-clock unit ("pseudopanel").
+	// Legacy turnaround (first_attempt_at -> posted_at) measures earliest
+	// job enqueue -> latest job finish and excludes comment-posting
+	// latency, so it slightly undercounts the panel-era PR-perceived
+	// turnaround (first poller attempt -> panel posted). Legacy cursors
+	// are namespaced and are rejected if replayed with Legacy unset, and
+	// vice versa.
 	Legacy bool
 }
 
@@ -200,74 +201,142 @@ func (db *DB) exportCIMetricsPanels(opts ExportCIMetricsOptions, cursor *ciMetri
 	return page, nil
 }
 
-// exportCIMetricsLegacy is the ci_pr_reviews-backed page builder used by
-// ExportCIMetrics when Legacy is set. Each row joins its linked review_jobs
-// row (job_id) and is shaped into the same ExportCIPanel struct: outcome is
-// always PanelOutcomeLegacyReview, attempt_count is always nil (legacy rows
-// predate retry-attempt tracking), and posted_at/first_attempt_at/
-// panel_created_at are derived from cr.created_at and j.enqueued_at rather
-// than from a real panel lifecycle. Jobs always contains exactly the one
-// linked job, tagged role "review".
+// legacyUnitTimeExpr normalizes a review_jobs timestamp column (SQLite
+// CURRENT_TIMESTAMP space format or RFC 3339) to sortable RFC 3339 UTC so
+// MIN/MAX aggregate correctly across mixed formats.
+func legacyUnitTimeExpr(col string) string {
+	return "strftime('%Y-%m-%dT%H:%M:%SZ', " + col + ")"
+}
+
+// legacyGithubRepo maps a repos.name value (CI clones store the remote URL)
+// to the owner/repo form used by panel-era github_repo, passing through
+// values that are not GitHub remotes.
+func legacyGithubRepo(name string) string {
+	for _, prefix := range []string{
+		"https://github.com/", "http://github.com/",
+		"git@github.com:", "ssh://git@github.com/",
+	} {
+		if rest, ok := strings.CutPrefix(name, prefix); ok {
+			return strings.TrimSuffix(rest, ".git")
+		}
+	}
+	return name
+}
+
+// legacyHeadSHA extracts the head of a git_ref: the part after ".." (or
+// "...") for range refs, the ref itself otherwise.
+func legacyHeadSHA(gitRef string) string {
+	if i := strings.LastIndex(gitRef, ".."); i >= 0 {
+		return strings.TrimPrefix(gitRef[i+2:], ".")
+	}
+	return gitRef
+}
+
+// exportCIMetricsLegacy is the review_jobs-backed page builder used by
+// ExportCIMetrics when Legacy is set. The pre-panel CI era enqueued
+// independent reviews of the same range — typically two agents x two review
+// types per PR head ("pseudopanels") — and the tables that linked them to
+// PRs (ci_pr_batches, then ci_pr_reviews) have no surviving production
+// rows. Each export row is therefore one (repo, git_ref) group of completed
+// source='ci' non-panel jobs collapsed into a single wall-clock unit:
+// panel_created_at/first_attempt_at is the group's earliest enqueue,
+// posted_at its latest finish, outcome is always PanelOutcomeLegacyReview,
+// pr_number is 0 (the PR linkage is unrecoverable), and head_sha is the
+// range head. Jobs lists the group's completed jobs tagged role "review";
+// synthesis_agent/synthesis_model stay nil (pseudopanels had no synthesis).
 func (db *DB) exportCIMetricsLegacy(opts ExportCIMetricsOptions, cursor *ciMetricsCursor) (ExportCIMetricsPage, error) {
-	createdExpr := sqliteNormalizedTimestampExpr("cr.created_at")
-	conditions := []string{"cr.created_at IS NOT NULL"}
+	postedExpr := "MAX(" + legacyUnitTimeExpr("j.finished_at") + ")"
+	having := []string{}
 	args := make([]any, 0)
 	if !opts.Since.IsZero() {
-		conditions = append(conditions, createdExpr+" >= datetime(?)")
+		having = append(having, postedExpr+" >= ?")
 		args = append(args, opts.Since.UTC().Format(time.RFC3339))
 	}
 	if !opts.Until.IsZero() {
-		conditions = append(conditions, createdExpr+" < datetime(?)")
+		having = append(having, postedExpr+" < ?")
 		args = append(args, opts.Until.UTC().Format(time.RFC3339))
 	}
 	if cursor != nil {
-		conditions = append(conditions,
-			"("+createdExpr+" > datetime(?) OR ("+createdExpr+" = datetime(?) AND cr.id > ?))")
+		having = append(having,
+			"("+postedExpr+" > ? OR ("+postedExpr+" = ? AND MIN(j.id) > ?))")
 		args = append(args, cursor.PostedAt, cursor.PostedAt, cursor.PanelID)
+	}
+	havingClause := ""
+	if len(having) > 0 {
+		havingClause = "HAVING " + strings.Join(having, " AND ")
 	}
 	args = append(args, opts.Limit+1)
 
 	query := `
-		SELECT cr.id, cr.github_repo, cr.pr_number, cr.head_sha, cr.created_at,
-		       j.uuid, j.enqueued_at, j.agent, j.model, j.provider, j.status,
-		       j.started_at, j.finished_at
-		FROM ci_pr_reviews cr
-		JOIN review_jobs j ON j.id = cr.job_id
-		WHERE ` + strings.Join(conditions, " AND ") + `
-		ORDER BY ` + createdExpr + ` ASC, cr.id ASC
+		SELECT MIN(j.id), j.repo_id, r.name, j.git_ref,
+		       MIN(` + legacyUnitTimeExpr("j.enqueued_at") + `),
+		       ` + postedExpr + `
+		FROM review_jobs j
+		JOIN repos r ON r.id = j.repo_id
+		WHERE j.source = ? AND (j.panel_run_uuid IS NULL OR j.panel_run_uuid = '')
+		  AND j.status = ? AND j.finished_at IS NOT NULL
+		GROUP BY j.repo_id, j.git_ref
+		` + havingClause + `
+		ORDER BY 6 ASC, 1 ASC
 		LIMIT ?`
-	rows, err := db.Query(query, args...)
+	rows, err := db.Query(query, append([]any{JobSourceCI, string(JobStatusDone)}, args...)...)
 	if err != nil {
 		return ExportCIMetricsPage{}, fmt.Errorf("query legacy ci metrics export: %w", err)
 	}
 	defer rows.Close()
 
-	page := ExportCIMetricsPage{Panels: []ExportCIPanel{}}
-	var lastID int64
-	var lastPosted string
+	type legacyUnit struct {
+		unitID int64
+		repoID int64
+		panel  ExportCIPanel
+	}
+	units := []legacyUnit{}
+	truncated := false
 	for rows.Next() {
-		id, panel, err := scanLegacyCIMetricsRow(rows)
+		var (
+			u        legacyUnit
+			repoName string
+			gitRef   string
+			first    sql.NullString
+			posted   sql.NullString
+		)
+		if err := rows.Scan(&u.unitID, &u.repoID, &repoName, &gitRef, &first, &posted); err != nil {
+			return ExportCIMetricsPage{}, fmt.Errorf("scan legacy ci metrics unit: %w", err)
+		}
+		if len(units) == opts.Limit {
+			truncated = true
+			break
+		}
+		u.panel.GithubRepo = legacyGithubRepo(repoName)
+		u.panel.HeadSHA = legacyHeadSHA(gitRef)
+		u.panel.Outcome = PanelOutcomeLegacyReview
+		u.panel.PostedAt = posted.String
+		if first.Valid {
+			v := first.String
+			u.panel.FirstAttemptAt = &v
+			u.panel.PanelCreatedAt = v
+		}
+		u.panel.Jobs, err = db.legacyUnitJobs(u.repoID, gitRef)
 		if err != nil {
 			return ExportCIMetricsPage{}, err
 		}
-		if len(page.Panels) == opts.Limit {
-			page.Truncated = true
-			break
-		}
-		page.Panels = append(page.Panels, panel)
-		lastID = id
-		lastPosted = panel.PostedAt
+		units = append(units, u)
 	}
 	if err := rows.Err(); err != nil {
 		return ExportCIMetricsPage{}, err
 	}
 
-	if len(page.Panels) > 0 {
+	page := ExportCIMetricsPage{Panels: make([]ExportCIPanel, 0, len(units)), Truncated: truncated}
+	for _, u := range units {
+		page.Panels = append(page.Panels, u.panel)
+	}
+	if len(units) > 0 {
 		databaseID, err := db.GetDatabaseID()
 		if err != nil {
 			return ExportCIMetricsPage{}, err
 		}
-		next := encodeCIMetricsCursor(databaseID, lastPosted, lastID, true)
+		last := units[len(units)-1]
+		next := encodeCIMetricsCursor(databaseID, last.panel.PostedAt, last.unitID, true)
 		if next != "" {
 			page.NextCursor = &next
 		}
@@ -275,60 +344,57 @@ func (db *DB) exportCIMetricsLegacy(opts ExportCIMetricsOptions, cursor *ciMetri
 	return page, nil
 }
 
-// scanLegacyCIMetricsRow scans one ci_pr_reviews-joined-review_jobs export
-// row into an ExportCIPanel, mirroring scanCIMetricsRow's null-handling for
-// the panel-era query.
-func scanLegacyCIMetricsRow(rows *sql.Rows) (int64, ExportCIPanel, error) {
-	var (
-		id         int64
-		panel      ExportCIPanel
-		createdAt  sql.NullString
-		jobUUID    string
-		enqueuedAt sql.NullString
-		agent      string
-		model      sql.NullString
-		provider   sql.NullString
-		status     string
-		startedAt  sql.NullString
-		finishedAt sql.NullString
-	)
-	if err := rows.Scan(&id, &panel.GithubRepo, &panel.PRNumber, &panel.HeadSHA, &createdAt,
-		&jobUUID, &enqueuedAt, &agent, &model, &provider, &status, &startedAt, &finishedAt); err != nil {
-		return 0, ExportCIPanel{}, fmt.Errorf("scan legacy ci metrics row: %w", err)
+// legacyUnitJobs returns the completed source='ci' non-panel jobs of one
+// legacy (repo, git_ref) unit in id order, shaped as ExportCIPanelJob rows
+// tagged role "review".
+func (db *DB) legacyUnitJobs(repoID int64, gitRef string) ([]ExportCIPanelJob, error) {
+	rows, err := db.Query(`
+		SELECT j.uuid, j.agent, j.model, j.provider, j.status,
+		       `+legacyUnitTimeExpr("j.started_at")+`,
+		       `+legacyUnitTimeExpr("j.finished_at")+`
+		FROM review_jobs j
+		WHERE j.repo_id = ? AND j.git_ref = ?
+		  AND j.source = ? AND (j.panel_run_uuid IS NULL OR j.panel_run_uuid = '')
+		  AND j.status = ? AND j.finished_at IS NOT NULL
+		ORDER BY j.id ASC`,
+		repoID, gitRef, JobSourceCI, string(JobStatusDone))
+	if err != nil {
+		return nil, fmt.Errorf("query legacy ci unit jobs: %w", err)
 	}
-	panel.Outcome = PanelOutcomeLegacyReview
-	if createdAt.Valid {
-		panel.PostedAt = formatExportTime(parseSQLiteTime(createdAt.String))
-	}
-	if enqueuedAt.Valid {
-		v := formatExportTime(parseSQLiteTime(enqueuedAt.String))
-		panel.FirstAttemptAt = &v
-		panel.PanelCreatedAt = v
-	}
-	if agent != "" {
-		panel.SynthesisAgent = &agent
-	}
-	if model.Valid && model.String != "" {
-		panel.SynthesisModel = &model.String
-	}
+	defer rows.Close()
 
-	job := ExportCIPanelJob{JobUUID: jobUUID, Role: "review", Agent: agent, Status: status}
-	if model.Valid && model.String != "" {
-		job.Model = &model.String
+	jobs := []ExportCIPanelJob{}
+	for rows.Next() {
+		var (
+			job        ExportCIPanelJob
+			model      sql.NullString
+			provider   sql.NullString
+			startedAt  sql.NullString
+			finishedAt sql.NullString
+		)
+		if err := rows.Scan(&job.JobUUID, &job.Agent, &model, &provider, &job.Status,
+			&startedAt, &finishedAt); err != nil {
+			return nil, fmt.Errorf("scan legacy ci unit job: %w", err)
+		}
+		job.Role = "review"
+		if model.Valid && model.String != "" {
+			job.Model = &model.String
+		}
+		if provider.Valid && provider.String != "" {
+			job.Provider = &provider.String
+		}
+		if startedAt.Valid {
+			job.StartedAt = &startedAt.String
+		}
+		if finishedAt.Valid {
+			job.FinishedAt = &finishedAt.String
+		}
+		jobs = append(jobs, job)
 	}
-	if provider.Valid && provider.String != "" {
-		job.Provider = &provider.String
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
-	if startedAt.Valid {
-		v := formatExportTime(parseSQLiteTime(startedAt.String))
-		job.StartedAt = &v
-	}
-	if finishedAt.Valid {
-		v := formatExportTime(parseSQLiteTime(finishedAt.String))
-		job.FinishedAt = &v
-	}
-	panel.Jobs = []ExportCIPanelJob{job}
-	return id, panel, nil
+	return jobs, nil
 }
 
 // scanCIMetricsRow scans one ci_pr_panels export row and maps its nullable
@@ -485,10 +551,20 @@ func (db *DB) resolveCIMetricsCursor(cursor string, legacy bool) (*ciMetricsCurs
 		WHERE cp.id = ? AND cp.posted_at IS NOT NULL
 		  AND ` + sqliteNormalizedTimestampExpr("cp.posted_at") + ` = datetime(?)`
 	if legacy {
+		// A legacy cursor names a pseudopanel unit by its MIN(j.id) anchor
+		// job and the unit's latest finish; re-derive that unit's group and
+		// check both still hold.
 		existsQuery = `
-			SELECT COUNT(1) FROM ci_pr_reviews cr
-			WHERE cr.id = ? AND cr.created_at IS NOT NULL
-			  AND ` + sqliteNormalizedTimestampExpr("cr.created_at") + ` = datetime(?)`
+			SELECT COUNT(1) FROM review_jobs a
+			WHERE a.id = ? AND a.source = '` + JobSourceCI + `'
+			  AND (a.panel_run_uuid IS NULL OR a.panel_run_uuid = '')
+			  AND a.status = 'done' AND a.finished_at IS NOT NULL
+			  AND (SELECT MAX(` + legacyUnitTimeExpr("j.finished_at") + `)
+			       FROM review_jobs j
+			       WHERE j.repo_id = a.repo_id AND j.git_ref = a.git_ref
+			         AND j.source = '` + JobSourceCI + `'
+			         AND (j.panel_run_uuid IS NULL OR j.panel_run_uuid = '')
+			         AND j.status = 'done' AND j.finished_at IS NOT NULL) = ?`
 	}
 	var count int
 	if err := db.QueryRow(existsQuery, decoded.PanelID, decoded.PostedAt).Scan(&count); err != nil {

--- a/internal/storage/export_ci.go
+++ b/internal/storage/export_ci.go
@@ -129,44 +129,13 @@ func (db *DB) ExportCIMetrics(opts ExportCIMetricsOptions) (ExportCIMetricsPage,
 	}
 	var pending []pendingPanel
 	for rows.Next() {
-		var (
-			id             int64
-			panel          ExportCIPanel
-			createdAt      sql.NullString
-			postedAt       sql.NullString
-			firstAttemptAt sql.NullString
-			attemptCount   sql.NullInt64
-			runUUID        string
-			synthAgent     sql.NullString
-			synthModel     sql.NullString
-		)
-		if err := rows.Scan(&id, &panel.GithubRepo, &panel.PRNumber, &panel.HeadSHA,
-			&createdAt, &postedAt, &firstAttemptAt, &attemptCount, &panel.Outcome,
-			&runUUID, &synthAgent, &synthModel); err != nil {
-			return ExportCIMetricsPage{}, fmt.Errorf("scan ci metrics row: %w", err)
+		id, panel, runUUID, err := scanCIMetricsRow(rows)
+		if err != nil {
+			return ExportCIMetricsPage{}, err
 		}
 		if len(pending) == opts.Limit {
 			page.Truncated = true
 			break
-		}
-		if createdAt.Valid {
-			panel.PanelCreatedAt = formatExportTime(parseSQLiteTime(createdAt.String))
-		}
-		if postedAt.Valid {
-			panel.PostedAt = formatExportTime(parseSQLiteTime(postedAt.String))
-		}
-		if firstAttemptAt.Valid {
-			v := formatExportTime(parseSQLiteTime(firstAttemptAt.String))
-			panel.FirstAttemptAt = &v
-		}
-		if attemptCount.Valid {
-			panel.AttemptCount = &attemptCount.Int64
-		}
-		if synthAgent.Valid && synthAgent.String != "" {
-			panel.SynthesisAgent = &synthAgent.String
-		}
-		if synthModel.Valid && synthModel.String != "" {
-			panel.SynthesisModel = &synthModel.String
 		}
 		pending = append(pending, pendingPanel{panel: panel, runUUID: runUUID})
 		lastID = id
@@ -196,6 +165,49 @@ func (db *DB) ExportCIMetrics(opts ExportCIMetricsOptions) (ExportCIMetricsPage,
 		}
 	}
 	return page, nil
+}
+
+// scanCIMetricsRow scans one ci_pr_panels export row and maps its nullable
+// SQL columns onto an ExportCIPanel. It returns the panel's database id and
+// panel_run_uuid alongside the populated panel so the caller can page and
+// join review_jobs without re-touching sql.Null* locals.
+func scanCIMetricsRow(rows *sql.Rows) (int64, ExportCIPanel, string, error) {
+	var (
+		id             int64
+		panel          ExportCIPanel
+		createdAt      sql.NullString
+		postedAt       sql.NullString
+		firstAttemptAt sql.NullString
+		attemptCount   sql.NullInt64
+		runUUID        string
+		synthAgent     sql.NullString
+		synthModel     sql.NullString
+	)
+	if err := rows.Scan(&id, &panel.GithubRepo, &panel.PRNumber, &panel.HeadSHA,
+		&createdAt, &postedAt, &firstAttemptAt, &attemptCount, &panel.Outcome,
+		&runUUID, &synthAgent, &synthModel); err != nil {
+		return 0, ExportCIPanel{}, "", fmt.Errorf("scan ci metrics row: %w", err)
+	}
+	if createdAt.Valid {
+		panel.PanelCreatedAt = formatExportTime(parseSQLiteTime(createdAt.String))
+	}
+	if postedAt.Valid {
+		panel.PostedAt = formatExportTime(parseSQLiteTime(postedAt.String))
+	}
+	if firstAttemptAt.Valid {
+		v := formatExportTime(parseSQLiteTime(firstAttemptAt.String))
+		panel.FirstAttemptAt = &v
+	}
+	if attemptCount.Valid {
+		panel.AttemptCount = &attemptCount.Int64
+	}
+	if synthAgent.Valid && synthAgent.String != "" {
+		panel.SynthesisAgent = &synthAgent.String
+	}
+	if synthModel.Valid && synthModel.String != "" {
+		panel.SynthesisModel = &synthModel.String
+	}
+	return id, panel, runUUID, nil
 }
 
 func (db *DB) exportCIPanelJobs(panelRunUUID string) ([]ExportCIPanelJob, error) {

--- a/internal/storage/export_ci.go
+++ b/internal/storage/export_ci.go
@@ -24,16 +24,17 @@ type ExportCIMetricsOptions struct {
 	Cursor string
 	Limit  int
 	// Legacy switches the export to the frozen pre-panel CI era: terminal
-	// (done or failed) review/range jobs with no panel run, enqueued
-	// before the database's first panel activity, grouped per
+	// (done, failed, or canceled) review/range jobs with no panel run,
+	// enqueued before the database's first panel activity, grouped per
 	// (repo, git_ref) into one wall-clock unit ("pseudopanel") when two or
 	// more terminal jobs share the ref and at least one succeeded (the
-	// batch flow posted whatever output was available). Singleton reviews
-	// are excluded as manual one-offs; a database with no panel activity
-	// exports no legacy rows. Legacy turnaround (earliest enqueue ->
-	// latest finish) excludes comment-posting latency, unlike panel-era
-	// turnaround. Legacy cursors are namespaced and rejected if replayed
-	// with Legacy unset, and vice versa.
+	// batch flow posted whatever output was available once every member
+	// reached a terminal state). Singleton reviews are excluded as manual
+	// one-offs; a database with no panel activity exports no legacy rows.
+	// Legacy turnaround (earliest enqueue -> latest finish) excludes
+	// comment-posting latency, unlike panel-era turnaround. Legacy cursors
+	// are namespaced and rejected if replayed with Legacy unset, and vice
+	// versa.
 	Legacy bool
 }
 
@@ -243,7 +244,7 @@ func legacyHeadSHA(gitRef string) string {
 // group collapses into one wall-clock unit: panel_created_at/
 // first_attempt_at is the group's earliest enqueue, posted_at its latest
 // finish (the batch posted only after every member was terminal, so a
-// failed sibling's finish counts), outcome is PanelOutcomeLegacyReview,
+// failed or canceled sibling's finish counts), outcome is PanelOutcomeLegacyReview,
 // pr_number is 0 (the PR linkage is unrecoverable), and head_sha is the
 // range head. Jobs lists the group's terminal jobs tagged role "review";
 // synthesis fields stay nil.
@@ -384,17 +385,21 @@ func (db *DB) legacyPanelEraEnd() (string, error) {
 
 // legacyUnitJobConditionsFor builds the shared WHERE fragment selecting jobs
 // that can belong to a legacy pseudopanel unit under the given table alias:
-// terminal (done or failed) review/range jobs with no panel run, enqueued
-// before the pre-panel era end (one bound parameter, see
-// legacyPanelEraEnd). Failed jobs count as members because the batch flow
-// posted whatever output was available; the unit query separately requires
-// at least one done job per group. Pre-panel rows carry no CI tagging, so
-// membership is structural (the unit query additionally requires groups of
-// two or more).
+// terminal (done, failed, or canceled) review/range jobs with no panel run,
+// enqueued before the pre-panel era end (one bound parameter, see
+// legacyPanelEraEnd). Failed and canceled jobs count as members because the
+// batch flow treated both as terminal and then posted whatever output was
+// available; the unit query separately requires at least one done job per
+// group. The finished_at guard is what keeps the panel migration's own
+// cleanup out: it canceled leftover in-flight batch jobs without stamping
+// finished_at, and those batches never posted. Pre-panel rows carry no CI
+// tagging, so membership is structural (the unit query additionally requires
+// groups of two or more).
 func legacyUnitJobConditionsFor(alias string) string {
 	return `(` + alias + `.panel_run_uuid IS NULL OR ` + alias + `.panel_run_uuid = '')
 		  AND ` + alias + `.job_type IN ('review', 'range')
-		  AND ` + alias + `.status IN ('done', 'failed') AND ` + alias + `.finished_at IS NOT NULL
+		  AND ` + alias + `.status IN ('done', 'failed', 'canceled')
+		  AND ` + alias + `.finished_at IS NOT NULL
 		  AND ` + legacyUnitTimeExpr(alias+".enqueued_at") + ` < ?`
 }
 

--- a/internal/storage/export_ci.go
+++ b/internal/storage/export_ci.go
@@ -23,6 +23,15 @@ type ExportCIMetricsOptions struct {
 	Until  time.Time
 	Cursor string
 	Limit  int
+	// Legacy switches the export to the frozen pre-panel ci_pr_reviews era
+	// (~2026-02 to ~2026-06), one row per reviewed PR head, before panels
+	// existed. Legacy turnaround (first_attempt_at -> posted_at) measures
+	// job enqueue time -> ci_pr_reviews record time; it is NOT comparable
+	// to panel-era turnaround (first poller attempt -> panel posted), so
+	// callers must not mix the two eras in one turnaround-time analysis.
+	// Legacy cursors are namespaced and are rejected if replayed with
+	// Legacy unset, and vice versa.
+	Legacy bool
 }
 
 // ExportCIMetricsPage is one bounded page of finalized CI panel records.
@@ -72,10 +81,20 @@ type ciMetricsCursor struct {
 	DatabaseID string `json:"database_id"`
 	PostedAt   string `json:"posted_at"`
 	PanelID    int64  `json:"panel_id"`
+	// Legacy namespaces the cursor to ExportCIMetricsOptions.Legacy so a
+	// panel-era cursor can never be replayed against the legacy export (or
+	// vice versa): the two eras page over different tables and ids, and
+	// silently mixing them would skip or repeat rows.
+	Legacy bool `json:"legacy,omitempty"`
 }
 
-// ExportCIMetrics returns one bounded page of finalized CI panel records
-// ordered by (posted_at, id) ascending, with the same opaque-cursor and
+// ErrExportCIMetricsCursorModeMismatch is returned when a cursor minted for
+// one ExportCIMetrics mode (legacy vs. panel) is replayed against the other.
+var ErrExportCIMetricsCursorModeMismatch = errors.New("ci metrics cursor mode mismatch")
+
+// ExportCIMetrics returns one bounded page of finalized CI panel records (or,
+// with Legacy set, frozen pre-panel ci_pr_reviews records) ordered by
+// (posted_at, id) ascending, with the same opaque-cursor and
 // database_id-reset contract as ExportReviews.
 func (db *DB) ExportCIMetrics(opts ExportCIMetricsOptions) (ExportCIMetricsPage, error) {
 	switch {
@@ -85,11 +104,19 @@ func (db *DB) ExportCIMetrics(opts ExportCIMetricsOptions) (ExportCIMetricsPage,
 		opts.Limit = ciMetricsMaxPageLimit
 	}
 
-	cursor, err := db.resolveCIMetricsCursor(opts.Cursor)
+	cursor, err := db.resolveCIMetricsCursor(opts.Cursor, opts.Legacy)
 	if err != nil {
 		return ExportCIMetricsPage{}, err
 	}
+	if opts.Legacy {
+		return db.exportCIMetricsLegacy(opts, cursor)
+	}
+	return db.exportCIMetricsPanels(opts, cursor)
+}
 
+// exportCIMetricsPanels is the ci_pr_panels-backed page builder used by
+// ExportCIMetrics when Legacy is unset.
+func (db *DB) exportCIMetricsPanels(opts ExportCIMetricsOptions, cursor *ciMetricsCursor) (ExportCIMetricsPage, error) {
 	postedExpr := sqliteNormalizedTimestampExpr("cp.posted_at")
 	conditions := []string{"cp.posted_at IS NOT NULL"}
 	args := make([]any, 0)
@@ -165,12 +192,143 @@ func (db *DB) ExportCIMetrics(opts ExportCIMetricsOptions) (ExportCIMetricsPage,
 		if err != nil {
 			return ExportCIMetricsPage{}, err
 		}
-		next := encodeCIMetricsCursor(databaseID, lastPosted, lastID)
+		next := encodeCIMetricsCursor(databaseID, lastPosted, lastID, false)
 		if next != "" {
 			page.NextCursor = &next
 		}
 	}
 	return page, nil
+}
+
+// exportCIMetricsLegacy is the ci_pr_reviews-backed page builder used by
+// ExportCIMetrics when Legacy is set. Each row joins its linked review_jobs
+// row (job_id) and is shaped into the same ExportCIPanel struct: outcome is
+// always PanelOutcomeLegacyReview, attempt_count is always nil (legacy rows
+// predate retry-attempt tracking), and posted_at/first_attempt_at/
+// panel_created_at are derived from cr.created_at and j.enqueued_at rather
+// than from a real panel lifecycle. Jobs always contains exactly the one
+// linked job, tagged role "review".
+func (db *DB) exportCIMetricsLegacy(opts ExportCIMetricsOptions, cursor *ciMetricsCursor) (ExportCIMetricsPage, error) {
+	createdExpr := sqliteNormalizedTimestampExpr("cr.created_at")
+	conditions := []string{"cr.created_at IS NOT NULL"}
+	args := make([]any, 0)
+	if !opts.Since.IsZero() {
+		conditions = append(conditions, createdExpr+" >= datetime(?)")
+		args = append(args, opts.Since.UTC().Format(time.RFC3339))
+	}
+	if !opts.Until.IsZero() {
+		conditions = append(conditions, createdExpr+" < datetime(?)")
+		args = append(args, opts.Until.UTC().Format(time.RFC3339))
+	}
+	if cursor != nil {
+		conditions = append(conditions,
+			"("+createdExpr+" > datetime(?) OR ("+createdExpr+" = datetime(?) AND cr.id > ?))")
+		args = append(args, cursor.PostedAt, cursor.PostedAt, cursor.PanelID)
+	}
+	args = append(args, opts.Limit+1)
+
+	query := `
+		SELECT cr.id, cr.github_repo, cr.pr_number, cr.head_sha, cr.created_at,
+		       j.uuid, j.enqueued_at, j.agent, j.model, j.provider, j.status,
+		       j.started_at, j.finished_at
+		FROM ci_pr_reviews cr
+		JOIN review_jobs j ON j.id = cr.job_id
+		WHERE ` + strings.Join(conditions, " AND ") + `
+		ORDER BY ` + createdExpr + ` ASC, cr.id ASC
+		LIMIT ?`
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return ExportCIMetricsPage{}, fmt.Errorf("query legacy ci metrics export: %w", err)
+	}
+	defer rows.Close()
+
+	page := ExportCIMetricsPage{Panels: []ExportCIPanel{}}
+	var lastID int64
+	var lastPosted string
+	for rows.Next() {
+		id, panel, err := scanLegacyCIMetricsRow(rows)
+		if err != nil {
+			return ExportCIMetricsPage{}, err
+		}
+		if len(page.Panels) == opts.Limit {
+			page.Truncated = true
+			break
+		}
+		page.Panels = append(page.Panels, panel)
+		lastID = id
+		lastPosted = panel.PostedAt
+	}
+	if err := rows.Err(); err != nil {
+		return ExportCIMetricsPage{}, err
+	}
+
+	if len(page.Panels) > 0 {
+		databaseID, err := db.GetDatabaseID()
+		if err != nil {
+			return ExportCIMetricsPage{}, err
+		}
+		next := encodeCIMetricsCursor(databaseID, lastPosted, lastID, true)
+		if next != "" {
+			page.NextCursor = &next
+		}
+	}
+	return page, nil
+}
+
+// scanLegacyCIMetricsRow scans one ci_pr_reviews-joined-review_jobs export
+// row into an ExportCIPanel, mirroring scanCIMetricsRow's null-handling for
+// the panel-era query.
+func scanLegacyCIMetricsRow(rows *sql.Rows) (int64, ExportCIPanel, error) {
+	var (
+		id         int64
+		panel      ExportCIPanel
+		createdAt  sql.NullString
+		jobUUID    string
+		enqueuedAt sql.NullString
+		agent      string
+		model      sql.NullString
+		provider   sql.NullString
+		status     string
+		startedAt  sql.NullString
+		finishedAt sql.NullString
+	)
+	if err := rows.Scan(&id, &panel.GithubRepo, &panel.PRNumber, &panel.HeadSHA, &createdAt,
+		&jobUUID, &enqueuedAt, &agent, &model, &provider, &status, &startedAt, &finishedAt); err != nil {
+		return 0, ExportCIPanel{}, fmt.Errorf("scan legacy ci metrics row: %w", err)
+	}
+	panel.Outcome = PanelOutcomeLegacyReview
+	if createdAt.Valid {
+		panel.PostedAt = formatExportTime(parseSQLiteTime(createdAt.String))
+	}
+	if enqueuedAt.Valid {
+		v := formatExportTime(parseSQLiteTime(enqueuedAt.String))
+		panel.FirstAttemptAt = &v
+		panel.PanelCreatedAt = v
+	}
+	if agent != "" {
+		panel.SynthesisAgent = &agent
+	}
+	if model.Valid && model.String != "" {
+		panel.SynthesisModel = &model.String
+	}
+
+	job := ExportCIPanelJob{JobUUID: jobUUID, Role: "review", Agent: agent, Status: status}
+	if model.Valid && model.String != "" {
+		job.Model = &model.String
+	}
+	if provider.Valid && provider.String != "" {
+		job.Provider = &provider.String
+	}
+	if startedAt.Valid {
+		v := formatExportTime(parseSQLiteTime(startedAt.String))
+		job.StartedAt = &v
+	}
+	if finishedAt.Valid {
+		v := formatExportTime(parseSQLiteTime(finishedAt.String))
+		job.FinishedAt = &v
+	}
+	panel.Jobs = []ExportCIPanelJob{job}
+	return id, panel, nil
 }
 
 // scanCIMetricsRow scans one ci_pr_panels export row and maps its nullable
@@ -261,7 +419,7 @@ func (db *DB) exportCIPanelJobs(panelRunUUID string) ([]ExportCIPanelJob, error)
 	return jobs, rows.Err()
 }
 
-func encodeCIMetricsCursor(databaseID, postedAt string, panelID int64) string {
+func encodeCIMetricsCursor(databaseID, postedAt string, panelID int64, legacy bool) string {
 	if databaseID == "" || postedAt == "" || panelID <= 0 {
 		return ""
 	}
@@ -270,6 +428,7 @@ func encodeCIMetricsCursor(databaseID, postedAt string, panelID int64) string {
 		DatabaseID: databaseID,
 		PostedAt:   postedAt,
 		PanelID:    panelID,
+		Legacy:     legacy,
 	})
 	if err != nil {
 		log.Printf("storage: warning: encode ci metrics cursor: %v", err)
@@ -278,7 +437,12 @@ func encodeCIMetricsCursor(databaseID, postedAt string, panelID int64) string {
 	return base64.RawURLEncoding.EncodeToString(data)
 }
 
-func (db *DB) resolveCIMetricsCursor(cursor string) (*ciMetricsCursor, error) {
+// resolveCIMetricsCursor decodes and validates an opaque cursor for the
+// requested export mode. legacy must match the mode the cursor was minted
+// for (ciMetricsCursor.Legacy); a mismatch is rejected with
+// ErrExportCIMetricsCursorModeMismatch since the two modes page over
+// different tables and ids.
+func (db *DB) resolveCIMetricsCursor(cursor string, legacy bool) (*ciMetricsCursor, error) {
 	if cursor == "" {
 		return nil, nil
 	}
@@ -296,6 +460,10 @@ func (db *DB) resolveCIMetricsCursor(cursor string) (*ciMetricsCursor, error) {
 	if decoded.DatabaseID == "" || decoded.PostedAt == "" || decoded.PanelID <= 0 {
 		return nil, errors.New("invalid ci metrics cursor: missing fields")
 	}
+	if decoded.Legacy != legacy {
+		return nil, fmt.Errorf("%w: cursor legacy=%v does not match requested legacy=%v",
+			ErrExportCIMetricsCursorModeMismatch, decoded.Legacy, legacy)
+	}
 	t, err := time.Parse(time.RFC3339Nano, decoded.PostedAt)
 	if err != nil {
 		return nil, fmt.Errorf("invalid ci metrics cursor timestamp: %w", err)
@@ -312,13 +480,18 @@ func (db *DB) resolveCIMetricsCursor(cursor string) (*ciMetricsCursor, error) {
 			ErrExportCursorDatabaseMismatch, decoded.DatabaseID, databaseID,
 		)
 	}
-	var count int
-	err = db.QueryRow(`
+	existsQuery := `
 		SELECT COUNT(1) FROM ci_pr_panels cp
 		WHERE cp.id = ? AND cp.posted_at IS NOT NULL
-		  AND `+sqliteNormalizedTimestampExpr("cp.posted_at")+` = datetime(?)`,
-		decoded.PanelID, decoded.PostedAt).Scan(&count)
-	if err != nil {
+		  AND ` + sqliteNormalizedTimestampExpr("cp.posted_at") + ` = datetime(?)`
+	if legacy {
+		existsQuery = `
+			SELECT COUNT(1) FROM ci_pr_reviews cr
+			WHERE cr.id = ? AND cr.created_at IS NOT NULL
+			  AND ` + sqliteNormalizedTimestampExpr("cr.created_at") + ` = datetime(?)`
+	}
+	var count int
+	if err := db.QueryRow(existsQuery, decoded.PanelID, decoded.PostedAt).Scan(&count); err != nil {
 		return nil, fmt.Errorf("validate ci metrics cursor: %w", err)
 	}
 	if count == 0 {

--- a/internal/storage/export_ci.go
+++ b/internal/storage/export_ci.go
@@ -272,12 +272,15 @@ func (db *DB) exportCIMetricsLegacy(opts ExportCIMetricsOptions, cursor *ciMetri
 	args = append(args, opts.Limit+1)
 
 	query := `
+		WITH ` + legacyUnitWindowCTE + `
 		SELECT MIN(j.id), j.repo_id, r.name, j.git_ref,
 		       MIN(` + legacyUnitTimeExpr("j.enqueued_at") + `),
 		       ` + postedExpr + `
 		FROM review_jobs j
 		JOIN repos r ON r.id = j.repo_id
+		JOIN unit_windows w ON w.repo_id = j.repo_id AND w.git_ref = j.git_ref
 		WHERE ` + legacyUnitJobConditions + `
+		  AND ` + legacyUnitTimeExpr("j.enqueued_at") + ` <= w.window_end
 		GROUP BY j.repo_id, j.git_ref
 		HAVING ` + strings.Join(having, " AND ") + `
 		ORDER BY 6 ASC, 1 ASC
@@ -355,16 +358,39 @@ const legacyUnitJobConditions = `(j.panel_run_uuid IS NULL OR j.panel_run_uuid =
 		  AND j.job_type IN ('review', 'range')
 		  AND j.status = 'done' AND j.finished_at IS NOT NULL`
 
+// legacyUnitWindowCTE bounds a unit to ADJACENT jobs: only jobs enqueued
+// within an hour of the ref's first enqueue belong to the pseudopanel, so a
+// manual re-review of the same ref days later cannot stretch the unit's
+// wall clock (observed in production: one ref re-reviewed 12 days later
+// inflated its turnaround to 290 hours). Pseudopanel members enqueue within
+// seconds of each other, so the hour window is generous for real units.
+const legacyUnitWindowCTE = `unit_windows AS (
+			SELECT j.repo_id, j.git_ref,
+			       strftime('%Y-%m-%dT%H:%M:%SZ',
+			                datetime(MIN(` + legacyUnitTimeExprConst + `), '+1 hour')) AS window_end
+			FROM review_jobs j
+			WHERE ` + legacyUnitJobConditions + `
+			GROUP BY j.repo_id, j.git_ref
+		)`
+
+// legacyUnitTimeExprConst mirrors legacyUnitTimeExpr("j.enqueued_at") for
+// use inside const SQL fragments.
+const legacyUnitTimeExprConst = `strftime('%Y-%m-%dT%H:%M:%SZ', j.enqueued_at)`
+
 // legacyUnitJobs returns the completed jobs of one legacy (repo, git_ref)
-// unit in id order, shaped as ExportCIPanelJob rows tagged role "review".
+// unit in id order — bounded to the adjacency window like the unit query —
+// shaped as ExportCIPanelJob rows tagged role "review".
 func (db *DB) legacyUnitJobs(repoID int64, gitRef string) ([]ExportCIPanelJob, error) {
 	rows, err := db.Query(`
+		WITH `+legacyUnitWindowCTE+`
 		SELECT j.uuid, j.agent, j.model, j.provider, j.status,
 		       `+legacyUnitTimeExpr("j.started_at")+`,
 		       `+legacyUnitTimeExpr("j.finished_at")+`
 		FROM review_jobs j
+		JOIN unit_windows w ON w.repo_id = j.repo_id AND w.git_ref = j.git_ref
 		WHERE j.repo_id = ? AND j.git_ref = ?
 		  AND `+legacyUnitJobConditions+`
+		  AND `+legacyUnitTimeExpr("j.enqueued_at")+` <= w.window_end
 		ORDER BY j.id ASC`,
 		repoID, gitRef)
 	if err != nil {
@@ -564,6 +590,7 @@ func (db *DB) resolveCIMetricsCursor(cursor string, legacy bool) (*ciMetricsCurs
 		// job and the unit's latest finish; re-derive that unit's group and
 		// check both still hold.
 		existsQuery = `
+			WITH ` + legacyUnitWindowCTE + `
 			SELECT COUNT(1) FROM review_jobs a
 			WHERE a.id = ?
 			  AND (a.panel_run_uuid IS NULL OR a.panel_run_uuid = '')
@@ -571,8 +598,10 @@ func (db *DB) resolveCIMetricsCursor(cursor string, legacy bool) (*ciMetricsCurs
 			  AND a.status = 'done' AND a.finished_at IS NOT NULL
 			  AND (SELECT MAX(` + legacyUnitTimeExpr("j.finished_at") + `)
 			       FROM review_jobs j
+			       JOIN unit_windows w ON w.repo_id = j.repo_id AND w.git_ref = j.git_ref
 			       WHERE j.repo_id = a.repo_id AND j.git_ref = a.git_ref
-			         AND ` + legacyUnitJobConditions + `) = ?`
+			         AND ` + legacyUnitJobConditions + `
+			         AND ` + legacyUnitTimeExpr("j.enqueued_at") + ` <= w.window_end) = ?`
 	}
 	var count int
 	if err := db.QueryRow(existsQuery, decoded.PanelID, decoded.PostedAt).Scan(&count); err != nil {

--- a/internal/storage/export_ci.go
+++ b/internal/storage/export_ci.go
@@ -377,22 +377,34 @@ const legacyUnitWindowCTE = `unit_windows AS MATERIALIZED (
 // use inside const SQL fragments.
 const legacyUnitTimeExprConst = `strftime('%Y-%m-%dT%H:%M:%SZ', j.enqueued_at)`
 
+// legacyUnitWindowEndSubquery computes one (repo, git_ref) unit's adjacency
+// window end (first enqueue + 1 hour) as a scalar subquery over two bound
+// parameters. Per-unit callers use this instead of legacyUnitWindowCTE: the
+// CTE aggregates every unit in the table, which is fine once per page but
+// pathological when repeated for each of the page's units.
+const legacyUnitWindowEndSubquery = `(
+		SELECT strftime('%Y-%m-%dT%H:%M:%SZ',
+		                datetime(MIN(strftime('%Y-%m-%dT%H:%M:%SZ', jj.enqueued_at)), '+1 hour'))
+		FROM review_jobs jj
+		WHERE jj.repo_id = ? AND jj.git_ref = ?
+		  AND (jj.panel_run_uuid IS NULL OR jj.panel_run_uuid = '')
+		  AND jj.job_type IN ('review', 'range')
+		  AND jj.status = 'done' AND jj.finished_at IS NOT NULL)`
+
 // legacyUnitJobs returns the completed jobs of one legacy (repo, git_ref)
 // unit in id order — bounded to the adjacency window like the unit query —
 // shaped as ExportCIPanelJob rows tagged role "review".
 func (db *DB) legacyUnitJobs(repoID int64, gitRef string) ([]ExportCIPanelJob, error) {
 	rows, err := db.Query(`
-		WITH `+legacyUnitWindowCTE+`
 		SELECT j.uuid, j.agent, j.model, j.provider, j.status,
 		       `+legacyUnitTimeExpr("j.started_at")+`,
 		       `+legacyUnitTimeExpr("j.finished_at")+`
 		FROM review_jobs j
-		JOIN unit_windows w ON w.repo_id = j.repo_id AND w.git_ref = j.git_ref
 		WHERE j.repo_id = ? AND j.git_ref = ?
 		  AND `+legacyUnitJobConditions+`
-		  AND `+legacyUnitTimeExpr("j.enqueued_at")+` <= w.window_end
+		  AND `+legacyUnitTimeExpr("j.enqueued_at")+` <= `+legacyUnitWindowEndSubquery+`
 		ORDER BY j.id ASC`,
-		repoID, gitRef)
+		repoID, gitRef, repoID, gitRef)
 	if err != nil {
 		return nil, fmt.Errorf("query legacy ci unit jobs: %w", err)
 	}
@@ -590,7 +602,6 @@ func (db *DB) resolveCIMetricsCursor(cursor string, legacy bool) (*ciMetricsCurs
 		// job and the unit's latest finish; re-derive that unit's group and
 		// check both still hold.
 		existsQuery = `
-			WITH ` + legacyUnitWindowCTE + `
 			SELECT COUNT(1) FROM review_jobs a
 			WHERE a.id = ?
 			  AND (a.panel_run_uuid IS NULL OR a.panel_run_uuid = '')
@@ -598,10 +609,16 @@ func (db *DB) resolveCIMetricsCursor(cursor string, legacy bool) (*ciMetricsCurs
 			  AND a.status = 'done' AND a.finished_at IS NOT NULL
 			  AND (SELECT MAX(` + legacyUnitTimeExpr("j.finished_at") + `)
 			       FROM review_jobs j
-			       JOIN unit_windows w ON w.repo_id = j.repo_id AND w.git_ref = j.git_ref
 			       WHERE j.repo_id = a.repo_id AND j.git_ref = a.git_ref
 			         AND ` + legacyUnitJobConditions + `
-			         AND ` + legacyUnitTimeExpr("j.enqueued_at") + ` <= w.window_end) = ?`
+			         AND ` + legacyUnitTimeExpr("j.enqueued_at") + ` <= (
+			           SELECT strftime('%Y-%m-%dT%H:%M:%SZ',
+			                    datetime(MIN(strftime('%Y-%m-%dT%H:%M:%SZ', jj.enqueued_at)), '+1 hour'))
+			           FROM review_jobs jj
+			           WHERE jj.repo_id = a.repo_id AND jj.git_ref = a.git_ref
+			             AND (jj.panel_run_uuid IS NULL OR jj.panel_run_uuid = '')
+			             AND jj.job_type IN ('review', 'range')
+			             AND jj.status = 'done' AND jj.finished_at IS NOT NULL)) = ?`
 	}
 	var count int
 	if err := db.QueryRow(existsQuery, decoded.PanelID, decoded.PostedAt).Scan(&count); err != nil {

--- a/internal/storage/export_ci.go
+++ b/internal/storage/export_ci.go
@@ -1,0 +1,311 @@
+package storage
+
+import (
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+)
+
+const (
+	ciMetricsCursorVersion    = 1
+	ciMetricsDefaultPageLimit = 500
+	ciMetricsMaxPageLimit     = 5000
+)
+
+// ExportCIMetricsOptions bounds one page of the CI metrics export.
+type ExportCIMetricsOptions struct {
+	Since  time.Time
+	Until  time.Time
+	Cursor string
+	Limit  int
+}
+
+// ExportCIMetricsPage is one bounded page of finalized CI panel records.
+type ExportCIMetricsPage struct {
+	Panels     []ExportCIPanel `json:"panels"`
+	Truncated  bool            `json:"truncated"`
+	NextCursor *string         `json:"next_cursor"`
+}
+
+// ExportCIPanel is one finalized CI panel run. Outcome is never empty:
+// rows finalized before outcome persistence existed export as "unknown",
+// and FirstAttemptAt/AttemptCount stay null for them (there is
+// deliberately no fallback to panel_created_at, which undercounts
+// deferred retries).
+type ExportCIPanel struct {
+	GithubRepo     string             `json:"github_repo"`
+	PRNumber       int64              `json:"pr_number"`
+	HeadSHA        string             `json:"head_sha"`
+	PanelCreatedAt string             `json:"panel_created_at"`
+	PostedAt       string             `json:"posted_at"`
+	FirstAttemptAt *string            `json:"first_attempt_at"`
+	AttemptCount   *int64             `json:"attempt_count"`
+	Outcome        string             `json:"outcome"`
+	SynthesisAgent *string            `json:"synthesis_agent"`
+	SynthesisModel *string            `json:"synthesis_model"`
+	Jobs           []ExportCIPanelJob `json:"jobs"`
+}
+
+// ExportCIPanelJob is one member or synthesis job of an exported panel.
+type ExportCIPanelJob struct {
+	JobUUID    string  `json:"job_uuid"`
+	Role       string  `json:"role"`
+	Agent      string  `json:"agent"`
+	Model      *string `json:"model"`
+	Provider   *string `json:"provider"`
+	Status     string  `json:"status"`
+	StartedAt  *string `json:"started_at"`
+	FinishedAt *string `json:"finished_at"`
+}
+
+type ciMetricsCursor struct {
+	Version    int    `json:"version"`
+	DatabaseID string `json:"database_id"`
+	PostedAt   string `json:"posted_at"`
+	PanelID    int64  `json:"panel_id"`
+}
+
+// ExportCIMetrics returns one bounded page of finalized CI panel records
+// ordered by (posted_at, id) ascending, with the same opaque-cursor and
+// database_id-reset contract as ExportReviews.
+func (db *DB) ExportCIMetrics(opts ExportCIMetricsOptions) (ExportCIMetricsPage, error) {
+	switch {
+	case opts.Limit <= 0:
+		opts.Limit = ciMetricsDefaultPageLimit
+	case opts.Limit > ciMetricsMaxPageLimit:
+		opts.Limit = ciMetricsMaxPageLimit
+	}
+
+	cursor, err := db.resolveCIMetricsCursor(opts.Cursor)
+	if err != nil {
+		return ExportCIMetricsPage{}, err
+	}
+
+	postedExpr := sqliteNormalizedTimestampExpr("cp.posted_at")
+	conditions := []string{"cp.posted_at IS NOT NULL"}
+	args := make([]any, 0)
+	if !opts.Since.IsZero() {
+		conditions = append(conditions, postedExpr+" >= datetime(?)")
+		args = append(args, opts.Since.UTC().Format(time.RFC3339))
+	}
+	if !opts.Until.IsZero() {
+		conditions = append(conditions, postedExpr+" < datetime(?)")
+		args = append(args, opts.Until.UTC().Format(time.RFC3339))
+	}
+	if cursor != nil {
+		conditions = append(conditions,
+			"("+postedExpr+" > datetime(?) OR ("+postedExpr+" = datetime(?) AND cp.id > ?))")
+		args = append(args, cursor.PostedAt, cursor.PostedAt, cursor.PanelID)
+	}
+	args = append(args, opts.Limit+1)
+
+	query := `
+		SELECT cp.id, cp.github_repo, cp.pr_number, cp.head_sha,
+		       cp.created_at, cp.posted_at, cp.first_attempt_at,
+		       cp.attempt_count, COALESCE(cp.outcome, '` + PanelOutcomeUnknown + `'),
+		       cp.panel_run_uuid, sj.agent, sj.model
+		FROM ci_pr_panels cp
+		LEFT JOIN review_jobs sj ON sj.id = cp.synthesis_job_id
+		WHERE ` + strings.Join(conditions, " AND ") + `
+		ORDER BY ` + postedExpr + ` ASC, cp.id ASC
+		LIMIT ?`
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return ExportCIMetricsPage{}, fmt.Errorf("query ci metrics export: %w", err)
+	}
+	defer rows.Close()
+
+	page := ExportCIMetricsPage{Panels: []ExportCIPanel{}}
+	var lastID int64
+	var lastPosted string
+	type pendingPanel struct {
+		panel   ExportCIPanel
+		runUUID string
+	}
+	var pending []pendingPanel
+	for rows.Next() {
+		var (
+			id             int64
+			panel          ExportCIPanel
+			createdAt      sql.NullString
+			postedAt       sql.NullString
+			firstAttemptAt sql.NullString
+			attemptCount   sql.NullInt64
+			runUUID        string
+			synthAgent     sql.NullString
+			synthModel     sql.NullString
+		)
+		if err := rows.Scan(&id, &panel.GithubRepo, &panel.PRNumber, &panel.HeadSHA,
+			&createdAt, &postedAt, &firstAttemptAt, &attemptCount, &panel.Outcome,
+			&runUUID, &synthAgent, &synthModel); err != nil {
+			return ExportCIMetricsPage{}, fmt.Errorf("scan ci metrics row: %w", err)
+		}
+		if len(pending) == opts.Limit {
+			page.Truncated = true
+			break
+		}
+		if createdAt.Valid {
+			panel.PanelCreatedAt = formatExportTime(parseSQLiteTime(createdAt.String))
+		}
+		if postedAt.Valid {
+			panel.PostedAt = formatExportTime(parseSQLiteTime(postedAt.String))
+		}
+		if firstAttemptAt.Valid {
+			v := formatExportTime(parseSQLiteTime(firstAttemptAt.String))
+			panel.FirstAttemptAt = &v
+		}
+		if attemptCount.Valid {
+			panel.AttemptCount = &attemptCount.Int64
+		}
+		if synthAgent.Valid && synthAgent.String != "" {
+			panel.SynthesisAgent = &synthAgent.String
+		}
+		if synthModel.Valid && synthModel.String != "" {
+			panel.SynthesisModel = &synthModel.String
+		}
+		pending = append(pending, pendingPanel{panel: panel, runUUID: runUUID})
+		lastID = id
+		lastPosted = panel.PostedAt
+	}
+	if err := rows.Err(); err != nil {
+		return ExportCIMetricsPage{}, err
+	}
+
+	for _, item := range pending {
+		jobs, err := db.exportCIPanelJobs(item.runUUID)
+		if err != nil {
+			return ExportCIMetricsPage{}, err
+		}
+		item.panel.Jobs = jobs
+		page.Panels = append(page.Panels, item.panel)
+	}
+
+	if len(page.Panels) > 0 {
+		databaseID, err := db.GetDatabaseID()
+		if err != nil {
+			return ExportCIMetricsPage{}, err
+		}
+		next := encodeCIMetricsCursor(databaseID, lastPosted, lastID)
+		if next != "" {
+			page.NextCursor = &next
+		}
+	}
+	return page, nil
+}
+
+func (db *DB) exportCIPanelJobs(panelRunUUID string) ([]ExportCIPanelJob, error) {
+	rows, err := db.Query(`
+		SELECT j.uuid, COALESCE(j.panel_role, ''), j.agent, j.model,
+		       j.provider, j.status, j.started_at, j.finished_at
+		FROM review_jobs j
+		WHERE j.panel_run_uuid = ?
+		  AND COALESCE(j.panel_role, '') IN ('member','synthesis')
+		ORDER BY j.id ASC`, panelRunUUID)
+	if err != nil {
+		return nil, fmt.Errorf("query ci panel jobs: %w", err)
+	}
+	defer rows.Close()
+
+	jobs := []ExportCIPanelJob{}
+	for rows.Next() {
+		var (
+			job        ExportCIPanelJob
+			model      sql.NullString
+			provider   sql.NullString
+			startedAt  sql.NullString
+			finishedAt sql.NullString
+		)
+		if err := rows.Scan(&job.JobUUID, &job.Role, &job.Agent, &model,
+			&provider, &job.Status, &startedAt, &finishedAt); err != nil {
+			return nil, fmt.Errorf("scan ci panel job: %w", err)
+		}
+		if model.Valid && model.String != "" {
+			job.Model = &model.String
+		}
+		if provider.Valid && provider.String != "" {
+			job.Provider = &provider.String
+		}
+		if startedAt.Valid {
+			v := formatExportTime(parseSQLiteTime(startedAt.String))
+			job.StartedAt = &v
+		}
+		if finishedAt.Valid {
+			v := formatExportTime(parseSQLiteTime(finishedAt.String))
+			job.FinishedAt = &v
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs, rows.Err()
+}
+
+func encodeCIMetricsCursor(databaseID, postedAt string, panelID int64) string {
+	if databaseID == "" || postedAt == "" || panelID <= 0 {
+		return ""
+	}
+	data, err := json.Marshal(ciMetricsCursor{
+		Version:    ciMetricsCursorVersion,
+		DatabaseID: databaseID,
+		PostedAt:   postedAt,
+		PanelID:    panelID,
+	})
+	if err != nil {
+		log.Printf("storage: warning: encode ci metrics cursor: %v", err)
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+func (db *DB) resolveCIMetricsCursor(cursor string) (*ciMetricsCursor, error) {
+	if cursor == "" {
+		return nil, nil
+	}
+	data, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return nil, fmt.Errorf("invalid ci metrics cursor: %w", err)
+	}
+	var decoded ciMetricsCursor
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return nil, fmt.Errorf("invalid ci metrics cursor: %w", err)
+	}
+	if decoded.Version != ciMetricsCursorVersion {
+		return nil, fmt.Errorf("invalid ci metrics cursor: unsupported version %d", decoded.Version)
+	}
+	if decoded.DatabaseID == "" || decoded.PostedAt == "" || decoded.PanelID <= 0 {
+		return nil, errors.New("invalid ci metrics cursor: missing fields")
+	}
+	t, err := time.Parse(time.RFC3339Nano, decoded.PostedAt)
+	if err != nil {
+		return nil, fmt.Errorf("invalid ci metrics cursor timestamp: %w", err)
+	}
+	decoded.PostedAt = t.UTC().Format(time.RFC3339)
+
+	databaseID, err := db.GetDatabaseID()
+	if err != nil {
+		return nil, err
+	}
+	if decoded.DatabaseID != databaseID {
+		return nil, fmt.Errorf(
+			"%w: cursor database_id %q does not match current database_id %q",
+			ErrExportCursorDatabaseMismatch, decoded.DatabaseID, databaseID,
+		)
+	}
+	var count int
+	err = db.QueryRow(`
+		SELECT COUNT(1) FROM ci_pr_panels cp
+		WHERE cp.id = ? AND cp.posted_at IS NOT NULL
+		  AND `+sqliteNormalizedTimestampExpr("cp.posted_at")+` = datetime(?)`,
+		decoded.PanelID, decoded.PostedAt).Scan(&count)
+	if err != nil {
+		return nil, fmt.Errorf("validate ci metrics cursor: %w", err)
+	}
+	if count == 0 {
+		return nil, fmt.Errorf("%w: posted_at %q panel_id %d",
+			ErrExportCursorNotFound, decoded.PostedAt, decoded.PanelID)
+	}
+	return &decoded, nil
+}

--- a/internal/storage/export_ci.go
+++ b/internal/storage/export_ci.go
@@ -36,7 +36,11 @@ type ExportCIMetricsPage struct {
 // rows finalized before outcome persistence existed export as "unknown",
 // and FirstAttemptAt/AttemptCount stay null for them (there is
 // deliberately no fallback to panel_created_at, which undercounts
-// deferred retries).
+// deferred retries). SynthesisAgent/SynthesisModel are self-contained
+// snapshots taken at finalization (MarkPanelPosted), so they survive
+// deletion of the underlying review_jobs rows (e.g. cascade repo delete).
+// Jobs, by contrast, reflects the currently retained review_jobs rows for
+// the panel run and may be empty for panels whose repo was cascade-deleted.
 type ExportCIPanel struct {
 	GithubRepo     string             `json:"github_repo"`
 	PRNumber       int64              `json:"pr_number"`
@@ -108,7 +112,9 @@ func (db *DB) ExportCIMetrics(opts ExportCIMetricsOptions) (ExportCIMetricsPage,
 		SELECT cp.id, cp.github_repo, cp.pr_number, cp.head_sha,
 		       cp.created_at, cp.posted_at, cp.first_attempt_at,
 		       cp.attempt_count, COALESCE(cp.outcome, '` + PanelOutcomeUnknown + `'),
-		       cp.panel_run_uuid, sj.agent, sj.model
+		       cp.panel_run_uuid,
+		       COALESCE(NULLIF(cp.synthesis_agent, ''), sj.agent),
+		       COALESCE(NULLIF(cp.synthesis_model, ''), sj.model)
 		FROM ci_pr_panels cp
 		LEFT JOIN review_jobs sj ON sj.id = cp.synthesis_job_id
 		WHERE ` + strings.Join(conditions, " AND ") + `

--- a/internal/storage/export_ci.go
+++ b/internal/storage/export_ci.go
@@ -24,10 +24,11 @@ type ExportCIMetricsOptions struct {
 	Cursor string
 	Limit  int
 	// Legacy switches the export to the pre-panel CI era (~2026-02 to
-	// ~2026-06): completed CI review_jobs rows with no panel run — tagged
-	// source='ci' or, for rows predating that tag, a non-empty
-	// ci_base_branch (the same markers ReviewJob.IsCI checks) — grouped
-	// per (repo, git_ref) into one wall-clock unit ("pseudopanel").
+	// ~2026-06): completed review/range jobs with no panel run, grouped
+	// per (repo, git_ref) into one wall-clock unit ("pseudopanel") when
+	// two or more reviews share the ref. Rows from that era predate all
+	// CI tagging, so membership is structural, and singleton reviews are
+	// excluded as manual one-offs.
 	// Legacy turnaround (first_attempt_at -> posted_at) measures earliest
 	// job enqueue -> latest job finish and excludes comment-posting
 	// latency, so it slightly undercounts the panel-era PR-perceived
@@ -237,15 +238,19 @@ func legacyHeadSHA(gitRef string) string {
 // exportCIMetricsLegacy is the review_jobs-backed page builder used by
 // ExportCIMetrics when Legacy is set. The pre-panel CI era enqueued
 // independent reviews of the same range — typically two agents x two review
-// types per PR head ("pseudopanels") — and the tables that linked them to
-// PRs (ci_pr_batches, then ci_pr_reviews) have no surviving production
-// rows. Each export row is therefore one (repo, git_ref) group of completed
-// source='ci' non-panel jobs collapsed into a single wall-clock unit:
-// panel_created_at/first_attempt_at is the group's earliest enqueue,
-// posted_at its latest finish, outcome is always PanelOutcomeLegacyReview,
-// pr_number is 0 (the PR linkage is unrecoverable), and head_sha is the
-// range head. Jobs lists the group's completed jobs tagged role "review";
-// synthesis_agent/synthesis_model stay nil (pseudopanels had no synthesis).
+// types per PR head ("pseudopanels") — before any CI tagging existed
+// (source='ci' and ci_base_branch both postdate those rows), and the tables
+// that linked them to PRs (ci_pr_batches, then ci_pr_reviews) have no
+// surviving production rows. A pseudopanel is therefore identified
+// structurally: two or more completed review/range jobs sharing
+// (repo, git_ref) with no panel run. Each such group collapses into one
+// wall-clock unit: panel_created_at/first_attempt_at is the group's
+// earliest enqueue, posted_at its latest finish, outcome is always
+// PanelOutcomeLegacyReview, pr_number is 0 (the PR linkage is
+// unrecoverable), and head_sha is the range head. Jobs lists the group's
+// completed jobs tagged role "review"; synthesis_agent/synthesis_model stay
+// nil (pseudopanels had no synthesis). Singleton reviews are excluded: a
+// lone job on a ref is a manual one-off, not a pseudopanel.
 func (db *DB) exportCIMetricsLegacy(opts ExportCIMetricsOptions, cursor *ciMetricsCursor) (ExportCIMetricsPage, error) {
 	postedExpr := "MAX(" + legacyUnitTimeExpr("j.finished_at") + ")"
 	having := []string{}
@@ -263,10 +268,7 @@ func (db *DB) exportCIMetricsLegacy(opts ExportCIMetricsOptions, cursor *ciMetri
 			"("+postedExpr+" > ? OR ("+postedExpr+" = ? AND MIN(j.id) > ?))")
 		args = append(args, cursor.PostedAt, cursor.PostedAt, cursor.PanelID)
 	}
-	havingClause := ""
-	if len(having) > 0 {
-		havingClause = "HAVING " + strings.Join(having, " AND ")
-	}
+	having = append(having, "COUNT(*) >= 2")
 	args = append(args, opts.Limit+1)
 
 	query := `
@@ -275,14 +277,12 @@ func (db *DB) exportCIMetricsLegacy(opts ExportCIMetricsOptions, cursor *ciMetri
 		       ` + postedExpr + `
 		FROM review_jobs j
 		JOIN repos r ON r.id = j.repo_id
-		WHERE (j.source = ? OR COALESCE(j.ci_base_branch, '') != '')
-		  AND (j.panel_run_uuid IS NULL OR j.panel_run_uuid = '')
-		  AND j.status = ? AND j.finished_at IS NOT NULL
+		WHERE ` + legacyUnitJobConditions + `
 		GROUP BY j.repo_id, j.git_ref
-		` + havingClause + `
+		HAVING ` + strings.Join(having, " AND ") + `
 		ORDER BY 6 ASC, 1 ASC
 		LIMIT ?`
-	rows, err := db.Query(query, append([]any{JobSourceCI, string(JobStatusDone)}, args...)...)
+	rows, err := db.Query(query, args...)
 	if err != nil {
 		return ExportCIMetricsPage{}, fmt.Errorf("query legacy ci metrics export: %w", err)
 	}
@@ -347,9 +347,16 @@ func (db *DB) exportCIMetricsLegacy(opts ExportCIMetricsOptions, cursor *ciMetri
 	return page, nil
 }
 
-// legacyUnitJobs returns the completed source='ci' non-panel jobs of one
-// legacy (repo, git_ref) unit in id order, shaped as ExportCIPanelJob rows
-// tagged role "review".
+// legacyUnitJobConditions is the shared WHERE fragment selecting jobs that
+// can belong to a legacy pseudopanel unit: completed review/range jobs with
+// no panel run. Pre-panel rows carry no CI tagging, so membership is
+// structural (the unit query additionally requires groups of two or more).
+const legacyUnitJobConditions = `(j.panel_run_uuid IS NULL OR j.panel_run_uuid = '')
+		  AND j.job_type IN ('review', 'range')
+		  AND j.status = 'done' AND j.finished_at IS NOT NULL`
+
+// legacyUnitJobs returns the completed jobs of one legacy (repo, git_ref)
+// unit in id order, shaped as ExportCIPanelJob rows tagged role "review".
 func (db *DB) legacyUnitJobs(repoID int64, gitRef string) ([]ExportCIPanelJob, error) {
 	rows, err := db.Query(`
 		SELECT j.uuid, j.agent, j.model, j.provider, j.status,
@@ -357,11 +364,9 @@ func (db *DB) legacyUnitJobs(repoID int64, gitRef string) ([]ExportCIPanelJob, e
 		       `+legacyUnitTimeExpr("j.finished_at")+`
 		FROM review_jobs j
 		WHERE j.repo_id = ? AND j.git_ref = ?
-		  AND (j.source = ? OR COALESCE(j.ci_base_branch, '') != '')
-		  AND (j.panel_run_uuid IS NULL OR j.panel_run_uuid = '')
-		  AND j.status = ? AND j.finished_at IS NOT NULL
+		  AND `+legacyUnitJobConditions+`
 		ORDER BY j.id ASC`,
-		repoID, gitRef, JobSourceCI, string(JobStatusDone))
+		repoID, gitRef)
 	if err != nil {
 		return nil, fmt.Errorf("query legacy ci unit jobs: %w", err)
 	}
@@ -561,15 +566,13 @@ func (db *DB) resolveCIMetricsCursor(cursor string, legacy bool) (*ciMetricsCurs
 		existsQuery = `
 			SELECT COUNT(1) FROM review_jobs a
 			WHERE a.id = ?
-			  AND (a.source = '` + JobSourceCI + `' OR COALESCE(a.ci_base_branch, '') != '')
 			  AND (a.panel_run_uuid IS NULL OR a.panel_run_uuid = '')
+			  AND a.job_type IN ('review', 'range')
 			  AND a.status = 'done' AND a.finished_at IS NOT NULL
 			  AND (SELECT MAX(` + legacyUnitTimeExpr("j.finished_at") + `)
 			       FROM review_jobs j
 			       WHERE j.repo_id = a.repo_id AND j.git_ref = a.git_ref
-			         AND (j.source = '` + JobSourceCI + `' OR COALESCE(j.ci_base_branch, '') != '')
-			         AND (j.panel_run_uuid IS NULL OR j.panel_run_uuid = '')
-			         AND j.status = 'done' AND j.finished_at IS NOT NULL) = ?`
+			         AND ` + legacyUnitJobConditions + `) = ?`
 	}
 	var count int
 	if err := db.QueryRow(existsQuery, decoded.PanelID, decoded.PostedAt).Scan(&count); err != nil {

--- a/internal/storage/export_ci_test.go
+++ b/internal/storage/export_ci_test.go
@@ -269,6 +269,32 @@ func TestExportCIMetricsLegacyCombinesPseudopanel(t *testing.T) {
 	assert.NotNil(t, page.NextCursor)
 }
 
+// TestExportCIMetricsLegacyExcludesNonAdjacentReReview covers the adjacency
+// window: a manual re-review of the same ref days after the pseudopanel ran
+// must not stretch the unit's wall clock (a production ref re-reviewed 12
+// days later inflated its turnaround to 290 hours before this bound).
+func TestExportCIMetricsLegacyExcludesNonAdjacentReReview(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
+	seedLegacyCIJob(t, db, repo.ID, "base..head-rerun", "codex",
+		"2026-03-01 10:00:00", "2026-03-01 10:05:00")
+	seedLegacyCIJob(t, db, repo.ID, "base..head-rerun", "gemini",
+		"2026-03-01 10:00:10", "2026-03-01 10:07:00")
+	// Re-reviewed 12 days later: outside the adjacency window.
+	seedLegacyCIJob(t, db, repo.ID, "base..head-rerun", "codex",
+		"2026-03-13 09:00:00", "2026-03-13 09:06:00")
+
+	page, err := db.ExportCIMetrics(ExportCIMetricsOptions{Legacy: true})
+	require.NoError(t, err)
+	require.Len(t, page.Panels, 1)
+	p := page.Panels[0]
+	assert.Equal(t, "2026-03-01T10:07:00Z", p.PostedAt,
+		"wall clock ends at the adjacent group's last finish, not the re-review's")
+	require.Len(t, p.Jobs, 2, "the non-adjacent re-review job is not part of the unit")
+}
+
 func TestExportCIMetricsLegacyPagination(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()

--- a/internal/storage/export_ci_test.go
+++ b/internal/storage/export_ci_test.go
@@ -57,6 +57,21 @@ func TestMigrationBackfillsPanelTerminalMetrics(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.DeleteReviewAttempt("o/r", 64, "sha-no-jobs"))
 
+	// (f) Synthesis failed on a transient outage AND a member produced
+	// output: the live path deferred rather than post the degraded raw
+	// fallback, so a posted row here is the exhausted transient give-up, not
+	// a review — the synthesis-failure classification outranks member output.
+	transientGiveup := seedPostedPanel(t, db, 65, "sha-transient-giveup", PanelOutcomeReviewPosted)
+	require.NotNil(t, transientGiveup.SynthesisJobID)
+	completeMemberWithOutput(t, db, transientGiveup.PanelRunUUID, "Partial output.")
+	failSynthesisWithError(t, db, *transientGiveup.SynthesisJobID, "outage: provider unavailable")
+
+	// (g) Same for a quota/session synthesis failure.
+	quotaGiveup := seedPostedPanel(t, db, 66, "sha-quota-giveup", PanelOutcomeReviewPosted)
+	require.NotNil(t, quotaGiveup.SynthesisJobID)
+	completeMemberWithOutput(t, db, quotaGiveup.PanelRunUUID, "Partial output.")
+	failSynthesisWithError(t, db, *quotaGiveup.SynthesisJobID, "quota: session limit reached")
+
 	// Simulate rows finalized before the terminal-metrics columns existed.
 	_, err = db.Exec(`UPDATE ci_pr_panels
 		SET outcome = NULL, first_attempt_at = NULL, attempt_count = NULL`)
@@ -69,7 +84,7 @@ func TestMigrationBackfillsPanelTerminalMetrics(t *testing.T) {
 
 	page, err := reopened.ExportCIMetrics(ExportCIMetricsOptions{})
 	require.NoError(t, err)
-	require.Len(t, page.Panels, 5)
+	require.Len(t, page.Panels, 7)
 	bySHA := map[string]ExportCIPanel{}
 	for _, p := range page.Panels {
 		bySHA[p.HeadSHA] = p
@@ -97,6 +112,22 @@ func TestMigrationBackfillsPanelTerminalMetrics(t *testing.T) {
 	assert.Equal(t, PanelOutcomeUnknown, p.Outcome,
 		"no surviving member rows leaves the outcome unknown")
 	assert.Nil(t, p.FirstAttemptAt)
+
+	assert.Equal(t, PanelOutcomeGiveupPosted, bySHA["sha-transient-giveup"].Outcome,
+		"a transient-failed synthesis is a give-up even with member output")
+	assert.Equal(t, PanelOutcomeGiveupPosted, bySHA["sha-quota-giveup"].Outcome,
+		"a quota-failed synthesis is a give-up even with member output")
+}
+
+// failSynthesisWithError marks a synthesis job failed with a classified
+// error string (e.g. "outage: ..." or "quota: ..."), the signal the outcome
+// backfill uses to tell a transient synthesis give-up from a genuine
+// synthesis failure that still posted the raw member fallback.
+func failSynthesisWithError(t *testing.T, db *DB, jobID int64, errText string) {
+	t.Helper()
+	_, err := db.Exec(`UPDATE review_jobs SET status = 'failed', error = ? WHERE id = ?`,
+		errText, jobID)
+	require.NoError(t, err)
 }
 
 // TestMigrationBackfillsSynthesisSnapshotSurvivesCascade covers the synthesis

--- a/internal/storage/export_ci_test.go
+++ b/internal/storage/export_ci_test.go
@@ -1,0 +1,116 @@
+package storage
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func seedPostedPanel(t *testing.T, db *DB, pr int, sha, outcome string) *CIPanel {
+	t.Helper()
+	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
+	now := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	created, err := db.ReserveReviewAttempt("o/r", pr, sha, now)
+	require.NoError(t, err)
+	require.True(t, created)
+	panel, _ := seedPanelRunForRepo(t, db, repo.ID, "o/r", pr, sha)
+	require.NoError(t, db.MarkPanelPosted(panel.ID, outcome))
+	got, err := db.GetCIPanelByPRSHA("o/r", pr, sha)
+	require.NoError(t, err)
+	return got
+}
+
+func TestExportCIMetricsIncludesOnlyPostedPanels(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	seedPostedPanel(t, db, 1, "sha-posted", PanelOutcomeReviewPosted)
+	// An unposted panel must not export.
+	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo2"))
+	seedPanelRunForRepo(t, db, repo.ID, "o/r", 2, "sha-unposted")
+
+	page, err := db.ExportCIMetrics(ExportCIMetricsOptions{})
+	require.NoError(t, err)
+	require.Len(t, page.Panels, 1)
+	p := page.Panels[0]
+	assert.Equal(t, "o/r", p.GithubRepo)
+	assert.Equal(t, int64(1), p.PRNumber)
+	assert.Equal(t, "sha-posted", p.HeadSHA)
+	assert.Equal(t, PanelOutcomeReviewPosted, p.Outcome)
+	require.NotNil(t, p.FirstAttemptAt)
+	require.NotNil(t, p.AttemptCount)
+	assert.Equal(t, int64(1), *p.AttemptCount)
+	assert.NotEmpty(t, p.PostedAt)
+	assert.NotEmpty(t, p.PanelCreatedAt)
+	assert.NotEmpty(t, p.Jobs, "panel jobs must be included")
+	for _, j := range p.Jobs {
+		assert.NotEmpty(t, j.JobUUID)
+		assert.Contains(t, []string{"member", "synthesis"}, j.Role)
+		assert.NotEmpty(t, j.Agent)
+		assert.NotEmpty(t, j.Status)
+	}
+	assert.False(t, page.Truncated)
+	require.NotNil(t, page.NextCursor)
+}
+
+func TestExportCIMetricsLegacyRowsAreUnknown(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	panel := seedPostedPanel(t, db, 3, "sha-legacy", PanelOutcomeReviewPosted)
+	// Simulate a row finalized before outcome persistence existed.
+	_, err := db.Exec(`UPDATE ci_pr_panels
+		SET outcome = NULL, first_attempt_at = NULL, attempt_count = NULL
+		WHERE id = ?`, panel.ID)
+	require.NoError(t, err)
+
+	page, err := db.ExportCIMetrics(ExportCIMetricsOptions{})
+	require.NoError(t, err)
+	require.Len(t, page.Panels, 1)
+	assert.Equal(t, PanelOutcomeUnknown, page.Panels[0].Outcome)
+	assert.Nil(t, page.Panels[0].FirstAttemptAt)
+	assert.Nil(t, page.Panels[0].AttemptCount)
+}
+
+func TestExportCIMetricsCursorPagination(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	seedPostedPanel(t, db, 10, "sha-a", PanelOutcomeReviewPosted)
+	seedPostedPanel(t, db, 11, "sha-b", PanelOutcomeGiveupPosted)
+
+	first, err := db.ExportCIMetrics(ExportCIMetricsOptions{Limit: 1})
+	require.NoError(t, err)
+	require.Len(t, first.Panels, 1)
+	assert.True(t, first.Truncated)
+	require.NotNil(t, first.NextCursor)
+
+	second, err := db.ExportCIMetrics(ExportCIMetricsOptions{Cursor: *first.NextCursor})
+	require.NoError(t, err)
+	require.Len(t, second.Panels, 1)
+	assert.False(t, second.Truncated)
+	assert.NotEqual(t, first.Panels[0].HeadSHA, second.Panels[0].HeadSHA)
+}
+
+func TestExportCIMetricsRejectsCursorFromDifferentDatabase(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	seedPostedPanel(t, db, 20, "sha-c", PanelOutcomeReviewPosted)
+	raw, err := json.Marshal(ciMetricsCursor{
+		Version:    ciMetricsCursorVersion,
+		DatabaseID: "some-other-database",
+		PostedAt:   "2026-07-01T00:00:00Z",
+		PanelID:    1,
+	})
+	require.NoError(t, err)
+	cursor := base64.RawURLEncoding.EncodeToString(raw)
+
+	_, err = db.ExportCIMetrics(ExportCIMetricsOptions{Cursor: cursor})
+	require.ErrorIs(t, err, ErrExportCursorDatabaseMismatch)
+}

--- a/internal/storage/export_ci_test.go
+++ b/internal/storage/export_ci_test.go
@@ -199,17 +199,15 @@ func TestExportCIMetricsRejectsCursorFromDifferentDatabase(t *testing.T) {
 }
 
 // seedLegacyCIJob inserts one completed pre-panel CI review job with no
-// panel run and explicit enqueue/finish timestamps, CI-tagged only through
-// ci_base_branch: rows from that era predate source='ci' tagging, and the
-// legacy export must honor both markers (ReviewJob.IsCI). The pre-panel era
-// wrote no PR linkage rows that survive, so the legacy export groups these
-// jobs by (repo, git_ref) into pseudopanel units.
+// panel run and explicit enqueue/finish timestamps. Rows from that era
+// predate all CI tagging (source and ci_base_branch stay empty), so the
+// legacy export identifies pseudopanels structurally: two or more completed
+// jobs sharing (repo, git_ref).
 func seedLegacyCIJob(t *testing.T, db *DB, repoID int64, gitRef, agent string, enqueued, finished string) *ReviewJob {
 	t.Helper()
 	job, err := db.EnqueueJob(EnqueueOpts{
 		RepoID: repoID, GitRef: gitRef,
 		Agent: agent, Model: "legacy-model", Provider: "legacy-provider",
-		CIBaseBranch: "main",
 	})
 	require.NoError(t, err)
 	_, err = db.Exec(`UPDATE review_jobs
@@ -233,10 +231,14 @@ func TestExportCIMetricsLegacyCombinesPseudopanel(t *testing.T) {
 		"2026-03-01 10:00:00", "2026-03-01 10:30:00")
 	_, err := db.Exec(`UPDATE review_jobs SET status = 'failed' WHERE id = ?`, failed.ID)
 	require.NoError(t, err)
+	// A singleton review of another ref is a manual one-off, not a
+	// pseudopanel, and must not export.
+	seedLegacyCIJob(t, db, repo.ID, "base..head-singleton", "codex",
+		"2026-03-02 10:00:00", "2026-03-02 10:05:00")
 
 	page, err := db.ExportCIMetrics(ExportCIMetricsOptions{Legacy: true})
 	require.NoError(t, err)
-	require.Len(t, page.Panels, 1, "one pseudopanel unit per (repo, git_ref)")
+	require.Len(t, page.Panels, 1, "one pseudopanel unit per (repo, git_ref); singletons excluded")
 	p := page.Panels[0]
 
 	assert.Equal(t, repo.Name, p.GithubRepo)
@@ -274,8 +276,12 @@ func TestExportCIMetricsLegacyPagination(t *testing.T) {
 	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
 	seedLegacyCIJob(t, db, repo.ID, "sha-legacy-a", "codex",
 		"2026-03-01 10:00:00", "2026-03-01 10:05:00")
+	seedLegacyCIJob(t, db, repo.ID, "sha-legacy-a", "gemini",
+		"2026-03-01 10:00:00", "2026-03-01 10:06:00")
 	seedLegacyCIJob(t, db, repo.ID, "sha-legacy-b", "codex",
 		"2026-03-02 10:00:00", "2026-03-02 10:05:00")
+	seedLegacyCIJob(t, db, repo.ID, "sha-legacy-b", "gemini",
+		"2026-03-02 10:00:00", "2026-03-02 10:06:00")
 
 	first, err := db.ExportCIMetrics(ExportCIMetricsOptions{Legacy: true, Limit: 1})
 	require.NoError(t, err)
@@ -299,6 +305,8 @@ func TestExportCIMetricsRejectsCursorModeMismatch(t *testing.T) {
 	seedPostedPanel(t, db, 40, "sha-panel", PanelOutcomeReviewPosted)
 	seedLegacyCIJob(t, db, repo.ID, "sha-legacy", "codex",
 		"2026-03-01 10:00:00", "2026-03-01 10:05:00")
+	seedLegacyCIJob(t, db, repo.ID, "sha-legacy", "gemini",
+		"2026-03-01 10:00:00", "2026-03-01 10:06:00")
 
 	panelPage, err := db.ExportCIMetrics(ExportCIMetricsOptions{})
 	require.NoError(t, err)
@@ -325,6 +333,8 @@ func TestExportCIMetricsLegacyAndPanelModesAreDisjoint(t *testing.T) {
 	seedPostedPanel(t, db, 50, "sha-panel-only", PanelOutcomeReviewPosted)
 	seedLegacyCIJob(t, db, repo.ID, "sha-legacy-only", "codex",
 		"2026-03-01 10:00:00", "2026-03-01 10:05:00")
+	seedLegacyCIJob(t, db, repo.ID, "sha-legacy-only", "gemini",
+		"2026-03-01 10:00:00", "2026-03-01 10:06:00")
 
 	panelPage, err := db.ExportCIMetrics(ExportCIMetricsOptions{})
 	require.NoError(t, err)

--- a/internal/storage/export_ci_test.go
+++ b/internal/storage/export_ci_test.go
@@ -99,6 +99,59 @@ func TestMigrationBackfillsPanelTerminalMetrics(t *testing.T) {
 	assert.Nil(t, p.FirstAttemptAt)
 }
 
+// TestMigrationBackfillsSynthesisSnapshotSurvivesCascade covers the synthesis
+// agent/model backfill: a panel finalized before those snapshot columns
+// existed relied on the live review_jobs join, so a later cascade repo
+// deletion would erase its model attribution. The startup backfill snapshots
+// the pair from the synthesis job, so the export still reports the model
+// after the repo (and its review_jobs rows) are deleted.
+func TestMigrationBackfillsSynthesisSnapshotSurvivesCascade(t *testing.T) {
+	tmpl, err := getTemplatePath()
+	require.NoError(t, err)
+	data, err := os.ReadFile(tmpl)
+	require.NoError(t, err)
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	require.NoError(t, os.WriteFile(dbPath, data, 0o644))
+	db, err := Open(dbPath)
+	require.NoError(t, err)
+
+	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
+	now := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	created, err := db.ReserveReviewAttempt("o/r", 70, "sha-cascade-pre", now)
+	require.NoError(t, err)
+	require.True(t, created)
+	members := []EnqueueOpts{{RepoID: repo.ID, GitRef: "b..h", Agent: "m", PanelMemberIndex: 0}}
+	synthesis := EnqueueOpts{RepoID: repo.ID, GitRef: "b..h", Agent: "test-synth", Model: "test-model"}
+	runCreated, _, _, err := db.CreateCIPanelRun("o/r", 70, "sha-cascade-pre", members, synthesis)
+	require.NoError(t, err)
+	require.True(t, runCreated)
+	panel, err := db.GetCIPanelByPRSHA("o/r", 70, "sha-cascade-pre")
+	require.NoError(t, err)
+	require.NoError(t, db.MarkPanelPosted(panel.ID, PanelOutcomeReviewPosted))
+	// Simulate a row finalized before the snapshot columns existed: clear
+	// the snapshot so only the live synthesis job carries the model.
+	_, err = db.Exec(`UPDATE ci_pr_panels
+		SET synthesis_agent = NULL, synthesis_model = NULL WHERE id = ?`, panel.ID)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	// Reopen to run the backfill, THEN cascade-delete the repo.
+	reopened, err := Open(dbPath)
+	require.NoError(t, err)
+	defer reopened.Close()
+	require.NoError(t, reopened.DeleteRepo(repo.ID, true))
+
+	page, err := reopened.ExportCIMetrics(ExportCIMetricsOptions{})
+	require.NoError(t, err)
+	require.Len(t, page.Panels, 1)
+	p := page.Panels[0]
+	require.NotNil(t, p.SynthesisAgent, "synthesis_agent survives cascade via the backfilled snapshot")
+	assert.Equal(t, "test-synth", *p.SynthesisAgent)
+	require.NotNil(t, p.SynthesisModel, "synthesis_model survives cascade via the backfilled snapshot")
+	assert.Equal(t, "test-model", *p.SynthesisModel)
+	assert.Empty(t, p.Jobs, "the underlying review_jobs rows are gone")
+}
+
 // panelMemberID returns the id of a panel run's single seeded member job.
 func panelMemberID(t *testing.T, db *DB, runUUID string) int64 {
 	t.Helper()

--- a/internal/storage/export_ci_test.go
+++ b/internal/storage/export_ci_test.go
@@ -356,9 +356,10 @@ func TestExportCIMetricsLegacyCombinesPseudopanel(t *testing.T) {
 }
 
 // TestExportCIMetricsLegacyPartialSuccessUnit covers the batch flow's
-// partial-success posting: one done + one failed job is a posted review and
-// must export as a unit, while an all-failed pair posted nothing reviewable
-// and is excluded.
+// partial-success posting: one done job plus a failed or canceled sibling is
+// a posted review and must export as a unit (the batch treated both failure
+// modes as terminal and posted the available output), while a group with no
+// successful job posted nothing reviewable and is excluded.
 func TestExportCIMetricsLegacyPartialSuccessUnit(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()
@@ -369,24 +370,72 @@ func TestExportCIMetricsLegacyPartialSuccessUnit(t *testing.T) {
 		"2026-03-01 10:00:00", "2026-03-01 10:05:00")
 	partialFailed := seedLegacyCIJob(t, db, repo.ID, "base..head-partial", "gemini",
 		"2026-03-01 10:00:00", "2026-03-01 10:07:00")
+	// A timed-out member was canceled, not failed: it is still a terminal
+	// member of the batch, so it counts toward the unit and its finish
+	// extends the wall clock.
+	seedLegacyCIJob(t, db, repo.ID, "base..head-canceled", "codex",
+		"2026-03-03 10:00:00", "2026-03-03 10:05:00")
+	canceledSibling := seedLegacyCIJob(t, db, repo.ID, "base..head-canceled", "gemini",
+		"2026-03-03 10:00:00", "2026-03-03 10:09:00")
 	allFailedA := seedLegacyCIJob(t, db, repo.ID, "base..head-all-failed", "codex",
 		"2026-03-02 10:00:00", "2026-03-02 10:05:00")
 	allFailedB := seedLegacyCIJob(t, db, repo.ID, "base..head-all-failed", "gemini",
 		"2026-03-02 10:00:00", "2026-03-02 10:06:00")
-	for _, id := range []int64{partialFailed.ID, allFailedA.ID, allFailedB.ID} {
+	for _, id := range []int64{partialFailed.ID, allFailedA.ID} {
 		_, err := db.Exec(`UPDATE review_jobs SET status = 'failed' WHERE id = ?`, id)
+		require.NoError(t, err)
+	}
+	for _, id := range []int64{canceledSibling.ID, allFailedB.ID} {
+		_, err := db.Exec(`UPDATE review_jobs SET status = 'canceled' WHERE id = ?`, id)
 		require.NoError(t, err)
 	}
 
 	page, err := db.ExportCIMetrics(ExportCIMetricsOptions{Legacy: true})
 	require.NoError(t, err)
-	require.Len(t, page.Panels, 1,
-		"partial-success units export; all-failed groups posted no review")
-	p := page.Panels[0]
-	assert.Equal(t, "head-partial", p.HeadSHA)
-	assert.Equal(t, "2026-03-01T10:07:00Z", p.PostedAt,
+	require.Len(t, page.Panels, 2,
+		"partial-success units export; a group with no successful job posted no review")
+	bySHA := map[string]ExportCIPanel{}
+	for _, p := range page.Panels {
+		bySHA[p.HeadSHA] = p
+	}
+
+	partial := bySHA["head-partial"]
+	assert.Equal(t, "2026-03-01T10:07:00Z", partial.PostedAt,
 		"wall clock ends at the failed sibling's finish")
-	require.Len(t, p.Jobs, 2)
+	require.Len(t, partial.Jobs, 2)
+
+	canceled := bySHA["head-canceled"]
+	assert.Equal(t, "2026-03-03T10:09:00Z", canceled.PostedAt,
+		"wall clock ends at the canceled sibling's finish")
+	require.Len(t, canceled.Jobs, 2, "the canceled member belongs to the unit")
+	assert.Equal(t, string(JobStatusCanceled), canceled.Jobs[1].Status)
+}
+
+// TestExportCIMetricsLegacyExcludesUnfinishedMigrationCancels covers the
+// panel migration's own cleanup: it canceled leftover in-flight batch jobs
+// without stamping finished_at, and those batches never posted a review. An
+// unfinished canceled sibling must not join a unit (which would stretch its
+// wall clock to the migration's timestamp), leaving its lone done job a
+// singleton.
+func TestExportCIMetricsLegacyExcludesUnfinishedMigrationCancels(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
+	seedPanelEraMarker(t, db, "2026-06-01 00:00:00")
+	seedLegacyCIJob(t, db, repo.ID, "base..head-inflight", "codex",
+		"2026-03-01 10:00:00", "2026-03-01 10:05:00")
+	superseded := seedLegacyCIJob(t, db, repo.ID, "base..head-inflight", "gemini",
+		"2026-03-01 10:00:00", "2026-03-01 10:06:00")
+	_, err := db.Exec(`UPDATE review_jobs
+		SET status = 'canceled', error = 'superseded by panel migration', finished_at = NULL
+		WHERE id = ?`, superseded.ID)
+	require.NoError(t, err)
+
+	page, err := db.ExportCIMetrics(ExportCIMetricsOptions{Legacy: true})
+	require.NoError(t, err)
+	assert.Empty(t, page.Panels,
+		"a never-finished cancel leaves the surviving job a singleton, not a unit")
 }
 
 // TestExportCIMetricsLegacyUsesRepoIdentity covers github_repo naming: the

--- a/internal/storage/export_ci_test.go
+++ b/internal/storage/export_ci_test.go
@@ -155,3 +155,133 @@ func TestExportCIMetricsRejectsCursorFromDifferentDatabase(t *testing.T) {
 	_, err = db.ExportCIMetrics(ExportCIMetricsOptions{Cursor: cursor})
 	require.ErrorIs(t, err, ErrExportCursorDatabaseMismatch)
 }
+
+// seedLegacyCIReview inserts a review_jobs row plus its ci_pr_reviews link,
+// mirroring the frozen pre-panel schema (ci_pr_reviews.job_id -> review_jobs,
+// created_at in SQLite's CURRENT_TIMESTAMP space format). No production
+// writer remains for ci_pr_reviews, so tests populate it directly.
+func seedLegacyCIReview(t *testing.T, db *DB, repoID int64, githubRepo string, pr int, headSHA, createdAt string) *ReviewJob {
+	t.Helper()
+	job, err := db.EnqueueJob(EnqueueOpts{
+		RepoID: repoID, GitRef: headSHA,
+		Agent: "legacy-agent", Model: "legacy-model", Provider: "legacy-provider",
+	})
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO ci_pr_reviews (github_repo, pr_number, head_sha, job_id, created_at)
+		VALUES (?, ?, ?, ?, ?)`, githubRepo, pr, headSHA, job.ID, createdAt)
+	require.NoError(t, err)
+	return job
+}
+
+func TestExportCIMetricsLegacyRowShape(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
+	job := seedLegacyCIReview(t, db, repo.ID, "o/r", 7, "sha-legacy", "2026-03-01 10:00:00")
+	setStatus(t, db, job.ID, JobStatusDone)
+	setStartedAt(t, db, job.ID, time.Date(2026, 3, 1, 9, 55, 0, 0, time.UTC))
+	_, err := db.Exec(`UPDATE review_jobs SET finished_at = ? WHERE id = ?`, "2026-03-01T10:05:00Z", job.ID)
+	require.NoError(t, err)
+
+	page, err := db.ExportCIMetrics(ExportCIMetricsOptions{Legacy: true})
+	require.NoError(t, err)
+	require.Len(t, page.Panels, 1)
+	p := page.Panels[0]
+
+	assert.Equal(t, "o/r", p.GithubRepo)
+	assert.Equal(t, int64(7), p.PRNumber)
+	assert.Equal(t, "sha-legacy", p.HeadSHA)
+	assert.Equal(t, PanelOutcomeLegacyReview, p.Outcome)
+	assert.NotEmpty(t, p.PostedAt)
+	require.NotNil(t, p.FirstAttemptAt)
+	assert.Equal(t, p.PanelCreatedAt, *p.FirstAttemptAt,
+		"legacy panel_created_at and first_attempt_at both snapshot job.enqueued_at")
+	assert.Nil(t, p.AttemptCount, "legacy rows predate retry-attempt tracking")
+	require.NotNil(t, p.SynthesisAgent)
+	assert.Equal(t, "legacy-agent", *p.SynthesisAgent)
+	require.NotNil(t, p.SynthesisModel)
+	assert.Equal(t, "legacy-model", *p.SynthesisModel)
+
+	require.Len(t, p.Jobs, 1)
+	j := p.Jobs[0]
+	assert.Equal(t, job.UUID, j.JobUUID)
+	assert.Equal(t, "review", j.Role)
+	assert.Equal(t, "legacy-agent", j.Agent)
+	require.NotNil(t, j.Model)
+	assert.Equal(t, "legacy-model", *j.Model)
+	require.NotNil(t, j.Provider)
+	assert.Equal(t, "legacy-provider", *j.Provider)
+	assert.Equal(t, string(JobStatusDone), j.Status)
+	assert.NotNil(t, j.StartedAt)
+	assert.NotNil(t, j.FinishedAt)
+	assert.NotNil(t, page.NextCursor)
+}
+
+func TestExportCIMetricsLegacyPagination(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
+	seedLegacyCIReview(t, db, repo.ID, "o/r", 30, "sha-legacy-a", "2026-03-01 10:00:00")
+	seedLegacyCIReview(t, db, repo.ID, "o/r", 31, "sha-legacy-b", "2026-03-02 10:00:00")
+
+	first, err := db.ExportCIMetrics(ExportCIMetricsOptions{Legacy: true, Limit: 1})
+	require.NoError(t, err)
+	require.Len(t, first.Panels, 1)
+	assert.Equal(t, "sha-legacy-a", first.Panels[0].HeadSHA)
+	assert.True(t, first.Truncated)
+	require.NotNil(t, first.NextCursor)
+
+	second, err := db.ExportCIMetrics(ExportCIMetricsOptions{Legacy: true, Cursor: *first.NextCursor})
+	require.NoError(t, err)
+	require.Len(t, second.Panels, 1)
+	assert.Equal(t, "sha-legacy-b", second.Panels[0].HeadSHA)
+	assert.False(t, second.Truncated)
+}
+
+func TestExportCIMetricsRejectsCursorModeMismatch(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
+	seedPostedPanel(t, db, 40, "sha-panel", PanelOutcomeReviewPosted)
+	seedLegacyCIReview(t, db, repo.ID, "o/r", 41, "sha-legacy", "2026-03-01 10:00:00")
+
+	panelPage, err := db.ExportCIMetrics(ExportCIMetricsOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, panelPage.NextCursor)
+
+	legacyPage, err := db.ExportCIMetrics(ExportCIMetricsOptions{Legacy: true})
+	require.NoError(t, err)
+	require.NotNil(t, legacyPage.NextCursor)
+
+	_, err = db.ExportCIMetrics(ExportCIMetricsOptions{Legacy: true, Cursor: *panelPage.NextCursor})
+	require.ErrorIs(t, err, ErrExportCIMetricsCursorModeMismatch,
+		"a panel cursor must not be replayable against the legacy export")
+
+	_, err = db.ExportCIMetrics(ExportCIMetricsOptions{Legacy: false, Cursor: *legacyPage.NextCursor})
+	require.ErrorIs(t, err, ErrExportCIMetricsCursorModeMismatch,
+		"a legacy cursor must not be replayable against the panel export")
+}
+
+func TestExportCIMetricsLegacyAndPanelModesAreDisjoint(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
+	seedPostedPanel(t, db, 50, "sha-panel-only", PanelOutcomeReviewPosted)
+	seedLegacyCIReview(t, db, repo.ID, "o/r", 51, "sha-legacy-only", "2026-03-01 10:00:00")
+
+	panelPage, err := db.ExportCIMetrics(ExportCIMetricsOptions{})
+	require.NoError(t, err)
+	require.Len(t, panelPage.Panels, 1, "legacy rows must not appear in the default export")
+	assert.Equal(t, "sha-panel-only", panelPage.Panels[0].HeadSHA)
+	assert.NotEqual(t, PanelOutcomeLegacyReview, panelPage.Panels[0].Outcome)
+
+	legacyPage, err := db.ExportCIMetrics(ExportCIMetricsOptions{Legacy: true})
+	require.NoError(t, err)
+	require.Len(t, legacyPage.Panels, 1, "posted panels must not appear in the legacy export")
+	assert.Equal(t, "sha-legacy-only", legacyPage.Panels[0].HeadSHA)
+	assert.Equal(t, PanelOutcomeLegacyReview, legacyPage.Panels[0].Outcome)
+}

--- a/internal/storage/export_ci_test.go
+++ b/internal/storage/export_ci_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"encoding/base64"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -10,6 +11,47 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestMigrationBackfillsPanelTerminalMetrics covers the startup backfill for
+// panels finalized before outcome persistence existed: reopening the
+// database reconstructs outcome from the retained synthesis job's terminal
+// status and first_attempt_at from the panel run's earliest job enqueue, so
+// pre-existing posted panels export with real terminal metrics instead of
+// "unknown"/NULL.
+func TestMigrationBackfillsPanelTerminalMetrics(t *testing.T) {
+	tmpl, err := getTemplatePath()
+	require.NoError(t, err)
+	data, err := os.ReadFile(tmpl)
+	require.NoError(t, err)
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	require.NoError(t, os.WriteFile(dbPath, data, 0o644))
+	db, err := Open(dbPath)
+	require.NoError(t, err)
+
+	panel := seedPostedPanel(t, db, 60, "sha-backfill", PanelOutcomeReviewPosted)
+	require.NotNil(t, panel.SynthesisJobID)
+	setStatus(t, db, *panel.SynthesisJobID, JobStatusDone)
+	// Simulate a row finalized before the terminal-metrics columns existed.
+	_, err = db.Exec(`UPDATE ci_pr_panels
+		SET outcome = NULL, first_attempt_at = NULL, attempt_count = NULL
+		WHERE id = ?`, panel.ID)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	reopened, err := Open(dbPath)
+	require.NoError(t, err)
+	defer reopened.Close()
+
+	page, err := reopened.ExportCIMetrics(ExportCIMetricsOptions{})
+	require.NoError(t, err)
+	require.Len(t, page.Panels, 1)
+	p := page.Panels[0]
+	assert.Equal(t, PanelOutcomeReviewPosted, p.Outcome,
+		"outcome reconstructed from the synthesis job's terminal status")
+	require.NotNil(t, p.FirstAttemptAt,
+		"first_attempt_at reconstructed from the run's earliest job enqueue")
+	assert.Nil(t, p.AttemptCount, "attempt counts are unrecoverable")
+}
 
 func seedPostedPanel(t *testing.T, db *DB, pr int, sha, outcome string) *CIPanel {
 	t.Helper()
@@ -156,65 +198,70 @@ func TestExportCIMetricsRejectsCursorFromDifferentDatabase(t *testing.T) {
 	require.ErrorIs(t, err, ErrExportCursorDatabaseMismatch)
 }
 
-// seedLegacyCIReview inserts a review_jobs row plus its ci_pr_reviews link,
-// mirroring the frozen pre-panel schema (ci_pr_reviews.job_id -> review_jobs,
-// created_at in SQLite's CURRENT_TIMESTAMP space format). No production
-// writer remains for ci_pr_reviews, so tests populate it directly.
-func seedLegacyCIReview(t *testing.T, db *DB, repoID int64, githubRepo string, pr int, headSHA, createdAt string) *ReviewJob {
+// seedLegacyCIJob inserts one completed pre-panel CI review job:
+// source='ci', no panel run, explicit enqueue/finish timestamps. The
+// pre-panel era wrote no PR linkage rows that survive, so the legacy export
+// groups these jobs by (repo, git_ref) into pseudopanel units.
+func seedLegacyCIJob(t *testing.T, db *DB, repoID int64, gitRef, agent string, enqueued, finished string) *ReviewJob {
 	t.Helper()
 	job, err := db.EnqueueJob(EnqueueOpts{
-		RepoID: repoID, GitRef: headSHA,
-		Agent: "legacy-agent", Model: "legacy-model", Provider: "legacy-provider",
+		RepoID: repoID, GitRef: gitRef,
+		Agent: agent, Model: "legacy-model", Provider: "legacy-provider",
+		Source: JobSourceCI,
 	})
 	require.NoError(t, err)
-	_, err = db.Exec(`INSERT INTO ci_pr_reviews (github_repo, pr_number, head_sha, job_id, created_at)
-		VALUES (?, ?, ?, ?, ?)`, githubRepo, pr, headSHA, job.ID, createdAt)
+	_, err = db.Exec(`UPDATE review_jobs
+		SET status = 'done', enqueued_at = ?, started_at = ?, finished_at = ?
+		WHERE id = ?`, enqueued, enqueued, finished, job.ID)
 	require.NoError(t, err)
 	return job
 }
 
-func TestExportCIMetricsLegacyRowShape(t *testing.T) {
+func TestExportCIMetricsLegacyCombinesPseudopanel(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()
 
 	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
-	job := seedLegacyCIReview(t, db, repo.ID, "o/r", 7, "sha-legacy", "2026-03-01 10:00:00")
-	setStatus(t, db, job.ID, JobStatusDone)
-	setStartedAt(t, db, job.ID, time.Date(2026, 3, 1, 9, 55, 0, 0, time.UTC))
-	_, err := db.Exec(`UPDATE review_jobs SET finished_at = ? WHERE id = ?`, "2026-03-01T10:05:00Z", job.ID)
+	jobA := seedLegacyCIJob(t, db, repo.ID, "base..head-legacy", "codex",
+		"2026-03-01 10:00:00", "2026-03-01 10:05:00")
+	jobB := seedLegacyCIJob(t, db, repo.ID, "base..head-legacy", "gemini",
+		"2026-03-01 10:00:00", "2026-03-01 10:08:00")
+	// A failed sibling contributes neither to the wall clock nor to Jobs.
+	failed := seedLegacyCIJob(t, db, repo.ID, "base..head-legacy", "codex",
+		"2026-03-01 10:00:00", "2026-03-01 10:30:00")
+	_, err := db.Exec(`UPDATE review_jobs SET status = 'failed' WHERE id = ?`, failed.ID)
 	require.NoError(t, err)
 
 	page, err := db.ExportCIMetrics(ExportCIMetricsOptions{Legacy: true})
 	require.NoError(t, err)
-	require.Len(t, page.Panels, 1)
+	require.Len(t, page.Panels, 1, "one pseudopanel unit per (repo, git_ref)")
 	p := page.Panels[0]
 
-	assert.Equal(t, "o/r", p.GithubRepo)
-	assert.Equal(t, int64(7), p.PRNumber)
-	assert.Equal(t, "sha-legacy", p.HeadSHA)
+	assert.Equal(t, repo.Name, p.GithubRepo)
+	assert.Equal(t, int64(0), p.PRNumber, "the PR linkage is unrecoverable for legacy units")
+	assert.Equal(t, "head-legacy", p.HeadSHA)
 	assert.Equal(t, PanelOutcomeLegacyReview, p.Outcome)
-	assert.NotEmpty(t, p.PostedAt)
+	assert.Equal(t, "2026-03-01T10:08:00Z", p.PostedAt, "latest finish of the unit's done jobs")
 	require.NotNil(t, p.FirstAttemptAt)
-	assert.Equal(t, p.PanelCreatedAt, *p.FirstAttemptAt,
-		"legacy panel_created_at and first_attempt_at both snapshot job.enqueued_at")
+	assert.Equal(t, "2026-03-01T10:00:00Z", *p.FirstAttemptAt, "earliest enqueue of the unit")
+	assert.Equal(t, p.PanelCreatedAt, *p.FirstAttemptAt)
 	assert.Nil(t, p.AttemptCount, "legacy rows predate retry-attempt tracking")
-	require.NotNil(t, p.SynthesisAgent)
-	assert.Equal(t, "legacy-agent", *p.SynthesisAgent)
-	require.NotNil(t, p.SynthesisModel)
-	assert.Equal(t, "legacy-model", *p.SynthesisModel)
+	assert.Nil(t, p.SynthesisAgent, "pseudopanels had no synthesis")
+	assert.Nil(t, p.SynthesisModel, "pseudopanels had no synthesis")
 
-	require.Len(t, p.Jobs, 1)
-	j := p.Jobs[0]
-	assert.Equal(t, job.UUID, j.JobUUID)
-	assert.Equal(t, "review", j.Role)
-	assert.Equal(t, "legacy-agent", j.Agent)
-	require.NotNil(t, j.Model)
-	assert.Equal(t, "legacy-model", *j.Model)
-	require.NotNil(t, j.Provider)
-	assert.Equal(t, "legacy-provider", *j.Provider)
-	assert.Equal(t, string(JobStatusDone), j.Status)
-	assert.NotNil(t, j.StartedAt)
-	assert.NotNil(t, j.FinishedAt)
+	require.Len(t, p.Jobs, 2)
+	assert.Equal(t, jobA.UUID, p.Jobs[0].JobUUID)
+	assert.Equal(t, jobB.UUID, p.Jobs[1].JobUUID)
+	for _, j := range p.Jobs {
+		assert.Equal(t, "review", j.Role)
+		assert.Equal(t, string(JobStatusDone), j.Status)
+		require.NotNil(t, j.Model)
+		assert.Equal(t, "legacy-model", *j.Model)
+		require.NotNil(t, j.Provider)
+		assert.Equal(t, "legacy-provider", *j.Provider)
+		assert.NotNil(t, j.StartedAt)
+		assert.NotNil(t, j.FinishedAt)
+	}
 	assert.NotNil(t, page.NextCursor)
 }
 
@@ -223,8 +270,10 @@ func TestExportCIMetricsLegacyPagination(t *testing.T) {
 	defer db.Close()
 
 	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
-	seedLegacyCIReview(t, db, repo.ID, "o/r", 30, "sha-legacy-a", "2026-03-01 10:00:00")
-	seedLegacyCIReview(t, db, repo.ID, "o/r", 31, "sha-legacy-b", "2026-03-02 10:00:00")
+	seedLegacyCIJob(t, db, repo.ID, "sha-legacy-a", "codex",
+		"2026-03-01 10:00:00", "2026-03-01 10:05:00")
+	seedLegacyCIJob(t, db, repo.ID, "sha-legacy-b", "codex",
+		"2026-03-02 10:00:00", "2026-03-02 10:05:00")
 
 	first, err := db.ExportCIMetrics(ExportCIMetricsOptions{Legacy: true, Limit: 1})
 	require.NoError(t, err)
@@ -246,7 +295,8 @@ func TestExportCIMetricsRejectsCursorModeMismatch(t *testing.T) {
 
 	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
 	seedPostedPanel(t, db, 40, "sha-panel", PanelOutcomeReviewPosted)
-	seedLegacyCIReview(t, db, repo.ID, "o/r", 41, "sha-legacy", "2026-03-01 10:00:00")
+	seedLegacyCIJob(t, db, repo.ID, "sha-legacy", "codex",
+		"2026-03-01 10:00:00", "2026-03-01 10:05:00")
 
 	panelPage, err := db.ExportCIMetrics(ExportCIMetricsOptions{})
 	require.NoError(t, err)
@@ -271,7 +321,8 @@ func TestExportCIMetricsLegacyAndPanelModesAreDisjoint(t *testing.T) {
 
 	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
 	seedPostedPanel(t, db, 50, "sha-panel-only", PanelOutcomeReviewPosted)
-	seedLegacyCIReview(t, db, repo.ID, "o/r", 51, "sha-legacy-only", "2026-03-01 10:00:00")
+	seedLegacyCIJob(t, db, repo.ID, "sha-legacy-only", "codex",
+		"2026-03-01 10:00:00", "2026-03-01 10:05:00")
 
 	panelPage, err := db.ExportCIMetrics(ExportCIMetricsOptions{})
 	require.NoError(t, err)

--- a/internal/storage/export_ci_test.go
+++ b/internal/storage/export_ci_test.go
@@ -198,16 +198,18 @@ func TestExportCIMetricsRejectsCursorFromDifferentDatabase(t *testing.T) {
 	require.ErrorIs(t, err, ErrExportCursorDatabaseMismatch)
 }
 
-// seedLegacyCIJob inserts one completed pre-panel CI review job:
-// source='ci', no panel run, explicit enqueue/finish timestamps. The
-// pre-panel era wrote no PR linkage rows that survive, so the legacy export
-// groups these jobs by (repo, git_ref) into pseudopanel units.
+// seedLegacyCIJob inserts one completed pre-panel CI review job with no
+// panel run and explicit enqueue/finish timestamps, CI-tagged only through
+// ci_base_branch: rows from that era predate source='ci' tagging, and the
+// legacy export must honor both markers (ReviewJob.IsCI). The pre-panel era
+// wrote no PR linkage rows that survive, so the legacy export groups these
+// jobs by (repo, git_ref) into pseudopanel units.
 func seedLegacyCIJob(t *testing.T, db *DB, repoID int64, gitRef, agent string, enqueued, finished string) *ReviewJob {
 	t.Helper()
 	job, err := db.EnqueueJob(EnqueueOpts{
 		RepoID: repoID, GitRef: gitRef,
 		Agent: agent, Model: "legacy-model", Provider: "legacy-provider",
-		Source: JobSourceCI,
+		CIBaseBranch: "main",
 	})
 	require.NoError(t, err)
 	_, err = db.Exec(`UPDATE review_jobs

--- a/internal/storage/export_ci_test.go
+++ b/internal/storage/export_ci_test.go
@@ -77,6 +77,47 @@ func TestExportCIMetricsLegacyRowsAreUnknown(t *testing.T) {
 	assert.Nil(t, page.Panels[0].AttemptCount)
 }
 
+// TestExportCIMetricsSurvivesCascadeRepoDeletion covers the snapshot fix: a
+// panel's synthesis_agent/synthesis_model are stamped onto ci_pr_panels at
+// MarkPanelPosted time, so ExportCIMetrics still reports them (via the
+// COALESCE(NULLIF(...)) fallback preferring the snapshot) after the repo and
+// its review_jobs rows are cascade-deleted. Jobs, which is sourced live from
+// review_jobs by panel_run_uuid, is expected to come back empty in that case.
+func TestExportCIMetricsSurvivesCascadeRepoDeletion(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
+	now := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	created, err := db.ReserveReviewAttempt("o/r", 42, "sha-cascade", now)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	members := []EnqueueOpts{{
+		RepoID: repo.ID, GitRef: "b..h", Agent: "test-member", PanelMemberIndex: 0,
+	}}
+	synthesis := EnqueueOpts{RepoID: repo.ID, GitRef: "b..h", Agent: "test-synth", Model: "test-model"}
+	runCreated, _, _, err := db.CreateCIPanelRun("o/r", 42, "sha-cascade", members, synthesis)
+	require.NoError(t, err)
+	require.True(t, runCreated)
+
+	panel, err := db.GetCIPanelByPRSHA("o/r", 42, "sha-cascade")
+	require.NoError(t, err)
+	require.NoError(t, db.MarkPanelPosted(panel.ID, PanelOutcomeReviewPosted))
+
+	require.NoError(t, db.DeleteRepo(repo.ID, true))
+
+	page, err := db.ExportCIMetrics(ExportCIMetricsOptions{})
+	require.NoError(t, err)
+	require.Len(t, page.Panels, 1)
+	p := page.Panels[0]
+	require.NotNil(t, p.SynthesisAgent, "synthesis_agent survives from the panel-row snapshot")
+	assert.Equal(t, "test-synth", *p.SynthesisAgent)
+	require.NotNil(t, p.SynthesisModel, "synthesis_model survives from the panel-row snapshot")
+	assert.Equal(t, "test-model", *p.SynthesisModel)
+	assert.Empty(t, p.Jobs, "jobs reflect only currently retained review_jobs rows")
+}
+
 func TestExportCIMetricsCursorPagination(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()

--- a/internal/storage/export_ci_test.go
+++ b/internal/storage/export_ci_test.go
@@ -14,10 +14,12 @@ import (
 
 // TestMigrationBackfillsPanelTerminalMetrics covers the startup backfill for
 // panels finalized before outcome persistence existed: reopening the
-// database reconstructs outcome from the retained synthesis job's terminal
-// status and first_attempt_at from the panel run's earliest job enqueue, so
-// pre-existing posted panels export with real terminal metrics instead of
-// "unknown"/NULL.
+// database reconstructs outcome from the retained MEMBER results, mirroring
+// the posting decision (a failed synthesis whose member produced output
+// still posted the raw fallback), and first_attempt_at/attempt_count from
+// the surviving ci_pr_review_attempts row — the same source the finalizer
+// snapshots — falling back to the run's earliest job enqueue when the
+// attempt row was cleaned up.
 func TestMigrationBackfillsPanelTerminalMetrics(t *testing.T) {
 	tmpl, err := getTemplatePath()
 	require.NoError(t, err)
@@ -28,13 +30,36 @@ func TestMigrationBackfillsPanelTerminalMetrics(t *testing.T) {
 	db, err := Open(dbPath)
 	require.NoError(t, err)
 
-	panel := seedPostedPanel(t, db, 60, "sha-backfill", PanelOutcomeReviewPosted)
-	require.NotNil(t, panel.SynthesisJobID)
-	setStatus(t, db, *panel.SynthesisJobID, JobStatusDone)
-	// Simulate a row finalized before the terminal-metrics columns existed.
+	// (a) Synthesis FAILED but a member produced real output: the raw
+	// fallback was posted, so the outcome is review_posted, not a give-up.
+	rawFallback := seedPostedPanel(t, db, 60, "sha-raw-fallback", PanelOutcomeReviewPosted)
+	require.NotNil(t, rawFallback.SynthesisJobID)
+	completeMemberWithOutput(t, db, rawFallback.PanelRunUUID, "Found a bug.")
+	setStatus(t, db, *rawFallback.SynthesisJobID, JobStatusFailed)
+
+	// (b) All members failed: the give-up note was posted.
+	giveup := seedPostedPanel(t, db, 61, "sha-giveup", PanelOutcomeReviewPosted)
+	setStatus(t, db, panelMemberID(t, db, giveup.PanelRunUUID), JobStatusFailed)
+
+	// (c) All members skipped: the all-skip notice was posted.
+	allSkip := seedPostedPanel(t, db, 62, "sha-all-skip", PanelOutcomeReviewPosted)
+	setStatus(t, db, panelMemberID(t, db, allSkip.PanelRunUUID), JobStatusSkipped)
+
+	// (d) Attempt row already cleaned up: first_attempt_at falls back to
+	// the run's earliest job enqueue; attempt_count is unrecoverable.
+	noAttempt := seedPostedPanel(t, db, 63, "sha-no-attempt", PanelOutcomeReviewPosted)
+	completeMemberWithOutput(t, db, noAttempt.PanelRunUUID, "Looks good.")
+	require.NoError(t, db.DeleteReviewAttempt("o/r", 63, "sha-no-attempt"))
+
+	// (e) Member rows gone entirely: the outcome is unrecoverable.
+	noJobs := seedPostedPanel(t, db, 64, "sha-no-jobs", PanelOutcomeReviewPosted)
+	_, err = db.Exec(`DELETE FROM review_jobs WHERE panel_run_uuid = ?`, noJobs.PanelRunUUID)
+	require.NoError(t, err)
+	require.NoError(t, db.DeleteReviewAttempt("o/r", 64, "sha-no-jobs"))
+
+	// Simulate rows finalized before the terminal-metrics columns existed.
 	_, err = db.Exec(`UPDATE ci_pr_panels
-		SET outcome = NULL, first_attempt_at = NULL, attempt_count = NULL
-		WHERE id = ?`, panel.ID)
+		SET outcome = NULL, first_attempt_at = NULL, attempt_count = NULL`)
 	require.NoError(t, err)
 	require.NoError(t, db.Close())
 
@@ -44,13 +69,55 @@ func TestMigrationBackfillsPanelTerminalMetrics(t *testing.T) {
 
 	page, err := reopened.ExportCIMetrics(ExportCIMetricsOptions{})
 	require.NoError(t, err)
-	require.Len(t, page.Panels, 1)
-	p := page.Panels[0]
+	require.Len(t, page.Panels, 5)
+	bySHA := map[string]ExportCIPanel{}
+	for _, p := range page.Panels {
+		bySHA[p.HeadSHA] = p
+	}
+
+	p := bySHA["sha-raw-fallback"]
 	assert.Equal(t, PanelOutcomeReviewPosted, p.Outcome,
-		"outcome reconstructed from the synthesis job's terminal status")
+		"a member with output posted the raw fallback despite the failed synthesis")
+	require.NotNil(t, p.FirstAttemptAt)
+	assert.Equal(t, "2026-07-01T10:00:00Z", *p.FirstAttemptAt,
+		"first_attempt_at snapshots the surviving attempt row")
+	require.NotNil(t, p.AttemptCount, "attempt_count snapshots the surviving attempt row")
+	assert.Equal(t, int64(1), *p.AttemptCount)
+
+	assert.Equal(t, PanelOutcomeGiveupPosted, bySHA["sha-giveup"].Outcome)
+	assert.Equal(t, PanelOutcomeNoReviewPosted, bySHA["sha-all-skip"].Outcome)
+
+	p = bySHA["sha-no-attempt"]
+	assert.Equal(t, PanelOutcomeReviewPosted, p.Outcome)
 	require.NotNil(t, p.FirstAttemptAt,
-		"first_attempt_at reconstructed from the run's earliest job enqueue")
-	assert.Nil(t, p.AttemptCount, "attempt counts are unrecoverable")
+		"first_attempt_at falls back to the run's earliest job enqueue")
+	assert.Nil(t, p.AttemptCount, "attempt counts are unrecoverable without the attempt row")
+
+	p = bySHA["sha-no-jobs"]
+	assert.Equal(t, PanelOutcomeUnknown, p.Outcome,
+		"no surviving member rows leaves the outcome unknown")
+	assert.Nil(t, p.FirstAttemptAt)
+}
+
+// panelMemberID returns the id of a panel run's single seeded member job.
+func panelMemberID(t *testing.T, db *DB, runUUID string) int64 {
+	t.Helper()
+	var id int64
+	require.NoError(t, db.QueryRow(`SELECT id FROM review_jobs
+		WHERE panel_run_uuid = ? AND panel_role = 'member'`, runUUID).Scan(&id))
+	return id
+}
+
+// completeMemberWithOutput marks a panel run's member job done and stores a
+// review row with the given output — the evidence the outcome backfill keys
+// on.
+func completeMemberWithOutput(t *testing.T, db *DB, runUUID, output string) {
+	t.Helper()
+	id := panelMemberID(t, db, runUUID)
+	setStatus(t, db, id, JobStatusDone)
+	_, err := db.Exec(`INSERT INTO reviews (job_id, agent, prompt, output)
+		VALUES (?, 'test', 'p', ?)`, id, output)
+	require.NoError(t, err)
 }
 
 func seedPostedPanel(t *testing.T, db *DB, pr int, sha, outcome string) *CIPanel {
@@ -201,8 +268,8 @@ func TestExportCIMetricsRejectsCursorFromDifferentDatabase(t *testing.T) {
 // seedLegacyCIJob inserts one completed pre-panel CI review job with no
 // panel run and explicit enqueue/finish timestamps. Rows from that era
 // predate all CI tagging (source and ci_base_branch stay empty), so the
-// legacy export identifies pseudopanels structurally: two or more completed
-// jobs sharing (repo, git_ref).
+// legacy export identifies pseudopanels structurally: two or more terminal
+// jobs sharing (repo, git_ref), at least one done.
 func seedLegacyCIJob(t *testing.T, db *DB, repoID int64, gitRef, agent string, enqueued, finished string) *ReviewJob {
 	t.Helper()
 	job, err := db.EnqueueJob(EnqueueOpts{
@@ -217,16 +284,30 @@ func seedLegacyCIJob(t *testing.T, db *DB, repoID int64, gitRef, agent string, e
 	return job
 }
 
+// seedPanelEraMarker inserts a minimal ci_pr_panels row so the database has
+// panel activity starting at createdAt: the pre-panel era ends there, and
+// only legacy jobs enqueued earlier remain exportable.
+func seedPanelEraMarker(t *testing.T, db *DB, createdAt string) {
+	t.Helper()
+	_, err := db.Exec(`INSERT INTO ci_pr_panels
+		(github_repo, pr_number, head_sha, panel_run_uuid, created_at)
+		VALUES ('era/marker', 999999, ?, ?, ?)`,
+		"sha-era-"+createdAt, "era-"+createdAt, createdAt)
+	require.NoError(t, err)
+}
+
 func TestExportCIMetricsLegacyCombinesPseudopanel(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()
 
 	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
+	seedPanelEraMarker(t, db, "2026-06-01 00:00:00")
 	jobA := seedLegacyCIJob(t, db, repo.ID, "base..head-legacy", "codex",
 		"2026-03-01 10:00:00", "2026-03-01 10:05:00")
 	jobB := seedLegacyCIJob(t, db, repo.ID, "base..head-legacy", "gemini",
 		"2026-03-01 10:00:00", "2026-03-01 10:08:00")
-	// A failed sibling contributes neither to the wall clock nor to Jobs.
+	// A failed sibling is part of the unit: the batch posted only after
+	// every member was terminal, so its finish extends the wall clock.
 	failed := seedLegacyCIJob(t, db, repo.ID, "base..head-legacy", "codex",
 		"2026-03-01 10:00:00", "2026-03-01 10:30:00")
 	_, err := db.Exec(`UPDATE review_jobs SET status = 'failed' WHERE id = ?`, failed.ID)
@@ -241,11 +322,13 @@ func TestExportCIMetricsLegacyCombinesPseudopanel(t *testing.T) {
 	require.Len(t, page.Panels, 1, "one pseudopanel unit per (repo, git_ref); singletons excluded")
 	p := page.Panels[0]
 
-	assert.Equal(t, repo.Name, p.GithubRepo)
+	assert.Equal(t, repo.Name, p.GithubRepo,
+		"falls back to repos.name when no identity is recorded")
 	assert.Equal(t, int64(0), p.PRNumber, "the PR linkage is unrecoverable for legacy units")
 	assert.Equal(t, "head-legacy", p.HeadSHA)
 	assert.Equal(t, PanelOutcomeLegacyReview, p.Outcome)
-	assert.Equal(t, "2026-03-01T10:08:00Z", p.PostedAt, "latest finish of the unit's done jobs")
+	assert.Equal(t, "2026-03-01T10:30:00Z", p.PostedAt,
+		"latest finish of the unit's terminal jobs, including the failed sibling")
 	require.NotNil(t, p.FirstAttemptAt)
 	assert.Equal(t, "2026-03-01T10:00:00Z", *p.FirstAttemptAt, "earliest enqueue of the unit")
 	assert.Equal(t, p.PanelCreatedAt, *p.FirstAttemptAt)
@@ -253,12 +336,15 @@ func TestExportCIMetricsLegacyCombinesPseudopanel(t *testing.T) {
 	assert.Nil(t, p.SynthesisAgent, "pseudopanels had no synthesis")
 	assert.Nil(t, p.SynthesisModel, "pseudopanels had no synthesis")
 
-	require.Len(t, p.Jobs, 2)
+	require.Len(t, p.Jobs, 3)
 	assert.Equal(t, jobA.UUID, p.Jobs[0].JobUUID)
 	assert.Equal(t, jobB.UUID, p.Jobs[1].JobUUID)
+	assert.Equal(t, failed.UUID, p.Jobs[2].JobUUID)
+	assert.Equal(t, string(JobStatusDone), p.Jobs[0].Status)
+	assert.Equal(t, string(JobStatusDone), p.Jobs[1].Status)
+	assert.Equal(t, string(JobStatusFailed), p.Jobs[2].Status)
 	for _, j := range p.Jobs {
 		assert.Equal(t, "review", j.Role)
-		assert.Equal(t, string(JobStatusDone), j.Status)
 		require.NotNil(t, j.Model)
 		assert.Equal(t, "legacy-model", *j.Model)
 		require.NotNil(t, j.Provider)
@@ -267,6 +353,98 @@ func TestExportCIMetricsLegacyCombinesPseudopanel(t *testing.T) {
 		assert.NotNil(t, j.FinishedAt)
 	}
 	assert.NotNil(t, page.NextCursor)
+}
+
+// TestExportCIMetricsLegacyPartialSuccessUnit covers the batch flow's
+// partial-success posting: one done + one failed job is a posted review and
+// must export as a unit, while an all-failed pair posted nothing reviewable
+// and is excluded.
+func TestExportCIMetricsLegacyPartialSuccessUnit(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
+	seedPanelEraMarker(t, db, "2026-06-01 00:00:00")
+	seedLegacyCIJob(t, db, repo.ID, "base..head-partial", "codex",
+		"2026-03-01 10:00:00", "2026-03-01 10:05:00")
+	partialFailed := seedLegacyCIJob(t, db, repo.ID, "base..head-partial", "gemini",
+		"2026-03-01 10:00:00", "2026-03-01 10:07:00")
+	allFailedA := seedLegacyCIJob(t, db, repo.ID, "base..head-all-failed", "codex",
+		"2026-03-02 10:00:00", "2026-03-02 10:05:00")
+	allFailedB := seedLegacyCIJob(t, db, repo.ID, "base..head-all-failed", "gemini",
+		"2026-03-02 10:00:00", "2026-03-02 10:06:00")
+	for _, id := range []int64{partialFailed.ID, allFailedA.ID, allFailedB.ID} {
+		_, err := db.Exec(`UPDATE review_jobs SET status = 'failed' WHERE id = ?`, id)
+		require.NoError(t, err)
+	}
+
+	page, err := db.ExportCIMetrics(ExportCIMetricsOptions{Legacy: true})
+	require.NoError(t, err)
+	require.Len(t, page.Panels, 1,
+		"partial-success units export; all-failed groups posted no review")
+	p := page.Panels[0]
+	assert.Equal(t, "head-partial", p.HeadSHA)
+	assert.Equal(t, "2026-03-01T10:07:00Z", p.PostedAt,
+		"wall clock ends at the failed sibling's finish")
+	require.Len(t, p.Jobs, 2)
+}
+
+// TestExportCIMetricsLegacyUsesRepoIdentity covers github_repo naming: the
+// export must use the repo's remote identity (mapped to owner/repo), not the
+// checkout basename, so same-named clones of different repositories are not
+// conflated.
+func TestExportCIMetricsLegacyUsesRepoIdentity(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo, err := db.GetOrCreateRepo(filepath.Join(t.TempDir(), "repo"),
+		"git@github.com:owner/project.git")
+	require.NoError(t, err)
+	seedPanelEraMarker(t, db, "2026-06-01 00:00:00")
+	seedLegacyCIJob(t, db, repo.ID, "base..head-ident", "codex",
+		"2026-03-01 10:00:00", "2026-03-01 10:05:00")
+	seedLegacyCIJob(t, db, repo.ID, "base..head-ident", "gemini",
+		"2026-03-01 10:00:00", "2026-03-01 10:06:00")
+
+	page, err := db.ExportCIMetrics(ExportCIMetricsOptions{Legacy: true})
+	require.NoError(t, err)
+	require.Len(t, page.Panels, 1)
+	assert.Equal(t, "owner/project", page.Panels[0].GithubRepo)
+}
+
+// TestExportCIMetricsLegacyBoundedToPrePanelEra covers the era bound: only
+// jobs enqueued before the database's first panel activity can form legacy
+// units, so post-panel manual reviews of the same ref never appear as new
+// pseudopanels, and a database with no panel activity exports nothing.
+func TestExportCIMetricsLegacyBoundedToPrePanelEra(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
+	seedLegacyCIJob(t, db, repo.ID, "base..head-pre", "codex",
+		"2026-03-01 10:00:00", "2026-03-01 10:05:00")
+	seedLegacyCIJob(t, db, repo.ID, "base..head-pre", "gemini",
+		"2026-03-01 10:00:00", "2026-03-01 10:06:00")
+
+	page, err := db.ExportCIMetrics(ExportCIMetricsOptions{Legacy: true})
+	require.NoError(t, err)
+	assert.Empty(t, page.Panels,
+		"a database with no panel activity has no pre-panel era")
+	assert.Nil(t, page.NextCursor)
+
+	// Panel era starts 2026-06-01: the March unit exports, but two manual
+	// reviews of one ref after that date must not form a pseudopanel.
+	seedPanelEraMarker(t, db, "2026-06-01 00:00:00")
+	seedLegacyCIJob(t, db, repo.ID, "base..head-post", "codex",
+		"2026-07-01 10:00:00", "2026-07-01 10:05:00")
+	seedLegacyCIJob(t, db, repo.ID, "base..head-post", "gemini",
+		"2026-07-01 10:00:00", "2026-07-01 10:06:00")
+
+	page, err = db.ExportCIMetrics(ExportCIMetricsOptions{Legacy: true})
+	require.NoError(t, err)
+	require.Len(t, page.Panels, 1)
+	assert.Equal(t, "head-pre", page.Panels[0].HeadSHA,
+		"post-panel-era jobs are excluded from legacy units")
 }
 
 // TestExportCIMetricsLegacyExcludesNonAdjacentReReview covers the adjacency
@@ -278,6 +456,7 @@ func TestExportCIMetricsLegacyExcludesNonAdjacentReReview(t *testing.T) {
 	defer db.Close()
 
 	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
+	seedPanelEraMarker(t, db, "2026-06-01 00:00:00")
 	seedLegacyCIJob(t, db, repo.ID, "base..head-rerun", "codex",
 		"2026-03-01 10:00:00", "2026-03-01 10:05:00")
 	seedLegacyCIJob(t, db, repo.ID, "base..head-rerun", "gemini",
@@ -300,6 +479,7 @@ func TestExportCIMetricsLegacyPagination(t *testing.T) {
 	defer db.Close()
 
 	repo := createRepo(t, db, filepath.Join(t.TempDir(), "repo"))
+	seedPanelEraMarker(t, db, "2026-06-01 00:00:00")
 	seedLegacyCIJob(t, db, repo.ID, "sha-legacy-a", "codex",
 		"2026-03-01 10:00:00", "2026-03-01 10:05:00")
 	seedLegacyCIJob(t, db, repo.ID, "sha-legacy-a", "gemini",

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -55,6 +55,10 @@ type ClientInterface interface {
 	EnqueueJob(ctx context.Context, options *EnqueueJobRequestOptions, reqEditors ...runtime.RequestEditorFn) (*EnqueueJobResponseJSON, error)
 	EnqueueJobWithResponse(ctx context.Context, options *EnqueueJobRequestOptions, reqEditors ...runtime.RequestEditorFn) (*EnqueueJobResp, error)
 
+	// ExportCiMetrics Export finalized CI panel metrics
+	ExportCiMetrics(ctx context.Context, options *ExportCiMetricsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ExportCiMetricsResponse, error)
+	ExportCiMetricsWithResponse(ctx context.Context, options *ExportCiMetricsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ExportCiMetricsResp, error)
+
 	// ExportReviews Export completed reviews
 	ExportReviews(ctx context.Context, options *ExportReviewsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ExportReviewsResponse, error)
 	ExportReviewsWithResponse(ctx context.Context, options *ExportReviewsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ExportReviewsResp, error)
@@ -565,6 +569,78 @@ func (c *Client) EnqueueJob(ctx context.Context, options *EnqueueJobRequestOptio
 	}
 
 	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/enqueue")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// ExportCiMetrics Export finalized CI panel metrics
+func (c *Client) ExportCiMetrics(ctx context.Context, options *ExportCiMetricsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ExportCiMetricsResponse, error) {
+	var err error
+
+	queryEncoding := map[string]runtime.QueryEncoding{
+		"cursor": {Style: "form", Explode: &[]bool{false}[0]},
+		"format": {Style: "form", Explode: &[]bool{false}[0]},
+		"limit":  {Style: "form", Explode: &[]bool{false}[0]},
+		"since":  {Style: "form", Explode: &[]bool{false}[0]},
+		"until":  {Style: "form", Explode: &[]bool{false}[0]},
+	}
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:    c.apiClient.GetBaseURL() + "/api/export/ci-metrics",
+		Method:        "GET",
+		Options:       options,
+		QueryEncoding: queryEncoding,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*ExportCiMetricsResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(ExportCiMetricsErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "ExportCiMetricsErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(ExportCiMetricsResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "ExportCiMetricsResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/export/ci-metrics")
 	if err != nil {
 		return nil, fmt.Errorf("error executing request: %w", err)
 	}

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -582,6 +582,7 @@ func (c *Client) ExportCiMetrics(ctx context.Context, options *ExportCiMetricsRe
 	queryEncoding := map[string]runtime.QueryEncoding{
 		"cursor": {Style: "form", Explode: &[]bool{false}[0]},
 		"format": {Style: "form", Explode: &[]bool{false}[0]},
+		"legacy": {Style: "form", Explode: &[]bool{false}[0]},
 		"limit":  {Style: "form", Explode: &[]bool{false}[0]},
 		"since":  {Style: "form", Explode: &[]bool{false}[0]},
 		"until":  {Style: "form", Explode: &[]bool{false}[0]},

--- a/pkg/client/generated/client_options.go
+++ b/pkg/client/generated/client_options.go
@@ -270,6 +270,50 @@ func (o *EnqueueJobRequestOptions) GetHeader() (map[string]string, error) {
 	return nil, nil
 }
 
+// ExportCiMetricsRequestOptions is the options needed to make a request to ExportCiMetrics.
+type ExportCiMetricsRequestOptions struct {
+	Query *ExportCiMetricsQuery
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *ExportCiMetricsRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.Query != nil {
+		if v, ok := any(o.Query).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Query", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *ExportCiMetricsRequestOptions) GetPathParams() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetQuery returns the query params as a map.
+func (o *ExportCiMetricsRequestOptions) GetQuery() (map[string]any, error) {
+	return runtime.AsMap[any](o.Query)
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *ExportCiMetricsRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *ExportCiMetricsRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
 // ExportReviewsRequestOptions is the options needed to make a request to ExportReviews.
 type ExportReviewsRequestOptions struct {
 	Query *ExportReviewsQuery

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -384,6 +384,69 @@ func (c *Client) EnqueueJobWithResponse(ctx context.Context, options *EnqueueJob
 	}
 }
 
+// ExportCiMetrics Export finalized CI panel metrics
+func (c *Client) ExportCiMetricsWithResponse(ctx context.Context, options *ExportCiMetricsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ExportCiMetricsResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/export/ci-metrics",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/export/ci-metrics")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &ExportCiMetricsResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(ExportCiMetricsResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ExportCiMetricsResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 409:
+		out.ApplicationProblemPlusJSON409 = new(ExportCiMetricsErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.ApplicationProblemPlusJSON409); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ExportCiMetricsErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
 // ExportReviews Export completed reviews
 func (c *Client) ExportReviewsWithResponse(ctx context.Context, options *ExportReviewsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ExportReviewsResp, error) {
 	var err error

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -71,6 +71,9 @@ type ExportCiMetricsQuery struct {
 
 	// Cursor Opaque next_cursor from a previous page. Resumes strictly after its (posted_at, panel_id) position; mutually exclusive with since.
 	Cursor *string `json:"cursor,omitempty"`
+
+	// Legacy Export the frozen pre-panel ci_pr_reviews era instead of panel runs. Cursors are namespaced to this mode and cannot be reused across modes.
+	Legacy *bool `json:"legacy,omitempty"`
 }
 
 type ExportReviewsQuery struct {

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -56,6 +56,23 @@ func (g GetCostQuery) Validate() error {
 	return errors
 }
 
+type ExportCiMetricsQuery struct {
+	// Format Output format; only json is supported
+	Format *string `json:"format,omitempty"`
+
+	// Since Inclusive posted_at lower bound (RFC3339 or YYYY-MM-DD)
+	Since *string `json:"since,omitempty"`
+
+	// Until Exclusive posted_at upper bound (RFC3339 or YYYY-MM-DD; date-only means through that UTC day)
+	Until *string `json:"until,omitempty"`
+
+	// Limit Maximum panels in this page
+	Limit *int64 `json:"limit,omitempty"`
+
+	// Cursor Opaque next_cursor from a previous page. Resumes strictly after its (posted_at, panel_id) position; mutually exclusive with since.
+	Cursor *string `json:"cursor,omitempty"`
+}
+
 type ExportReviewsQuery struct {
 	// Format Output format; only json is supported
 	Format *string `json:"format,omitempty"`

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -115,6 +115,10 @@ type EnqueueJobErrorResponseJSON500 = ErrorResponse
 
 type EnqueueJobErrorResponseJSON503 = ErrorResponse
 
+type ExportCiMetricsResponse = ExportCIMetricsDocument
+
+type ExportCiMetricsErrorResponse = ErrorModel
+
 type ExportReviewsResponse = ExportReviewsDocument
 
 type ExportReviewsErrorResponse = ErrorModel
@@ -274,6 +278,14 @@ type EnqueueJobResp struct {
 	JSON413      *EnqueueJobErrorResponseJSON
 	JSON500      *EnqueueJobErrorResponseJSON500
 	JSON503      *EnqueueJobErrorResponseJSON503
+}
+
+type ExportCiMetricsResp struct {
+	HTTPResponse                  *http.Response
+	Body                          []byte
+	StatusCode                    int
+	JSON200                       *ExportCiMetricsResponse
+	ApplicationProblemPlusJSON409 *ExportCiMetricsErrorResponse
 }
 
 type ExportReviewsResp struct {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -356,6 +356,137 @@ func (s ErrorResponse) Error() string {
 	return "unmapped client error"
 }
 
+type ExportCIMetricsDocument struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema *string `json:"$schema,omitempty"`
+
+	// DatabaseID Stable identity for the local review database; changes when the database is recreated.
+	DatabaseID  string `json:"database_id" validate:"required"`
+	GeneratedAt string `json:"generated_at" validate:"required"`
+
+	// NextCursor Opaque resume cursor emitted when panels is non-empty.
+	NextCursor    *string         `json:"next_cursor,omitempty" validate:"required"`
+	Panels        []ExportCIPanel `json:"panels,omitempty" validate:"required"`
+	SchemaVersion int64           `json:"schema_version"`
+	Tool          string          `json:"tool" validate:"required"`
+	ToolVersion   string          `json:"tool_version" validate:"required"`
+
+	// Truncated True when more matching rows are available immediately.
+	Truncated bool                `json:"truncated"`
+	Window    ExportReviewsWindow `json:"window"`
+}
+
+func (e ExportCIMetricsDocument) Validate() error {
+	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(e.DatabaseID, "required"); err != nil {
+		errors = errors.Append("DatabaseID", err)
+	}
+	if err := typesValidator.Var(e.GeneratedAt, "required"); err != nil {
+		errors = errors.Append("GeneratedAt", err)
+	}
+	if e.NextCursor != nil {
+		if err := typesValidator.Var(e.NextCursor, "required"); err != nil {
+			errors = errors.Append("NextCursor", err)
+		}
+	}
+	for i, item := range e.Panels {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Panels[%d]", i), err)
+			}
+		}
+	}
+	if err := typesValidator.Var(e.Tool, "required"); err != nil {
+		errors = errors.Append("Tool", err)
+	}
+	if err := typesValidator.Var(e.ToolVersion, "required"); err != nil {
+		errors = errors.Append("ToolVersion", err)
+	}
+	if v, ok := any(e.Window).(runtime.Validator); ok {
+		if err := v.Validate(); err != nil {
+			errors = errors.Append("Window", err)
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type ExportCIPanel struct {
+	AttemptCount   *int64             `json:"attempt_count,omitempty"`
+	FirstAttemptAt *string            `json:"first_attempt_at,omitempty" validate:"required"`
+	GithubRepo     string             `json:"github_repo" validate:"required"`
+	HeadSha        string             `json:"head_sha" validate:"required"`
+	Jobs           []ExportCIPanelJob `json:"jobs,omitempty" validate:"required"`
+	Outcome        string             `json:"outcome" validate:"required"`
+	PanelCreatedAt string             `json:"panel_created_at" validate:"required"`
+	PostedAt       string             `json:"posted_at" validate:"required"`
+	PrNumber       int64              `json:"pr_number"`
+	SynthesisAgent *string            `json:"synthesis_agent,omitempty" validate:"required"`
+	SynthesisModel *string            `json:"synthesis_model,omitempty" validate:"required"`
+}
+
+func (e ExportCIPanel) Validate() error {
+	var errors runtime.ValidationErrors
+	if e.FirstAttemptAt != nil {
+		if err := typesValidator.Var(e.FirstAttemptAt, "required"); err != nil {
+			errors = errors.Append("FirstAttemptAt", err)
+		}
+	}
+	if err := typesValidator.Var(e.GithubRepo, "required"); err != nil {
+		errors = errors.Append("GithubRepo", err)
+	}
+	if err := typesValidator.Var(e.HeadSha, "required"); err != nil {
+		errors = errors.Append("HeadSha", err)
+	}
+	for i, item := range e.Jobs {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Jobs[%d]", i), err)
+			}
+		}
+	}
+	if err := typesValidator.Var(e.Outcome, "required"); err != nil {
+		errors = errors.Append("Outcome", err)
+	}
+	if err := typesValidator.Var(e.PanelCreatedAt, "required"); err != nil {
+		errors = errors.Append("PanelCreatedAt", err)
+	}
+	if err := typesValidator.Var(e.PostedAt, "required"); err != nil {
+		errors = errors.Append("PostedAt", err)
+	}
+	if e.SynthesisAgent != nil {
+		if err := typesValidator.Var(e.SynthesisAgent, "required"); err != nil {
+			errors = errors.Append("SynthesisAgent", err)
+		}
+	}
+	if e.SynthesisModel != nil {
+		if err := typesValidator.Var(e.SynthesisModel, "required"); err != nil {
+			errors = errors.Append("SynthesisModel", err)
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type ExportCIPanelJob struct {
+	Agent      string  `json:"agent" validate:"required"`
+	FinishedAt *string `json:"finished_at,omitempty" validate:"required"`
+	JobUUID    string  `json:"job_uuid" validate:"required"`
+	Model      *string `json:"model,omitempty" validate:"required"`
+	Provider   *string `json:"provider,omitempty" validate:"required"`
+	Role       string  `json:"role" validate:"required"`
+	StartedAt  *string `json:"started_at,omitempty" validate:"required"`
+	Status     string  `json:"status" validate:"required"`
+}
+
+func (e ExportCIPanelJob) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(e))
+}
+
 type ExportReview struct {
 	Agent       string           `json:"agent" validate:"required"`
 	Branch      *string          `json:"branch,omitempty" validate:"required"`

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -2262,6 +2262,13 @@ paths:
           schema:
             description: Opaque next_cursor from a previous page. Resumes strictly after its (posted_at, panel_id) position; mutually exclusive with since.
             type: string
+        - description: Export the frozen pre-panel ci_pr_reviews era instead of panel runs. Cursors are namespaced to this mode and cannot be reused across modes.
+          explode: false
+          in: query
+          name: legacy
+          schema:
+            description: Export the frozen pre-panel ci_pr_reviews era instead of panel runs. Cursors are namespaced to this mode and cannot be reused across modes.
+            type: boolean
       responses:
         "200":
           content:

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -564,6 +564,144 @@ components:
       required:
         - error
       type: object
+    ExportCIMetricsDocument:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - https://example.com/ExportCIMetricsDocument.json
+          format: uri
+          readOnly: true
+          type: string
+        database_id:
+          description: Stable identity for the local review database; changes when the database is recreated.
+          type: string
+        generated_at:
+          type: string
+        next_cursor:
+          description: Opaque resume cursor emitted when panels is non-empty.
+          type:
+            - string
+            - "null"
+        panels:
+          items:
+            $ref: "#/components/schemas/ExportCIPanel"
+          type:
+            - array
+            - "null"
+        schema_version:
+          format: int64
+          type: integer
+        tool:
+          type: string
+        tool_version:
+          type: string
+        truncated:
+          description: True when more matching rows are available immediately.
+          type: boolean
+        window:
+          $ref: "#/components/schemas/ExportReviewsWindow"
+      required:
+        - schema_version
+        - tool
+        - tool_version
+        - generated_at
+        - database_id
+        - window
+        - truncated
+        - next_cursor
+        - panels
+      type: object
+    ExportCIPanel:
+      additionalProperties: false
+      properties:
+        attempt_count:
+          format: int64
+          type:
+            - integer
+            - "null"
+        first_attempt_at:
+          type:
+            - string
+            - "null"
+        github_repo:
+          type: string
+        head_sha:
+          type: string
+        jobs:
+          items:
+            $ref: "#/components/schemas/ExportCIPanelJob"
+          type:
+            - array
+            - "null"
+        outcome:
+          type: string
+        panel_created_at:
+          type: string
+        posted_at:
+          type: string
+        pr_number:
+          format: int64
+          type: integer
+        synthesis_agent:
+          type:
+            - string
+            - "null"
+        synthesis_model:
+          type:
+            - string
+            - "null"
+      required:
+        - github_repo
+        - pr_number
+        - head_sha
+        - panel_created_at
+        - posted_at
+        - first_attempt_at
+        - attempt_count
+        - outcome
+        - synthesis_agent
+        - synthesis_model
+        - jobs
+      type: object
+    ExportCIPanelJob:
+      additionalProperties: false
+      properties:
+        agent:
+          type: string
+        finished_at:
+          type:
+            - string
+            - "null"
+        job_uuid:
+          type: string
+        model:
+          type:
+            - string
+            - "null"
+        provider:
+          type:
+            - string
+            - "null"
+        role:
+          type: string
+        started_at:
+          type:
+            - string
+            - "null"
+        status:
+          type: string
+      required:
+        - job_uuid
+        - role
+        - agent
+        - model
+        - provider
+        - status
+        - started_at
+        - finished_at
+      type: object
     ExportReview:
       additionalProperties: false
       properties:
@@ -2082,6 +2220,70 @@ paths:
       summary: Enqueue a daemon job
       tags:
         - jobs
+  /api/export/ci-metrics:
+    get:
+      operationId: export-ci-metrics
+      parameters:
+        - description: Output format; only json is supported
+          explode: false
+          in: query
+          name: format
+          schema:
+            default: json
+            description: Output format; only json is supported
+            type: string
+        - description: Inclusive posted_at lower bound (RFC3339 or YYYY-MM-DD)
+          explode: false
+          in: query
+          name: since
+          schema:
+            description: Inclusive posted_at lower bound (RFC3339 or YYYY-MM-DD)
+            type: string
+        - description: Exclusive posted_at upper bound (RFC3339 or YYYY-MM-DD; date-only means through that UTC day)
+          explode: false
+          in: query
+          name: until
+          schema:
+            description: Exclusive posted_at upper bound (RFC3339 or YYYY-MM-DD; date-only means through that UTC day)
+            type: string
+        - description: Maximum panels in this page
+          explode: false
+          in: query
+          name: limit
+          schema:
+            default: 500
+            description: Maximum panels in this page
+            format: int64
+            type: integer
+        - description: Opaque next_cursor from a previous page. Resumes strictly after its (posted_at, panel_id) position; mutually exclusive with since.
+          explode: false
+          in: query
+          name: cursor
+          schema:
+            description: Opaque next_cursor from a previous page. Resumes strictly after its (posted_at, panel_id) position; mutually exclusive with since.
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExportCIMetricsDocument"
+          description: OK
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Cursor database_id does not match this local database
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      summary: Export finalized CI panel metrics
+      tags:
+        - reviews
   /api/export/reviews:
     get:
       operationId: export-reviews


### PR DESCRIPTION
Persist each CI panel's terminal outcome durably and expose a paginated export for turnaround-time tracking.

- `ci_pr_panels` stores `outcome`, `first_attempt_at`, `attempt_count`, and synthesis agent/model snapshots at finalization so metrics survive attempt and repository cleanup.
- Outcomes distinguish posted reviews, all-skipped summaries, give-up comments, and panels abandoned after permanent posting failures.
- A startup backfill reconstructs terminal metrics for existing panels from retained jobs and attempts, including transient synthesis give-ups. Rows whose source jobs were already deleted remain explicitly `unknown`.
- `GET /api/export/ci-metrics` and `roborev export ci-metrics` provide opaque versioned cursors, database-reset detection, and each panel's member and synthesis job timing and model metadata.
- `--legacy` provides a one-time backfill for the pre-panel era. It derives multi-job pseudopanels from completed review jobs before the database's first panel activity, bounds membership to adjacent jobs, uses repository identity, and emits `legacy_review` rows with namespaced cursors.
