### PR TITLE
Update flake.nix for v0.62.1

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
         {
           default = pkgs.buildGoModule {
             pname = "roborev";
-            version = "0.62.0";
+            version = "0.62.1";
             go = pkgs.go_1_26;
 
             src = ./.;


### PR DESCRIPTION
Updates flake.nix version to 0.62.1 for the v0.62.1 release.