### PR TITLE
Document the 0.62.1 release

### DIFF
--- a/docs/advanced/acp.md
+++ b/docs/advanced/acp.md
@@ -238,6 +238,12 @@ still applies when the selected ACP agent is also the matching default agent.
 To confirm which agent and model served a job, run `roborev show --job <id>
 --json` and inspect `job.agent` and `job.model`.
 
+Backup models follow the same pairing rule. A global `default_backup_model`
+belongs to `default_backup_agent`; it is not passed to a different ACP agent
+selected by a more-specific workflow or repo backup setting. On a mismatch,
+the selected ACP agent keeps its `[acp].model`. See [Backup
+Agents](/configuration/#backup-agents) for the full resolution order.
+
 ### `--agent` is ignored and a panel runs instead
 
 When `default_panel` is configured, `roborev review` fans out to the panel.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,33 @@ description: Release history for roborev
 
 All notable changes to roborev, grouped by minor release.
 
+## 0.62.1
+<small>2026-07-13</small>
+
+**New features**
+
+- Completed CI panel metrics are now persisted at finalization, including terminal outcome, retry timing, and synthesis agent/model snapshots. `roborev export ci-metrics` exports those records with member and synthesis job timing, opaque resumable cursors, database-reset detection, and an optional `--legacy` backfill for pre-panel CI history. See [Exporting CI Metrics](/commands/#exporting-ci-metrics).
+- `roborev version --json` provides a stable machine-readable contract with the canonical tool name and build version. See [Version JSON Contract](/commands/#version-json-contract).
+
+**Improvements**
+
+- The TUI Prompt view now wraps the full agent command by default, while the Log view keeps its compact single-line default. Press `i` to toggle each view independently. See [Prompt View](/integrations/tui/#prompt-view).
+- The Codex `roborev-fix` skill remains model-invocable so Agent Hook can start the requested fix loop; every other bundled Codex skill remains explicit-only. See [Agent Skills](/guides/agent-skills/#usage).
+- The Nix flake no longer depends on `flake-utils`, reducing transitive flake inputs while preserving the supported system outputs.
+
+**Bug fixes**
+
+- ACP backup agents no longer inherit a backup model paired with a different agent. A mismatched inherited model is skipped so the selected ACP agent keeps its own `[acp].model` instead of failing model validation. See [Backup Agents](/configuration/#backup-agents).
+
+**Acknowledgements**
+
+- Thanks to [Wes McKinney](https://github.com/wesm) for persistent CI panel metrics and export, wrapped TUI prompt commands, and Codex Agent Hook skill invocation.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for the stable JSON version contract.
+- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for ACP backup-model pairing safeguards and expanded Gemini ACP documentation.
+- Thanks to [Luis Quiñones](https://github.com/luisnquin) for simplifying the Nix flake dependencies.
+
+---
+
 ## 0.62.0
 <small>2026-07-11</small>
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -36,7 +36,7 @@ roborev version --json           # Show stable machine-readable version data
 requiring a repository or a running daemon:
 
 ```json
-{"name":"roborev","version":"v0.62.0"}
+{"name":"roborev","version":"v0.62.1"}
 ```
 
 The stable fields are:
@@ -231,6 +231,50 @@ reviews should run their own overlapping completed-at window separately.
     include repository-specific details or other sensitive context. Use
     `--profile metadata` when you do not need review prose, and handle content
     exports with the same care as local review data.
+
+## Exporting CI Metrics
+
+```bash
+roborev export ci-metrics
+roborev export ci-metrics --since 2026-07-01 --until 2026-07-31
+roborev export ci-metrics --limit 1000
+roborev export ci-metrics --cursor "$NEXT_CURSOR" --until 2026-08-01
+roborev export ci-metrics --legacy
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format json` | Output format. JSON is the only supported format and the default |
+| `--since <time>` | Inclusive `posted_at` lower bound. Accepts RFC3339 or `YYYY-MM-DD` |
+| `--until <time>` | Exclusive `posted_at` upper bound. Accepts RFC3339 or `YYYY-MM-DD` |
+| `--cursor <opaque>` | Resume strictly after a previous `next_cursor`. Mutually exclusive with `--since` |
+| `--limit <n>` | Maximum panels to emit |
+| `--legacy` | Export the frozen pre-panel CI era as a one-time backfill instead of panel runs |
+
+`roborev export ci-metrics` emits one JSON document containing finalized CI
+panel runs for external turnaround-time analysis. Each panel records its GitHub
+repository, pull request, head SHA, creation and posting times, first-attempt
+time, attempt count, terminal outcome, synthesis agent/model snapshot, and the
+retained member and synthesis jobs with their timing and model metadata.
+
+Terminal outcomes distinguish `review_posted`, `no_review_posted`,
+`giveup_posted`, and `abandoned`. roborev backfills metrics for older finalized
+panels from retained jobs and attempts when the daemon starts. If the source
+rows have already been deleted, the panel remains exportable with outcome
+`unknown` and unavailable fields set to `null`.
+
+Export documents use `schema_version: 1` and the same stable `database_id`
+contract as review exports. Rows are ordered by `(posted_at, panel_id)`
+ascending. Every non-empty export includes an opaque `next_cursor`; pass it to
+`--cursor` to resume strictly after the last panel. A cursor from a recreated
+database is rejected with exit code `3`, so callers can discard it and backfill
+from a time window. Other cursor rejections also require discarding the cursor.
+Date-only `--until` bounds include the full named UTC day.
+
+`--legacy` exports the frozen pre-panel CI era as `legacy_review` pseudopanels,
+grouped from related completed review jobs before the database's first panel
+activity. It is intended for a one-time historical backfill. Legacy and
+panel-era cursors are namespaced and cannot be resumed against each other.
 
 ## Job Logs
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -360,10 +360,13 @@ If the primary agent is unavailable (for example, its command is not visible to 
 # ~/.roborev/config.toml
 default_agent = "codex"
 default_backup_agent = "claude-code"  # Fallback for any workflow
-default_backup_model = "claude-sonnet-4-20250514"  # Model for the backup agent
+default_backup_model = "claude-sonnet-4-20250514"  # Model paired with default_backup_agent
 ```
 
-When a backup agent takes over, it uses the model specified by `default_backup_model`. Without this setting, the backup agent uses whatever model is configured for it normally. This is useful when your backup agent needs a different model than the one configured as `default_model` (which is typically chosen for the primary agent).
+When `default_backup_agent` takes over, it uses the model paired with it in
+`default_backup_model`. Without this setting, the backup agent uses its normal
+configured model. This is useful when your backup agent needs a different model
+than `default_model`, which is typically chosen for the primary agent.
 
 You can also set backup agents per workflow:
 
@@ -390,6 +393,19 @@ When a workflow needs a backup agent, roborev resolves it in this order:
 4. Global `default_backup_agent`
 
 If a backup agent is found and installed, roborev uses that agent instead. If no backup is configured or the backup agent isn't installed, the job fails normally. roborev does not choose unrelated installed agents from the built-in agent list for workflow-configured reviews or fixes.
+
+Backup models follow the agent selected at the corresponding configuration
+layer. Repo-level workflow-specific and generic backup models pair with the
+fully resolved repo backup agent. A global workflow-specific backup model pairs
+with the workflow backup agent resolved from global configuration, and
+`default_backup_model` pairs only with `default_backup_agent`.
+
+This pairing is enforced for ACP backups because ACP agents validate model
+names against their advertised model list. If a more-specific backup setting
+selects an ACP agent but the inherited model belongs to a different backup
+agent, roborev skips the mismatched model and keeps the selected agent's
+`[acp].model`. Explicitly paired backup models and non-ACP backup behavior are
+unchanged.
 
 ### Agent Command Overrides
 
@@ -515,7 +531,7 @@ Create `~/.roborev/config.toml` to set system-wide defaults.
 ```toml
 default_agent = "codex"
 default_model = "gpt-5.5"  # Default LLM
-default_backup_model = "claude-sonnet-4-20250514"  # Fallback model for backup agent
+default_backup_model = "claude-sonnet-4-20250514"  # Model paired with default_backup_agent
 server_addr = "127.0.0.1:7373"
 max_workers = 4
 job_timeout_minutes = 30          # Per-job timeout in minutes
@@ -536,7 +552,7 @@ column_borders = true             # Show separators between TUI columns
 |--------|------|---------|-------------|------------|
 | `default_agent` | string | auto-detect | Default AI agent to use | Yes |
 | `default_backup_agent` | string | - | Fallback agent when the primary is unavailable or fails | Yes |
-| `default_backup_model` | string | - | Fallback model used when a backup agent runs | Yes |
+| `default_backup_model` | string | - | Model paired with `default_backup_agent` | Yes |
 | `default_model` | string | agent default | Model to use (format varies by agent) | Yes |
 | `server_addr` | string | 127.0.0.1:7373 | Daemon listen address. Use `unix://` for Unix domain socket (see [Unix Domain Socket](#unix-domain-socket)) | No |
 | `max_workers` | int | 4 | Number of parallel review workers | No |

--- a/docs/guides/agent-skills.md
+++ b/docs/guides/agent-skills.md
@@ -31,9 +31,11 @@ roborev skills install
 ## Usage
 
 !!! note "Explicit invocation"
-    All bundled roborev skills are **explicit-only**. An ordinary request such
-    as "Review the changes in this branch" uses your agent's native behavior;
-    it must not activate a roborev skill or run roborev.
+    All bundled roborev skills require explicit roborev workflow intent. An
+    ordinary request such as "Review the changes in this branch" uses your
+    agent's native behavior; it must not activate a roborev skill or run
+    roborev. Skill metadata prevents model invocation except for
+    `roborev-fix`, which Agent Hook explicitly instructs the model to invoke.
 
     **Claude Code** enforces this in skill metadata: the bundled skills set
     `disable-model-invocation: true`, so the model never selects a roborev
@@ -53,8 +55,11 @@ roborev skills install
     - Select the roborev skill directly in Codex's structured skill picker.
 
     The namespace distinguishes plugin-contributed skills from personal skills
-    that may have the same name. See the [syntax table](#agent-specific-syntax)
-    for more examples.
+    that may have the same name. `roborev-fix` is the one model-invocable Codex
+    exception so [`roborev agent-hook`](../agent-hook.md) can start the fix
+    workflow it names; every other bundled Codex skill is implicit-disabled.
+    The fix skill's description still requires explicit roborev invocation.
+    See the [syntax table](#agent-specific-syntax) for more examples.
 
 ### Review a commit
 
@@ -266,7 +271,9 @@ skills. Invoke a plugin-managed skill as `$roborev:roborev-<workflow>` (for
 example, `$roborev:roborev-fix`); invoke a personal skill installed by roborev
 as `$roborev-<workflow>` (for example, `$roborev-fix`). Both forms are explicit
 invocations. General requests such as "fix the issues in this branch" remain
-native Codex tasks and do not select roborev.
+native Codex tasks and do not select roborev. `roborev-fix` alone is
+model-invocable so the [agent-hook](../agent-hook.md) instruction can invoke
+it; every other Codex skill sets `allow_implicit_invocation: false`.
 
 Claude Code likewise namespaces plugin-managed skills: invoke them as
 `/roborev:roborev-<workflow>` (for example, `/roborev:roborev-fix`). Personal

--- a/docs/integrations/tui.md
+++ b/docs/integrations/tui.md
@@ -198,7 +198,7 @@ Press `p` from the queue view or review view to see the prompt that was sent to 
 | `?` | Show all commands |
 | `Esc`, `q` | Back to queue |
 
-The prompt header shows the job ID, git ref, and agent. Below the header, the command line used to run the agent is displayed. It is truncated to terminal width by default; press `i` to wrap and inspect the full command line. The log view uses the same toggle.
+The prompt header shows the job ID, git ref, and agent. Below the header, the full command line used to run the agent is wrapped by default; press `i` to collapse it to one truncated line or expand it again. The Log view starts collapsed, and its `i` toggle is independent from the Prompt view.
 
 ## Copying Reviews
 


### PR DESCRIPTION
0.62.1 introduces durable CI panel metrics and a machine-readable version contract while changing user-visible TUI, Agent Hook, ACP backup, and Nix behavior. Without matching release documentation, users would have to infer new export and configuration semantics from implementation details, and contributors would not receive release credit.

This update grounds the changelog in the tagged code, documents the new public contracts and behavior changes, corrects stale reference guidance, and acknowledges each contributor whose user-facing work shipped in the release.