### PR TITLE
feat: add machine-readable run launch receipts

### DIFF
--- a/cmd/roborev/run.go
+++ b/cmd/roborev/run.go
@@ -24,14 +24,15 @@ import (
 
 func runCmd() *cobra.Command {
 	var (
-		agentName string
-		model     string
-		reasoning string
-		wait      bool
-		quiet     bool
-		noContext bool
-		agentic   bool
-		label     string
+		agentName  string
+		model      string
+		reasoning  string
+		wait       bool
+		quiet      bool
+		noContext  bool
+		agentic    bool
+		label      string
+		jsonOutput bool
 	)
 
 	cmd := &cobra.Command{
@@ -49,6 +50,10 @@ The task can be provided as:
 By default, the job is enqueued and the command returns immediately.
 Use --wait to wait for completion and display the result.
 
+Use --json to emit one machine-readable launch receipt containing job_id,
+job_uuid, git_ref, and status. It cannot be combined with --quiet, --wait,
+or the global --verbose flag.
+
 By default, context about the repository (name, path, and any project
 guidelines from .roborev.toml) is included. Use --no-context to disable.
 
@@ -63,10 +68,11 @@ Examples:
   roborev run --no-context "What is 2+2?"
   roborev run --agentic "Create a new test file for main.go"
   roborev run --label refactor "Refactor the config module"
+  roborev run --json "Explain the architecture of this codebase"
   cat instructions.txt | roborev run --wait
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPrompt(cmd, args, agentName, model, reasoning, wait, quiet, !noContext, agentic, label)
+			return runPrompt(cmd, args, agentName, model, reasoning, wait, quiet, !noContext, agentic, label, jsonOutput)
 		},
 	}
 
@@ -79,6 +85,7 @@ Examples:
 	cmd.Flags().BoolVar(&agentic, "agentic", false, "enable agentic mode (allow file edits and commands)")
 	cmd.Flags().BoolVar(&agentic, "yolo", false, "alias for --agentic")
 	cmd.Flags().StringVar(&label, "label", "", "custom label to display in TUI (default: run)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit a machine-readable launch receipt")
 	registerAgentCompletion(cmd)
 	registerReasoningCompletion(cmd)
 
@@ -93,7 +100,43 @@ func promptCmd() *cobra.Command {
 	return cmd
 }
 
-func runPrompt(cmd *cobra.Command, args []string, agentName, modelStr, reasoningStr string, wait, quiet, includeContext, agentic bool, label string) error {
+type runLaunchReceipt struct {
+	JobID   int64             `json:"job_id"`
+	JobUUID string            `json:"job_uuid"`
+	GitRef  string            `json:"git_ref"`
+	Status  storage.JobStatus `json:"status"`
+}
+
+func newRunLaunchReceipt(job storage.ReviewJob) (runLaunchReceipt, error) {
+	switch {
+	case job.ID <= 0:
+		return runLaunchReceipt{}, fmt.Errorf("enqueue response is missing job id")
+	case strings.TrimSpace(job.UUID) == "":
+		return runLaunchReceipt{}, fmt.Errorf("enqueue response is missing job uuid")
+	case strings.TrimSpace(job.GitRef) == "":
+		return runLaunchReceipt{}, fmt.Errorf("enqueue response is missing git ref")
+	case strings.TrimSpace(string(job.Status)) == "":
+		return runLaunchReceipt{}, fmt.Errorf("enqueue response is missing status")
+	}
+	return runLaunchReceipt{
+		JobID: job.ID, JobUUID: job.UUID, GitRef: job.GitRef, Status: job.Status,
+	}, nil
+}
+
+func runPrompt(cmd *cobra.Command, args []string, agentName, modelStr, reasoningStr string, wait, quiet, includeContext, agentic bool, label string, jsonOutput bool) error {
+	if jsonOutput {
+		cmd.SilenceUsage = true
+	}
+	if jsonOutput && quiet {
+		return fmt.Errorf("--json cannot be combined with --quiet")
+	}
+	if jsonOutput && wait {
+		return fmt.Errorf("--json cannot be combined with --wait")
+	}
+	if jsonOutput && verbose {
+		return fmt.Errorf("--json cannot be combined with --verbose")
+	}
+
 	// Get prompt from args or stdin
 	var promptText string
 	if len(args) > 0 {
@@ -177,6 +220,14 @@ func runPrompt(cmd *cobra.Command, args []string, agentName, modelStr, reasoning
 	var job storage.ReviewJob
 	if err := json.Unmarshal(body, &job); err != nil {
 		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if jsonOutput {
+		receipt, err := newRunLaunchReceipt(job)
+		if err != nil {
+			return err
+		}
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(receipt)
 	}
 
 	if !quiet {

--- a/cmd/roborev/run_test.go
+++ b/cmd/roborev/run_test.go
@@ -204,7 +204,11 @@ func TestRunLaunchReceiptOutput(t *testing.T) {
 				writeJSON(w, map[string]string{"version": version.Version})
 			case "/api/enqueue":
 				var req daemon.EnqueueRequest
-				require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					t.Errorf("decode enqueue request: %v", err)
+					http.Error(w, "invalid enqueue request", http.StatusBadRequest)
+					return
+				}
 				persisted = &storage.ReviewJob{
 					ID:     42,
 					UUID:   "00000000-0000-4000-8000-000000000042",

--- a/cmd/roborev/run_test.go
+++ b/cmd/roborev/run_test.go
@@ -38,6 +38,7 @@ type mockServerConfig struct {
 	review      *storage.Review
 	status      int // Default 200
 	receivedRef *string
+	enqueueJob  *storage.ReviewJob
 }
 
 // newRunTestServer creates a unified test server for run command tests.
@@ -76,12 +77,18 @@ func newRunTestServer(t *testing.T, cfg mockServerConfig) *httptest.Server {
 				if cfg.receivedRef != nil {
 					*cfg.receivedRef = req.GitRef
 				}
-				w.WriteHeader(http.StatusCreated)
-				writeJSON(w, storage.ReviewJob{
+				job := storage.ReviewJob{
 					ID:     1,
+					UUID:   "00000000-0000-4000-8000-000000000001",
 					Agent:  "test",
 					GitRef: req.GitRef,
-				})
+					Status: storage.JobStatusQueued,
+				}
+				if cfg.enqueueJob != nil {
+					job = *cfg.enqueueJob
+				}
+				w.WriteHeader(http.StatusCreated)
+				writeJSON(w, job)
 			}
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -89,6 +96,157 @@ func newRunTestServer(t *testing.T, cfg mockServerConfig) *httptest.Server {
 	}))
 	t.Cleanup(s.Close)
 	return s
+}
+
+func TestRunLaunchReceiptOutput(t *testing.T) {
+	t.Run("human output is unchanged", func(t *testing.T) {
+		server := newRunTestServer(t, mockServerConfig{})
+		patchServerAddr(t, server.URL)
+
+		cmd := runCmd()
+		var out strings.Builder
+		cmd.SetOut(&out)
+		cmd.SetErr(io.Discard)
+		cmd.SetArgs([]string{"test prompt"})
+
+		require.NoError(t, cmd.Execute())
+		assert.Equal(t, "Enqueued task 1 (agent: test)\n", out.String())
+	})
+
+	t.Run("json emits one document with the full launch identity", func(t *testing.T) {
+		server := newRunTestServer(t, mockServerConfig{})
+		patchServerAddr(t, server.URL)
+
+		cmd := runCmd()
+		var out strings.Builder
+		cmd.SetOut(&out)
+		cmd.SetErr(io.Discard)
+		fullRef := "refs/heads/feature/keep-this-full-ref"
+		cmd.SetArgs([]string{"test prompt", "--label", fullRef, "--json"})
+
+		require.NoError(t, cmd.Execute())
+		var receipt struct {
+			JobID   int64             `json:"job_id"`
+			JobUUID string            `json:"job_uuid"`
+			GitRef  string            `json:"git_ref"`
+			Status  storage.JobStatus `json:"status"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(out.String()), &receipt), out.String())
+		assert.Equal(t, int64(1), receipt.JobID)
+		assert.Equal(t, "00000000-0000-4000-8000-000000000001", receipt.JobUUID)
+		assert.Equal(t, fullRef, receipt.GitRef)
+		assert.Equal(t, storage.JobStatusQueued, receipt.Status)
+		assert.Equal(t, 1, strings.Count(strings.TrimSpace(out.String()), "{"),
+			"machine stdout must contain one JSON document and no human prelude")
+		assert.NotContains(t, out.String(), "Enqueued task")
+	})
+
+	t.Run("json rejects an enqueue response without uuid before writing stdout", func(t *testing.T) {
+		job := storage.ReviewJob{
+			ID: 1, Agent: "test", GitRef: "run", Status: storage.JobStatusQueued,
+		}
+		server := newRunTestServer(t, mockServerConfig{enqueueJob: &job})
+		patchServerAddr(t, server.URL)
+
+		cmd := runCmd()
+		var out strings.Builder
+		cmd.SetOut(&out)
+		cmd.SetErr(io.Discard)
+		cmd.SetArgs([]string{"test prompt", "--json"})
+
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "uuid")
+		assert.Empty(t, out.String())
+	})
+
+	for _, conflict := range []string{"--quiet", "--wait"} {
+		t.Run("json rejects conflicting mode "+conflict, func(t *testing.T) {
+			cmd := runCmd()
+			var out strings.Builder
+			cmd.SetOut(&out)
+			cmd.SetErr(io.Discard)
+			cmd.SetArgs([]string{"test prompt", "--json", conflict})
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "--json")
+			assert.Contains(t, err.Error(), conflict)
+			assert.Empty(t, out.String())
+		})
+	}
+
+	t.Run("json rejects global verbose mode", func(t *testing.T) {
+		oldVerbose := verbose
+		verbose = true
+		t.Cleanup(func() { verbose = oldVerbose })
+
+		cmd := runCmd()
+		var out strings.Builder
+		cmd.SetOut(&out)
+		cmd.SetErr(io.Discard)
+		cmd.SetArgs([]string{"test prompt", "--json"})
+
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--json")
+		assert.Contains(t, err.Error(), "--verbose")
+		assert.Empty(t, out.String())
+	})
+
+	t.Run("returned job id re-queries the same launch", func(t *testing.T) {
+		var persisted *storage.ReviewJob
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/ping":
+				writeJSON(w, daemon.PingInfo{OK: true, Service: "roborev", Version: version.Version})
+			case "/api/status":
+				writeJSON(w, map[string]string{"version": version.Version})
+			case "/api/enqueue":
+				var req daemon.EnqueueRequest
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+				persisted = &storage.ReviewJob{
+					ID:     42,
+					UUID:   "00000000-0000-4000-8000-000000000042",
+					Agent:  "test",
+					GitRef: req.GitRef,
+					Status: storage.JobStatusQueued,
+				}
+				w.WriteHeader(http.StatusCreated)
+				writeJSON(w, persisted)
+			case "/api/jobs":
+				if persisted != nil && r.URL.Query().Get("id") == "42" {
+					writeJSON(w, map[string][]storage.ReviewJob{"jobs": {*persisted}})
+					return
+				}
+				writeJSON(w, map[string][]storage.ReviewJob{"jobs": {}})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		t.Cleanup(server.Close)
+		patchServerAddr(t, server.URL)
+
+		cmd := runCmd()
+		var out strings.Builder
+		cmd.SetOut(&out)
+		cmd.SetErr(io.Discard)
+		fullRef := "refs/heads/feature/requery"
+		cmd.SetArgs([]string{"test prompt", "--json", "--label", fullRef})
+		require.NoError(t, cmd.Execute())
+
+		var receipt struct {
+			JobID   int64  `json:"job_id"`
+			JobUUID string `json:"job_uuid"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(out.String()), &receipt))
+		api := newDaemonReviewAPI(server.URL, server.Client())
+		queried, err := api.getJob(t.Context(), receipt.JobID)
+		require.NoError(t, err)
+		assert.Equal(t, receipt.JobUUID, queried.UUID)
+		assert.Equal(t, fullRef, queried.GitRef)
+		assert.Equal(t, storage.JobStatusQueued, queried.Status)
+	})
 }
 
 // stubReview creates a storage.Review with common defaults.

--- a/docs/advanced/custom-tasks.md
+++ b/docs/advanced/custom-tasks.md
@@ -14,6 +14,23 @@ roborev run --wait "Find simplification opportunities in this codebase"
 roborev run --agentic "Add input validation to the user controller"
 ```
 
+For automation that needs a durable handle immediately after enqueue, use
+`roborev run --json`. Successful machine mode writes exactly one JSON document
+to stdout:
+
+```json
+{"job_id":42,"job_uuid":"00000000-0000-4000-8000-000000000042","git_ref":"run","status":"queued"}
+```
+
+The receipt comes from the atomic enqueue response; it does not parse human
+console output. `--json` cannot be combined with `--quiet`, `--wait`, or the
+global `--verbose` flag.
+
+The daemon documents successful enqueue responses with a dedicated
+`EnqueueCreatedResponse` schema whose `id`, `uuid`, `git_ref`, and `status` are
+required. The general `ReviewJob` schema keeps `uuid` optional for compatibility
+with older stored and synchronized job records.
+
 ## Use Cases
 
 ### Targeted File Reviews
@@ -87,6 +104,7 @@ cat review-checklist.txt | roborev run --wait
 | `--agentic` | Enable agentic mode (allow file edits and commands) |
 | `--yolo` | Alias for `--agentic` |
 | `--quiet` | Suppress output (just enqueue) |
+| `--json` | Emit one machine-readable launch receipt (incompatible with `--quiet`, `--wait`, and global `--verbose`) |
 
 ## Repository Context
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -577,6 +577,7 @@ roborev run "Explain the architecture"
 roborev run --wait "Review src/auth/ for security issues"
 roborev run "Find simplification opportunities in src/utils/"
 roborev run --agentic "Add input validation to all endpoints"
+roborev run --json "Explain the architecture"
 cat review-checklist.txt | roborev run --wait
 ```
 
@@ -589,6 +590,7 @@ cat review-checklist.txt | roborev run --wait
 | `--agentic, --yolo` | Enable agentic mode (can modify files) |
 | `--no-context` | Don't include repository context |
 | `--label <string>` | Custom label displayed in TUI (default: `run`) |
+| `--json` | Emit one launch receipt with `job_id`, `job_uuid`, `git_ref`, and `status`; incompatible with `--quiet`, `--wait`, and global `--verbose` |
 
 See: [Custom Agent Tasks](/advanced/custom-tasks/)
 

--- a/internal/daemon/enqueue_descriptor_test.go
+++ b/internal/daemon/enqueue_descriptor_test.go
@@ -220,6 +220,7 @@ func TestEnqueueResponseUnchanged(t *testing.T) {
 	var job storage.ReviewJob
 	testutil.DecodeJSON(t, w, &job)
 	assert.Positive(t, job.ID)
+	assert.NotEmpty(t, job.UUID, "created enqueue response must emit its launch UUID")
 	assert.Equal(t, "test", job.Agent)
 	assert.Equal(t, storage.JobStatusQueued, job.Status)
 }

--- a/internal/daemon/routes.go
+++ b/internal/daemon/routes.go
@@ -33,7 +33,7 @@ func (s *Server) registerHumaAPI(mux *http.ServeMux) huma.API {
 	errorSchema := jsonSchema(api, ErrorResponse{})
 	enqueueSuccessSchema := oneOfJSONSchema(
 		api,
-		storage.ReviewJob{},
+		EnqueueCreatedResponse{},
 		EnqueueSkippedResponse{},
 	)
 	jobSchema := jsonSchema(api, storage.ReviewJob{})

--- a/internal/daemon/routes_test.go
+++ b/internal/daemon/routes_test.go
@@ -844,6 +844,41 @@ func TestHumaOpenAPISpec(t *testing.T) {
 	oneOf, ok := schema["oneOf"].([]any)
 	require.True(t, ok, "enqueue 200 response should use oneOf")
 	assert.Len(t, oneOf, 2)
+
+	components, ok := spec["components"].(map[string]any)
+	require.True(t, ok, "spec must have components")
+	schemas, ok := components["schemas"].(map[string]any)
+	require.True(t, ok, "components must have schemas")
+	reviewJob, ok := schemas["ReviewJob"].(map[string]any)
+	require.True(t, ok, "schemas must include ReviewJob")
+	reviewJobRequired, ok := reviewJob["required"].([]any)
+	require.True(t, ok, "ReviewJob must declare required fields")
+	assert.NotContains(t, reviewJobRequired, "uuid",
+		"general ReviewJob must preserve optional UUID compatibility")
+
+	enqueueCreated, ok := schemas["EnqueueCreatedResponse"].(map[string]any)
+	require.True(t, ok, "schemas must include a dedicated enqueue response")
+	enqueueRequired, ok := enqueueCreated["required"].([]any)
+	require.True(t, ok, "enqueue response must declare required fields")
+	for _, field := range []string{"id", "uuid", "git_ref", "status"} {
+		assert.Contains(t, enqueueRequired, field,
+			"enqueue response must require %s", field)
+	}
+
+	statusCreated, ok := responses["201"].(map[string]any)
+	require.True(t, ok, "enqueue should document created response")
+	createdContent, ok := statusCreated["content"].(map[string]any)
+	require.True(t, ok, "enqueue 201 response should have content")
+	createdJSON, ok := createdContent["application/json"].(map[string]any)
+	require.True(t, ok, "enqueue 201 response should document JSON")
+	createdSchema, ok := createdJSON["schema"].(map[string]any)
+	require.True(t, ok, "enqueue 201 response should have a schema")
+	createdOneOf, ok := createdSchema["oneOf"].([]any)
+	require.True(t, ok, "enqueue 201 response should use oneOf")
+	require.NotEmpty(t, createdOneOf)
+	createdRef, ok := createdOneOf[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "#/components/schemas/EnqueueCreatedResponse", createdRef["$ref"])
 }
 
 func TestHumaListRepos(t *testing.T) {

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -28,6 +28,16 @@ type EnqueueRequest struct {
 	Source       string   `json:"source,omitempty"`        // Provenance, e.g. "post_commit" (empty = foreground)
 }
 
+// EnqueueCreatedResponse documents the stronger contract of a successfully
+// created job without changing the general ReviewJob model used by list and
+// legacy APIs. The shallow UUID field shadows ReviewJob.UUID so OpenAPI and
+// generated enqueue clients require the launch UUID that storage assigns
+// atomically before the response is returned.
+type EnqueueCreatedResponse struct {
+	*storage.ReviewJob
+	UUID string `json:"uuid"`
+}
+
 // PanelEnqueueResponse is returned when an enqueue fans out into a panel run.
 // It embeds the synthesis job (the run handle = its ID) and lists the member
 // job IDs and the shared run uuid.

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -240,6 +240,97 @@ type DurationStats struct {
 	ReviewP99Secs float64 `json:"review_p99_secs"`
 }
 
+type EnqueueCreatedResponse struct {
+	Agent                 string        `json:"agent" validate:"required"`
+	Agentic               bool          `json:"agentic"`
+	BackupAgent           *string       `json:"backup_agent,omitempty"`
+	BackupModel           *string       `json:"backup_model,omitempty"`
+	Branch                *string       `json:"branch,omitempty"`
+	ClaimBlocked          *bool         `json:"claim_blocked,omitempty"`
+	Closed                *bool         `json:"closed,omitempty"`
+	CommandLine           *string       `json:"command_line,omitempty"`
+	CommitID              *int64        `json:"commit_id,omitempty"`
+	CommitSubject         *string       `json:"commit_subject,omitempty"`
+	DiffContent           *string       `json:"diff_content,omitempty"`
+	DirtyFiles            []string      `json:"dirty_files,omitempty"`
+	EnqueuedAt            time.Time     `json:"enqueued_at" validate:"required"`
+	ErrorData             *string       `json:"error,omitempty"`
+	FinishedAt            *time.Time    `json:"finished_at,omitempty"`
+	GitRef                string        `json:"git_ref" validate:"required"`
+	ID                    int64         `json:"id"`
+	JobType               string        `json:"job_type" validate:"required"`
+	MinSeverity           *string       `json:"min_severity,omitempty"`
+	Model                 *string       `json:"model,omitempty"`
+	OutputPrefix          *string       `json:"output_prefix,omitempty"`
+	PanelMemberConfigJSON *string       `json:"panel_member_config_json,omitempty"`
+	PanelMemberIndex      *int64        `json:"panel_member_index,omitempty"`
+	PanelMemberName       *string       `json:"panel_member_name,omitempty"`
+	PanelName             *string       `json:"panel_name,omitempty"`
+	PanelRole             *string       `json:"panel_role,omitempty"`
+	PanelRunUUID          *string       `json:"panel_run_uuid,omitempty"`
+	PanelSummary          *PanelSummary `json:"panel_summary,omitempty"`
+	ParentJobID           *int64        `json:"parent_job_id,omitempty"`
+	Patch                 *string       `json:"patch,omitempty"`
+	PatchID               *string       `json:"patch_id,omitempty"`
+	Prompt                *string       `json:"prompt,omitempty"`
+	PromptPrebuilt        bool          `json:"prompt_prebuilt"`
+	Provider              *string       `json:"provider,omitempty"`
+	Reasoning             *string       `json:"reasoning,omitempty"`
+	RepoID                int64         `json:"repo_id"`
+	RepoName              *string       `json:"repo_name,omitempty"`
+	RepoPath              *string       `json:"repo_path,omitempty"`
+	RequestedModel        *string       `json:"requested_model,omitempty"`
+	RequestedProvider     *string       `json:"requested_provider,omitempty"`
+	RetryCount            int64         `json:"retry_count"`
+	ReviewType            *string       `json:"review_type,omitempty"`
+	SessionID             *string       `json:"session_id,omitempty"`
+	SkipReason            *string       `json:"skip_reason,omitempty"`
+	Source                *string       `json:"source,omitempty"`
+	SourceMachineID       *string       `json:"source_machine_id,omitempty"`
+	StartedAt             *time.Time    `json:"started_at,omitempty"`
+	Status                string        `json:"status" validate:"required"`
+	SyncedAt              *time.Time    `json:"synced_at,omitempty"`
+	TokenUsage            *string       `json:"token_usage,omitempty"`
+	UpdatedAt             *time.Time    `json:"updated_at,omitempty"`
+	UUID                  string        `json:"uuid" validate:"required"`
+	Verdict               *string       `json:"verdict,omitempty"`
+	WorkerID              *string       `json:"worker_id,omitempty"`
+	WorktreePath          *string       `json:"worktree_path,omitempty"`
+}
+
+func (e EnqueueCreatedResponse) Validate() error {
+	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(e.Agent, "required"); err != nil {
+		errors = errors.Append("Agent", err)
+	}
+	if err := typesValidator.Var(e.EnqueuedAt, "required"); err != nil {
+		errors = errors.Append("EnqueuedAt", err)
+	}
+	if err := typesValidator.Var(e.GitRef, "required"); err != nil {
+		errors = errors.Append("GitRef", err)
+	}
+	if err := typesValidator.Var(e.JobType, "required"); err != nil {
+		errors = errors.Append("JobType", err)
+	}
+	if e.PanelSummary != nil {
+		if v, ok := any(e.PanelSummary).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PanelSummary", err)
+			}
+		}
+	}
+	if err := typesValidator.Var(e.Status, "required"); err != nil {
+		errors = errors.Append("Status", err)
+	}
+	if err := typesValidator.Var(e.UUID, "required"); err != nil {
+		errors = errors.Append("UUID", err)
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
 type EnqueueRequest struct {
 	// Schema A URL to the JSON Schema for this object.
 	Schema       *string  `json:"$schema,omitempty"`

--- a/pkg/client/generated/unions.go
+++ b/pkg/client/generated/unions.go
@@ -7,7 +7,7 @@ import (
 )
 
 type EnqueueJob_Response_OneOf struct {
-	runtime.Either[ReviewJob, EnqueueSkippedResponse]
+	runtime.Either[EnqueueCreatedResponse, EnqueueSkippedResponse]
 }
 
 func (e *EnqueueJob_Response_OneOf) Validate() error {
@@ -25,7 +25,7 @@ func (e *EnqueueJob_Response_OneOf) Validate() error {
 }
 
 type EnqueueJob_Response_201_OneOf struct {
-	runtime.Either[ReviewJob, EnqueueSkippedResponse]
+	runtime.Either[EnqueueCreatedResponse, EnqueueSkippedResponse]
 }
 
 func (e *EnqueueJob_Response_201_OneOf) Validate() error {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -403,6 +403,147 @@ components:
         - queue_p90_secs
         - queue_p99_secs
       type: object
+    EnqueueCreatedResponse:
+      additionalProperties: false
+      properties:
+        agent:
+          type: string
+        agentic:
+          type: boolean
+        backup_agent:
+          type: string
+        backup_model:
+          type: string
+        branch:
+          type: string
+        claim_blocked:
+          type: boolean
+        closed:
+          type: boolean
+        command_line:
+          type: string
+        commit_id:
+          format: int64
+          type: integer
+        commit_subject:
+          type: string
+        diff_content:
+          type: string
+        dirty_files:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        enqueued_at:
+          format: date-time
+          type: string
+        error:
+          type: string
+        finished_at:
+          format: date-time
+          type: string
+        git_ref:
+          type: string
+        id:
+          format: int64
+          type: integer
+        job_type:
+          type: string
+        min_severity:
+          type: string
+        model:
+          type: string
+        output_prefix:
+          type: string
+        panel_member_config_json:
+          type: string
+        panel_member_index:
+          format: int64
+          type: integer
+        panel_member_name:
+          type: string
+        panel_name:
+          type: string
+        panel_role:
+          type: string
+        panel_run_uuid:
+          type: string
+        panel_summary:
+          $ref: "#/components/schemas/PanelSummary"
+        parent_job_id:
+          format: int64
+          type: integer
+        patch:
+          type: string
+        patch_id:
+          type: string
+        prompt:
+          type: string
+        prompt_prebuilt:
+          type: boolean
+        provider:
+          type: string
+        reasoning:
+          type: string
+        repo_id:
+          format: int64
+          type: integer
+        repo_name:
+          type: string
+        repo_path:
+          type: string
+        requested_model:
+          type: string
+        requested_provider:
+          type: string
+        retry_count:
+          format: int64
+          type: integer
+        review_type:
+          type: string
+        session_id:
+          type: string
+        skip_reason:
+          type: string
+        source:
+          type: string
+        source_machine_id:
+          type: string
+        started_at:
+          format: date-time
+          type: string
+        status:
+          type: string
+        synced_at:
+          format: date-time
+          type: string
+        token_usage:
+          type: string
+        updated_at:
+          format: date-time
+          type: string
+        uuid:
+          type: string
+        verdict:
+          type: string
+        worker_id:
+          type: string
+        worktree_path:
+          type: string
+      required:
+        - uuid
+        - id
+        - repo_id
+        - git_ref
+        - agent
+        - job_type
+        - status
+        - enqueued_at
+        - retry_count
+        - agentic
+        - prompt_prebuilt
+      type: object
     EnqueueRequest:
       additionalProperties: false
       properties:
@@ -2187,14 +2328,14 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: "#/components/schemas/ReviewJob"
+                  - $ref: "#/components/schemas/EnqueueCreatedResponse"
                   - $ref: "#/components/schemas/EnqueueSkippedResponse"
         "201":
           content:
             application/json:
               schema:
                 oneOf:
-                  - $ref: "#/components/schemas/ReviewJob"
+                  - $ref: "#/components/schemas/EnqueueCreatedResponse"
                   - $ref: "#/components/schemas/EnqueueSkippedResponse"
           description: Created
         "400":


### PR DESCRIPTION
## What changed

- Add `roborev run --json` for a machine-readable launch receipt after a review job is accepted.
- Emit exactly one JSON object with `{job_id,job_uuid,git_ref,status}`.
- Add a dedicated enqueue response schema and generated client type for the launch boundary.
- Cover the CLI behavior, JSON shape, and HTTP client decoding with tests.

## Why

Automation needs an atomic, stable receipt that identifies the job it just launched. The existing command prints a human-oriented enqueue message, which requires callers to parse presentation text and cannot serve as a durable machine contract.

The root cause is that the enqueue endpoint and CLI did not expose a narrow launch-receipt contract. Reusing the general `ReviewJob` response would also couple enqueue callers to a broader model whose compatibility requirements can evolve independently.

## Impact and design choices

With `--json`, callers receive:

```json
{"job_id":1,"job_uuid":"example-uuid","git_ref":"example-ref","status":"queued"}
```

Normal human-readable output remains unchanged when `--json` is absent. The implementation uses a dedicated enqueue schema so the existing general `ReviewJob` client contract remains compatible.

The following alternatives were intentionally rejected:

- `--quiet`: suppresses output instead of providing structured identity.
- `--wait`: changes lifecycle behavior and does not solve the launch-receipt boundary.
- global `--verbose`: is intended for diagnostics, not stable machine-readable data.

No real provider job was launched while validating this change.

## Validation

- `go test ./... -count=1`
- `make lint-ci` using the pinned `golangci-lint` version
- `go vet ./...`
- `go build ./...`
- `make api-generate`
- `git diff --check`
