### PR TITLE
Add machine-readable run launch receipts

### DIFF
--- a/cmd/roborev/run.go
+++ b/cmd/roborev/run.go
@@ -24,14 +24,15 @@ import (
 
 func runCmd() *cobra.Command {
 	var (
-		agentName string
-		model     string
-		reasoning string
-		wait      bool
-		quiet     bool
-		noContext bool
-		agentic   bool
-		label     string
+		agentName  string
+		model      string
+		reasoning  string
+		wait       bool
+		quiet      bool
+		noContext  bool
+		agentic    bool
+		label      string
+		jsonOutput bool
 	)
 
 	cmd := &cobra.Command{
@@ -49,6 +50,10 @@ The task can be provided as:
 By default, the job is enqueued and the command returns immediately.
 Use --wait to wait for completion and display the result.
 
+Use --json to emit one machine-readable launch receipt containing job_id,
+job_uuid, git_ref, and status. It cannot be combined with --quiet, --wait,
+or the global --verbose flag.
+
 By default, context about the repository (name, path, and any project
 guidelines from .roborev.toml) is included. Use --no-context to disable.
 
@@ -63,10 +68,11 @@ Examples:
   roborev run --no-context "What is 2+2?"
   roborev run --agentic "Create a new test file for main.go"
   roborev run --label refactor "Refactor the config module"
+  roborev run --json "Explain the architecture of this codebase"
   cat instructions.txt | roborev run --wait
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPrompt(cmd, args, agentName, model, reasoning, wait, quiet, !noContext, agentic, label)
+			return runPrompt(cmd, args, agentName, model, reasoning, wait, quiet, !noContext, agentic, label, jsonOutput)
 		},
 	}
 
@@ -79,6 +85,7 @@ Examples:
 	cmd.Flags().BoolVar(&agentic, "agentic", false, "enable agentic mode (allow file edits and commands)")
 	cmd.Flags().BoolVar(&agentic, "yolo", false, "alias for --agentic")
 	cmd.Flags().StringVar(&label, "label", "", "custom label to display in TUI (default: run)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit a machine-readable launch receipt")
 	registerAgentCompletion(cmd)
 	registerReasoningCompletion(cmd)
 
@@ -93,7 +100,43 @@ func promptCmd() *cobra.Command {
 	return cmd
 }
 
-func runPrompt(cmd *cobra.Command, args []string, agentName, modelStr, reasoningStr string, wait, quiet, includeContext, agentic bool, label string) error {
+type runLaunchReceipt struct {
+	JobID   int64             `json:"job_id"`
+	JobUUID string            `json:"job_uuid"`
+	GitRef  string            `json:"git_ref"`
+	Status  storage.JobStatus `json:"status"`
+}
+
+func newRunLaunchReceipt(job storage.ReviewJob) (runLaunchReceipt, error) {
+	switch {
+	case job.ID <= 0:
+		return runLaunchReceipt{}, fmt.Errorf("enqueue response is missing job id")
+	case strings.TrimSpace(job.UUID) == "":
+		return runLaunchReceipt{}, fmt.Errorf("enqueue response is missing job uuid")
+	case strings.TrimSpace(job.GitRef) == "":
+		return runLaunchReceipt{}, fmt.Errorf("enqueue response is missing git ref")
+	case strings.TrimSpace(string(job.Status)) == "":
+		return runLaunchReceipt{}, fmt.Errorf("enqueue response is missing status")
+	}
+	return runLaunchReceipt{
+		JobID: job.ID, JobUUID: job.UUID, GitRef: job.GitRef, Status: job.Status,
+	}, nil
+}
+
+func runPrompt(cmd *cobra.Command, args []string, agentName, modelStr, reasoningStr string, wait, quiet, includeContext, agentic bool, label string, jsonOutput bool) error {
+	if jsonOutput {
+		cmd.SilenceUsage = true
+	}
+	if jsonOutput && quiet {
+		return fmt.Errorf("--json cannot be combined with --quiet")
+	}
+	if jsonOutput && wait {
+		return fmt.Errorf("--json cannot be combined with --wait")
+	}
+	if jsonOutput && verbose {
+		return fmt.Errorf("--json cannot be combined with --verbose")
+	}
+
 	// Get prompt from args or stdin
 	var promptText string
 	if len(args) > 0 {
@@ -177,6 +220,14 @@ func runPrompt(cmd *cobra.Command, args []string, agentName, modelStr, reasoning
 	var job storage.ReviewJob
 	if err := json.Unmarshal(body, &job); err != nil {
 		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if jsonOutput {
+		receipt, err := newRunLaunchReceipt(job)
+		if err != nil {
+			return err
+		}
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(receipt)
 	}
 
 	if !quiet {

--- a/cmd/roborev/run.go
+++ b/cmd/roborev/run.go
@@ -51,8 +51,10 @@ By default, the job is enqueued and the command returns immediately.
 Use --wait to wait for completion and display the result.
 
 Use --json to emit one machine-readable launch receipt containing job_id,
-job_uuid, git_ref, and status. It cannot be combined with --quiet, --wait,
-or the global --verbose flag.
+job_uuid, git_ref, and status. If the daemon skips the enqueue (for example
+on an excluded branch), the single document is {"skipped":true,"reason":...}
+instead. --json cannot be combined with --quiet, --wait, or the global
+--verbose flag.
 
 By default, context about the repository (name, path, and any project
 guidelines from .roborev.toml) is included. Use --no-context to disable.
@@ -72,7 +74,17 @@ Examples:
   cat instructions.txt | roborev run --wait
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPrompt(cmd, args, agentName, model, reasoning, wait, quiet, !noContext, agentic, label, jsonOutput)
+			return runPrompt(cmd, args, runOptions{
+				agentName:      agentName,
+				model:          model,
+				reasoning:      reasoning,
+				label:          label,
+				wait:           wait,
+				quiet:          quiet,
+				includeContext: !noContext,
+				agentic:        agentic,
+				jsonOutput:     jsonOutput,
+			})
 		},
 	}
 
@@ -100,6 +112,19 @@ func promptCmd() *cobra.Command {
 	return cmd
 }
 
+// runOptions holds the flag values for a `roborev run` invocation.
+type runOptions struct {
+	agentName      string
+	model          string
+	reasoning      string
+	label          string
+	wait           bool
+	quiet          bool
+	includeContext bool
+	agentic        bool
+	jsonOutput     bool
+}
+
 type runLaunchReceipt struct {
 	JobID   int64             `json:"job_id"`
 	JobUUID string            `json:"job_uuid"`
@@ -107,58 +132,87 @@ type runLaunchReceipt struct {
 	Status  storage.JobStatus `json:"status"`
 }
 
+// newRunLaunchReceipt builds the --json receipt. The daemon assigns the
+// uuid atomically at insert, so a missing uuid means the daemon predates
+// launch receipts (reachable only with ROBOREV_SKIP_VERSION_CHECK=1).
 func newRunLaunchReceipt(job storage.ReviewJob) (runLaunchReceipt, error) {
-	switch {
-	case job.ID <= 0:
-		return runLaunchReceipt{}, fmt.Errorf("enqueue response is missing job id")
-	case strings.TrimSpace(job.UUID) == "":
-		return runLaunchReceipt{}, fmt.Errorf("enqueue response is missing job uuid")
-	case strings.TrimSpace(job.GitRef) == "":
-		return runLaunchReceipt{}, fmt.Errorf("enqueue response is missing git ref")
-	case strings.TrimSpace(string(job.Status)) == "":
-		return runLaunchReceipt{}, fmt.Errorf("enqueue response is missing status")
+	if job.UUID == "" {
+		return runLaunchReceipt{}, fmt.Errorf(
+			"task %d was enqueued, but the daemon response is missing its uuid; "+
+				"the daemon is likely older than this CLI - restart or update it",
+			job.ID)
 	}
 	return runLaunchReceipt{
 		JobID: job.ID, JobUUID: job.UUID, GitRef: job.GitRef, Status: job.Status,
 	}, nil
 }
 
-func runPrompt(cmd *cobra.Command, args []string, agentName, modelStr, reasoningStr string, wait, quiet, includeContext, agentic bool, label string, jsonOutput bool) error {
-	if jsonOutput {
-		cmd.SilenceUsage = true
+// validateRunFlags rejects modes that would corrupt --json's
+// single-document stdout contract.
+func validateRunFlags(opts runOptions) error {
+	if !opts.jsonOutput {
+		return nil
 	}
-	if jsonOutput && quiet {
-		return fmt.Errorf("--json cannot be combined with --quiet")
+	conflicts := []struct {
+		set  bool
+		name string
+	}{
+		{opts.quiet, "--quiet"},
+		{opts.wait, "--wait"},
+		{verbose, "--verbose"},
 	}
-	if jsonOutput && wait {
-		return fmt.Errorf("--json cannot be combined with --wait")
+	for _, conflict := range conflicts {
+		if conflict.set {
+			return fmt.Errorf("--json cannot be combined with %s", conflict.name)
+		}
 	}
-	if jsonOutput && verbose {
-		return fmt.Errorf("--json cannot be combined with --verbose")
-	}
+	return nil
+}
 
-	// Get prompt from args or stdin
-	var promptText string
+// readRunPrompt returns the task text from args or piped stdin.
+func readRunPrompt(args []string) (string, error) {
 	if len(args) > 0 {
-		promptText = strings.Join(args, " ")
-	} else {
-		// Read from stdin
-		stat, err := os.Stdin.Stat()
-		if err != nil {
-			return fmt.Errorf("unable to read stdin: %w", err)
-		}
-		if (stat.Mode() & os.ModeCharDevice) == 0 {
-			// Stdin has data (piped) - use io.ReadAll to handle large prompts
-			data, err := io.ReadAll(os.Stdin)
-			if err != nil {
-				return fmt.Errorf("reading stdin: %w", err)
-			}
-			promptText = string(data)
-		} else {
-			return fmt.Errorf("no prompt provided - pass as argument or pipe via stdin")
-		}
+		return strings.Join(args, " "), nil
+	}
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return "", fmt.Errorf("unable to read stdin: %w", err)
+	}
+	if (stat.Mode() & os.ModeCharDevice) != 0 {
+		return "", fmt.Errorf("no prompt provided - pass as argument or pipe via stdin")
+	}
+	// Stdin has data (piped) - use io.ReadAll to handle large prompts
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return "", fmt.Errorf("reading stdin: %w", err)
+	}
+	return string(data), nil
+}
+
+// reportRunSkipped emits a skipped-enqueue result: one JSON document in
+// --json mode, the daemon's reason otherwise. The exit code stays zero,
+// mirroring how `roborev insights` reports skipped enqueues.
+func reportRunSkipped(
+	cmd *cobra.Command, opts runOptions, skipped daemon.EnqueueSkippedResponse,
+) error {
+	if opts.jsonOutput {
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(skipped)
+	}
+	if !opts.quiet {
+		cmd.Println(skipped.Reason)
+	}
+	return nil
+}
+
+func runPrompt(cmd *cobra.Command, args []string, opts runOptions) error {
+	if err := validateRunFlags(opts); err != nil {
+		return usageErr(cmd, err)
 	}
 
+	promptText, err := readRunPrompt(args)
+	if err != nil {
+		return err
+	}
 	if strings.TrimSpace(promptText) == "" {
 		return fmt.Errorf("empty prompt")
 	}
@@ -168,8 +222,6 @@ func runPrompt(cmd *cobra.Command, args []string, agentName, modelStr, reasoning
 	if err != nil {
 		return fmt.Errorf("get working directory: %w", err)
 	}
-
-	// Try to use git repo root if available
 	repoRoot := workDir
 	if root, err := gitrepo.Root(cmd.Context(), workDir); err == nil {
 		repoRoot = root
@@ -177,7 +229,7 @@ func runPrompt(cmd *cobra.Command, args []string, agentName, modelStr, reasoning
 
 	// Build the full prompt with context if enabled
 	fullPrompt := promptText
-	if includeContext {
+	if opts.includeContext {
 		fullPrompt = buildPromptWithContext(repoRoot, promptText)
 	}
 
@@ -186,23 +238,23 @@ func runPrompt(cmd *cobra.Command, args []string, agentName, modelStr, reasoning
 		return err
 	}
 
-	// Build the request
 	gitRef := "run"
-	if label != "" {
-		gitRef = label
+	if opts.label != "" {
+		gitRef = opts.label
 	}
 	reqBody, _ := json.Marshal(daemon.EnqueueRequest{
 		RepoPath:     repoRoot,
 		GitRef:       gitRef,
-		Agent:        agentName,
-		Model:        modelStr,
-		Reasoning:    reasoningStr,
+		Agent:        opts.agentName,
+		Model:        opts.model,
+		Reasoning:    opts.reasoning,
 		CustomPrompt: fullPrompt,
-		Agentic:      agentic,
+		Agentic:      opts.agentic,
 	})
 
 	ep := getDaemonEndpoint()
-	resp, err := ep.HTTPClient(10*time.Second).Post(ep.BaseURL()+"/api/enqueue", "application/json", bytes.NewReader(reqBody))
+	resp, err := ep.HTTPClient(10*time.Second).
+		Post(ep.BaseURL()+"/api/enqueue", "application/json", bytes.NewReader(reqBody))
 	if err != nil {
 		return fmt.Errorf("failed to connect to daemon: %w", err)
 	}
@@ -213,6 +265,12 @@ func runPrompt(cmd *cobra.Command, args []string, agentName, modelStr, reasoning
 		return fmt.Errorf("failed to read response: %w", err)
 	}
 
+	if resp.StatusCode == http.StatusOK {
+		var skipped daemon.EnqueueSkippedResponse
+		if err := json.Unmarshal(body, &skipped); err == nil && skipped.Skipped {
+			return reportRunSkipped(cmd, opts, skipped)
+		}
+	}
 	if resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("enqueue failed: %s", body)
 	}
@@ -222,7 +280,7 @@ func runPrompt(cmd *cobra.Command, args []string, agentName, modelStr, reasoning
 		return fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	if jsonOutput {
+	if opts.jsonOutput {
 		receipt, err := newRunLaunchReceipt(job)
 		if err != nil {
 			return err
@@ -230,13 +288,13 @@ func runPrompt(cmd *cobra.Command, args []string, agentName, modelStr, reasoning
 		return json.NewEncoder(cmd.OutOrStdout()).Encode(receipt)
 	}
 
-	if !quiet {
+	if !opts.quiet {
 		cmd.Printf("Enqueued task %d (agent: %s)\n", job.ID, job.Agent)
 	}
 
 	// If --wait, poll until job completes and show result
-	if wait {
-		return waitForPromptJob(cmd, ep, job.ID, quiet, promptPollInterval)
+	if opts.wait {
+		return waitForPromptJob(cmd, ep, job.ID, opts.quiet, promptPollInterval)
 	}
 
 	return nil

--- a/cmd/roborev/run_test.go
+++ b/cmd/roborev/run_test.go
@@ -204,7 +204,11 @@ func TestRunLaunchReceiptOutput(t *testing.T) {
 				writeJSON(w, map[string]string{"version": version.Version})
 			case "/api/enqueue":
 				var req daemon.EnqueueRequest
-				require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					t.Errorf("decode enqueue request: %v", err)
+					http.Error(w, "invalid enqueue request", http.StatusBadRequest)
+					return
+				}
 				persisted = &storage.ReviewJob{
 					ID:     42,
 					UUID:   "00000000-0000-4000-8000-000000000042",

--- a/cmd/roborev/run_test.go
+++ b/cmd/roborev/run_test.go
@@ -38,6 +38,7 @@ type mockServerConfig struct {
 	review      *storage.Review
 	status      int // Default 200
 	receivedRef *string
+	enqueueJob  *storage.ReviewJob
 }
 
 // newRunTestServer creates a unified test server for run command tests.
@@ -76,12 +77,18 @@ func newRunTestServer(t *testing.T, cfg mockServerConfig) *httptest.Server {
 				if cfg.receivedRef != nil {
 					*cfg.receivedRef = req.GitRef
 				}
-				w.WriteHeader(http.StatusCreated)
-				writeJSON(w, storage.ReviewJob{
+				job := storage.ReviewJob{
 					ID:     1,
+					UUID:   "00000000-0000-4000-8000-000000000001",
 					Agent:  "test",
 					GitRef: req.GitRef,
-				})
+					Status: storage.JobStatusQueued,
+				}
+				if cfg.enqueueJob != nil {
+					job = *cfg.enqueueJob
+				}
+				w.WriteHeader(http.StatusCreated)
+				writeJSON(w, job)
 			}
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -89,6 +96,157 @@ func newRunTestServer(t *testing.T, cfg mockServerConfig) *httptest.Server {
 	}))
 	t.Cleanup(s.Close)
 	return s
+}
+
+func TestRunLaunchReceiptOutput(t *testing.T) {
+	t.Run("human output is unchanged", func(t *testing.T) {
+		server := newRunTestServer(t, mockServerConfig{})
+		patchServerAddr(t, server.URL)
+
+		cmd := runCmd()
+		var out strings.Builder
+		cmd.SetOut(&out)
+		cmd.SetErr(io.Discard)
+		cmd.SetArgs([]string{"test prompt"})
+
+		require.NoError(t, cmd.Execute())
+		assert.Equal(t, "Enqueued task 1 (agent: test)\n", out.String())
+	})
+
+	t.Run("json emits one document with the full launch identity", func(t *testing.T) {
+		server := newRunTestServer(t, mockServerConfig{})
+		patchServerAddr(t, server.URL)
+
+		cmd := runCmd()
+		var out strings.Builder
+		cmd.SetOut(&out)
+		cmd.SetErr(io.Discard)
+		fullRef := "refs/heads/feature/keep-this-full-ref"
+		cmd.SetArgs([]string{"test prompt", "--label", fullRef, "--json"})
+
+		require.NoError(t, cmd.Execute())
+		var receipt struct {
+			JobID   int64             `json:"job_id"`
+			JobUUID string            `json:"job_uuid"`
+			GitRef  string            `json:"git_ref"`
+			Status  storage.JobStatus `json:"status"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(out.String()), &receipt), out.String())
+		assert.Equal(t, int64(1), receipt.JobID)
+		assert.Equal(t, "00000000-0000-4000-8000-000000000001", receipt.JobUUID)
+		assert.Equal(t, fullRef, receipt.GitRef)
+		assert.Equal(t, storage.JobStatusQueued, receipt.Status)
+		assert.Equal(t, 1, strings.Count(strings.TrimSpace(out.String()), "{"),
+			"machine stdout must contain one JSON document and no human prelude")
+		assert.NotContains(t, out.String(), "Enqueued task")
+	})
+
+	t.Run("json rejects an enqueue response without uuid before writing stdout", func(t *testing.T) {
+		job := storage.ReviewJob{
+			ID: 1, Agent: "test", GitRef: "run", Status: storage.JobStatusQueued,
+		}
+		server := newRunTestServer(t, mockServerConfig{enqueueJob: &job})
+		patchServerAddr(t, server.URL)
+
+		cmd := runCmd()
+		var out strings.Builder
+		cmd.SetOut(&out)
+		cmd.SetErr(io.Discard)
+		cmd.SetArgs([]string{"test prompt", "--json"})
+
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "uuid")
+		assert.Empty(t, out.String())
+	})
+
+	for _, conflict := range []string{"--quiet", "--wait"} {
+		t.Run("json rejects conflicting mode "+conflict, func(t *testing.T) {
+			cmd := runCmd()
+			var out strings.Builder
+			cmd.SetOut(&out)
+			cmd.SetErr(io.Discard)
+			cmd.SetArgs([]string{"test prompt", "--json", conflict})
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "--json")
+			assert.Contains(t, err.Error(), conflict)
+			assert.Empty(t, out.String())
+		})
+	}
+
+	t.Run("json rejects global verbose mode", func(t *testing.T) {
+		oldVerbose := verbose
+		verbose = true
+		t.Cleanup(func() { verbose = oldVerbose })
+
+		cmd := runCmd()
+		var out strings.Builder
+		cmd.SetOut(&out)
+		cmd.SetErr(io.Discard)
+		cmd.SetArgs([]string{"test prompt", "--json"})
+
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--json")
+		assert.Contains(t, err.Error(), "--verbose")
+		assert.Empty(t, out.String())
+	})
+
+	t.Run("returned job id re-queries the same launch", func(t *testing.T) {
+		var persisted *storage.ReviewJob
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/ping":
+				writeJSON(w, daemon.PingInfo{OK: true, Service: "roborev", Version: version.Version})
+			case "/api/status":
+				writeJSON(w, map[string]string{"version": version.Version})
+			case "/api/enqueue":
+				var req daemon.EnqueueRequest
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+				persisted = &storage.ReviewJob{
+					ID:     42,
+					UUID:   "00000000-0000-4000-8000-000000000042",
+					Agent:  "test",
+					GitRef: req.GitRef,
+					Status: storage.JobStatusQueued,
+				}
+				w.WriteHeader(http.StatusCreated)
+				writeJSON(w, persisted)
+			case "/api/jobs":
+				if persisted != nil && r.URL.Query().Get("id") == "42" {
+					writeJSON(w, map[string][]storage.ReviewJob{"jobs": {*persisted}})
+					return
+				}
+				writeJSON(w, map[string][]storage.ReviewJob{"jobs": {}})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		t.Cleanup(server.Close)
+		patchServerAddr(t, server.URL)
+
+		cmd := runCmd()
+		var out strings.Builder
+		cmd.SetOut(&out)
+		cmd.SetErr(io.Discard)
+		fullRef := "refs/heads/feature/requery"
+		cmd.SetArgs([]string{"test prompt", "--json", "--label", fullRef})
+		require.NoError(t, cmd.Execute())
+
+		var receipt struct {
+			JobID   int64  `json:"job_id"`
+			JobUUID string `json:"job_uuid"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(out.String()), &receipt))
+		api := newDaemonReviewAPI(server.URL, server.Client())
+		queried, err := api.getJob(t.Context(), receipt.JobID)
+		require.NoError(t, err)
+		assert.Equal(t, receipt.JobUUID, queried.UUID)
+		assert.Equal(t, fullRef, queried.GitRef)
+		assert.Equal(t, storage.JobStatusQueued, queried.Status)
+	})
 }
 
 // stubReview creates a storage.Review with common defaults.

--- a/cmd/roborev/run_test.go
+++ b/cmd/roborev/run_test.go
@@ -39,6 +39,7 @@ type mockServerConfig struct {
 	status      int // Default 200
 	receivedRef *string
 	enqueueJob  *storage.ReviewJob
+	skipReason  string // If set, enqueue returns 200 skipped instead of 201
 }
 
 // newRunTestServer creates a unified test server for run command tests.
@@ -76,6 +77,12 @@ func newRunTestServer(t *testing.T, cfg mockServerConfig) *httptest.Server {
 				}
 				if cfg.receivedRef != nil {
 					*cfg.receivedRef = req.GitRef
+				}
+				if cfg.skipReason != "" {
+					writeJSON(w, daemon.EnqueueSkippedResponse{
+						Skipped: true, Reason: cfg.skipReason,
+					})
+					return
 				}
 				job := storage.ReviewJob{
 					ID:     1,
@@ -149,6 +156,9 @@ func TestRunLaunchReceiptOutput(t *testing.T) {
 		patchServerAddr(t, server.URL)
 
 		cmd := runCmd()
+		// The root command's PersistentPreRunE silences usage for runtime
+		// errors in production; replicate that for this bare subcommand.
+		cmd.SilenceUsage = true
 		var out strings.Builder
 		cmd.SetOut(&out)
 		cmd.SetErr(io.Discard)
@@ -157,9 +167,51 @@ func TestRunLaunchReceiptOutput(t *testing.T) {
 		err := cmd.Execute()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "uuid")
+		assert.Contains(t, err.Error(), "enqueued",
+			"error must disclose that the job was created so callers do not retry blindly")
 		assert.Empty(t, out.String())
 	})
 
+	t.Run("json emits a skipped document when the daemon skips the enqueue", func(t *testing.T) {
+		server := newRunTestServer(t, mockServerConfig{skipReason: "branch excluded by config"})
+		patchServerAddr(t, server.URL)
+
+		cmd := runCmd()
+		var out strings.Builder
+		cmd.SetOut(&out)
+		cmd.SetErr(io.Discard)
+		cmd.SetArgs([]string{"test prompt", "--json"})
+
+		require.NoError(t, cmd.Execute())
+		var skipped struct {
+			Skipped bool   `json:"skipped"`
+			Reason  string `json:"reason"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(out.String()), &skipped), out.String())
+		assert.True(t, skipped.Skipped)
+		assert.Equal(t, "branch excluded by config", skipped.Reason)
+		assert.Equal(t, 1, strings.Count(strings.TrimSpace(out.String()), "{"),
+			"machine stdout must contain one JSON document")
+	})
+
+	t.Run("human mode prints the skip reason", func(t *testing.T) {
+		server := newRunTestServer(t, mockServerConfig{skipReason: "branch excluded by config"})
+		patchServerAddr(t, server.URL)
+
+		cmd := runCmd()
+		var out strings.Builder
+		cmd.SetOut(&out)
+		cmd.SetErr(io.Discard)
+		cmd.SetArgs([]string{"test prompt"})
+
+		require.NoError(t, cmd.Execute())
+		assert.Equal(t, "branch excluded by config\n", out.String())
+	})
+
+	// Flag conflicts go through usageErr, so cobra prints the usage block.
+	// In production that lands on stderr; these bare subcommands redirect it
+	// into out via SetOut, so assert stdout carries no receipt instead of
+	// asserting emptiness.
 	for _, conflict := range []string{"--quiet", "--wait"} {
 		t.Run("json rejects conflicting mode "+conflict, func(t *testing.T) {
 			cmd := runCmd()
@@ -172,7 +224,8 @@ func TestRunLaunchReceiptOutput(t *testing.T) {
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "--json")
 			assert.Contains(t, err.Error(), conflict)
-			assert.Empty(t, out.String())
+			assert.NotContains(t, out.String(), "job_id",
+				"conflict errors must not write a receipt to stdout")
 		})
 	}
 
@@ -191,51 +244,29 @@ func TestRunLaunchReceiptOutput(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "--json")
 		assert.Contains(t, err.Error(), "--verbose")
-		assert.Empty(t, out.String())
+		assert.NotContains(t, out.String(), "job_id",
+			"conflict errors must not write a receipt to stdout")
 	})
 
 	t.Run("returned job id re-queries the same launch", func(t *testing.T) {
-		var persisted *storage.ReviewJob
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch r.URL.Path {
-			case "/api/ping":
-				writeJSON(w, daemon.PingInfo{OK: true, Service: "roborev", Version: version.Version})
-			case "/api/status":
-				writeJSON(w, map[string]string{"version": version.Version})
-			case "/api/enqueue":
-				var req daemon.EnqueueRequest
-				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-					t.Errorf("decode enqueue request: %v", err)
-					http.Error(w, "invalid enqueue request", http.StatusBadRequest)
-					return
-				}
-				persisted = &storage.ReviewJob{
-					ID:     42,
-					UUID:   "00000000-0000-4000-8000-000000000042",
-					Agent:  "test",
-					GitRef: req.GitRef,
-					Status: storage.JobStatusQueued,
-				}
-				w.WriteHeader(http.StatusCreated)
-				writeJSON(w, persisted)
-			case "/api/jobs":
-				if persisted != nil && r.URL.Query().Get("id") == "42" {
-					writeJSON(w, map[string][]storage.ReviewJob{"jobs": {*persisted}})
-					return
-				}
-				writeJSON(w, map[string][]storage.ReviewJob{"jobs": {}})
-			default:
-				w.WriteHeader(http.StatusNotFound)
-			}
-		}))
-		t.Cleanup(server.Close)
+		fullRef := "refs/heads/feature/requery"
+		job := storage.ReviewJob{
+			ID:     42,
+			UUID:   "00000000-0000-4000-8000-000000000042",
+			Agent:  "test",
+			GitRef: fullRef,
+			Status: storage.JobStatusQueued,
+		}
+		server := newRunTestServer(t, mockServerConfig{
+			enqueueJob: &job,
+			jobs:       []storage.ReviewJob{job},
+		})
 		patchServerAddr(t, server.URL)
 
 		cmd := runCmd()
 		var out strings.Builder
 		cmd.SetOut(&out)
 		cmd.SetErr(io.Discard)
-		fullRef := "refs/heads/feature/requery"
 		cmd.SetArgs([]string{"test prompt", "--json", "--label", fullRef})
 		require.NoError(t, cmd.Execute())
 
@@ -244,6 +275,7 @@ func TestRunLaunchReceiptOutput(t *testing.T) {
 			JobUUID string `json:"job_uuid"`
 		}
 		require.NoError(t, json.Unmarshal([]byte(out.String()), &receipt))
+		assert.Equal(t, int64(42), receipt.JobID)
 		api := newDaemonReviewAPI(server.URL, server.Client())
 		queried, err := api.getJob(t.Context(), receipt.JobID)
 		require.NoError(t, err)

--- a/docs/advanced/custom-tasks.md
+++ b/docs/advanced/custom-tasks.md
@@ -23,13 +23,10 @@ to stdout:
 ```
 
 The receipt comes from the atomic enqueue response; it does not parse human
-console output. `--json` cannot be combined with `--quiet`, `--wait`, or the
-global `--verbose` flag.
-
-The daemon documents successful enqueue responses with a dedicated
-`EnqueueCreatedResponse` schema whose `id`, `uuid`, `git_ref`, and `status` are
-required. The general `ReviewJob` schema keeps `uuid` optional for compatibility
-with older stored and synchronized job records.
+console output. If the daemon skips the enqueue (for example on an excluded
+branch), machine mode instead writes a single `{"skipped":true,"reason":"..."}`
+document and exits zero. `--json` cannot be combined with `--quiet`, `--wait`,
+or the global `--verbose` flag.
 
 ## Use Cases
 

--- a/docs/advanced/custom-tasks.md
+++ b/docs/advanced/custom-tasks.md
@@ -14,6 +14,23 @@ roborev run --wait "Find simplification opportunities in this codebase"
 roborev run --agentic "Add input validation to the user controller"
 ```
 
+For automation that needs a durable handle immediately after enqueue, use
+`roborev run --json`. Successful machine mode writes exactly one JSON document
+to stdout:
+
+```json
+{"job_id":42,"job_uuid":"00000000-0000-4000-8000-000000000042","git_ref":"run","status":"queued"}
+```
+
+The receipt comes from the atomic enqueue response; it does not parse human
+console output. `--json` cannot be combined with `--quiet`, `--wait`, or the
+global `--verbose` flag.
+
+The daemon documents successful enqueue responses with a dedicated
+`EnqueueCreatedResponse` schema whose `id`, `uuid`, `git_ref`, and `status` are
+required. The general `ReviewJob` schema keeps `uuid` optional for compatibility
+with older stored and synchronized job records.
+
 ## Use Cases
 
 ### Targeted File Reviews
@@ -87,6 +104,7 @@ cat review-checklist.txt | roborev run --wait
 | `--agentic` | Enable agentic mode (allow file edits and commands) |
 | `--yolo` | Alias for `--agentic` |
 | `--quiet` | Suppress output (just enqueue) |
+| `--json` | Emit one machine-readable launch receipt (incompatible with `--quiet`, `--wait`, and global `--verbose`) |
 
 ## Repository Context
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -577,6 +577,7 @@ roborev run "Explain the architecture"
 roborev run --wait "Review src/auth/ for security issues"
 roborev run "Find simplification opportunities in src/utils/"
 roborev run --agentic "Add input validation to all endpoints"
+roborev run --json "Explain the architecture"
 cat review-checklist.txt | roborev run --wait
 ```
 
@@ -589,6 +590,7 @@ cat review-checklist.txt | roborev run --wait
 | `--agentic, --yolo` | Enable agentic mode (can modify files) |
 | `--no-context` | Don't include repository context |
 | `--label <string>` | Custom label displayed in TUI (default: `run`) |
+| `--json` | Emit one launch receipt with `job_id`, `job_uuid`, `git_ref`, and `status`; incompatible with `--quiet`, `--wait`, and global `--verbose` |
 
 See: [Custom Agent Tasks](/advanced/custom-tasks/)
 

--- a/internal/daemon/enqueue_descriptor_test.go
+++ b/internal/daemon/enqueue_descriptor_test.go
@@ -220,6 +220,7 @@ func TestEnqueueResponseUnchanged(t *testing.T) {
 	var job storage.ReviewJob
 	testutil.DecodeJSON(t, w, &job)
 	assert.Positive(t, job.ID)
+	assert.NotEmpty(t, job.UUID, "created enqueue response must emit its launch UUID")
 	assert.Equal(t, "test", job.Agent)
 	assert.Equal(t, storage.JobStatusQueued, job.Status)
 }

--- a/internal/daemon/enqueue_descriptor_test.go
+++ b/internal/daemon/enqueue_descriptor_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -197,8 +198,9 @@ func TestEnqueuePromptJobUnchanged(t *testing.T) {
 	assert.False(claimed.PromptPrebuilt, "humaEnqueue never marks prompts prebuilt")
 }
 
-// TestEnqueueResponseUnchanged pins the HTTP response shape: a bare
-// storage.ReviewJob (status 201), decodable directly into the model.
+// TestEnqueueResponseUnchanged pins the HTTP response shape: a bare JSON
+// object (status 201) wire-compatible with storage.ReviewJob, with the
+// launch UUID always present and no undeclared extra fields.
 func TestEnqueueResponseUnchanged(t *testing.T) {
 	server, _, _ := newTestServer(t)
 
@@ -216,6 +218,12 @@ func TestEnqueueResponseUnchanged(t *testing.T) {
 	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
 	assert.True(t, strings.HasPrefix(strings.TrimSpace(w.Body.String()), "{"),
 		"response must be a bare JSON object, not a wrapper")
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &raw))
+	assert.NotContains(t, raw, "$schema",
+		"created enqueue response must not carry huma's injected $schema link; "+
+			"the EnqueueCreatedResponse schema declares additionalProperties:false")
 
 	var job storage.ReviewJob
 	testutil.DecodeJSON(t, w, &job)

--- a/internal/daemon/routes.go
+++ b/internal/daemon/routes.go
@@ -34,6 +34,7 @@ func (s *Server) registerHumaAPI(mux *http.ServeMux) huma.API {
 	enqueueSuccessSchema := oneOfJSONSchema(
 		api,
 		EnqueueCreatedResponse{},
+		PanelEnqueueResponse{},
 		EnqueueSkippedResponse{},
 	)
 	jobSchema := jsonSchema(api, storage.ReviewJob{})

--- a/internal/daemon/routes.go
+++ b/internal/daemon/routes.go
@@ -33,7 +33,7 @@ func (s *Server) registerHumaAPI(mux *http.ServeMux) huma.API {
 	errorSchema := jsonSchema(api, ErrorResponse{})
 	enqueueSuccessSchema := oneOfJSONSchema(
 		api,
-		storage.ReviewJob{},
+		EnqueueCreatedResponse{},
 		EnqueueSkippedResponse{},
 	)
 	jobSchema := jsonSchema(api, storage.ReviewJob{})

--- a/internal/daemon/routes_test.go
+++ b/internal/daemon/routes_test.go
@@ -844,6 +844,41 @@ func TestHumaOpenAPISpec(t *testing.T) {
 	oneOf, ok := schema["oneOf"].([]any)
 	require.True(t, ok, "enqueue 200 response should use oneOf")
 	assert.Len(t, oneOf, 2)
+
+	components, ok := spec["components"].(map[string]any)
+	require.True(t, ok, "spec must have components")
+	schemas, ok := components["schemas"].(map[string]any)
+	require.True(t, ok, "components must have schemas")
+	reviewJob, ok := schemas["ReviewJob"].(map[string]any)
+	require.True(t, ok, "schemas must include ReviewJob")
+	reviewJobRequired, ok := reviewJob["required"].([]any)
+	require.True(t, ok, "ReviewJob must declare required fields")
+	assert.NotContains(t, reviewJobRequired, "uuid",
+		"general ReviewJob must preserve optional UUID compatibility")
+
+	enqueueCreated, ok := schemas["EnqueueCreatedResponse"].(map[string]any)
+	require.True(t, ok, "schemas must include a dedicated enqueue response")
+	enqueueRequired, ok := enqueueCreated["required"].([]any)
+	require.True(t, ok, "enqueue response must declare required fields")
+	for _, field := range []string{"id", "uuid", "git_ref", "status"} {
+		assert.Contains(t, enqueueRequired, field,
+			"enqueue response must require %s", field)
+	}
+
+	statusCreated, ok := responses["201"].(map[string]any)
+	require.True(t, ok, "enqueue should document created response")
+	createdContent, ok := statusCreated["content"].(map[string]any)
+	require.True(t, ok, "enqueue 201 response should have content")
+	createdJSON, ok := createdContent["application/json"].(map[string]any)
+	require.True(t, ok, "enqueue 201 response should document JSON")
+	createdSchema, ok := createdJSON["schema"].(map[string]any)
+	require.True(t, ok, "enqueue 201 response should have a schema")
+	createdOneOf, ok := createdSchema["oneOf"].([]any)
+	require.True(t, ok, "enqueue 201 response should use oneOf")
+	require.NotEmpty(t, createdOneOf)
+	createdRef, ok := createdOneOf[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "#/components/schemas/EnqueueCreatedResponse", createdRef["$ref"])
 }
 
 func TestHumaListRepos(t *testing.T) {

--- a/internal/daemon/routes_test.go
+++ b/internal/daemon/routes_test.go
@@ -843,7 +843,7 @@ func TestHumaOpenAPISpec(t *testing.T) {
 	require.True(t, ok, "enqueue 200 response should have a schema")
 	oneOf, ok := schema["oneOf"].([]any)
 	require.True(t, ok, "enqueue 200 response should use oneOf")
-	assert.Len(t, oneOf, 2)
+	assert.Len(t, oneOf, 3)
 
 	components, ok := spec["components"].(map[string]any)
 	require.True(t, ok, "spec must have components")
@@ -875,10 +875,17 @@ func TestHumaOpenAPISpec(t *testing.T) {
 	require.True(t, ok, "enqueue 201 response should have a schema")
 	createdOneOf, ok := createdSchema["oneOf"].([]any)
 	require.True(t, ok, "enqueue 201 response should use oneOf")
-	require.NotEmpty(t, createdOneOf)
-	createdRef, ok := createdOneOf[0].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, "#/components/schemas/EnqueueCreatedResponse", createdRef["$ref"])
+	require.Len(t, createdOneOf, 3,
+		"enqueue 201 must document created, panel, and skipped responses")
+	createdRefs := make([]any, 0, len(createdOneOf))
+	for _, member := range createdOneOf {
+		ref, ok := member.(map[string]any)
+		require.True(t, ok)
+		createdRefs = append(createdRefs, ref["$ref"])
+	}
+	assert.Equal(t, "#/components/schemas/EnqueueCreatedResponse", createdRefs[0])
+	assert.Contains(t, createdRefs, "#/components/schemas/PanelEnqueueResponse")
+	assert.Contains(t, createdRefs, "#/components/schemas/EnqueueSkippedResponse")
 }
 
 func TestHumaListRepos(t *testing.T) {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -2189,7 +2189,10 @@ func (s *Server) enqueueSingleAgent(
 	job.RepoName = in.repo.Name
 
 	s.finishSingleEnqueue(ctx, job, agentName, in)
-	return rawJSONOutput(http.StatusCreated, job)
+	return rawJSONOutput(http.StatusCreated, EnqueueCreatedResponse{
+		ReviewJob: job,
+		UUID:      job.UUID,
+	})
 }
 
 // finishSingleEnqueue runs the no-panel post-enqueue side effects: auto-design

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -28,6 +28,16 @@ type EnqueueRequest struct {
 	Source       string   `json:"source,omitempty"`        // Provenance, e.g. "post_commit" (empty = foreground)
 }
 
+// EnqueueCreatedResponse documents the stronger contract of a successfully
+// created job without changing the general ReviewJob model used by list and
+// legacy APIs. The shallow UUID field shadows ReviewJob.UUID so OpenAPI and
+// generated enqueue clients require the launch UUID that storage assigns
+// atomically before the response is returned.
+type EnqueueCreatedResponse struct {
+	*storage.ReviewJob
+	UUID string `json:"uuid"`
+}
+
 // PanelEnqueueResponse is returned when an enqueue fans out into a panel run.
 // It embeds the synthesis job (the run handle = its ID) and lists the member
 // job IDs and the shared run uuid.

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -28,11 +28,12 @@ type EnqueueRequest struct {
 	Source       string   `json:"source,omitempty"`        // Provenance, e.g. "post_commit" (empty = foreground)
 }
 
-// EnqueueCreatedResponse documents the stronger contract of a successfully
-// created job without changing the general ReviewJob model used by list and
-// legacy APIs. The shallow UUID field shadows ReviewJob.UUID so OpenAPI and
-// generated enqueue clients require the launch UUID that storage assigns
-// atomically before the response is returned.
+// EnqueueCreatedResponse is returned when an enqueue creates a single job.
+// It documents the stronger contract of a successfully created job without
+// changing the general ReviewJob model used by list and legacy APIs: the
+// UUID field shadows ReviewJob.UUID (encoding/json keeps the shallower
+// field), so the launch UUID that storage assigns atomically at insert is
+// always emitted and OpenAPI marks it required.
 type EnqueueCreatedResponse struct {
 	*storage.ReviewJob
 	UUID string `json:"uuid"`

--- a/internal/daemon_client/client.gen.go
+++ b/internal/daemon_client/client.gen.go
@@ -293,6 +293,65 @@ type DurationStats struct {
 	ReviewP99Secs float64 `json:"review_p99_secs"`
 }
 
+// EnqueueCreatedResponse defines model for EnqueueCreatedResponse.
+type EnqueueCreatedResponse struct {
+	Agent                 string        `json:"agent"`
+	Agentic               bool          `json:"agentic"`
+	BackupAgent           *string       `json:"backup_agent,omitempty"`
+	BackupModel           *string       `json:"backup_model,omitempty"`
+	Branch                *string       `json:"branch,omitempty"`
+	ClaimBlocked          *bool         `json:"claim_blocked,omitempty"`
+	Closed                *bool         `json:"closed,omitempty"`
+	CommandLine           *string       `json:"command_line,omitempty"`
+	CommitId              *int64        `json:"commit_id,omitempty"`
+	CommitSubject         *string       `json:"commit_subject,omitempty"`
+	DiffContent           *string       `json:"diff_content,omitempty"`
+	DirtyFiles            *[]string     `json:"dirty_files,omitempty"`
+	EnqueuedAt            time.Time     `json:"enqueued_at"`
+	Error                 *string       `json:"error,omitempty"`
+	FinishedAt            *time.Time    `json:"finished_at,omitempty"`
+	GitRef                string        `json:"git_ref"`
+	Id                    int64         `json:"id"`
+	JobType               string        `json:"job_type"`
+	MinSeverity           *string       `json:"min_severity,omitempty"`
+	Model                 *string       `json:"model,omitempty"`
+	OutputPrefix          *string       `json:"output_prefix,omitempty"`
+	PanelMemberConfigJson *string       `json:"panel_member_config_json,omitempty"`
+	PanelMemberIndex      *int64        `json:"panel_member_index,omitempty"`
+	PanelMemberName       *string       `json:"panel_member_name,omitempty"`
+	PanelName             *string       `json:"panel_name,omitempty"`
+	PanelRole             *string       `json:"panel_role,omitempty"`
+	PanelRunUuid          *string       `json:"panel_run_uuid,omitempty"`
+	PanelSummary          *PanelSummary `json:"panel_summary,omitempty"`
+	ParentJobId           *int64        `json:"parent_job_id,omitempty"`
+	Patch                 *string       `json:"patch,omitempty"`
+	PatchId               *string       `json:"patch_id,omitempty"`
+	Prompt                *string       `json:"prompt,omitempty"`
+	PromptPrebuilt        bool          `json:"prompt_prebuilt"`
+	Provider              *string       `json:"provider,omitempty"`
+	Reasoning             *string       `json:"reasoning,omitempty"`
+	RepoId                int64         `json:"repo_id"`
+	RepoName              *string       `json:"repo_name,omitempty"`
+	RepoPath              *string       `json:"repo_path,omitempty"`
+	RequestedModel        *string       `json:"requested_model,omitempty"`
+	RequestedProvider     *string       `json:"requested_provider,omitempty"`
+	RetryCount            int64         `json:"retry_count"`
+	ReviewType            *string       `json:"review_type,omitempty"`
+	SessionId             *string       `json:"session_id,omitempty"`
+	SkipReason            *string       `json:"skip_reason,omitempty"`
+	Source                *string       `json:"source,omitempty"`
+	SourceMachineId       *string       `json:"source_machine_id,omitempty"`
+	StartedAt             *time.Time    `json:"started_at,omitempty"`
+	Status                string        `json:"status"`
+	SyncedAt              *time.Time    `json:"synced_at,omitempty"`
+	TokenUsage            *string       `json:"token_usage,omitempty"`
+	UpdatedAt             *time.Time    `json:"updated_at,omitempty"`
+	Uuid                  string        `json:"uuid"`
+	Verdict               *string       `json:"verdict,omitempty"`
+	WorkerId              *string       `json:"worker_id,omitempty"`
+	WorktreePath          *string       `json:"worktree_path,omitempty"`
+}
+
 // EnqueueRequest defines model for EnqueueRequest.
 type EnqueueRequest struct {
 	// Schema A URL to the JSON Schema for this object.
@@ -374,6 +433,54 @@ type ErrorResponse struct {
 	// Schema A URL to the JSON Schema for this object.
 	Schema *string `json:"$schema,omitempty"`
 	Error  string  `json:"error"`
+}
+
+// ExportCIMetricsDocument defines model for ExportCIMetricsDocument.
+type ExportCIMetricsDocument struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema *string `json:"$schema,omitempty"`
+
+	// DatabaseId Stable identity for the local review database; changes when the database is recreated.
+	DatabaseId  string `json:"database_id"`
+	GeneratedAt string `json:"generated_at"`
+
+	// NextCursor Opaque resume cursor emitted when panels is non-empty.
+	NextCursor    *string          `json:"next_cursor"`
+	Panels        *[]ExportCIPanel `json:"panels"`
+	SchemaVersion int64            `json:"schema_version"`
+	Tool          string           `json:"tool"`
+	ToolVersion   string           `json:"tool_version"`
+
+	// Truncated True when more matching rows are available immediately.
+	Truncated bool                `json:"truncated"`
+	Window    ExportReviewsWindow `json:"window"`
+}
+
+// ExportCIPanel defines model for ExportCIPanel.
+type ExportCIPanel struct {
+	AttemptCount   *int64              `json:"attempt_count"`
+	FirstAttemptAt *string             `json:"first_attempt_at"`
+	GithubRepo     string              `json:"github_repo"`
+	HeadSha        string              `json:"head_sha"`
+	Jobs           *[]ExportCIPanelJob `json:"jobs"`
+	Outcome        string              `json:"outcome"`
+	PanelCreatedAt string              `json:"panel_created_at"`
+	PostedAt       string              `json:"posted_at"`
+	PrNumber       int64               `json:"pr_number"`
+	SynthesisAgent *string             `json:"synthesis_agent"`
+	SynthesisModel *string             `json:"synthesis_model"`
+}
+
+// ExportCIPanelJob defines model for ExportCIPanelJob.
+type ExportCIPanelJob struct {
+	Agent      string  `json:"agent"`
+	FinishedAt *string `json:"finished_at"`
+	JobUuid    string  `json:"job_uuid"`
+	Model      *string `json:"model"`
+	Provider   *string `json:"provider"`
+	Role       string  `json:"role"`
+	StartedAt  *string `json:"started_at"`
+	Status     string  `json:"status"`
 }
 
 // ExportReview defines model for ExportReview.
@@ -554,6 +661,66 @@ type OverviewStats struct {
 	Rebased  int64 `json:"rebased"`
 	Running  int64 `json:"running"`
 	Total    int64 `json:"total"`
+}
+
+// PanelEnqueueResponse defines model for PanelEnqueueResponse.
+type PanelEnqueueResponse struct {
+	Agent                 string        `json:"agent"`
+	Agentic               bool          `json:"agentic"`
+	BackupAgent           *string       `json:"backup_agent,omitempty"`
+	BackupModel           *string       `json:"backup_model,omitempty"`
+	Branch                *string       `json:"branch,omitempty"`
+	ClaimBlocked          *bool         `json:"claim_blocked,omitempty"`
+	Closed                *bool         `json:"closed,omitempty"`
+	CommandLine           *string       `json:"command_line,omitempty"`
+	CommitId              *int64        `json:"commit_id,omitempty"`
+	CommitSubject         *string       `json:"commit_subject,omitempty"`
+	DiffContent           *string       `json:"diff_content,omitempty"`
+	DirtyFiles            *[]string     `json:"dirty_files,omitempty"`
+	EnqueuedAt            time.Time     `json:"enqueued_at"`
+	Error                 *string       `json:"error,omitempty"`
+	FinishedAt            *time.Time    `json:"finished_at,omitempty"`
+	GitRef                string        `json:"git_ref"`
+	Id                    int64         `json:"id"`
+	JobType               string        `json:"job_type"`
+	MemberJobIds          *[]int64      `json:"member_job_ids"`
+	MinSeverity           *string       `json:"min_severity,omitempty"`
+	Model                 *string       `json:"model,omitempty"`
+	OutputPrefix          *string       `json:"output_prefix,omitempty"`
+	PanelMemberConfigJson *string       `json:"panel_member_config_json,omitempty"`
+	PanelMemberIndex      *int64        `json:"panel_member_index,omitempty"`
+	PanelMemberName       *string       `json:"panel_member_name,omitempty"`
+	PanelName             *string       `json:"panel_name,omitempty"`
+	PanelRole             *string       `json:"panel_role,omitempty"`
+	PanelRunUuid          string        `json:"panel_run_uuid"`
+	PanelSummary          *PanelSummary `json:"panel_summary,omitempty"`
+	ParentJobId           *int64        `json:"parent_job_id,omitempty"`
+	Patch                 *string       `json:"patch,omitempty"`
+	PatchId               *string       `json:"patch_id,omitempty"`
+	Prompt                *string       `json:"prompt,omitempty"`
+	PromptPrebuilt        bool          `json:"prompt_prebuilt"`
+	Provider              *string       `json:"provider,omitempty"`
+	Reasoning             *string       `json:"reasoning,omitempty"`
+	RepoId                int64         `json:"repo_id"`
+	RepoName              *string       `json:"repo_name,omitempty"`
+	RepoPath              *string       `json:"repo_path,omitempty"`
+	RequestedModel        *string       `json:"requested_model,omitempty"`
+	RequestedProvider     *string       `json:"requested_provider,omitempty"`
+	RetryCount            int64         `json:"retry_count"`
+	ReviewType            *string       `json:"review_type,omitempty"`
+	SessionId             *string       `json:"session_id,omitempty"`
+	SkipReason            *string       `json:"skip_reason,omitempty"`
+	Source                *string       `json:"source,omitempty"`
+	SourceMachineId       *string       `json:"source_machine_id,omitempty"`
+	StartedAt             *time.Time    `json:"started_at,omitempty"`
+	Status                string        `json:"status"`
+	SyncedAt              *time.Time    `json:"synced_at,omitempty"`
+	TokenUsage            *string       `json:"token_usage,omitempty"`
+	UpdatedAt             *time.Time    `json:"updated_at,omitempty"`
+	Uuid                  *string       `json:"uuid,omitempty"`
+	Verdict               *string       `json:"verdict,omitempty"`
+	WorkerId              *string       `json:"worker_id,omitempty"`
+	WorktreePath          *string       `json:"worktree_path,omitempty"`
 }
 
 // PanelSummary defines model for PanelSummary.
@@ -910,6 +1077,27 @@ type GetCostParams struct {
 // GetCostParamsBranchEmpty defines parameters for GetCost.
 type GetCostParamsBranchEmpty string
 
+// ExportCiMetricsParams defines parameters for ExportCiMetrics.
+type ExportCiMetricsParams struct {
+	// Format Output format; only json is supported
+	Format *string `form:"format,omitempty" json:"format,omitempty"`
+
+	// Since Inclusive posted_at lower bound (RFC3339 or YYYY-MM-DD)
+	Since *string `form:"since,omitempty" json:"since,omitempty"`
+
+	// Until Exclusive posted_at upper bound (RFC3339 or YYYY-MM-DD; date-only means through that UTC day)
+	Until *string `form:"until,omitempty" json:"until,omitempty"`
+
+	// Limit Maximum panels in this page
+	Limit *int64 `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Cursor Opaque next_cursor from a previous page. Resumes strictly after its (posted_at, panel_id) position; mutually exclusive with since.
+	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
+
+	// Legacy Export the frozen pre-panel ci_pr_reviews era instead of panel runs. Cursors are namespaced to this mode and cannot be reused across modes.
+	Legacy *bool `form:"legacy,omitempty" json:"legacy,omitempty"`
+}
+
 // ExportReviewsParams defines parameters for ExportReviews.
 type ExportReviewsParams struct {
 	// Format Output format; only json is supported
@@ -1215,6 +1403,9 @@ type ClientInterface interface {
 
 	EnqueueJob(ctx context.Context, body EnqueueJobJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ExportCiMetrics request
+	ExportCiMetrics(ctx context.Context, params *ExportCiMetricsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ExportReviews request
 	ExportReviews(ctx context.Context, params *ExportReviewsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -1411,6 +1602,18 @@ func (c *Client) EnqueueJobWithBody(ctx context.Context, contentType string, bod
 
 func (c *Client) EnqueueJob(ctx context.Context, body EnqueueJobJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewEnqueueJobRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ExportCiMetrics(ctx context.Context, params *ExportCiMetricsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewExportCiMetricsRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2253,6 +2456,135 @@ func NewEnqueueJobRequestWithBody(server string, contentType string, body io.Rea
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewExportCiMetricsRequest generates requests for ExportCiMetrics
+func NewExportCiMetricsRequest(server string, params *ExportCiMetricsParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/export/ci-metrics")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Format != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "format", *params.Format, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Since != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "since", *params.Since, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Until != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "until", *params.Until, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "limit", *params.Limit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: "int64"}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Cursor != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "cursor", *params.Cursor, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Legacy != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "legacy", *params.Legacy, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "boolean", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return req, nil
 }
@@ -3970,6 +4302,9 @@ type ClientWithResponsesInterface interface {
 
 	EnqueueJobWithResponse(ctx context.Context, body EnqueueJobJSONRequestBody, reqEditors ...RequestEditorFn) (*EnqueueJobResponse, error)
 
+	// ExportCiMetricsWithResponse request
+	ExportCiMetricsWithResponse(ctx context.Context, params *ExportCiMetricsParams, reqEditors ...RequestEditorFn) (*ExportCiMetricsResponse, error)
+
 	// ExportReviewsWithResponse request
 	ExportReviewsWithResponse(ctx context.Context, params *ExportReviewsParams, reqEditors ...RequestEditorFn) (*ExportReviewsResponse, error)
 
@@ -4220,6 +4555,30 @@ func (r EnqueueJobResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r EnqueueJobResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ExportCiMetricsResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *ExportCIMetricsDocument
+	ApplicationproblemJSON409     *ErrorModel
+	ApplicationproblemJSONDefault *ErrorModel
+}
+
+// Status returns HTTPResponse.Status
+func (r ExportCiMetricsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ExportCiMetricsResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -4963,6 +5322,15 @@ func (c *ClientWithResponses) EnqueueJobWithResponse(ctx context.Context, body E
 	return ParseEnqueueJobResponse(rsp)
 }
 
+// ExportCiMetricsWithResponse request returning *ExportCiMetricsResponse
+func (c *ClientWithResponses) ExportCiMetricsWithResponse(ctx context.Context, params *ExportCiMetricsParams, reqEditors ...RequestEditorFn) (*ExportCiMetricsResponse, error) {
+	rsp, err := c.ExportCiMetrics(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseExportCiMetricsResponse(rsp)
+}
+
 // ExportReviewsWithResponse request returning *ExportReviewsResponse
 func (c *ClientWithResponses) ExportReviewsWithResponse(ctx context.Context, params *ExportReviewsParams, reqEditors ...RequestEditorFn) (*ExportReviewsResponse, error) {
 	rsp, err := c.ExportReviews(ctx, params, reqEditors...)
@@ -5536,6 +5904,46 @@ func ParseEnqueueJobResponse(rsp *http.Response) (*EnqueueJobResponse, error) {
 			return nil, err
 		}
 		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseExportCiMetricsResponse parses an HTTP response from a ExportCiMetricsWithResponse call
+func ParseExportCiMetricsResponse(rsp *http.Response) (*ExportCiMetricsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ExportCiMetricsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ExportCIMetricsDocument
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
 
 	}
 

--- a/internal/daemon_client/openapi-3.0.json
+++ b/internal/daemon_client/openapi-3.0.json
@@ -523,6 +523,205 @@
         ],
         "type": "object"
       },
+      "EnqueueCreatedResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "agent": {
+            "type": "string"
+          },
+          "agentic": {
+            "type": "boolean"
+          },
+          "backup_agent": {
+            "type": "string"
+          },
+          "backup_model": {
+            "type": "string"
+          },
+          "branch": {
+            "type": "string"
+          },
+          "claim_blocked": {
+            "type": "boolean"
+          },
+          "closed": {
+            "type": "boolean"
+          },
+          "command_line": {
+            "type": "string"
+          },
+          "commit_id": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "commit_subject": {
+            "type": "string"
+          },
+          "diff_content": {
+            "type": "string"
+          },
+          "dirty_files": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "enqueued_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "error": {
+            "type": "string"
+          },
+          "finished_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "git_ref": {
+            "type": "string"
+          },
+          "id": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "job_type": {
+            "type": "string"
+          },
+          "min_severity": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "output_prefix": {
+            "type": "string"
+          },
+          "panel_member_config_json": {
+            "type": "string"
+          },
+          "panel_member_index": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "panel_member_name": {
+            "type": "string"
+          },
+          "panel_name": {
+            "type": "string"
+          },
+          "panel_role": {
+            "type": "string"
+          },
+          "panel_run_uuid": {
+            "type": "string"
+          },
+          "panel_summary": {
+            "$ref": "#/components/schemas/PanelSummary"
+          },
+          "parent_job_id": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "patch": {
+            "type": "string"
+          },
+          "patch_id": {
+            "type": "string"
+          },
+          "prompt": {
+            "type": "string"
+          },
+          "prompt_prebuilt": {
+            "type": "boolean"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "reasoning": {
+            "type": "string"
+          },
+          "repo_id": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "repo_name": {
+            "type": "string"
+          },
+          "repo_path": {
+            "type": "string"
+          },
+          "requested_model": {
+            "type": "string"
+          },
+          "requested_provider": {
+            "type": "string"
+          },
+          "retry_count": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "review_type": {
+            "type": "string"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "skip_reason": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "source_machine_id": {
+            "type": "string"
+          },
+          "started_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "synced_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "token_usage": {
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "uuid": {
+            "type": "string"
+          },
+          "verdict": {
+            "type": "string"
+          },
+          "worker_id": {
+            "type": "string"
+          },
+          "worktree_path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "uuid",
+          "id",
+          "repo_id",
+          "git_ref",
+          "agent",
+          "job_type",
+          "status",
+          "enqueued_at",
+          "retry_count",
+          "agentic",
+          "prompt_prebuilt"
+        ],
+        "type": "object"
+      },
       "EnqueueRequest": {
         "additionalProperties": false,
         "properties": {
@@ -728,6 +927,172 @@
         },
         "required": [
           "error"
+        ],
+        "type": "object"
+      },
+      "ExportCIMetricsDocument": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/ExportCIMetricsDocument.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "database_id": {
+            "description": "Stable identity for the local review database; changes when the database is recreated.",
+            "type": "string"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "next_cursor": {
+            "description": "Opaque resume cursor emitted when panels is non-empty.",
+            "nullable": true,
+            "type": "string"
+          },
+          "panels": {
+            "items": {
+              "$ref": "#/components/schemas/ExportCIPanel"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "schema_version": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "tool": {
+            "type": "string"
+          },
+          "tool_version": {
+            "type": "string"
+          },
+          "truncated": {
+            "description": "True when more matching rows are available immediately.",
+            "type": "boolean"
+          },
+          "window": {
+            "$ref": "#/components/schemas/ExportReviewsWindow"
+          }
+        },
+        "required": [
+          "schema_version",
+          "tool",
+          "tool_version",
+          "generated_at",
+          "database_id",
+          "window",
+          "truncated",
+          "next_cursor",
+          "panels"
+        ],
+        "type": "object"
+      },
+      "ExportCIPanel": {
+        "additionalProperties": false,
+        "properties": {
+          "attempt_count": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "first_attempt_at": {
+            "nullable": true,
+            "type": "string"
+          },
+          "github_repo": {
+            "type": "string"
+          },
+          "head_sha": {
+            "type": "string"
+          },
+          "jobs": {
+            "items": {
+              "$ref": "#/components/schemas/ExportCIPanelJob"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "outcome": {
+            "type": "string"
+          },
+          "panel_created_at": {
+            "type": "string"
+          },
+          "posted_at": {
+            "type": "string"
+          },
+          "pr_number": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "synthesis_agent": {
+            "nullable": true,
+            "type": "string"
+          },
+          "synthesis_model": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "github_repo",
+          "pr_number",
+          "head_sha",
+          "panel_created_at",
+          "posted_at",
+          "first_attempt_at",
+          "attempt_count",
+          "outcome",
+          "synthesis_agent",
+          "synthesis_model",
+          "jobs"
+        ],
+        "type": "object"
+      },
+      "ExportCIPanelJob": {
+        "additionalProperties": false,
+        "properties": {
+          "agent": {
+            "type": "string"
+          },
+          "finished_at": {
+            "nullable": true,
+            "type": "string"
+          },
+          "job_uuid": {
+            "type": "string"
+          },
+          "model": {
+            "nullable": true,
+            "type": "string"
+          },
+          "provider": {
+            "nullable": true,
+            "type": "string"
+          },
+          "role": {
+            "type": "string"
+          },
+          "started_at": {
+            "nullable": true,
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "job_uuid",
+          "role",
+          "agent",
+          "model",
+          "provider",
+          "status",
+          "started_at",
+          "finished_at"
         ],
         "type": "object"
       },
@@ -1350,6 +1715,214 @@
           "canceled",
           "applied",
           "rebased"
+        ],
+        "type": "object"
+      },
+      "PanelEnqueueResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "agent": {
+            "type": "string"
+          },
+          "agentic": {
+            "type": "boolean"
+          },
+          "backup_agent": {
+            "type": "string"
+          },
+          "backup_model": {
+            "type": "string"
+          },
+          "branch": {
+            "type": "string"
+          },
+          "claim_blocked": {
+            "type": "boolean"
+          },
+          "closed": {
+            "type": "boolean"
+          },
+          "command_line": {
+            "type": "string"
+          },
+          "commit_id": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "commit_subject": {
+            "type": "string"
+          },
+          "diff_content": {
+            "type": "string"
+          },
+          "dirty_files": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "enqueued_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "error": {
+            "type": "string"
+          },
+          "finished_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "git_ref": {
+            "type": "string"
+          },
+          "id": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "job_type": {
+            "type": "string"
+          },
+          "member_job_ids": {
+            "items": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "min_severity": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "output_prefix": {
+            "type": "string"
+          },
+          "panel_member_config_json": {
+            "type": "string"
+          },
+          "panel_member_index": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "panel_member_name": {
+            "type": "string"
+          },
+          "panel_name": {
+            "type": "string"
+          },
+          "panel_role": {
+            "type": "string"
+          },
+          "panel_run_uuid": {
+            "type": "string"
+          },
+          "panel_summary": {
+            "$ref": "#/components/schemas/PanelSummary"
+          },
+          "parent_job_id": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "patch": {
+            "type": "string"
+          },
+          "patch_id": {
+            "type": "string"
+          },
+          "prompt": {
+            "type": "string"
+          },
+          "prompt_prebuilt": {
+            "type": "boolean"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "reasoning": {
+            "type": "string"
+          },
+          "repo_id": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "repo_name": {
+            "type": "string"
+          },
+          "repo_path": {
+            "type": "string"
+          },
+          "requested_model": {
+            "type": "string"
+          },
+          "requested_provider": {
+            "type": "string"
+          },
+          "retry_count": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "review_type": {
+            "type": "string"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "skip_reason": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "source_machine_id": {
+            "type": "string"
+          },
+          "started_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "synced_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "token_usage": {
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "uuid": {
+            "type": "string"
+          },
+          "verdict": {
+            "type": "string"
+          },
+          "worker_id": {
+            "type": "string"
+          },
+          "worktree_path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "panel_run_uuid",
+          "member_job_ids",
+          "id",
+          "repo_id",
+          "git_ref",
+          "agent",
+          "job_type",
+          "status",
+          "enqueued_at",
+          "retry_count",
+          "agentic",
+          "prompt_prebuilt"
         ],
         "type": "object"
       },
@@ -2690,7 +3263,10 @@
                 "schema": {
                   "oneOf": [
                     {
-                      "$ref": "#/components/schemas/ReviewJob"
+                      "$ref": "#/components/schemas/EnqueueCreatedResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/PanelEnqueueResponse"
                     },
                     {
                       "$ref": "#/components/schemas/EnqueueSkippedResponse"
@@ -2706,7 +3282,10 @@
                 "schema": {
                   "oneOf": [
                     {
-                      "$ref": "#/components/schemas/ReviewJob"
+                      "$ref": "#/components/schemas/EnqueueCreatedResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/PanelEnqueueResponse"
                     },
                     {
                       "$ref": "#/components/schemas/EnqueueSkippedResponse"
@@ -2757,6 +3336,112 @@
         "summary": "Enqueue a daemon job",
         "tags": [
           "jobs"
+        ]
+      }
+    },
+    "/api/export/ci-metrics": {
+      "get": {
+        "operationId": "export-ci-metrics",
+        "parameters": [
+          {
+            "description": "Output format; only json is supported",
+            "explode": false,
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "default": "json",
+              "description": "Output format; only json is supported",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive posted_at lower bound (RFC3339 or YYYY-MM-DD)",
+            "explode": false,
+            "in": "query",
+            "name": "since",
+            "schema": {
+              "description": "Inclusive posted_at lower bound (RFC3339 or YYYY-MM-DD)",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Exclusive posted_at upper bound (RFC3339 or YYYY-MM-DD; date-only means through that UTC day)",
+            "explode": false,
+            "in": "query",
+            "name": "until",
+            "schema": {
+              "description": "Exclusive posted_at upper bound (RFC3339 or YYYY-MM-DD; date-only means through that UTC day)",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum panels in this page",
+            "explode": false,
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "default": 500,
+              "description": "Maximum panels in this page",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Opaque next_cursor from a previous page. Resumes strictly after its (posted_at, panel_id) position; mutually exclusive with since.",
+            "explode": false,
+            "in": "query",
+            "name": "cursor",
+            "schema": {
+              "description": "Opaque next_cursor from a previous page. Resumes strictly after its (posted_at, panel_id) position; mutually exclusive with since.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Export the frozen pre-panel ci_pr_reviews era instead of panel runs. Cursors are namespaced to this mode and cannot be reused across modes.",
+            "explode": false,
+            "in": "query",
+            "name": "legacy",
+            "schema": {
+              "description": "Export the frozen pre-panel ci_pr_reviews era instead of panel runs. Cursors are namespaced to this mode and cannot be reused across modes.",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExportCIMetricsDocument"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Cursor database_id does not match this local database"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Export finalized CI panel metrics",
+        "tags": [
+          "reviews"
         ]
       }
     },

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -1019,6 +1019,101 @@ type OverviewStats struct {
 	Total    int64 `json:"total"`
 }
 
+type PanelEnqueueResponse struct {
+	Agent                 string        `json:"agent" validate:"required"`
+	Agentic               bool          `json:"agentic"`
+	BackupAgent           *string       `json:"backup_agent,omitempty"`
+	BackupModel           *string       `json:"backup_model,omitempty"`
+	Branch                *string       `json:"branch,omitempty"`
+	ClaimBlocked          *bool         `json:"claim_blocked,omitempty"`
+	Closed                *bool         `json:"closed,omitempty"`
+	CommandLine           *string       `json:"command_line,omitempty"`
+	CommitID              *int64        `json:"commit_id,omitempty"`
+	CommitSubject         *string       `json:"commit_subject,omitempty"`
+	DiffContent           *string       `json:"diff_content,omitempty"`
+	DirtyFiles            []string      `json:"dirty_files,omitempty"`
+	EnqueuedAt            time.Time     `json:"enqueued_at" validate:"required"`
+	ErrorData             *string       `json:"error,omitempty"`
+	FinishedAt            *time.Time    `json:"finished_at,omitempty"`
+	GitRef                string        `json:"git_ref" validate:"required"`
+	ID                    int64         `json:"id"`
+	JobType               string        `json:"job_type" validate:"required"`
+	MemberJobIds          []int64       `json:"member_job_ids,omitempty" validate:"required"`
+	MinSeverity           *string       `json:"min_severity,omitempty"`
+	Model                 *string       `json:"model,omitempty"`
+	OutputPrefix          *string       `json:"output_prefix,omitempty"`
+	PanelMemberConfigJSON *string       `json:"panel_member_config_json,omitempty"`
+	PanelMemberIndex      *int64        `json:"panel_member_index,omitempty"`
+	PanelMemberName       *string       `json:"panel_member_name,omitempty"`
+	PanelName             *string       `json:"panel_name,omitempty"`
+	PanelRole             *string       `json:"panel_role,omitempty"`
+	PanelRunUUID          string        `json:"panel_run_uuid" validate:"required"`
+	PanelSummary          *PanelSummary `json:"panel_summary,omitempty"`
+	ParentJobID           *int64        `json:"parent_job_id,omitempty"`
+	Patch                 *string       `json:"patch,omitempty"`
+	PatchID               *string       `json:"patch_id,omitempty"`
+	Prompt                *string       `json:"prompt,omitempty"`
+	PromptPrebuilt        bool          `json:"prompt_prebuilt"`
+	Provider              *string       `json:"provider,omitempty"`
+	Reasoning             *string       `json:"reasoning,omitempty"`
+	RepoID                int64         `json:"repo_id"`
+	RepoName              *string       `json:"repo_name,omitempty"`
+	RepoPath              *string       `json:"repo_path,omitempty"`
+	RequestedModel        *string       `json:"requested_model,omitempty"`
+	RequestedProvider     *string       `json:"requested_provider,omitempty"`
+	RetryCount            int64         `json:"retry_count"`
+	ReviewType            *string       `json:"review_type,omitempty"`
+	SessionID             *string       `json:"session_id,omitempty"`
+	SkipReason            *string       `json:"skip_reason,omitempty"`
+	Source                *string       `json:"source,omitempty"`
+	SourceMachineID       *string       `json:"source_machine_id,omitempty"`
+	StartedAt             *time.Time    `json:"started_at,omitempty"`
+	Status                string        `json:"status" validate:"required"`
+	SyncedAt              *time.Time    `json:"synced_at,omitempty"`
+	TokenUsage            *string       `json:"token_usage,omitempty"`
+	UpdatedAt             *time.Time    `json:"updated_at,omitempty"`
+	UUID                  *string       `json:"uuid,omitempty"`
+	Verdict               *string       `json:"verdict,omitempty"`
+	WorkerID              *string       `json:"worker_id,omitempty"`
+	WorktreePath          *string       `json:"worktree_path,omitempty"`
+}
+
+func (p PanelEnqueueResponse) Validate() error {
+	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(p.Agent, "required"); err != nil {
+		errors = errors.Append("Agent", err)
+	}
+	if err := typesValidator.Var(p.EnqueuedAt, "required"); err != nil {
+		errors = errors.Append("EnqueuedAt", err)
+	}
+	if err := typesValidator.Var(p.GitRef, "required"); err != nil {
+		errors = errors.Append("GitRef", err)
+	}
+	if err := typesValidator.Var(p.JobType, "required"); err != nil {
+		errors = errors.Append("JobType", err)
+	}
+	if err := typesValidator.Var(p.MemberJobIds, "required"); err != nil {
+		errors = errors.Append("MemberJobIds", err)
+	}
+	if err := typesValidator.Var(p.PanelRunUUID, "required"); err != nil {
+		errors = errors.Append("PanelRunUUID", err)
+	}
+	if p.PanelSummary != nil {
+		if v, ok := any(p.PanelSummary).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PanelSummary", err)
+			}
+		}
+	}
+	if err := typesValidator.Var(p.Status, "required"); err != nil {
+		errors = errors.Append("Status", err)
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
 type PanelSummary struct {
 	FirstStartedAt      *time.Time `json:"first_started_at,omitempty"`
 	MembersCanceled     int64      `json:"members_canceled"`

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -240,6 +240,97 @@ type DurationStats struct {
 	ReviewP99Secs float64 `json:"review_p99_secs"`
 }
 
+type EnqueueCreatedResponse struct {
+	Agent                 string        `json:"agent" validate:"required"`
+	Agentic               bool          `json:"agentic"`
+	BackupAgent           *string       `json:"backup_agent,omitempty"`
+	BackupModel           *string       `json:"backup_model,omitempty"`
+	Branch                *string       `json:"branch,omitempty"`
+	ClaimBlocked          *bool         `json:"claim_blocked,omitempty"`
+	Closed                *bool         `json:"closed,omitempty"`
+	CommandLine           *string       `json:"command_line,omitempty"`
+	CommitID              *int64        `json:"commit_id,omitempty"`
+	CommitSubject         *string       `json:"commit_subject,omitempty"`
+	DiffContent           *string       `json:"diff_content,omitempty"`
+	DirtyFiles            []string      `json:"dirty_files,omitempty"`
+	EnqueuedAt            time.Time     `json:"enqueued_at" validate:"required"`
+	ErrorData             *string       `json:"error,omitempty"`
+	FinishedAt            *time.Time    `json:"finished_at,omitempty"`
+	GitRef                string        `json:"git_ref" validate:"required"`
+	ID                    int64         `json:"id"`
+	JobType               string        `json:"job_type" validate:"required"`
+	MinSeverity           *string       `json:"min_severity,omitempty"`
+	Model                 *string       `json:"model,omitempty"`
+	OutputPrefix          *string       `json:"output_prefix,omitempty"`
+	PanelMemberConfigJSON *string       `json:"panel_member_config_json,omitempty"`
+	PanelMemberIndex      *int64        `json:"panel_member_index,omitempty"`
+	PanelMemberName       *string       `json:"panel_member_name,omitempty"`
+	PanelName             *string       `json:"panel_name,omitempty"`
+	PanelRole             *string       `json:"panel_role,omitempty"`
+	PanelRunUUID          *string       `json:"panel_run_uuid,omitempty"`
+	PanelSummary          *PanelSummary `json:"panel_summary,omitempty"`
+	ParentJobID           *int64        `json:"parent_job_id,omitempty"`
+	Patch                 *string       `json:"patch,omitempty"`
+	PatchID               *string       `json:"patch_id,omitempty"`
+	Prompt                *string       `json:"prompt,omitempty"`
+	PromptPrebuilt        bool          `json:"prompt_prebuilt"`
+	Provider              *string       `json:"provider,omitempty"`
+	Reasoning             *string       `json:"reasoning,omitempty"`
+	RepoID                int64         `json:"repo_id"`
+	RepoName              *string       `json:"repo_name,omitempty"`
+	RepoPath              *string       `json:"repo_path,omitempty"`
+	RequestedModel        *string       `json:"requested_model,omitempty"`
+	RequestedProvider     *string       `json:"requested_provider,omitempty"`
+	RetryCount            int64         `json:"retry_count"`
+	ReviewType            *string       `json:"review_type,omitempty"`
+	SessionID             *string       `json:"session_id,omitempty"`
+	SkipReason            *string       `json:"skip_reason,omitempty"`
+	Source                *string       `json:"source,omitempty"`
+	SourceMachineID       *string       `json:"source_machine_id,omitempty"`
+	StartedAt             *time.Time    `json:"started_at,omitempty"`
+	Status                string        `json:"status" validate:"required"`
+	SyncedAt              *time.Time    `json:"synced_at,omitempty"`
+	TokenUsage            *string       `json:"token_usage,omitempty"`
+	UpdatedAt             *time.Time    `json:"updated_at,omitempty"`
+	UUID                  string        `json:"uuid" validate:"required"`
+	Verdict               *string       `json:"verdict,omitempty"`
+	WorkerID              *string       `json:"worker_id,omitempty"`
+	WorktreePath          *string       `json:"worktree_path,omitempty"`
+}
+
+func (e EnqueueCreatedResponse) Validate() error {
+	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(e.Agent, "required"); err != nil {
+		errors = errors.Append("Agent", err)
+	}
+	if err := typesValidator.Var(e.EnqueuedAt, "required"); err != nil {
+		errors = errors.Append("EnqueuedAt", err)
+	}
+	if err := typesValidator.Var(e.GitRef, "required"); err != nil {
+		errors = errors.Append("GitRef", err)
+	}
+	if err := typesValidator.Var(e.JobType, "required"); err != nil {
+		errors = errors.Append("JobType", err)
+	}
+	if e.PanelSummary != nil {
+		if v, ok := any(e.PanelSummary).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PanelSummary", err)
+			}
+		}
+	}
+	if err := typesValidator.Var(e.Status, "required"); err != nil {
+		errors = errors.Append("Status", err)
+	}
+	if err := typesValidator.Var(e.UUID, "required"); err != nil {
+		errors = errors.Append("UUID", err)
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
 type EnqueueRequest struct {
 	// Schema A URL to the JSON Schema for this object.
 	Schema       *string  `json:"$schema,omitempty"`

--- a/pkg/client/generated/unions.go
+++ b/pkg/client/generated/unions.go
@@ -3,41 +3,291 @@
 package generated
 
 import (
+	"encoding/json"
+
 	"github.com/doordash-oss/oapi-codegen-dd/v3/pkg/runtime"
 )
 
 type EnqueueJob_Response_OneOf struct {
-	runtime.Either[EnqueueCreatedResponse, EnqueueSkippedResponse]
+	union json.RawMessage
 }
 
 func (e *EnqueueJob_Response_OneOf) Validate() error {
-	if e.IsA() {
-		if v, ok := any(e.A).(runtime.Validator); ok {
-			return v.Validate()
-		}
+	// NOTE: Validation is not supported for unions with more than 2 elements.
+	// Validating would require unmarshaling against each possible type, which is inefficient.
+	// Use AsValidated<Type>() methods to validate after retrieving the specific type.
+	return nil
+}
+
+// Raw returns the union data inside the EnqueueJob_Response_OneOf as bytes
+func (e *EnqueueJob_Response_OneOf) Raw() json.RawMessage {
+	return e.union
+}
+
+// AsEnqueueCreatedResponse returns the union data inside the EnqueueJob_Response_OneOf as a EnqueueCreatedResponse
+func (e *EnqueueJob_Response_OneOf) AsEnqueueCreatedResponse() (EnqueueCreatedResponse, error) {
+	return runtime.UnmarshalAs[EnqueueCreatedResponse](e.union)
+}
+
+// AsValidatedEnqueueCreatedResponse returns the union data inside the EnqueueJob_Response_OneOf as a validated EnqueueCreatedResponse
+func (e *EnqueueJob_Response_OneOf) AsValidatedEnqueueCreatedResponse() (EnqueueCreatedResponse, error) {
+	val, err := e.AsEnqueueCreatedResponse()
+	if err != nil {
+		var zero EnqueueCreatedResponse
+		return zero, err
 	}
-	if e.IsB() {
-		if v, ok := any(e.B).(runtime.Validator); ok {
-			return v.Validate()
-		}
+	if err := e.validateEnqueueCreatedResponse(val); err != nil {
+		var zero EnqueueCreatedResponse
+		return zero, err
+	}
+	return val, nil
+}
+
+// FromEnqueueCreatedResponse overwrites any union data inside the EnqueueJob_Response_OneOf as the provided EnqueueCreatedResponse
+func (e *EnqueueJob_Response_OneOf) FromEnqueueCreatedResponse(val EnqueueCreatedResponse) error {
+	// Validate before storing
+	if err := e.validateEnqueueCreatedResponse(val); err != nil {
+		return err
+	}
+	bts, err := json.Marshal(val)
+	e.union = bts
+	return err
+}
+
+// AsPanelEnqueueResponse returns the union data inside the EnqueueJob_Response_OneOf as a PanelEnqueueResponse
+func (e *EnqueueJob_Response_OneOf) AsPanelEnqueueResponse() (PanelEnqueueResponse, error) {
+	return runtime.UnmarshalAs[PanelEnqueueResponse](e.union)
+}
+
+// AsValidatedPanelEnqueueResponse returns the union data inside the EnqueueJob_Response_OneOf as a validated PanelEnqueueResponse
+func (e *EnqueueJob_Response_OneOf) AsValidatedPanelEnqueueResponse() (PanelEnqueueResponse, error) {
+	val, err := e.AsPanelEnqueueResponse()
+	if err != nil {
+		var zero PanelEnqueueResponse
+		return zero, err
+	}
+	if err := e.validatePanelEnqueueResponse(val); err != nil {
+		var zero PanelEnqueueResponse
+		return zero, err
+	}
+	return val, nil
+}
+
+// FromPanelEnqueueResponse overwrites any union data inside the EnqueueJob_Response_OneOf as the provided PanelEnqueueResponse
+func (e *EnqueueJob_Response_OneOf) FromPanelEnqueueResponse(val PanelEnqueueResponse) error {
+	// Validate before storing
+	if err := e.validatePanelEnqueueResponse(val); err != nil {
+		return err
+	}
+	bts, err := json.Marshal(val)
+	e.union = bts
+	return err
+}
+
+// AsEnqueueSkippedResponse returns the union data inside the EnqueueJob_Response_OneOf as a EnqueueSkippedResponse
+func (e *EnqueueJob_Response_OneOf) AsEnqueueSkippedResponse() (EnqueueSkippedResponse, error) {
+	return runtime.UnmarshalAs[EnqueueSkippedResponse](e.union)
+}
+
+// AsValidatedEnqueueSkippedResponse returns the union data inside the EnqueueJob_Response_OneOf as a validated EnqueueSkippedResponse
+func (e *EnqueueJob_Response_OneOf) AsValidatedEnqueueSkippedResponse() (EnqueueSkippedResponse, error) {
+	val, err := e.AsEnqueueSkippedResponse()
+	if err != nil {
+		var zero EnqueueSkippedResponse
+		return zero, err
+	}
+	if err := e.validateEnqueueSkippedResponse(val); err != nil {
+		var zero EnqueueSkippedResponse
+		return zero, err
+	}
+	return val, nil
+}
+
+// FromEnqueueSkippedResponse overwrites any union data inside the EnqueueJob_Response_OneOf as the provided EnqueueSkippedResponse
+func (e *EnqueueJob_Response_OneOf) FromEnqueueSkippedResponse(val EnqueueSkippedResponse) error {
+	// Validate before storing
+	if err := e.validateEnqueueSkippedResponse(val); err != nil {
+		return err
+	}
+	bts, err := json.Marshal(val)
+	e.union = bts
+	return err
+}
+
+// validateEnqueueCreatedResponse validates a EnqueueCreatedResponse value
+func (e *EnqueueJob_Response_OneOf) validateEnqueueCreatedResponse(val EnqueueCreatedResponse) error {
+	if v, ok := any(val).(runtime.Validator); ok {
+		return v.Validate()
 	}
 	return nil
+}
+
+// validatePanelEnqueueResponse validates a PanelEnqueueResponse value
+func (e *EnqueueJob_Response_OneOf) validatePanelEnqueueResponse(val PanelEnqueueResponse) error {
+	if v, ok := any(val).(runtime.Validator); ok {
+		return v.Validate()
+	}
+	return nil
+}
+
+// validateEnqueueSkippedResponse validates a EnqueueSkippedResponse value
+func (e *EnqueueJob_Response_OneOf) validateEnqueueSkippedResponse(val EnqueueSkippedResponse) error {
+	if v, ok := any(val).(runtime.Validator); ok {
+		return v.Validate()
+	}
+	return nil
+}
+
+func (e EnqueueJob_Response_OneOf) MarshalJSON() ([]byte, error) {
+	bts, err := e.union.MarshalJSON()
+
+	return bts, err
+}
+
+func (e *EnqueueJob_Response_OneOf) UnmarshalJSON(bts []byte) error {
+	err := e.union.UnmarshalJSON(bts)
+
+	return err
 }
 
 type EnqueueJob_Response_201_OneOf struct {
-	runtime.Either[EnqueueCreatedResponse, EnqueueSkippedResponse]
+	union json.RawMessage
 }
 
 func (e *EnqueueJob_Response_201_OneOf) Validate() error {
-	if e.IsA() {
-		if v, ok := any(e.A).(runtime.Validator); ok {
-			return v.Validate()
-		}
+	// NOTE: Validation is not supported for unions with more than 2 elements.
+	// Validating would require unmarshaling against each possible type, which is inefficient.
+	// Use AsValidated<Type>() methods to validate after retrieving the specific type.
+	return nil
+}
+
+// Raw returns the union data inside the EnqueueJob_Response_201_OneOf as bytes
+func (e *EnqueueJob_Response_201_OneOf) Raw() json.RawMessage {
+	return e.union
+}
+
+// AsEnqueueCreatedResponse returns the union data inside the EnqueueJob_Response_201_OneOf as a EnqueueCreatedResponse
+func (e *EnqueueJob_Response_201_OneOf) AsEnqueueCreatedResponse() (EnqueueCreatedResponse, error) {
+	return runtime.UnmarshalAs[EnqueueCreatedResponse](e.union)
+}
+
+// AsValidatedEnqueueCreatedResponse returns the union data inside the EnqueueJob_Response_201_OneOf as a validated EnqueueCreatedResponse
+func (e *EnqueueJob_Response_201_OneOf) AsValidatedEnqueueCreatedResponse() (EnqueueCreatedResponse, error) {
+	val, err := e.AsEnqueueCreatedResponse()
+	if err != nil {
+		var zero EnqueueCreatedResponse
+		return zero, err
 	}
-	if e.IsB() {
-		if v, ok := any(e.B).(runtime.Validator); ok {
-			return v.Validate()
-		}
+	if err := e.validateEnqueueCreatedResponse(val); err != nil {
+		var zero EnqueueCreatedResponse
+		return zero, err
+	}
+	return val, nil
+}
+
+// FromEnqueueCreatedResponse overwrites any union data inside the EnqueueJob_Response_201_OneOf as the provided EnqueueCreatedResponse
+func (e *EnqueueJob_Response_201_OneOf) FromEnqueueCreatedResponse(val EnqueueCreatedResponse) error {
+	// Validate before storing
+	if err := e.validateEnqueueCreatedResponse(val); err != nil {
+		return err
+	}
+	bts, err := json.Marshal(val)
+	e.union = bts
+	return err
+}
+
+// AsPanelEnqueueResponse returns the union data inside the EnqueueJob_Response_201_OneOf as a PanelEnqueueResponse
+func (e *EnqueueJob_Response_201_OneOf) AsPanelEnqueueResponse() (PanelEnqueueResponse, error) {
+	return runtime.UnmarshalAs[PanelEnqueueResponse](e.union)
+}
+
+// AsValidatedPanelEnqueueResponse returns the union data inside the EnqueueJob_Response_201_OneOf as a validated PanelEnqueueResponse
+func (e *EnqueueJob_Response_201_OneOf) AsValidatedPanelEnqueueResponse() (PanelEnqueueResponse, error) {
+	val, err := e.AsPanelEnqueueResponse()
+	if err != nil {
+		var zero PanelEnqueueResponse
+		return zero, err
+	}
+	if err := e.validatePanelEnqueueResponse(val); err != nil {
+		var zero PanelEnqueueResponse
+		return zero, err
+	}
+	return val, nil
+}
+
+// FromPanelEnqueueResponse overwrites any union data inside the EnqueueJob_Response_201_OneOf as the provided PanelEnqueueResponse
+func (e *EnqueueJob_Response_201_OneOf) FromPanelEnqueueResponse(val PanelEnqueueResponse) error {
+	// Validate before storing
+	if err := e.validatePanelEnqueueResponse(val); err != nil {
+		return err
+	}
+	bts, err := json.Marshal(val)
+	e.union = bts
+	return err
+}
+
+// AsEnqueueSkippedResponse returns the union data inside the EnqueueJob_Response_201_OneOf as a EnqueueSkippedResponse
+func (e *EnqueueJob_Response_201_OneOf) AsEnqueueSkippedResponse() (EnqueueSkippedResponse, error) {
+	return runtime.UnmarshalAs[EnqueueSkippedResponse](e.union)
+}
+
+// AsValidatedEnqueueSkippedResponse returns the union data inside the EnqueueJob_Response_201_OneOf as a validated EnqueueSkippedResponse
+func (e *EnqueueJob_Response_201_OneOf) AsValidatedEnqueueSkippedResponse() (EnqueueSkippedResponse, error) {
+	val, err := e.AsEnqueueSkippedResponse()
+	if err != nil {
+		var zero EnqueueSkippedResponse
+		return zero, err
+	}
+	if err := e.validateEnqueueSkippedResponse(val); err != nil {
+		var zero EnqueueSkippedResponse
+		return zero, err
+	}
+	return val, nil
+}
+
+// FromEnqueueSkippedResponse overwrites any union data inside the EnqueueJob_Response_201_OneOf as the provided EnqueueSkippedResponse
+func (e *EnqueueJob_Response_201_OneOf) FromEnqueueSkippedResponse(val EnqueueSkippedResponse) error {
+	// Validate before storing
+	if err := e.validateEnqueueSkippedResponse(val); err != nil {
+		return err
+	}
+	bts, err := json.Marshal(val)
+	e.union = bts
+	return err
+}
+
+// validateEnqueueCreatedResponse validates a EnqueueCreatedResponse value
+func (e *EnqueueJob_Response_201_OneOf) validateEnqueueCreatedResponse(val EnqueueCreatedResponse) error {
+	if v, ok := any(val).(runtime.Validator); ok {
+		return v.Validate()
 	}
 	return nil
+}
+
+// validatePanelEnqueueResponse validates a PanelEnqueueResponse value
+func (e *EnqueueJob_Response_201_OneOf) validatePanelEnqueueResponse(val PanelEnqueueResponse) error {
+	if v, ok := any(val).(runtime.Validator); ok {
+		return v.Validate()
+	}
+	return nil
+}
+
+// validateEnqueueSkippedResponse validates a EnqueueSkippedResponse value
+func (e *EnqueueJob_Response_201_OneOf) validateEnqueueSkippedResponse(val EnqueueSkippedResponse) error {
+	if v, ok := any(val).(runtime.Validator); ok {
+		return v.Validate()
+	}
+	return nil
+}
+
+func (e EnqueueJob_Response_201_OneOf) MarshalJSON() ([]byte, error) {
+	bts, err := e.union.MarshalJSON()
+
+	return bts, err
+}
+
+func (e *EnqueueJob_Response_201_OneOf) UnmarshalJSON(bts []byte) error {
+	err := e.union.UnmarshalJSON(bts)
+
+	return err
 }

--- a/pkg/client/generated/unions.go
+++ b/pkg/client/generated/unions.go
@@ -7,7 +7,7 @@ import (
 )
 
 type EnqueueJob_Response_OneOf struct {
-	runtime.Either[ReviewJob, EnqueueSkippedResponse]
+	runtime.Either[EnqueueCreatedResponse, EnqueueSkippedResponse]
 }
 
 func (e *EnqueueJob_Response_OneOf) Validate() error {
@@ -25,7 +25,7 @@ func (e *EnqueueJob_Response_OneOf) Validate() error {
 }
 
 type EnqueueJob_Response_201_OneOf struct {
-	runtime.Either[ReviewJob, EnqueueSkippedResponse]
+	runtime.Either[EnqueueCreatedResponse, EnqueueSkippedResponse]
 }
 
 func (e *EnqueueJob_Response_201_OneOf) Validate() error {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -403,6 +403,147 @@ components:
         - queue_p90_secs
         - queue_p99_secs
       type: object
+    EnqueueCreatedResponse:
+      additionalProperties: false
+      properties:
+        agent:
+          type: string
+        agentic:
+          type: boolean
+        backup_agent:
+          type: string
+        backup_model:
+          type: string
+        branch:
+          type: string
+        claim_blocked:
+          type: boolean
+        closed:
+          type: boolean
+        command_line:
+          type: string
+        commit_id:
+          format: int64
+          type: integer
+        commit_subject:
+          type: string
+        diff_content:
+          type: string
+        dirty_files:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        enqueued_at:
+          format: date-time
+          type: string
+        error:
+          type: string
+        finished_at:
+          format: date-time
+          type: string
+        git_ref:
+          type: string
+        id:
+          format: int64
+          type: integer
+        job_type:
+          type: string
+        min_severity:
+          type: string
+        model:
+          type: string
+        output_prefix:
+          type: string
+        panel_member_config_json:
+          type: string
+        panel_member_index:
+          format: int64
+          type: integer
+        panel_member_name:
+          type: string
+        panel_name:
+          type: string
+        panel_role:
+          type: string
+        panel_run_uuid:
+          type: string
+        panel_summary:
+          $ref: "#/components/schemas/PanelSummary"
+        parent_job_id:
+          format: int64
+          type: integer
+        patch:
+          type: string
+        patch_id:
+          type: string
+        prompt:
+          type: string
+        prompt_prebuilt:
+          type: boolean
+        provider:
+          type: string
+        reasoning:
+          type: string
+        repo_id:
+          format: int64
+          type: integer
+        repo_name:
+          type: string
+        repo_path:
+          type: string
+        requested_model:
+          type: string
+        requested_provider:
+          type: string
+        retry_count:
+          format: int64
+          type: integer
+        review_type:
+          type: string
+        session_id:
+          type: string
+        skip_reason:
+          type: string
+        source:
+          type: string
+        source_machine_id:
+          type: string
+        started_at:
+          format: date-time
+          type: string
+        status:
+          type: string
+        synced_at:
+          format: date-time
+          type: string
+        token_usage:
+          type: string
+        updated_at:
+          format: date-time
+          type: string
+        uuid:
+          type: string
+        verdict:
+          type: string
+        worker_id:
+          type: string
+        worktree_path:
+          type: string
+      required:
+        - uuid
+        - id
+        - repo_id
+        - git_ref
+        - agent
+        - job_type
+        - status
+        - enqueued_at
+        - retry_count
+        - agentic
+        - prompt_prebuilt
+      type: object
     EnqueueRequest:
       additionalProperties: false
       properties:
@@ -2187,14 +2328,14 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: "#/components/schemas/ReviewJob"
+                  - $ref: "#/components/schemas/EnqueueCreatedResponse"
                   - $ref: "#/components/schemas/EnqueueSkippedResponse"
         "201":
           content:
             application/json:
               schema:
                 oneOf:
-                  - $ref: "#/components/schemas/ReviewJob"
+                  - $ref: "#/components/schemas/EnqueueCreatedResponse"
                   - $ref: "#/components/schemas/EnqueueSkippedResponse"
           description: Created
         "400":

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -1343,6 +1343,155 @@ components:
         - applied
         - rebased
       type: object
+    PanelEnqueueResponse:
+      additionalProperties: false
+      properties:
+        agent:
+          type: string
+        agentic:
+          type: boolean
+        backup_agent:
+          type: string
+        backup_model:
+          type: string
+        branch:
+          type: string
+        claim_blocked:
+          type: boolean
+        closed:
+          type: boolean
+        command_line:
+          type: string
+        commit_id:
+          format: int64
+          type: integer
+        commit_subject:
+          type: string
+        diff_content:
+          type: string
+        dirty_files:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        enqueued_at:
+          format: date-time
+          type: string
+        error:
+          type: string
+        finished_at:
+          format: date-time
+          type: string
+        git_ref:
+          type: string
+        id:
+          format: int64
+          type: integer
+        job_type:
+          type: string
+        member_job_ids:
+          items:
+            format: int64
+            type: integer
+          type:
+            - array
+            - "null"
+        min_severity:
+          type: string
+        model:
+          type: string
+        output_prefix:
+          type: string
+        panel_member_config_json:
+          type: string
+        panel_member_index:
+          format: int64
+          type: integer
+        panel_member_name:
+          type: string
+        panel_name:
+          type: string
+        panel_role:
+          type: string
+        panel_run_uuid:
+          type: string
+        panel_summary:
+          $ref: "#/components/schemas/PanelSummary"
+        parent_job_id:
+          format: int64
+          type: integer
+        patch:
+          type: string
+        patch_id:
+          type: string
+        prompt:
+          type: string
+        prompt_prebuilt:
+          type: boolean
+        provider:
+          type: string
+        reasoning:
+          type: string
+        repo_id:
+          format: int64
+          type: integer
+        repo_name:
+          type: string
+        repo_path:
+          type: string
+        requested_model:
+          type: string
+        requested_provider:
+          type: string
+        retry_count:
+          format: int64
+          type: integer
+        review_type:
+          type: string
+        session_id:
+          type: string
+        skip_reason:
+          type: string
+        source:
+          type: string
+        source_machine_id:
+          type: string
+        started_at:
+          format: date-time
+          type: string
+        status:
+          type: string
+        synced_at:
+          format: date-time
+          type: string
+        token_usage:
+          type: string
+        updated_at:
+          format: date-time
+          type: string
+        uuid:
+          type: string
+        verdict:
+          type: string
+        worker_id:
+          type: string
+        worktree_path:
+          type: string
+      required:
+        - panel_run_uuid
+        - member_job_ids
+        - id
+        - repo_id
+        - git_ref
+        - agent
+        - job_type
+        - status
+        - enqueued_at
+        - retry_count
+        - agentic
+        - prompt_prebuilt
+      type: object
     PanelSummary:
       additionalProperties: false
       properties:
@@ -2329,6 +2478,7 @@ paths:
               schema:
                 oneOf:
                   - $ref: "#/components/schemas/EnqueueCreatedResponse"
+                  - $ref: "#/components/schemas/PanelEnqueueResponse"
                   - $ref: "#/components/schemas/EnqueueSkippedResponse"
         "201":
           content:
@@ -2336,6 +2486,7 @@ paths:
               schema:
                 oneOf:
                   - $ref: "#/components/schemas/EnqueueCreatedResponse"
+                  - $ref: "#/components/schemas/PanelEnqueueResponse"
                   - $ref: "#/components/schemas/EnqueueSkippedResponse"
           description: Created
         "400":


### PR DESCRIPTION
## Summary

- Add a `--json` flag to `roborev run` that emits one machine-readable launch receipt (`job_id`, `job_uuid`, `git_ref`, `status`) from the atomic enqueue response; incompatible with `--quiet`, `--wait`, and the global `--verbose`
- When the daemon skips the enqueue (e.g. excluded branch), `--json` emits a single `{"skipped":true,"reason":...}` document and human mode prints the reason
- Return a dedicated `EnqueueCreatedResponse` (required `uuid`) from the created enqueue path and document it in the OpenAPI spec alongside `PanelEnqueueResponse` and `EnqueueSkippedResponse` in the success oneOf; the general `ReviewJob` schema keeps `uuid` optional for older stored records
- Stop huma's `ReviewJob` link transformer from injecting an undeclared `$schema` field into 201 enqueue bodies, and pin that with a test
- Regenerate `pkg/client` and `internal/daemon_client` from the updated spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)