### PR TITLE
Update flake.nix for v0.63.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
         {
           default = pkgs.buildGoModule {
             pname = "roborev";
-            version = "0.62.1";
+            version = "0.63.0";
             go = pkgs.go_1_26;
 
             src = ./.;


### PR DESCRIPTION
Updates flake.nix version to 0.63.0 for the v0.63.0 release.