### PR TITLE
Document the 0.63.0 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,29 @@ description: Release history for roborev
 
 All notable changes to roborev, grouped by minor release.
 
+## 0.63.0
+<small>2026-07-16</small>
+
+**New features**
+
+- CI quiet hours add a recurring daily window with an additional per-PR review throttle. Configure `[ci.quiet_hours]` with `start`, `end`, `timezone`, and `throttle_interval`; the additional interval applies by default even to authors listed in `[ci].throttle_bypass_users`. See [Quiet Hours](/integrations/github/#quiet-hours).
+- `[ci.quiet_hours].bypass_users` lets selected GitHub authors skip only the additional quiet-hours interval. Authors who should bypass both throttle layers must also appear in `[ci].throttle_bypass_users`. See [Quiet Hours Options](/integrations/github/#quiet-hours-options).
+- `roborev run --json` emits one machine-readable launch receipt with `job_id`, `job_uuid`, `git_ref`, and `status`. Skipped enqueues emit a machine-readable reason instead, allowing automation to distinguish a successful launch from a policy skip without parsing human output. See [Custom Tasks & Agentic Mode](/advanced/custom-tasks/).
+
+**Improvements**
+
+- The bundled `roborev-fix` skills now distinguish current operative invocations and direct Agent Hook instructions from literal skill syntax inside pasted findings, logs, transcripts, quotations, and examples, preventing historical text from unexpectedly starting a roborev workflow. See [Agent Skills](/guides/agent-skills/#usage).
+
+**Bug fixes**
+
+- Review enqueues from detached-HEAD checkouts now infer an unambiguous local branch from the target commit, restoring branch-scoped TUI grouping, fix/refine discovery, and hook matching for tooling-managed worktrees. Ambiguous matches still remain branchless, and inferred branches continue to honor `excluded_branches`. See [Detached HEAD Worktrees](/guides/repository-management/#detached-head-worktrees).
+
+**Acknowledgements**
+
+- Thanks to [Wes McKinney](https://github.com/wesm) for CI quiet-hours throttling and bypass controls, machine-readable task launch receipts, safer `roborev-fix` trigger boundaries, and detached-HEAD branch inference.
+
+---
+
 ## 0.62.1
 <small>2026-07-13</small>
 

--- a/docs/integrations/github.md
+++ b/docs/integrations/github.md
@@ -460,7 +460,7 @@ throttle_bypass_users = ["wesm"]      # these users bypass throttling
 
 When a PR is pushed within the throttle window, the poller defers the review and posts a pending GitHub status showing the next eligible review time. Set `throttle_interval = "0"` to disable throttling entirely.
 
-Throttling is bypassed when a new push supersedes an in-progress review: the old review is canceled and the new one starts immediately, so you always get feedback on the latest code.
+When the ordinary throttle defers a new push, roborev cancels any in-progress review for the older HEAD so stale results cannot post. The latest HEAD is reviewed after the interval elapses. Authors listed in `throttle_bypass_users` skip that delay, so their new push cancels the older run and starts its replacement immediately.
 
 Users listed in `throttle_bypass_users` get immediate reviews on every push regardless of the interval. Matching is case-insensitive.
 
@@ -477,7 +477,7 @@ throttle_interval = "1h"   # per-PR minimum between reviews in the window; defau
 bypass_users = ["trusted-contributor"] # skips only the quiet-hours throttle
 ```
 
-While the window is active, the effective throttle for every PR is the larger of `throttle_interval` and `quiet_hours.throttle_interval`. The quiet-hours interval applies to every author except those listed in `quiet_hours.bypass_users`; matching is case-insensitive. The ordinary throttle remains independent, so a quiet-hours bypass user must also appear in `[ci].throttle_bypass_users` to bypass both intervals. A PR's first-ever review is never blocked, and throttled pushes get the usual pending "review deferred" status. When the window ends, the next poll reviews the latest HEAD once, so overnight pushes collapse into a single fresh review.
+While the window is active, the effective throttle for every PR is the larger of `throttle_interval` and `quiet_hours.throttle_interval`. The quiet-hours interval applies to every author except those listed in `quiet_hours.bypass_users`; matching is case-insensitive. The ordinary throttle remains independent, so a quiet-hours bypass user must also appear in `[ci].throttle_bypass_users` to bypass both intervals. A PR's first-ever review is never blocked, and throttled pushes get the usual pending "review deferred" status. When the window ends, the latest HEAD becomes eligible under the ordinary throttle again, so quiet-hours-only deferrals collapse overnight pushes into a single fresh review.
 
 A push deferred only by quiet hours (one the base throttle would have allowed) does not cancel an in-flight review — unlike ordinary throttling, where a new push supersedes the stale run. Frequent overnight pushes would otherwise kill every review before it completes; instead, the running review finishes and posts, so a busy PR gets one snapshot review per interval. Pushes deferred by the base throttle keep their existing supersede behavior, inside or outside the window.
 


### PR DESCRIPTION
roborev 0.63.0 introduces a new automation contract and two-layer CI throttling whose interaction is easy to misconfigure. This documents the exact quiet-hours and bypass semantics, machine-readable run receipts, safer skill activation, and detached-HEAD attribution, with contributor credit grounded in merged PR authorship.

The CI guide also corrects the ordinary-throttle supersede description and clarifies that leaving quiet hours returns a PR to ordinary throttle eligibility. This avoids implying immediate replacement runs or an unconditional post-window review.