### PR TITLE
fix(cli): read prompt from queued jobs in show --prompt

### DIFF
--- a/cmd/roborev/show.go
+++ b/cmd/roborev/show.go
@@ -111,6 +111,11 @@ Examples:
 
 			var queryURL string
 			var displayRef string
+			// jobIDForPromptFallback carries the numeric job ID when the
+			// lookup is keyed by job ID, so a 404 from /api/review (no
+			// review row yet) can fall back to the job's stored prompt for
+			// queued/running jobs. -1 means "not applicable" (SHA lookups).
+			jobIDForPromptFallback := int64(-1)
 
 			if len(args) == 0 {
 				if forceJobID {
@@ -152,6 +157,9 @@ Examples:
 				if isJobID {
 					queryURL = addr + "/api/review?job_id=" + arg
 					displayRef = "job " + arg
+					if id, perr := strconv.ParseInt(arg, 10, 64); perr == nil {
+						jobIDForPromptFallback = id
+					}
 				} else {
 					sha := arg
 					if resolvedSHA != "" {
@@ -168,12 +176,18 @@ Examples:
 			}
 			defer resp.Body.Close()
 
-			if resp.StatusCode == http.StatusNotFound {
-				return fmt.Errorf("no review found for %s", displayRef)
-			}
-
 			var review storage.Review
-			if err := json.NewDecoder(resp.Body).Decode(&review); err != nil {
+			if resp.StatusCode == http.StatusNotFound {
+				// Queued/running jobs don't have a review row yet, but the
+				// prompt was already recorded on the job at enqueue time.
+				// Mirror the TUI's fallback (handlers_review.go) so
+				// `show --prompt` works before the job completes.
+				fallback := showPrompt && jobIDForPromptFallback >= 0 &&
+					fetchQueuedJobPromptReview(client, addr, jobIDForPromptFallback, &review)
+				if !fallback {
+					return fmt.Errorf("no review found for %s", displayRef)
+				}
+			} else if err := json.NewDecoder(resp.Body).Decode(&review); err != nil {
 				return fmt.Errorf("failed to parse response: %w", err)
 			}
 
@@ -239,6 +253,50 @@ Examples:
 	cmd.Flags().BoolVar(&showPrompt, "prompt", false, "show the prompt sent to the agent instead of the review output")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output as JSON")
 	return cmd
+}
+
+// fetchQueuedJobPromptReview looks up a job by ID and, if it is queued or
+// running and has a stored prompt, populates out with a minimal review built
+// from the job (Agent, Prompt, Job) and reports true. It reports false if the
+// job can't be found, isn't queued/running, or has no prompt yet — in which
+// case out is left untouched.
+//
+// This mirrors the TUI's queued-job prompt fallback (handlePromptKey in
+// cmd/roborev/tui/handlers_review.go), which reads Prompt straight off the
+// job object because no review row exists until the job completes.
+func fetchQueuedJobPromptReview(client *http.Client, addr string, jobID int64, out *storage.Review) bool {
+	resp, err := client.Get(fmt.Sprintf("%s/api/jobs?id=%d", addr, jobID))
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+
+	var result struct {
+		Jobs []storage.ReviewJob `json:"jobs"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil || len(result.Jobs) == 0 {
+		return false
+	}
+
+	job := result.Jobs[0]
+	if job.Prompt == "" {
+		return false
+	}
+	if job.Status != storage.JobStatusQueued && job.Status != storage.JobStatusRunning {
+		return false
+	}
+
+	jobCopy := job
+	*out = storage.Review{
+		JobID:  job.ID,
+		Agent:  job.Agent,
+		Prompt: job.Prompt,
+		Job:    &jobCopy,
+	}
+	return true
 }
 
 // fetchPanelMembers loads a panel run's member rows (ordered by member index)

--- a/cmd/roborev/show_test.go
+++ b/cmd/roborev/show_test.go
@@ -292,6 +292,110 @@ func TestShowDirtyReviewSkipsBaseCommitLegacyComments(t *testing.T) {
 	}
 }
 
+func TestShowPromptForQueuedJob(t *testing.T) {
+	t.Run("falls back to job prompt when no review row exists yet", func(t *testing.T) {
+		daemonFromHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/review":
+				http.Error(w, "not found", http.StatusNotFound)
+			case "/api/jobs":
+				assert.Equal(t, "id=42", r.URL.RawQuery)
+				json.NewEncoder(w).Encode(map[string]any{
+					"jobs": []storage.ReviewJob{
+						{
+							ID:     42,
+							Agent:  "codex",
+							Status: storage.JobStatusQueued,
+							Prompt: "Review this diff please",
+						},
+					},
+				})
+			default:
+				http.Error(w, "unexpected path: "+r.URL.Path, http.StatusBadRequest)
+			}
+		}))
+
+		output := runShowCmd(t, "--job", "42", "--prompt")
+
+		assert.Contains(t, output, "Review this diff please")
+		assert.Contains(t, output, "codex")
+	})
+
+	t.Run("running job also falls back", func(t *testing.T) {
+		daemonFromHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/review":
+				http.Error(w, "not found", http.StatusNotFound)
+			case "/api/jobs":
+				json.NewEncoder(w).Encode(map[string]any{
+					"jobs": []storage.ReviewJob{
+						{
+							ID:     42,
+							Agent:  "codex",
+							Status: storage.JobStatusRunning,
+							Prompt: "Review this diff please",
+						},
+					},
+				})
+			}
+		}))
+
+		output := runShowCmd(t, "--job", "42", "--prompt")
+
+		assert.Contains(t, output, "Review this diff please")
+	})
+
+	t.Run("without --prompt, queued job still reports not found", func(t *testing.T) {
+		daemonFromHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/review":
+				http.Error(w, "not found", http.StatusNotFound)
+			case "/api/jobs":
+				json.NewEncoder(w).Encode(map[string]any{
+					"jobs": []storage.ReviewJob{
+						{
+							ID:     42,
+							Agent:  "codex",
+							Status: storage.JobStatusQueued,
+							Prompt: "Review this diff please",
+						},
+					},
+				})
+			}
+		}))
+
+		cmd := showCmd()
+		cmd.SetArgs([]string{"--job", "42"})
+		err := cmd.Execute()
+		assertErrorContains(t, err, "no review found")
+	})
+
+	t.Run("queued job without a stored prompt still reports not found", func(t *testing.T) {
+		daemonFromHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/review":
+				http.Error(w, "not found", http.StatusNotFound)
+			case "/api/jobs":
+				json.NewEncoder(w).Encode(map[string]any{
+					"jobs": []storage.ReviewJob{
+						{
+							ID:     42,
+							Agent:  "codex",
+							Status: storage.JobStatusQueued,
+							Prompt: "",
+						},
+					},
+				})
+			}
+		}))
+
+		cmd := showCmd()
+		cmd.SetArgs([]string{"--job", "42", "--prompt"})
+		err := cmd.Execute()
+		assertErrorContains(t, err, "no review found")
+	})
+}
+
 func TestShowNoComments(t *testing.T) {
 	repo := newTestGitRepo(t)
 	repo.CommitFile("file.txt", "content", "initial commit")


### PR DESCRIPTION
`roborev show --prompt <job-id>` fails with `no review found for job N` when the job is still queued or running, because the CLI resolves everything through `GET /api/review`, which requires a review row that only exists once the job completes. The TUI has no such restriction: its prompt view reads `Prompt` straight off the job object for queued/running jobs.

This mirrors that fallback in the CLI. When `/api/review` returns 404, `--prompt` was requested, and the lookup was by numeric job ID, the CLI fetches the job via the existing `GET /api/jobs?id=<id>` endpoint and, if the job is queued/running with a non-empty stored prompt, renders it through the unchanged print/JSON path. Deliberately scoped: plain `show <job-id>` without `--prompt` still reports not-found (there is no review output to show yet), and a queued job with an empty stored prompt still errors rather than printing nothing.

Fixes #638
