### PR TITLE
fix(tui): show detached-HEAD placeholder instead of blank branch

### DIFF
--- a/cmd/roborev/tui/detached_branch_test.go
+++ b/cmd/roborev/tui/detached_branch_test.go
@@ -57,6 +57,11 @@ func TestDetachedBranchLabel(t *testing.T) {
 			want: "",
 		},
 		{
+			name: "fix job from a task parent carries a non-SHA ref, no placeholder",
+			job:  storage.ReviewJob{JobType: storage.JobTypeFix, GitRef: "analyze"},
+			want: "",
+		},
+		{
 			name: "CI review deliberately leaves branch blank",
 			job: storage.ReviewJob{
 				JobType:      storage.JobTypeReview,

--- a/cmd/roborev/tui/detached_branch_test.go
+++ b/cmd/roborev/tui/detached_branch_test.go
@@ -57,6 +57,11 @@ func TestDetachedBranchLabel(t *testing.T) {
 			want: "",
 		},
 		{
+			name: "fix job on a detached commit shows placeholder",
+			job:  storage.ReviewJob{JobType: storage.JobTypeFix, GitRef: "abc1234def"},
+			want: "(detached @ abc1234)",
+		},
+		{
 			name: "CI review deliberately leaves branch blank",
 			job: storage.ReviewJob{
 				JobType:      storage.JobTypeReview,

--- a/cmd/roborev/tui/detached_branch_test.go
+++ b/cmd/roborev/tui/detached_branch_test.go
@@ -37,13 +37,8 @@ func TestDetachedBranchLabel(t *testing.T) {
 			want: "(detached @ abc12)",
 		},
 		{
-			name: "backfilled branchNone sentinel treated as missing",
+			name: "backfilled branchNone sentinel counts as stored, no placeholder",
 			job:  storage.ReviewJob{JobType: storage.JobTypeReview, Branch: branchNone, GitRef: "abc1234567", CommitID: &commitID},
-			want: "(detached @ abc1234)",
-		},
-		{
-			name: "branchNone sentinel on task job still no placeholder",
-			job:  storage.ReviewJob{JobType: storage.JobTypeTask, Branch: branchNone, GitRef: "abc1234567"},
 			want: "",
 		},
 		{

--- a/cmd/roborev/tui/detached_branch_test.go
+++ b/cmd/roborev/tui/detached_branch_test.go
@@ -37,6 +37,16 @@ func TestDetachedBranchLabel(t *testing.T) {
 			want: "(detached @ abc12)",
 		},
 		{
+			name: "backfilled branchNone sentinel treated as missing",
+			job:  storage.ReviewJob{JobType: storage.JobTypeReview, Branch: branchNone, GitRef: "abc1234567", CommitID: &commitID},
+			want: "(detached @ abc1234)",
+		},
+		{
+			name: "branchNone sentinel on task job still no placeholder",
+			job:  storage.ReviewJob{JobType: storage.JobTypeTask, Branch: branchNone, GitRef: "abc1234567"},
+			want: "",
+		},
+		{
 			name: "task job has no branch concept",
 			job:  storage.ReviewJob{JobType: storage.JobTypeTask, GitRef: "abc1234567"},
 			want: "",

--- a/cmd/roborev/tui/detached_branch_test.go
+++ b/cmd/roborev/tui/detached_branch_test.go
@@ -1,0 +1,77 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.kenn.io/roborev/internal/storage"
+)
+
+// TestDetachedBranchLabel exercises the placeholder used when a review job's
+// branch is empty because the commit was made on top of a detached HEAD
+// (e.g. mid git-bisect), per issue #499. A blank branch cell reads as a bug,
+// so the queue/tasks views and review screen should show something like
+// "(detached @ <sha>)" instead - but only for jobs where a branch is
+// meaningful in the first place.
+func TestDetachedBranchLabel(t *testing.T) {
+	commitID := int64(42)
+	tests := []struct {
+		name string
+		job  storage.ReviewJob
+		want string
+	}{
+		{
+			name: "stored branch wins, no placeholder needed",
+			job:  storage.ReviewJob{Branch: "main", GitRef: "abc1234", CommitID: &commitID},
+			want: "",
+		},
+		{
+			name: "detached commit review with no stored branch",
+			job:  storage.ReviewJob{JobType: storage.JobTypeReview, GitRef: "abc1234567", CommitID: &commitID},
+			want: "(detached @ abc1234)",
+		},
+		{
+			name: "detached commit review, short sha left as-is",
+			job:  storage.ReviewJob{JobType: storage.JobTypeReview, GitRef: "abc12", CommitID: &commitID},
+			want: "(detached @ abc12)",
+		},
+		{
+			name: "task job has no branch concept",
+			job:  storage.ReviewJob{JobType: storage.JobTypeTask, GitRef: "abc1234567"},
+			want: "",
+		},
+		{
+			name: "dirty job has no branch concept",
+			job:  storage.ReviewJob{JobType: storage.JobTypeDirty, GitRef: "dirty"},
+			want: "",
+		},
+		{
+			name: "CI review deliberately leaves branch blank",
+			job: storage.ReviewJob{
+				JobType:      storage.JobTypeReview,
+				GitRef:       "abc1234567",
+				CommitID:     &commitID,
+				Source:       storage.JobSourceCI,
+				CIBaseBranch: "main",
+			},
+			want: "",
+		},
+		{
+			name: "range refs are left unchanged",
+			job:  storage.ReviewJob{JobType: storage.JobTypeRange, GitRef: "abc1234..def5678", CommitID: &commitID},
+			want: "",
+		},
+		{
+			name: "empty ref",
+			job:  storage.ReviewJob{JobType: storage.JobTypeReview},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detachedBranchLabel(tt.job)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/cmd/roborev/tui/detached_branch_test.go
+++ b/cmd/roborev/tui/detached_branch_test.go
@@ -62,6 +62,26 @@ func TestDetachedBranchLabel(t *testing.T) {
 			want: "(detached @ abc1234)",
 		},
 		{
+			name: "panel synthesis row on a detached commit shows placeholder",
+			job:  storage.ReviewJob{JobType: storage.JobTypeSynthesis, GitRef: "abc1234def", CommitID: &commitID},
+			want: "(detached @ abc1234)",
+		},
+		{
+			name: "synthesis of a dirty panel stays blank",
+			job:  storage.ReviewJob{JobType: storage.JobTypeSynthesis, GitRef: "dirty"},
+			want: "",
+		},
+		{
+			name: "synthesis of a range panel stays blank",
+			job:  storage.ReviewJob{JobType: storage.JobTypeSynthesis, GitRef: "abc1234..def5678"},
+			want: "",
+		},
+		{
+			name: "synthesis of a prompt panel carries a non-SHA ref, stays blank",
+			job:  storage.ReviewJob{JobType: storage.JobTypeSynthesis, GitRef: "analyze"},
+			want: "",
+		},
+		{
 			name: "CI review deliberately leaves branch blank",
 			job: storage.ReviewJob{
 				JobType:      storage.JobTypeReview,

--- a/cmd/roborev/tui/fetch.go
+++ b/cmd/roborev/tui/fetch.go
@@ -715,7 +715,10 @@ func reviewBranchName(job *storage.ReviewJob) string {
 		return ""
 	}
 	if job.Branch == branchNone {
-		return ""
+		// Backfill already attempted a git lookup and found nothing;
+		// surface the detached placeholder when eligible instead of a
+		// blank field (#499).
+		return detachedBranchLabel(*job)
 	}
 	if job.Branch != "" {
 		return job.Branch

--- a/cmd/roborev/tui/fetch.go
+++ b/cmd/roborev/tui/fetch.go
@@ -491,6 +491,37 @@ func (m model) fetchBranchesForRepo(
 	}
 }
 
+// backfillBranchValue decides what branch value, if any, to persist for a
+// job with no stored branch. ok=false means the row is deliberately left
+// unbackfilled: a detached single-commit review renders a
+// "(detached @ <sha>)" placeholder from its empty stored branch, and
+// persisting the branchNone sentinel would freeze the row at "(none)"
+// (#499). Backfill runs once per TUI session (branchBackfillDone), so the
+// repeated lookup cost for skipped rows is bounded.
+func backfillBranchValue(job storage.ReviewJob, machineID string) (string, bool) {
+	// Mark task jobs (run, analyze, custom) or dirty jobs with no-branch sentinel
+	if job.IsTaskJob() || job.IsDirtyJob() {
+		return branchNone, true
+	}
+	// Mark remote jobs with no-branch sentinel (can't look up)
+	if job.RepoPath == "" || (machineID != "" && job.SourceMachineID != "" && job.SourceMachineID != machineID) {
+		return branchNone, true
+	}
+
+	sha := job.GitRef
+	if idx := strings.Index(sha, ".."); idx != -1 {
+		sha = sha[idx+2:]
+	}
+	branch := git.GetBranchName(job.RepoPath, sha)
+	if branch == "" {
+		if detachedBranchLabel(job) != "" {
+			return "", false
+		}
+		branch = branchNone // Mark as attempted but not found
+	}
+	return branch, true
+}
+
 func (m model) backfillBranches() tea.Cmd {
 	// Capture values for use in goroutine
 	machineID := m.status.MachineID
@@ -521,24 +552,9 @@ func (m model) backfillBranches() tea.Cmd {
 				if job.Branch != "" {
 					continue // Already has branch
 				}
-				// Mark task jobs (run, analyze, custom) or dirty jobs with no-branch sentinel
-				if job.IsTaskJob() || job.IsDirtyJob() {
-					toBackfill = append(toBackfill, backfillJob{id: job.ID, branch: branchNone})
+				branch, ok := backfillBranchValue(job, machineID)
+				if !ok {
 					continue
-				}
-				// Mark remote jobs with no-branch sentinel (can't look up)
-				if job.RepoPath == "" || (machineID != "" && job.SourceMachineID != "" && job.SourceMachineID != machineID) {
-					toBackfill = append(toBackfill, backfillJob{id: job.ID, branch: branchNone})
-					continue
-				}
-
-				sha := job.GitRef
-				if idx := strings.Index(sha, ".."); idx != -1 {
-					sha = sha[idx+2:]
-				}
-				branch := git.GetBranchName(job.RepoPath, sha)
-				if branch == "" {
-					branch = branchNone // Mark as attempted but not found
 				}
 				toBackfill = append(toBackfill, backfillJob{id: job.ID, branch: branch})
 			}
@@ -696,7 +712,7 @@ func (m model) fetchReview(jobID int64) tea.Cmd {
 
 		responses := m.loadResponses(jobID, review)
 
-		branchName := reviewBranchName(review.Job, m.status.MachineID)
+		branchName := reviewBranchName(review.Job)
 
 		return reviewMsg{review: review, responses: responses, jobID: jobID, branchName: branchName}
 	}
@@ -710,14 +726,12 @@ func (m model) fetchReview(jobID int64) tea.Cmd {
 // a "(detached @ <sha>)" placeholder when neither resolves a branch, so a
 // commit made on top of a detached HEAD doesn't render as a blank field
 // (#499).
-func reviewBranchName(job *storage.ReviewJob, machineID string) string {
+func reviewBranchName(job *storage.ReviewJob) string {
 	if job == nil {
 		return ""
 	}
 	if job.Branch == branchNone {
-		// Backfill found no branch or could not look one up; only claim
-		// detached after a local lookup verifies it (#499).
-		return verifiedDetachedLabel(*job, machineID)
+		return ""
 	}
 	if job.Branch != "" {
 		return job.Branch

--- a/cmd/roborev/tui/fetch.go
+++ b/cmd/roborev/tui/fetch.go
@@ -706,7 +706,10 @@ func (m model) fetchReview(jobID int64) tea.Cmd {
 // It prefers the stored job.Branch (set at enqueue time) over a dynamic
 // git name-rev lookup, which can be misled by worktree branches
 // reachable from the same SHA. Falls back to git lookup only for
-// single-commit reviews when the stored branch is empty.
+// single-commit reviews when the stored branch is empty, and finally to
+// a "(detached @ <sha>)" placeholder when neither resolves a branch, so a
+// commit made on top of a detached HEAD doesn't render as a blank field
+// (#499).
 func reviewBranchName(job *storage.ReviewJob) string {
 	if job == nil {
 		return ""
@@ -718,9 +721,11 @@ func reviewBranchName(job *storage.ReviewJob) string {
 		return job.Branch
 	}
 	if job.RepoPath != "" && !strings.Contains(job.GitRef, "..") {
-		return git.GetBranchName(job.RepoPath, job.GitRef)
+		if branch := git.GetBranchName(job.RepoPath, job.GitRef); branch != "" {
+			return branch
+		}
 	}
-	return ""
+	return detachedBranchLabel(*job)
 }
 
 func (m model) fetchReviewForPrompt(jobID int64) tea.Cmd {

--- a/cmd/roborev/tui/fetch.go
+++ b/cmd/roborev/tui/fetch.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	neturl "net/url"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -505,6 +506,13 @@ func backfillBranchValue(job storage.ReviewJob, machineID string) (string, bool)
 	}
 	// Mark remote jobs with no-branch sentinel (can't look up)
 	if job.RepoPath == "" || (machineID != "" && job.SourceMachineID != "" && job.SourceMachineID != machineID) {
+		return branchNone, true
+	}
+
+	// Preserve the old sentinel backfill when the repo cannot be verified
+	// locally: an empty lookup there means "couldn't look", not "detached",
+	// and skipping would strand the row with NullsRemaining nonzero.
+	if _, err := os.Stat(job.RepoPath); err != nil {
 		return branchNone, true
 	}
 

--- a/cmd/roborev/tui/fetch.go
+++ b/cmd/roborev/tui/fetch.go
@@ -696,7 +696,7 @@ func (m model) fetchReview(jobID int64) tea.Cmd {
 
 		responses := m.loadResponses(jobID, review)
 
-		branchName := reviewBranchName(review.Job)
+		branchName := reviewBranchName(review.Job, m.status.MachineID)
 
 		return reviewMsg{review: review, responses: responses, jobID: jobID, branchName: branchName}
 	}
@@ -710,15 +710,14 @@ func (m model) fetchReview(jobID int64) tea.Cmd {
 // a "(detached @ <sha>)" placeholder when neither resolves a branch, so a
 // commit made on top of a detached HEAD doesn't render as a blank field
 // (#499).
-func reviewBranchName(job *storage.ReviewJob) string {
+func reviewBranchName(job *storage.ReviewJob, machineID string) string {
 	if job == nil {
 		return ""
 	}
 	if job.Branch == branchNone {
-		// Backfill already attempted a git lookup and found nothing;
-		// surface the detached placeholder when eligible instead of a
-		// blank field (#499).
-		return detachedBranchLabel(*job)
+		// Backfill found no branch or could not look one up; only claim
+		// detached after a local lookup verifies it (#499).
+		return verifiedDetachedLabel(*job, machineID)
 	}
 	if job.Branch != "" {
 		return job.Branch

--- a/cmd/roborev/tui/filter.go
+++ b/cmd/roborev/tui/filter.go
@@ -295,9 +295,8 @@ func (m model) isJobVisible(job storage.ReviewJob) bool {
 func (m model) branchMatchesFilter(job storage.ReviewJob) bool {
 	branch := m.getBranchForJob(job)
 	// The detached placeholder is display-only; for filter identity those
-	// jobs group under (none) (#499). A real branch recovered by
-	// re-verifying a stale branchNone sentinel keeps driving identity, so
-	// filtering always agrees with what the row displays.
+	// jobs group under (none), matching how the server-side branch list
+	// counts their empty stored branch (#499).
 	if branch == "" || isDetachedLabel(branch) {
 		branch = branchNone
 	}

--- a/cmd/roborev/tui/filter.go
+++ b/cmd/roborev/tui/filter.go
@@ -294,7 +294,9 @@ func (m model) isJobVisible(job storage.ReviewJob) bool {
 // branchMatchesFilter checks if a job's branch matches the active branch filter
 func (m model) branchMatchesFilter(job storage.ReviewJob) bool {
 	branch := m.getBranchForJob(job)
-	if branch == "" {
+	// The detached placeholder is display-only; for filter identity these
+	// jobs group under (none), matching the branch picker's counts (#499).
+	if branch == "" || job.Branch == branchNone || isDetachedLabel(branch) {
 		branch = branchNone
 	}
 	return branch == m.activeBranchFilter

--- a/cmd/roborev/tui/filter.go
+++ b/cmd/roborev/tui/filter.go
@@ -294,9 +294,11 @@ func (m model) isJobVisible(job storage.ReviewJob) bool {
 // branchMatchesFilter checks if a job's branch matches the active branch filter
 func (m model) branchMatchesFilter(job storage.ReviewJob) bool {
 	branch := m.getBranchForJob(job)
-	// The detached placeholder is display-only; for filter identity these
-	// jobs group under (none), matching the branch picker's counts (#499).
-	if branch == "" || job.Branch == branchNone || isDetachedLabel(branch) {
+	// The detached placeholder is display-only; for filter identity those
+	// jobs group under (none) (#499). A real branch recovered by
+	// re-verifying a stale branchNone sentinel keeps driving identity, so
+	// filtering always agrees with what the row displays.
+	if branch == "" || isDetachedLabel(branch) {
 		branch = branchNone
 	}
 	return branch == m.activeBranchFilter

--- a/cmd/roborev/tui/get_branch_for_job_test.go
+++ b/cmd/roborev/tui/get_branch_for_job_test.go
@@ -1,0 +1,64 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/testutil"
+)
+
+// TestGetBranchForJobDetachedHead covers the queue view's branch fallback
+// (#499): a review job with no stored branch, enqueued from a commit made on
+// top of a detached HEAD (e.g. mid git-bisect), has no branch reachable via
+// git name-rev either. Instead of caching and returning "", getBranchForJob
+// should surface a "(detached @ <sha>)" placeholder.
+func TestGetBranchForJobDetachedHead(t *testing.T) {
+	repo := testutil.InitTestRepo(t)
+	repo.CommitFile("a.txt", "one", "first")
+	// Detach HEAD and commit again, mirroring a commit made mid git-bisect:
+	// the resulting SHA is reachable from HEAD but from no local branch.
+	repo.CheckoutDetached()
+	sha := repo.CommitFile("a.txt", "two", "second, on detached HEAD")
+
+	commitID := int64(1)
+	job := storage.ReviewJob{
+		ID:       1,
+		JobType:  storage.JobTypeReview,
+		GitRef:   sha,
+		RepoPath: repo.Path(),
+		CommitID: &commitID,
+	}
+
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	got := m.getBranchForJob(job)
+
+	assert.Equal(t, "(detached @ "+sha[:7]+")", got)
+
+	// Result is cached rather than re-derived on the next call.
+	assert.Equal(t, got, m.branchNames[job.ID])
+}
+
+// TestGetBranchForJobReachableFromBranch ensures the existing git name-rev
+// fallback still wins over the new placeholder when the commit is in fact
+// reachable from a local branch.
+func TestGetBranchForJobReachableFromBranch(t *testing.T) {
+	repo := testutil.InitTestRepo(t)
+	sha := repo.CommitFile("a.txt", "one", "first")
+
+	commitID := int64(2)
+	job := storage.ReviewJob{
+		ID:       2,
+		JobType:  storage.JobTypeReview,
+		GitRef:   sha,
+		RepoPath: repo.Path(),
+		CommitID: &commitID,
+	}
+
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	got := m.getBranchForJob(job)
+
+	assert.NotEmpty(t, got)
+	assert.NotContains(t, got, "detached")
+}

--- a/cmd/roborev/tui/get_branch_for_job_test.go
+++ b/cmd/roborev/tui/get_branch_for_job_test.go
@@ -40,6 +40,80 @@ func TestGetBranchForJobDetachedHead(t *testing.T) {
 	assert.Equal(t, got, m.branchNames[job.ID])
 }
 
+// TestGetBranchForJobBranchNoneSentinel covers backfilled jobs whose stored
+// branch is the branchNone sentinel (#499 follow-up): the detached
+// placeholder is only shown after a local lookup verifies it; remote or
+// repo-less jobs keep the sentinel.
+func TestGetBranchForJobBranchNoneSentinel(t *testing.T) {
+	repo := testutil.InitTestRepo(t)
+	repo.CommitFile("a.txt", "one", "first")
+	repo.CheckoutDetached()
+	sha := repo.CommitFile("a.txt", "two", "second, on detached HEAD")
+
+	commitID := int64(1)
+	base := storage.ReviewJob{
+		ID:       7,
+		JobType:  storage.JobTypeReview,
+		Branch:   branchNone,
+		GitRef:   sha,
+		RepoPath: repo.Path(),
+		CommitID: &commitID,
+	}
+
+	t.Run("verified locally shows placeholder and caches", func(t *testing.T) {
+		m := newModel(localhostEndpoint, withExternalIODisabled())
+		got := m.getBranchForJob(base)
+		assert.Equal(t, "(detached @ "+sha[:7]+")", got)
+		assert.Equal(t, got, m.branchNames[base.ID])
+	})
+
+	t.Run("remote job keeps sentinel, uncached", func(t *testing.T) {
+		m := newModel(localhostEndpoint, withExternalIODisabled())
+		m.status.MachineID = "machine-a"
+		job := base
+		job.SourceMachineID = "machine-b"
+		assert.Equal(t, branchNone, m.getBranchForJob(job))
+		assert.NotContains(t, m.branchNames, job.ID)
+	})
+
+	t.Run("missing repo keeps sentinel, uncached", func(t *testing.T) {
+		m := newModel(localhostEndpoint, withExternalIODisabled())
+		job := base
+		job.RepoPath = "/nonexistent/repo"
+		assert.Equal(t, branchNone, m.getBranchForJob(job))
+		assert.NotContains(t, m.branchNames, job.ID)
+	})
+}
+
+// TestBranchMatchesFilterDetachedGroupsUnderNone pins filter identity: jobs
+// rendered with the detached placeholder still match the (none) branch
+// filter, agreeing with the branch picker's counts (#499 follow-up).
+func TestBranchMatchesFilterDetachedGroupsUnderNone(t *testing.T) {
+	repo := testutil.InitTestRepo(t)
+	repo.CommitFile("a.txt", "one", "first")
+	repo.CheckoutDetached()
+	sha := repo.CommitFile("a.txt", "two", "second, on detached HEAD")
+
+	commitID := int64(9)
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.activeBranchFilter = branchNone
+
+	detached := storage.ReviewJob{
+		ID:       9,
+		JobType:  storage.JobTypeReview,
+		GitRef:   sha,
+		RepoPath: repo.Path(),
+		CommitID: &commitID,
+	}
+	assert.True(t, m.branchMatchesFilter(detached), "empty-branch detached job should match (none)")
+
+	detached.Branch = branchNone
+	// Fresh model so the cached display label from the first call is not reused.
+	m2 := newModel(localhostEndpoint, withExternalIODisabled())
+	m2.activeBranchFilter = branchNone
+	assert.True(t, m2.branchMatchesFilter(detached), "backfilled branchNone detached job should match (none)")
+}
+
 // TestGetBranchForJobReachableFromBranch ensures the existing git name-rev
 // fallback still wins over the new placeholder when the commit is in fact
 // reachable from a local branch.

--- a/cmd/roborev/tui/get_branch_for_job_test.go
+++ b/cmd/roborev/tui/get_branch_for_job_test.go
@@ -75,6 +75,13 @@ func TestBackfillBranchValue(t *testing.T) {
 		assert.Equal(t, branchNone, branch)
 	})
 
+	t.Run("locally missing repo persists sentinel instead of stranding the row", func(t *testing.T) {
+		job := storage.ReviewJob{JobType: storage.JobTypeReview, GitRef: detachedSHA, RepoPath: "/nonexistent/repo", CommitID: &commitID}
+		branch, ok := backfillBranchValue(job, "")
+		assert.True(t, ok)
+		assert.Equal(t, branchNone, branch)
+	})
+
 	t.Run("remote job persists sentinel without lookup", func(t *testing.T) {
 		job := storage.ReviewJob{JobType: storage.JobTypeReview, GitRef: detachedSHA, RepoPath: repo.Path(), CommitID: &commitID, SourceMachineID: "machine-b"}
 		branch, ok := backfillBranchValue(job, "machine-a")

--- a/cmd/roborev/tui/get_branch_for_job_test.go
+++ b/cmd/roborev/tui/get_branch_for_job_test.go
@@ -40,48 +40,46 @@ func TestGetBranchForJobDetachedHead(t *testing.T) {
 	assert.Equal(t, got, m.branchNames[job.ID])
 }
 
-// TestGetBranchForJobBranchNoneSentinel covers backfilled jobs whose stored
-// branch is the branchNone sentinel (#499 follow-up): the detached
-// placeholder is only shown after a local lookup verifies it; remote or
-// repo-less jobs keep the sentinel.
-func TestGetBranchForJobBranchNoneSentinel(t *testing.T) {
+// TestBackfillBranchValue covers the once-per-session branch backfill
+// decision (#499 follow-up): detached single-commit reviews are left
+// unbackfilled so their empty stored branch keeps rendering the detached
+// placeholder, while task/remote/reachable jobs persist as before.
+func TestBackfillBranchValue(t *testing.T) {
 	repo := testutil.InitTestRepo(t)
-	repo.CommitFile("a.txt", "one", "first")
+	firstSHA := repo.CommitFile("a.txt", "one", "first")
 	repo.CheckoutDetached()
-	sha := repo.CommitFile("a.txt", "two", "second, on detached HEAD")
+	detachedSHA := repo.CommitFile("a.txt", "two", "second, on detached HEAD")
+	// Branch from the first commit so detachedSHA stays unreachable.
+	repo.CheckoutNewBranch("feature-x", firstSHA)
+	reachableSHA := repo.CommitFile("b.txt", "three", "third, on a branch")
 
 	commitID := int64(1)
-	base := storage.ReviewJob{
-		ID:       7,
-		JobType:  storage.JobTypeReview,
-		Branch:   branchNone,
-		GitRef:   sha,
-		RepoPath: repo.Path(),
-		CommitID: &commitID,
-	}
 
-	t.Run("verified locally shows placeholder and caches", func(t *testing.T) {
-		m := newModel(localhostEndpoint, withExternalIODisabled())
-		got := m.getBranchForJob(base)
-		assert.Equal(t, "(detached @ "+sha[:7]+")", got)
-		assert.Equal(t, got, m.branchNames[base.ID])
+	t.Run("detached review left unbackfilled", func(t *testing.T) {
+		job := storage.ReviewJob{JobType: storage.JobTypeReview, GitRef: detachedSHA, RepoPath: repo.Path(), CommitID: &commitID}
+		_, ok := backfillBranchValue(job, "")
+		assert.False(t, ok)
 	})
 
-	t.Run("remote job keeps sentinel, uncached", func(t *testing.T) {
-		m := newModel(localhostEndpoint, withExternalIODisabled())
-		m.status.MachineID = "machine-a"
-		job := base
-		job.SourceMachineID = "machine-b"
-		assert.Equal(t, branchNone, m.getBranchForJob(job))
-		assert.NotContains(t, m.branchNames, job.ID)
+	t.Run("reachable commit persists its branch", func(t *testing.T) {
+		job := storage.ReviewJob{JobType: storage.JobTypeReview, GitRef: reachableSHA, RepoPath: repo.Path(), CommitID: &commitID}
+		branch, ok := backfillBranchValue(job, "")
+		assert.True(t, ok)
+		assert.Equal(t, "feature-x", branch)
 	})
 
-	t.Run("missing repo keeps sentinel, uncached", func(t *testing.T) {
-		m := newModel(localhostEndpoint, withExternalIODisabled())
-		job := base
-		job.RepoPath = "/nonexistent/repo"
-		assert.Equal(t, branchNone, m.getBranchForJob(job))
-		assert.NotContains(t, m.branchNames, job.ID)
+	t.Run("task job persists sentinel", func(t *testing.T) {
+		job := storage.ReviewJob{JobType: storage.JobTypeTask, GitRef: "analyze"}
+		branch, ok := backfillBranchValue(job, "")
+		assert.True(t, ok)
+		assert.Equal(t, branchNone, branch)
+	})
+
+	t.Run("remote job persists sentinel without lookup", func(t *testing.T) {
+		job := storage.ReviewJob{JobType: storage.JobTypeReview, GitRef: detachedSHA, RepoPath: repo.Path(), CommitID: &commitID, SourceMachineID: "machine-b"}
+		branch, ok := backfillBranchValue(job, "machine-a")
+		assert.True(t, ok)
+		assert.Equal(t, branchNone, branch)
 	})
 }
 
@@ -107,35 +105,11 @@ func TestBranchMatchesFilterDetachedGroupsUnderNone(t *testing.T) {
 	}
 	assert.True(t, m.branchMatchesFilter(detached), "empty-branch detached job should match (none)")
 
+	// A backfilled branchNone sentinel also groups under (none).
 	detached.Branch = branchNone
-	// Fresh model so the cached display label from the first call is not reused.
 	m2 := newModel(localhostEndpoint, withExternalIODisabled())
 	m2.activeBranchFilter = branchNone
-	assert.True(t, m2.branchMatchesFilter(detached), "backfilled branchNone detached job should match (none)")
-
-	// A stale sentinel on a commit that IS reachable from a branch recovers
-	// the real branch, which then drives filter identity (agreeing with the
-	// displayed value), so the job no longer matches (none).
-	repo.CheckoutNewBranch("feature-x")
-	reachableSHA := repo.CommitFile("b.txt", "three", "third, back on a branch")
-	reachableID := int64(10)
-	reachable := storage.ReviewJob{
-		ID:       10,
-		JobType:  storage.JobTypeReview,
-		Branch:   branchNone,
-		GitRef:   reachableSHA,
-		RepoPath: repo.Path(),
-		CommitID: &reachableID,
-	}
-	m3 := newModel(localhostEndpoint, withExternalIODisabled())
-	realBranch := m3.getBranchForJob(reachable)
-	assert.NotEqual(t, branchNone, realBranch)
-	assert.False(t, isDetachedLabel(realBranch))
-
-	m3.activeBranchFilter = branchNone
-	assert.False(t, m3.branchMatchesFilter(reachable), "recovered real branch should not match (none)")
-	m3.activeBranchFilter = realBranch
-	assert.True(t, m3.branchMatchesFilter(reachable), "recovered real branch should match its own filter")
+	assert.True(t, m2.branchMatchesFilter(detached), "backfilled branchNone job should match (none)")
 }
 
 // TestGetBranchForJobReachableFromBranch ensures the existing git name-rev

--- a/cmd/roborev/tui/get_branch_for_job_test.go
+++ b/cmd/roborev/tui/get_branch_for_job_test.go
@@ -38,6 +38,17 @@ func TestGetBranchForJobDetachedHead(t *testing.T) {
 
 	// Result is cached rather than re-derived on the next call.
 	assert.Equal(t, got, m.branchNames[job.ID])
+
+	// The canonical queue row for a detached single-commit panel review is
+	// its synthesis job; it gets the same placeholder.
+	synthesis := storage.ReviewJob{
+		ID:       2,
+		JobType:  storage.JobTypeSynthesis,
+		GitRef:   sha,
+		RepoPath: repo.Path(),
+		CommitID: &commitID,
+	}
+	assert.Equal(t, "(detached @ "+sha[:7]+")", m.getBranchForJob(synthesis))
 }
 
 // TestBackfillBranchValue covers the once-per-session branch backfill
@@ -57,6 +68,12 @@ func TestBackfillBranchValue(t *testing.T) {
 
 	t.Run("detached review left unbackfilled", func(t *testing.T) {
 		job := storage.ReviewJob{JobType: storage.JobTypeReview, GitRef: detachedSHA, RepoPath: repo.Path(), CommitID: &commitID}
+		_, ok := backfillBranchValue(job, "")
+		assert.False(t, ok)
+	})
+
+	t.Run("detached panel synthesis row left unbackfilled", func(t *testing.T) {
+		job := storage.ReviewJob{JobType: storage.JobTypeSynthesis, GitRef: detachedSHA, RepoPath: repo.Path(), CommitID: &commitID}
 		_, ok := backfillBranchValue(job, "")
 		assert.False(t, ok)
 	})

--- a/cmd/roborev/tui/get_branch_for_job_test.go
+++ b/cmd/roborev/tui/get_branch_for_job_test.go
@@ -112,6 +112,30 @@ func TestBranchMatchesFilterDetachedGroupsUnderNone(t *testing.T) {
 	m2 := newModel(localhostEndpoint, withExternalIODisabled())
 	m2.activeBranchFilter = branchNone
 	assert.True(t, m2.branchMatchesFilter(detached), "backfilled branchNone detached job should match (none)")
+
+	// A stale sentinel on a commit that IS reachable from a branch recovers
+	// the real branch, which then drives filter identity (agreeing with the
+	// displayed value), so the job no longer matches (none).
+	repo.CheckoutNewBranch("feature-x")
+	reachableSHA := repo.CommitFile("b.txt", "three", "third, back on a branch")
+	reachableID := int64(10)
+	reachable := storage.ReviewJob{
+		ID:       10,
+		JobType:  storage.JobTypeReview,
+		Branch:   branchNone,
+		GitRef:   reachableSHA,
+		RepoPath: repo.Path(),
+		CommitID: &reachableID,
+	}
+	m3 := newModel(localhostEndpoint, withExternalIODisabled())
+	realBranch := m3.getBranchForJob(reachable)
+	assert.NotEqual(t, branchNone, realBranch)
+	assert.False(t, isDetachedLabel(realBranch))
+
+	m3.activeBranchFilter = branchNone
+	assert.False(t, m3.branchMatchesFilter(reachable), "recovered real branch should not match (none)")
+	m3.activeBranchFilter = realBranch
+	assert.True(t, m3.branchMatchesFilter(reachable), "recovered real branch should match its own filter")
 }
 
 // TestGetBranchForJobReachableFromBranch ensures the existing git name-rev

--- a/cmd/roborev/tui/render_tasks.go
+++ b/cmd/roborev/tui/render_tasks.go
@@ -123,9 +123,10 @@ func (m model) taskCells(job storage.ReviewJob) []string {
 	}
 
 	branch := job.Branch
-	if branch == "" {
+	switch branch {
+	case "":
 		branch = detachedBranchLabel(job)
-	} else if branch == branchNone {
+	case branchNone:
 		if label := verifiedDetachedLabel(job, m.status.MachineID); label != "" {
 			branch = label
 		}

--- a/cmd/roborev/tui/render_tasks.go
+++ b/cmd/roborev/tui/render_tasks.go
@@ -123,13 +123,8 @@ func (m model) taskCells(job storage.ReviewJob) []string {
 	}
 
 	branch := job.Branch
-	switch branch {
-	case "":
+	if branch == "" {
 		branch = detachedBranchLabel(job)
-	case branchNone:
-		if label := verifiedDetachedLabel(job, m.status.MachineID); label != "" {
-			branch = label
-		}
 	}
 
 	defaultRepoName := job.RepoName

--- a/cmd/roborev/tui/render_tasks.go
+++ b/cmd/roborev/tui/render_tasks.go
@@ -123,6 +123,9 @@ func (m model) taskCells(job storage.ReviewJob) []string {
 	}
 
 	branch := job.Branch
+	if branch == "" {
+		branch = detachedBranchLabel(job)
+	}
 
 	defaultRepoName := job.RepoName
 	if defaultRepoName == "" && job.RepoPath != "" {

--- a/cmd/roborev/tui/render_tasks.go
+++ b/cmd/roborev/tui/render_tasks.go
@@ -123,8 +123,10 @@ func (m model) taskCells(job storage.ReviewJob) []string {
 	}
 
 	branch := job.Branch
-	if branch == "" || branch == branchNone {
-		if label := detachedBranchLabel(job); label != "" {
+	if branch == "" {
+		branch = detachedBranchLabel(job)
+	} else if branch == branchNone {
+		if label := verifiedDetachedLabel(job, m.status.MachineID); label != "" {
 			branch = label
 		}
 	}

--- a/cmd/roborev/tui/render_tasks.go
+++ b/cmd/roborev/tui/render_tasks.go
@@ -122,10 +122,9 @@ func (m model) taskCells(job storage.ReviewJob) []string {
 		}
 	}
 
-	branch := job.Branch
-	if branch == "" {
-		branch = detachedBranchLabel(job)
-	}
+	// Same branch resolution as the queue view: stored branch, then local
+	// git lookup, then the detached placeholder (#499).
+	branch := m.getBranchForJob(job)
 
 	defaultRepoName := job.RepoName
 	if defaultRepoName == "" && job.RepoPath != "" {

--- a/cmd/roborev/tui/render_tasks.go
+++ b/cmd/roborev/tui/render_tasks.go
@@ -123,8 +123,10 @@ func (m model) taskCells(job storage.ReviewJob) []string {
 	}
 
 	branch := job.Branch
-	if branch == "" {
-		branch = detachedBranchLabel(job)
+	if branch == "" || branch == branchNone {
+		if label := detachedBranchLabel(job); label != "" {
+			branch = label
+		}
 	}
 
 	defaultRepoName := job.RepoName

--- a/cmd/roborev/tui/render_tasks_branch_test.go
+++ b/cmd/roborev/tui/render_tasks_branch_test.go
@@ -34,6 +34,16 @@ func TestTaskCellsBranchColumn(t *testing.T) {
 			job:        storage.ReviewJob{JobType: storage.JobTypeTask, GitRef: "abc1234567"},
 			wantBranch: "",
 		},
+		{
+			name:       "backfilled branchNone renders detached placeholder",
+			job:        storage.ReviewJob{JobType: storage.JobTypeReview, Branch: branchNone, GitRef: "abc1234567", CommitID: &commitID},
+			wantBranch: "(detached @ abc1234)",
+		},
+		{
+			name:       "branchNone on task job keeps the sentinel",
+			job:        storage.ReviewJob{JobType: storage.JobTypeTask, Branch: branchNone, GitRef: "abc1234567"},
+			wantBranch: branchNone,
+		},
 	}
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	for _, tt := range tests {

--- a/cmd/roborev/tui/render_tasks_branch_test.go
+++ b/cmd/roborev/tui/render_tasks_branch_test.go
@@ -1,0 +1,47 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.kenn.io/roborev/internal/storage"
+)
+
+// TestTaskCellsBranchColumn covers the Tasks view "Branch" column (#499):
+// a job enqueued on a detached HEAD should show a "(detached @ <sha>)"
+// placeholder instead of a blank cell, while jobs that have (or should
+// have) no branch concept stay blank.
+func TestTaskCellsBranchColumn(t *testing.T) {
+	commitID := int64(7)
+	tests := []struct {
+		name       string
+		job        storage.ReviewJob
+		wantBranch string
+	}{
+		{
+			name:       "stored branch is used as-is",
+			job:        storage.ReviewJob{JobType: storage.JobTypeReview, Branch: "main", GitRef: "abc1234567", CommitID: &commitID},
+			wantBranch: "main",
+		},
+		{
+			name:       "detached commit review shows placeholder",
+			job:        storage.ReviewJob{JobType: storage.JobTypeReview, GitRef: "abc1234567", CommitID: &commitID},
+			wantBranch: "(detached @ abc1234)",
+		},
+		{
+			name:       "task job stays blank",
+			job:        storage.ReviewJob{JobType: storage.JobTypeTask, GitRef: "abc1234567"},
+			wantBranch: "",
+		},
+	}
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cells := m.taskCells(tt.job)
+			// taskCells omits the always-visible tcolSel selection column, so
+			// every other column constant is offset by one in the slice.
+			assert.Equal(t, tt.wantBranch, cells[tcolBranch-1])
+		})
+	}
+}

--- a/cmd/roborev/tui/render_tasks_branch_test.go
+++ b/cmd/roborev/tui/render_tasks_branch_test.go
@@ -35,6 +35,16 @@ func TestTaskCellsBranchColumn(t *testing.T) {
 			wantBranch: "",
 		},
 		{
+			name:       "fix job on a detached commit shows placeholder (Tasks view data path)",
+			job:        storage.ReviewJob{JobType: storage.JobTypeFix, GitRef: "abc1234def"},
+			wantBranch: "(detached @ abc1234)",
+		},
+		{
+			name:       "fix job from a task parent stays blank",
+			job:        storage.ReviewJob{JobType: storage.JobTypeFix, GitRef: "analyze"},
+			wantBranch: "",
+		},
+		{
 			name:       "unverifiable branchNone keeps the sentinel",
 			job:        storage.ReviewJob{JobType: storage.JobTypeReview, Branch: branchNone, GitRef: "abc1234567", CommitID: &commitID},
 			wantBranch: branchNone,

--- a/cmd/roborev/tui/render_tasks_branch_test.go
+++ b/cmd/roborev/tui/render_tasks_branch_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/testutil"
 )
 
 // TestTaskCellsBranchColumn covers the Tasks view "Branch" column (#499):
@@ -13,6 +14,14 @@ import (
 // placeholder instead of a blank cell, while jobs that have (or should
 // have) no branch concept stay blank.
 func TestTaskCellsBranchColumn(t *testing.T) {
+	repo := testutil.InitTestRepo(t)
+	firstSHA := repo.CommitFile("a.txt", "one", "first")
+	repo.CheckoutDetached()
+	detachedSHA := repo.CommitFile("a.txt", "two", "second, on detached HEAD")
+	// Branch from the first commit so detachedSHA stays unreachable.
+	repo.CheckoutNewBranch("feature-x", firstSHA)
+	reachableSHA := repo.CommitFile("b.txt", "three", "third, on a branch")
+
 	commitID := int64(7)
 	tests := []struct {
 		name       string
@@ -21,37 +30,42 @@ func TestTaskCellsBranchColumn(t *testing.T) {
 	}{
 		{
 			name:       "stored branch is used as-is",
-			job:        storage.ReviewJob{JobType: storage.JobTypeReview, Branch: "main", GitRef: "abc1234567", CommitID: &commitID},
+			job:        storage.ReviewJob{ID: 1, JobType: storage.JobTypeReview, Branch: "main", GitRef: detachedSHA, CommitID: &commitID},
 			wantBranch: "main",
 		},
 		{
 			name:       "detached commit review shows placeholder",
-			job:        storage.ReviewJob{JobType: storage.JobTypeReview, GitRef: "abc1234567", CommitID: &commitID},
-			wantBranch: "(detached @ abc1234)",
+			job:        storage.ReviewJob{ID: 2, JobType: storage.JobTypeReview, GitRef: detachedSHA, RepoPath: repo.Path(), CommitID: &commitID},
+			wantBranch: "(detached @ " + detachedSHA[:7] + ")",
 		},
 		{
 			name:       "task job stays blank",
-			job:        storage.ReviewJob{JobType: storage.JobTypeTask, GitRef: "abc1234567"},
+			job:        storage.ReviewJob{ID: 3, JobType: storage.JobTypeTask, GitRef: "analyze"},
 			wantBranch: "",
 		},
 		{
 			name:       "fix job on a detached commit shows placeholder (Tasks view data path)",
-			job:        storage.ReviewJob{JobType: storage.JobTypeFix, GitRef: "abc1234def"},
-			wantBranch: "(detached @ abc1234)",
+			job:        storage.ReviewJob{ID: 4, JobType: storage.JobTypeFix, GitRef: detachedSHA, RepoPath: repo.Path()},
+			wantBranch: "(detached @ " + detachedSHA[:7] + ")",
+		},
+		{
+			name:       "branchless fix job on a reachable commit shows the real branch",
+			job:        storage.ReviewJob{ID: 5, JobType: storage.JobTypeFix, GitRef: reachableSHA, RepoPath: repo.Path()},
+			wantBranch: "feature-x",
 		},
 		{
 			name:       "fix job from a task parent stays blank",
-			job:        storage.ReviewJob{JobType: storage.JobTypeFix, GitRef: "analyze"},
+			job:        storage.ReviewJob{ID: 6, JobType: storage.JobTypeFix, GitRef: "analyze", RepoPath: repo.Path()},
 			wantBranch: "",
 		},
 		{
 			name:       "unverifiable branchNone keeps the sentinel",
-			job:        storage.ReviewJob{JobType: storage.JobTypeReview, Branch: branchNone, GitRef: "abc1234567", CommitID: &commitID},
+			job:        storage.ReviewJob{ID: 7, JobType: storage.JobTypeReview, Branch: branchNone, GitRef: detachedSHA, CommitID: &commitID},
 			wantBranch: branchNone,
 		},
 		{
 			name:       "branchNone on task job keeps the sentinel",
-			job:        storage.ReviewJob{JobType: storage.JobTypeTask, Branch: branchNone, GitRef: "abc1234567"},
+			job:        storage.ReviewJob{ID: 8, JobType: storage.JobTypeTask, Branch: branchNone, GitRef: "analyze"},
 			wantBranch: branchNone,
 		},
 	}

--- a/cmd/roborev/tui/render_tasks_branch_test.go
+++ b/cmd/roborev/tui/render_tasks_branch_test.go
@@ -35,9 +35,9 @@ func TestTaskCellsBranchColumn(t *testing.T) {
 			wantBranch: "",
 		},
 		{
-			name:       "backfilled branchNone renders detached placeholder",
+			name:       "unverifiable branchNone keeps the sentinel",
 			job:        storage.ReviewJob{JobType: storage.JobTypeReview, Branch: branchNone, GitRef: "abc1234567", CommitID: &commitID},
-			wantBranch: "(detached @ abc1234)",
+			wantBranch: branchNone,
 		},
 		{
 			name:       "branchNone on task job keeps the sentinel",

--- a/cmd/roborev/tui/review_branch_test.go
+++ b/cmd/roborev/tui/review_branch_test.go
@@ -78,6 +78,18 @@ func TestReviewBranchName(t *testing.T) {
 			want: "",
 		},
 		{
+			name: "detached panel synthesis row shows placeholder instead of blank",
+			job: &storage.ReviewJob{
+				JobType: storage.JobTypeSynthesis,
+				GitRef:  "abc1234567",
+				CommitID: func() *int64 {
+					id := int64(2)
+					return &id
+				}(),
+			},
+			want: "(detached @ abc1234)",
+		},
+		{
 			name: "detached commit review shows placeholder instead of blank",
 			job: &storage.ReviewJob{
 				JobType: storage.JobTypeReview,

--- a/cmd/roborev/tui/review_branch_test.go
+++ b/cmd/roborev/tui/review_branch_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.kenn.io/roborev/internal/storage"
-	"go.kenn.io/roborev/internal/testutil"
 )
 
 func TestTUIReviewMsgSetsBranchName(t *testing.T) {
@@ -54,18 +53,13 @@ func TestReviewBranchName(t *testing.T) {
 			want: "main",
 		},
 		{
-			name: "branchNone without local repo stays blank (unverifiable)",
+			name: "branchNone sentinel treated as empty",
 			job:  &storage.ReviewJob{JobType: storage.JobTypeReview, Branch: "(none)", GitRef: "abc123"},
 			want: "",
 		},
 		{
-			name: "branchNone with unavailable repo stays blank (unverifiable)",
+			name: "branchNone with repo path skips git lookup",
 			job:  &storage.ReviewJob{JobType: storage.JobTypeReview, Branch: "(none)", GitRef: "abc123", RepoPath: "/nonexistent/repo"},
-			want: "",
-		},
-		{
-			name: "legacy branchNone job without job_type stays empty",
-			job:  &storage.ReviewJob{Branch: "(none)", GitRef: "abc123"},
 			want: "",
 		},
 		{
@@ -98,36 +92,10 @@ func TestReviewBranchName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := reviewBranchName(tt.job, "")
+			got := reviewBranchName(tt.job)
 			assert.Equal(t, tt.want, got)
 		})
 	}
-}
-
-// TestReviewBranchNameBranchNoneVerified covers the backfilled branchNone
-// sentinel against a real repo (#499 follow-up): the placeholder is only
-// claimed when a local lookup verifies no branch reaches the commit, and a
-// fresh lookup that now finds a branch wins over the stale sentinel.
-func TestReviewBranchNameBranchNoneVerified(t *testing.T) {
-	repo := testutil.InitTestRepo(t)
-	repo.CommitFile("a.txt", "one", "first")
-	repo.CheckoutDetached()
-	detachedSHA := repo.CommitFile("a.txt", "two", "second, on detached HEAD")
-
-	commitID := int64(1)
-	detachedJob := &storage.ReviewJob{
-		JobType:  storage.JobTypeReview,
-		Branch:   branchNone,
-		GitRef:   detachedSHA,
-		RepoPath: repo.Path(),
-		CommitID: &commitID,
-	}
-	assert.Equal(t, "(detached @ "+detachedSHA[:7]+")", reviewBranchName(detachedJob, ""))
-
-	// A job from another machine is never verified locally, even when a
-	// same-named repo path exists here.
-	detachedJob.SourceMachineID = "machine-b"
-	assert.Empty(t, reviewBranchName(detachedJob, "machine-a"))
 }
 
 func TestTUIReviewMsgEmptyBranchForRange(t *testing.T) {

--- a/cmd/roborev/tui/review_branch_test.go
+++ b/cmd/roborev/tui/review_branch_test.go
@@ -127,7 +127,7 @@ func TestReviewBranchNameBranchNoneVerified(t *testing.T) {
 	// A job from another machine is never verified locally, even when a
 	// same-named repo path exists here.
 	detachedJob.SourceMachineID = "machine-b"
-	assert.Equal(t, "", reviewBranchName(detachedJob, "machine-a"))
+	assert.Empty(t, reviewBranchName(detachedJob, "machine-a"))
 }
 
 func TestTUIReviewMsgEmptyBranchForRange(t *testing.T) {

--- a/cmd/roborev/tui/review_branch_test.go
+++ b/cmd/roborev/tui/review_branch_test.go
@@ -72,6 +72,18 @@ func TestReviewBranchName(t *testing.T) {
 			job:  &storage.ReviewJob{GitRef: "abc123"},
 			want: "",
 		},
+		{
+			name: "detached commit review shows placeholder instead of blank",
+			job: &storage.ReviewJob{
+				JobType: storage.JobTypeReview,
+				GitRef:  "abc1234567",
+				CommitID: func() *int64 {
+					id := int64(1)
+					return &id
+				}(),
+			},
+			want: "(detached @ abc1234)",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/roborev/tui/review_branch_test.go
+++ b/cmd/roborev/tui/review_branch_test.go
@@ -53,13 +53,23 @@ func TestReviewBranchName(t *testing.T) {
 			want: "main",
 		},
 		{
-			name: "branchNone sentinel treated as empty",
+			name: "backfilled branchNone renders detached placeholder",
+			job:  &storage.ReviewJob{JobType: storage.JobTypeReview, Branch: "(none)", GitRef: "abc123"},
+			want: "(detached @ abc123)",
+		},
+		{
+			name: "branchNone with repo path skips git lookup, placeholder still shown",
+			job:  &storage.ReviewJob{JobType: storage.JobTypeReview, Branch: "(none)", GitRef: "abc123", RepoPath: "/tmp/repo"},
+			want: "(detached @ abc123)",
+		},
+		{
+			name: "legacy branchNone job without job_type stays empty",
 			job:  &storage.ReviewJob{Branch: "(none)", GitRef: "abc123"},
 			want: "",
 		},
 		{
-			name: "branchNone with repo path skips git lookup",
-			job:  &storage.ReviewJob{Branch: "(none)", GitRef: "abc123", RepoPath: "/tmp/repo"},
+			name: "branchNone on task job stays empty",
+			job:  &storage.ReviewJob{JobType: storage.JobTypeTask, Branch: "(none)", GitRef: "abc123"},
 			want: "",
 		},
 		{

--- a/cmd/roborev/tui/review_branch_test.go
+++ b/cmd/roborev/tui/review_branch_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/testutil"
 )
 
 func TestTUIReviewMsgSetsBranchName(t *testing.T) {
@@ -53,14 +54,14 @@ func TestReviewBranchName(t *testing.T) {
 			want: "main",
 		},
 		{
-			name: "backfilled branchNone renders detached placeholder",
+			name: "branchNone without local repo stays blank (unverifiable)",
 			job:  &storage.ReviewJob{JobType: storage.JobTypeReview, Branch: "(none)", GitRef: "abc123"},
-			want: "(detached @ abc123)",
+			want: "",
 		},
 		{
-			name: "branchNone with repo path skips git lookup, placeholder still shown",
-			job:  &storage.ReviewJob{JobType: storage.JobTypeReview, Branch: "(none)", GitRef: "abc123", RepoPath: "/tmp/repo"},
-			want: "(detached @ abc123)",
+			name: "branchNone with unavailable repo stays blank (unverifiable)",
+			job:  &storage.ReviewJob{JobType: storage.JobTypeReview, Branch: "(none)", GitRef: "abc123", RepoPath: "/nonexistent/repo"},
+			want: "",
 		},
 		{
 			name: "legacy branchNone job without job_type stays empty",
@@ -97,10 +98,36 @@ func TestReviewBranchName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := reviewBranchName(tt.job)
+			got := reviewBranchName(tt.job, "")
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestReviewBranchNameBranchNoneVerified covers the backfilled branchNone
+// sentinel against a real repo (#499 follow-up): the placeholder is only
+// claimed when a local lookup verifies no branch reaches the commit, and a
+// fresh lookup that now finds a branch wins over the stale sentinel.
+func TestReviewBranchNameBranchNoneVerified(t *testing.T) {
+	repo := testutil.InitTestRepo(t)
+	repo.CommitFile("a.txt", "one", "first")
+	repo.CheckoutDetached()
+	detachedSHA := repo.CommitFile("a.txt", "two", "second, on detached HEAD")
+
+	commitID := int64(1)
+	detachedJob := &storage.ReviewJob{
+		JobType:  storage.JobTypeReview,
+		Branch:   branchNone,
+		GitRef:   detachedSHA,
+		RepoPath: repo.Path(),
+		CommitID: &commitID,
+	}
+	assert.Equal(t, "(detached @ "+detachedSHA[:7]+")", reviewBranchName(detachedJob, ""))
+
+	// A job from another machine is never verified locally, even when a
+	// same-named repo path exists here.
+	detachedJob.SourceMachineID = "machine-b"
+	assert.Equal(t, "", reviewBranchName(detachedJob, "machine-a"))
 }
 
 func TestTUIReviewMsgEmptyBranchForRange(t *testing.T) {

--- a/cmd/roborev/tui/tui.go
+++ b/cmd/roborev/tui/tui.go
@@ -797,7 +797,14 @@ func (m *model) getBranchForJob(job storage.ReviewJob) string {
 	}
 
 	branch := git.GetBranchName(job.RepoPath, sha)
-	// Cache result (including empty for detached HEAD / commit not on branch)
+	if branch == "" {
+		// The commit isn't reachable from any local branch - typically a
+		// commit made on top of a detached HEAD (e.g. mid git-bisect).
+		// Surface that instead of leaving the queue cell blank (#499).
+		branch = detachedBranchLabel(job)
+	}
+	// Cache result (including "" when neither lookup nor the detached
+	// placeholder apply, e.g. task/dirty/CI jobs).
 	// We only skip caching above when repo doesn't exist yet
 	if m.branchNames != nil {
 		m.branchNames[job.ID] = branch

--- a/cmd/roborev/tui/tui.go
+++ b/cmd/roborev/tui/tui.go
@@ -759,13 +759,23 @@ func uniqueJobRepoPaths(jobs []storage.ReviewJob) []string {
 // if the stored branch is empty and the repo is available locally.
 // Results are cached to avoid repeated git calls on render.
 func (m *model) getBranchForJob(job storage.ReviewJob) string {
-	// A stored branchNone sentinel means backfill already tried a git
-	// lookup and found nothing; show the detached placeholder when
-	// eligible instead of the sentinel (#499).
+	// A stored branchNone sentinel means backfill found no branch OR
+	// could not look one up (remote job, repo unavailable). Re-verify
+	// locally before claiming detached; keep the sentinel otherwise
+	// (#499).
 	if job.Branch == branchNone {
-		if label := detachedBranchLabel(job); label != "" {
+		if m.branchNames != nil {
+			if cached, ok := m.branchNames[job.ID]; ok {
+				return cached
+			}
+		}
+		if label := verifiedDetachedLabel(job, m.status.MachineID); label != "" {
+			if m.branchNames != nil {
+				m.branchNames[job.ID] = label
+			}
 			return label
 		}
+		// Not cached: the repo may become available later.
 		return job.Branch
 	}
 	// Use stored branch if available

--- a/cmd/roborev/tui/tui.go
+++ b/cmd/roborev/tui/tui.go
@@ -759,25 +759,6 @@ func uniqueJobRepoPaths(jobs []storage.ReviewJob) []string {
 // if the stored branch is empty and the repo is available locally.
 // Results are cached to avoid repeated git calls on render.
 func (m *model) getBranchForJob(job storage.ReviewJob) string {
-	// A stored branchNone sentinel means backfill found no branch OR
-	// could not look one up (remote job, repo unavailable). Re-verify
-	// locally before claiming detached; keep the sentinel otherwise
-	// (#499).
-	if job.Branch == branchNone {
-		if m.branchNames != nil {
-			if cached, ok := m.branchNames[job.ID]; ok {
-				return cached
-			}
-		}
-		if label := verifiedDetachedLabel(job, m.status.MachineID); label != "" {
-			if m.branchNames != nil {
-				m.branchNames[job.ID] = label
-			}
-			return label
-		}
-		// Not cached: the repo may become available later.
-		return job.Branch
-	}
 	// Use stored branch if available
 	if job.Branch != "" {
 		return job.Branch

--- a/cmd/roborev/tui/tui.go
+++ b/cmd/roborev/tui/tui.go
@@ -759,6 +759,15 @@ func uniqueJobRepoPaths(jobs []storage.ReviewJob) []string {
 // if the stored branch is empty and the repo is available locally.
 // Results are cached to avoid repeated git calls on render.
 func (m *model) getBranchForJob(job storage.ReviewJob) string {
+	// A stored branchNone sentinel means backfill already tried a git
+	// lookup and found nothing; show the detached placeholder when
+	// eligible instead of the sentinel (#499).
+	if job.Branch == branchNone {
+		if label := detachedBranchLabel(job); label != "" {
+			return label
+		}
+		return job.Branch
+	}
 	// Use stored branch if available
 	if job.Branch != "" {
 		return job.Branch

--- a/cmd/roborev/tui/util.go
+++ b/cmd/roborev/tui/util.go
@@ -2,10 +2,12 @@ package tui
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	gitrepo "go.kenn.io/kit/git/repo"
 
+	"go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -58,5 +60,43 @@ func detachedBranchLabel(job storage.ReviewJob) string {
 	if ref == "" || ref == "dirty" || ref == "prompt" || strings.Contains(ref, "..") {
 		return ""
 	}
-	return "(detached @ " + gitrepo.ShortSHA(ref) + ")"
+	return detachedLabelPrefix + gitrepo.ShortSHA(ref) + ")"
+}
+
+// detachedLabelPrefix opens every detachedBranchLabel result; filters use it
+// to keep the display placeholder out of branch identity.
+const detachedLabelPrefix = "(detached @ "
+
+// isDetachedLabel reports whether a branch display value is the detached
+// placeholder rather than a real branch name.
+func isDetachedLabel(branch string) bool {
+	return strings.HasPrefix(branch, detachedLabelPrefix)
+}
+
+// verifiedDetachedLabel resolves the display for a job whose stored branch is
+// the backfilled branchNone sentinel. The backfill stores the sentinel both
+// when a local lookup found no branch and when no lookup was possible (remote
+// job, repo unavailable), so "detached" is only claimed after re-running the
+// lookup locally. Returns the fresh branch when one now reaches the commit,
+// the detached placeholder when the local lookup confirms none does, and ""
+// when no local verification is possible, leaving the caller's existing
+// sentinel behavior intact.
+func verifiedDetachedLabel(job storage.ReviewJob, machineID string) string {
+	if job.Branch != branchNone {
+		return ""
+	}
+	label := detachedBranchLabel(job)
+	if label == "" {
+		return ""
+	}
+	if job.RepoPath == "" || (machineID != "" && job.SourceMachineID != "" && job.SourceMachineID != machineID) {
+		return ""
+	}
+	if _, err := os.Stat(job.RepoPath); err != nil {
+		return ""
+	}
+	if branch := git.GetBranchName(job.RepoPath, strings.TrimSpace(job.GitRef)); branch != "" {
+		return branch
+	}
+	return label
 }

--- a/cmd/roborev/tui/util.go
+++ b/cmd/roborev/tui/util.go
@@ -2,12 +2,10 @@ package tui
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	gitrepo "go.kenn.io/kit/git/repo"
 
-	"go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -44,18 +42,14 @@ func formatAgentLabel(agent string, model string) string {
 // (see issue #499), so this surfaces the commit instead.
 //
 // Returns "" (leaving the caller's existing blank/fallback behavior intact)
-// when: a branch is already stored; the job is not a single-commit review
-// (task, insights, compact, and fix jobs can carry non-SHA refs like
-// "analyze", and dirty jobs have no branch concept); the job is a CI
-// review, which deliberately leaves Branch empty in favor of CIBaseBranch
-// (see storage.ReviewJob.HookBranch); or the ref is a range, "dirty", or
-// "prompt" rather than a single commit.
-//
-// The backfill path persists the branchNone sentinel when a git lookup
-// finds no branch, so a stored "(none)" means "no branch data", not "has a
-// branch" — treat it the same as empty.
+// when: a branch (or the branchNone sentinel) is already stored; the job is
+// not a single-commit review (task, insights, compact, and fix jobs can
+// carry non-SHA refs like "analyze", and dirty jobs have no branch
+// concept); the job is a CI review, which deliberately leaves Branch empty
+// in favor of CIBaseBranch (see storage.ReviewJob.HookBranch); or the ref
+// is a range, "dirty", or "prompt" rather than a single commit.
 func detachedBranchLabel(job storage.ReviewJob) string {
-	if (job.Branch != "" && job.Branch != branchNone) || !job.IsReviewJob() || job.IsDirtyJob() || job.IsCIReview() {
+	if job.Branch != "" || !job.IsReviewJob() || job.IsDirtyJob() || job.IsCIReview() {
 		return ""
 	}
 	ref := strings.TrimSpace(job.GitRef)
@@ -73,32 +67,4 @@ const detachedLabelPrefix = "(detached @ "
 // placeholder rather than a real branch name.
 func isDetachedLabel(branch string) bool {
 	return strings.HasPrefix(branch, detachedLabelPrefix)
-}
-
-// verifiedDetachedLabel resolves the display for a job whose stored branch is
-// the backfilled branchNone sentinel. The backfill stores the sentinel both
-// when a local lookup found no branch and when no lookup was possible (remote
-// job, repo unavailable), so "detached" is only claimed after re-running the
-// lookup locally. Returns the fresh branch when one now reaches the commit,
-// the detached placeholder when the local lookup confirms none does, and ""
-// when no local verification is possible, leaving the caller's existing
-// sentinel behavior intact.
-func verifiedDetachedLabel(job storage.ReviewJob, machineID string) string {
-	if job.Branch != branchNone {
-		return ""
-	}
-	label := detachedBranchLabel(job)
-	if label == "" {
-		return ""
-	}
-	if job.RepoPath == "" || (machineID != "" && job.SourceMachineID != "" && job.SourceMachineID != machineID) {
-		return ""
-	}
-	if _, err := os.Stat(job.RepoPath); err != nil {
-		return ""
-	}
-	if branch := git.GetBranchName(job.RepoPath, strings.TrimSpace(job.GitRef)); branch != "" {
-		return branch
-	}
-	return label
 }

--- a/cmd/roborev/tui/util.go
+++ b/cmd/roborev/tui/util.go
@@ -44,16 +44,18 @@ func formatAgentLabel(agent string, model string) string {
 // (see issue #499), so this surfaces the commit instead.
 //
 // Returns "" (leaving the caller's existing blank/fallback behavior intact)
-// when: a branch is already stored; the job is a task or dirty job, which
-// have no branch concept; the job is a CI review, which deliberately leaves
-// Branch empty in favor of CIBaseBranch (see storage.ReviewJob.HookBranch);
-// or the ref is a range, "dirty", or "prompt" rather than a single commit.
+// when: a branch is already stored; the job is not a single-commit review
+// (task, insights, compact, and fix jobs can carry non-SHA refs like
+// "analyze", and dirty jobs have no branch concept); the job is a CI
+// review, which deliberately leaves Branch empty in favor of CIBaseBranch
+// (see storage.ReviewJob.HookBranch); or the ref is a range, "dirty", or
+// "prompt" rather than a single commit.
 //
 // The backfill path persists the branchNone sentinel when a git lookup
 // finds no branch, so a stored "(none)" means "no branch data", not "has a
 // branch" — treat it the same as empty.
 func detachedBranchLabel(job storage.ReviewJob) string {
-	if (job.Branch != "" && job.Branch != branchNone) || job.IsTaskJob() || job.IsDirtyJob() || job.IsCIReview() {
+	if (job.Branch != "" && job.Branch != branchNone) || !job.IsReviewJob() || job.IsDirtyJob() || job.IsCIReview() {
 		return ""
 	}
 	ref := strings.TrimSpace(job.GitRef)

--- a/cmd/roborev/tui/util.go
+++ b/cmd/roborev/tui/util.go
@@ -43,25 +43,27 @@ func formatAgentLabel(agent string, model string) string {
 //
 // Returns "" (leaving the caller's existing blank/fallback behavior intact)
 // when: a branch (or the branchNone sentinel) is already stored; the job is
-// neither a single-commit review nor a fix job on a commit (task, insights,
-// and compact jobs carry non-SHA refs like "analyze", and dirty jobs have
-// no branch concept); the job is a CI review, which deliberately leaves
-// Branch empty in favor of CIBaseBranch (see storage.ReviewJob.HookBranch);
-// or the ref is a range, "dirty", or "prompt" rather than a single commit.
-// Fix jobs additionally require a SHA-like ref, since fixes created from
-// task or custom-prompt parents reuse the parent's prompt-word ref.
+// not a single-commit review, a fix job on a commit, or a panel synthesis
+// row for a single-commit review (task, insights, and compact jobs carry
+// non-SHA refs like "analyze", and dirty jobs have no branch concept); the
+// job is a CI review, which deliberately leaves Branch empty in favor of
+// CIBaseBranch (see storage.ReviewJob.HookBranch); or the ref is a range,
+// "dirty", or "prompt" rather than a single commit. Fix and synthesis jobs
+// additionally require a commit ID or SHA-like ref, since fixes created
+// from task or custom-prompt parents (and syntheses of prompt panels)
+// reuse the parent's prompt-word ref.
 func detachedBranchLabel(job storage.ReviewJob) string {
 	if job.Branch != "" || job.IsDirtyJob() || job.IsCIReview() {
 		return ""
 	}
-	if !job.IsReviewJob() && !job.IsFixJob() {
+	if !job.IsReviewJob() && !job.IsFixJob() && !job.IsSynthesisJob() {
 		return ""
 	}
 	ref := strings.TrimSpace(job.GitRef)
 	if ref == "" || ref == "dirty" || ref == "prompt" || strings.Contains(ref, "..") {
 		return ""
 	}
-	if job.IsFixJob() && !isCommitSHA(ref) {
+	if (job.IsFixJob() || job.IsSynthesisJob()) && job.CommitID == nil && !isCommitSHA(ref) {
 		return ""
 	}
 	return detachedLabelPrefix + gitrepo.ShortSHA(ref) + ")"

--- a/cmd/roborev/tui/util.go
+++ b/cmd/roborev/tui/util.go
@@ -46,8 +46,12 @@ func formatAgentLabel(agent string, model string) string {
 // have no branch concept; the job is a CI review, which deliberately leaves
 // Branch empty in favor of CIBaseBranch (see storage.ReviewJob.HookBranch);
 // or the ref is a range, "dirty", or "prompt" rather than a single commit.
+//
+// The backfill path persists the branchNone sentinel when a git lookup
+// finds no branch, so a stored "(none)" means "no branch data", not "has a
+// branch" — treat it the same as empty.
 func detachedBranchLabel(job storage.ReviewJob) string {
-	if job.Branch != "" || job.IsTaskJob() || job.IsDirtyJob() || job.IsCIReview() {
+	if (job.Branch != "" && job.Branch != branchNone) || job.IsTaskJob() || job.IsDirtyJob() || job.IsCIReview() {
 		return ""
 	}
 	ref := strings.TrimSpace(job.GitRef)

--- a/cmd/roborev/tui/util.go
+++ b/cmd/roborev/tui/util.go
@@ -34,3 +34,25 @@ func formatAgentLabel(agent string, model string) string {
 	}
 	return agent
 }
+
+// detachedBranchLabel formats a placeholder branch label for a review job
+// whose branch is empty because the commit was made on top of a detached
+// HEAD (for example, mid git-bisect) rather than because the branch concept
+// simply does not apply. A blank branch cell in the queue reads as a bug
+// (see issue #499), so this surfaces the commit instead.
+//
+// Returns "" (leaving the caller's existing blank/fallback behavior intact)
+// when: a branch is already stored; the job is a task or dirty job, which
+// have no branch concept; the job is a CI review, which deliberately leaves
+// Branch empty in favor of CIBaseBranch (see storage.ReviewJob.HookBranch);
+// or the ref is a range, "dirty", or "prompt" rather than a single commit.
+func detachedBranchLabel(job storage.ReviewJob) string {
+	if job.Branch != "" || job.IsTaskJob() || job.IsDirtyJob() || job.IsCIReview() {
+		return ""
+	}
+	ref := strings.TrimSpace(job.GitRef)
+	if ref == "" || ref == "dirty" || ref == "prompt" || strings.Contains(ref, "..") {
+		return ""
+	}
+	return "(detached @ " + gitrepo.ShortSHA(ref) + ")"
+}

--- a/cmd/roborev/tui/util.go
+++ b/cmd/roborev/tui/util.go
@@ -43,20 +43,44 @@ func formatAgentLabel(agent string, model string) string {
 //
 // Returns "" (leaving the caller's existing blank/fallback behavior intact)
 // when: a branch (or the branchNone sentinel) is already stored; the job is
-// not a single-commit review (task, insights, compact, and fix jobs can
-// carry non-SHA refs like "analyze", and dirty jobs have no branch
-// concept); the job is a CI review, which deliberately leaves Branch empty
-// in favor of CIBaseBranch (see storage.ReviewJob.HookBranch); or the ref
-// is a range, "dirty", or "prompt" rather than a single commit.
+// neither a single-commit review nor a fix job on a commit (task, insights,
+// and compact jobs carry non-SHA refs like "analyze", and dirty jobs have
+// no branch concept); the job is a CI review, which deliberately leaves
+// Branch empty in favor of CIBaseBranch (see storage.ReviewJob.HookBranch);
+// or the ref is a range, "dirty", or "prompt" rather than a single commit.
+// Fix jobs additionally require a SHA-like ref, since fixes created from
+// task or custom-prompt parents reuse the parent's prompt-word ref.
 func detachedBranchLabel(job storage.ReviewJob) string {
-	if job.Branch != "" || !job.IsReviewJob() || job.IsDirtyJob() || job.IsCIReview() {
+	if job.Branch != "" || job.IsDirtyJob() || job.IsCIReview() {
+		return ""
+	}
+	if !job.IsReviewJob() && !job.IsFixJob() {
 		return ""
 	}
 	ref := strings.TrimSpace(job.GitRef)
 	if ref == "" || ref == "dirty" || ref == "prompt" || strings.Contains(ref, "..") {
 		return ""
 	}
+	if job.IsFixJob() && !isCommitSHA(ref) {
+		return ""
+	}
 	return detachedLabelPrefix + gitrepo.ShortSHA(ref) + ")"
+}
+
+// isCommitSHA reports whether ref looks like an abbreviated or full commit
+// SHA (hex, 7-40 chars). Used to tell fix jobs reviewing a commit apart
+// from fix jobs created off task/custom-prompt parents, whose ref is a
+// prompt word like "analyze".
+func isCommitSHA(ref string) bool {
+	if len(ref) < 7 || len(ref) > 40 {
+		return false
+	}
+	for _, c := range ref {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
+			return false
+		}
+	}
+	return true
 }
 
 // detachedLabelPrefix opens every detachedBranchLabel result; filters use it


### PR DESCRIPTION
A commit made on top of a detached HEAD (e.g. mid `git bisect`) has no branch at enqueue time and no branch reachable via `git name-rev`, so the queue, Tasks, and review screens rendered a blank Branch cell that reads as a bug. They now show `(detached @ <shortsha>)` instead.

How it works:

- The placeholder is derived at render time from an empty stored branch, only for single-commit review jobs and for fix jobs whose ref is SHA-like (fixes created from task/custom-prompt parents reuse prompt-word refs such as `analyze` and stay blank). Task, dirty, and CI jobs keep their existing blank/`CIBaseBranch` behavior, as do range refs.
- The Tasks view now resolves branches through the same `getBranchForJob` path as the queue (stored branch, then local git lookup, then placeholder), so a branchless fix job on a commit that is reachable shows its real branch rather than a detached label.
- The once-per-session branch backfill no longer persists the `(none)` sentinel for locally verified detached reviews — persisting it would freeze the row at `(none)` — while still persisting it for task/remote rows and for repos that cannot be verified locally, so no row is left stranded with `NullsRemaining` nonzero. The per-job decision is extracted into a testable `backfillBranchValue` helper.
- For filtering, the placeholder is display-only: those rows keep grouping under `(none)`, matching the server-side branch counts. Rows already backfilled with the `(none)` sentinel keep displaying `(none)`.

Tradeoff: an earlier iteration re-verified stale `(none)` sentinels at render time to recover fresh branches, but that raced TUI status loading and diverged from server-side picker counts, so it was dropped in favor of the render-only invariant above.

Fixes #499
