### PR TITLE
fix(agent): fail empty Antigravity reviews instead of recording them as done

### DIFF
--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -182,6 +182,44 @@ Antigravity runs in print mode — the prompt is passed via `--prompt` on `agy` 
 probes `agy --version` to pick the contract). Review jobs get `--sandbox`;
 agentic jobs get `--dangerously-skip-permissions`.
 
+Since
+[agy 1.1.3](https://github.com/google-antigravity/antigravity-cli/releases/tag/1.1.3),
+print mode soft-denies tool calls that would need a permission confirmation
+instead of silently auto-approving them. Sandboxed review jobs hit this on the
+model's first tool call — typically a file read or a terminal command: agy exits
+cleanly having produced no review, and roborev fails the job (retrying, then
+failing over to a configured backup agent when one is available). To unblock
+reviews, add allow-rules to `~/.gemini/antigravity-cli/settings.json`:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "read_file(*)",
+      "command(pwd)",
+      "command(ls)"
+    ]
+  }
+}
+```
+
+`read_file(*)` is the rule that matters: agy's native read tools (view file,
+search, list directory) do the real work of a review once file reads are
+allowed. The `command` rules only keep a stray `pwd` or `ls` from aborting the
+run — under `--sandbox`, shell commands are confined to agy's scratch directory
+anyway.
+
+These rules are global to every agy session, and command targets are prefix
+matchers (see the
+[agy permissions docs](https://antigravity.google/docs/cli-permissions)), so
+treat any `command(...)` rule as broad shell authority rather than a read-only
+grant. The same global scope applies to `read_file(*)`, which auto-approves
+reads of any path on the system — narrow its target to your source roots if that
+is broader than you want. If a review still aborts on a `command` denial, allow
+that specific command; avoid `command(*)`, and do not add `unsandboxed(*)` — it
+lifts the sandbox confinement for every agy use. Agentic jobs are unaffected:
+`--dangerously-skip-permissions` auto-approves all tools.
+
 Antigravity does not currently accept a `--model` flag, so an explicit `--model`
 returns an error whenever the Gemini agent resolves to `agy` — even when the
 legacy `gemini` CLI is also installed — rather than silently ignoring the

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -288,7 +288,27 @@ func (a *GeminiAgent) runAntigravity(ctx context.Context, repoPath, prompt strin
 		return runResult.Result, runResult.Stderr, nil
 	}
 
-	return "No review output generated", runResult.Stderr, nil
+	// Agentic jobs keep the shared non-fatal placeholder: fix jobs
+	// legitimately emit no text (they are judged by their worktree patch,
+	// and erroring here would discard valid edits before capture). This
+	// gates on workflow intent, not agenticMode: allow_unsafe_agents
+	// changes tool permissions, not what a review must produce.
+	if a.Agentic {
+		return "No review output generated", runResult.Stderr, nil
+	}
+
+	// A clean exit with no output is a failure, not an empty review: agy >=
+	// 1.1.3 soft-denies tools that need a permission confirmation in headless
+	// print mode and exits 0 having produced nothing. Returning an error lets
+	// the worker retry and fail over instead of recording an empty review.
+	msg := "antigravity produced no review output"
+	if strings.Contains(runResult.Stderr, "permissions.allow") {
+		msg += "; add read_file(*) to permissions.allow in agy's settings.json"
+	}
+	if s := truncateStderr(runResult.Stderr); s != "" {
+		msg += "\nstderr: " + s
+	}
+	return "", runResult.Stderr, errors.New(msg)
 }
 
 // antigravityPromptViaFlag reports whether the installed agy expects the prompt

--- a/internal/agent/gemini_test.go
+++ b/internal/agent/gemini_test.go
@@ -380,6 +380,85 @@ echo "No issues found."
 	assert.NotContains(t, argsOut, "--prompt\n")
 }
 
+func TestGeminiAntigravityEmptyOutput(t *testing.T) {
+	skipIfWindows(t)
+
+	// agy >= 1.1.3 can exit 0 after soft-denying tools in headless print
+	// mode; empty review output must error so the worker retries and fails
+	// over. Agentic runs keep the non-fatal placeholder: fix jobs are
+	// judged by their worktree patch, not text output.
+	silentScript := `#!/bin/sh
+if [ "$1" = "--version" ]; then echo "1.1.3"; exit 0; fi
+exit 0
+`
+	denialScript := `#!/bin/sh
+if [ "$1" = "--version" ]; then echo "1.1.3"; exit 0; fi
+echo 'jetski: no output produced - a tool required the "read_file" permission that headless mode cannot prompt for, so it was auto-denied. Add an allow-rule under permissions.allow in settings.json (e.g. read_file(<target>)).' >&2
+exit 0
+`
+	tests := []struct {
+		name         string
+		script       string
+		agentic      bool
+		unsafeGlobal bool
+		wantResult   string
+		wantInError  []string
+	}{
+		{
+			name:        "SilentExitIsError",
+			script:      silentScript,
+			wantInError: []string{"produced no review output"},
+		},
+		{
+			// allow_unsafe_agents changes tool permissions, not what a
+			// review must produce: empty output stays an error.
+			name:         "ReviewErrorsEvenWithUnsafeAgents",
+			script:       silentScript,
+			unsafeGlobal: true,
+			wantInError:  []string{"produced no review output"},
+		},
+		{
+			name:        "PermissionDenialHint",
+			script:      denialScript,
+			wantInError: []string{"produced no review output", "permissions.allow", "read_file(*)", "auto-denied"},
+		},
+		{
+			name:       "AgenticStaysNonFatal",
+			script:     silentScript,
+			agentic:    true,
+			wantResult: "No review output generated",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scriptPath := writeTempCommand(t, tt.script)
+			ga := NewGeminiAgent(scriptPath)
+			ga.Command = filepath.Join(filepath.Dir(scriptPath), "agy")
+			require.NoError(t, os.Rename(scriptPath, ga.Command))
+			withUnsafeAgents(t, tt.unsafeGlobal)
+			var a Agent = ga
+			if tt.agentic {
+				a = a.WithAgentic(true)
+			}
+
+			var output bytes.Buffer
+			res, err := a.Review(context.Background(), t.TempDir(), "sha", "prompt", &output)
+
+			if tt.wantInError == nil {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantResult, res)
+				return
+			}
+			require.Error(t, err)
+			assert.Empty(t, res)
+			for _, want := range tt.wantInError {
+				assert.ErrorContains(t, err, want)
+			}
+		})
+	}
+}
+
 func TestUTF16CodeUnits(t *testing.T) {
 	assert := assert.New(t)
 	assert.Equal(0, utf16CodeUnits(""))


### PR DESCRIPTION
Fixes #988.

## Summary

- Treat an Antigravity (`agy`) run that exits cleanly with no output as an agent error instead of storing the "No review output generated" placeholder as a completed review, so the worker's existing retry and failover machinery engages. agy >= 1.1.3 soft-denies tool calls that need a permission confirmation in headless print mode and exits 0 having produced nothing, which previously left every affected review silently empty while a healthy backup agent sat idle.
- Preserve agy's stderr tail in the error for diagnosis, and when it carries agy's permission-denial notice, append the `permissions.allow` remedy for the user's settings.json.
- Only non-agentic Antigravity invocations change. Agentic runs (`--dangerously-skip-permissions`) cannot hit the soft-deny and keep the pre-existing placeholder contract — fix jobs legitimately emit no text and are judged by their worktree patch. Other agents are untouched. (A job-type-aware empty-output policy across all agents would be a worthwhile separate follow-up.)
- Add table-driven coverage for the empty-output cases (silent exit, permission-denial notice on stderr, agentic non-error).
- Document the agy >= 1.1.3 behaviour change on the agents page: recommend a minimal allow-list centred on `read_file(*)` (agy's native read tools do the real review work, and sandboxed shell commands are confined to agy's scratch directory, so shell git cannot operate on the reviewed repository either way), describe the token-prefix rule grammar per the upstream permissions docs, and warn that allow-rules are global to every agy session.
