### PR TITLE
Recognize CI synthesis pass summaries

### DIFF
--- a/internal/storage/verdict.go
+++ b/internal/storage/verdict.go
@@ -101,6 +101,7 @@ func normalizeVerdictLine(line string) string {
 
 func hasPassPrefix(line string) bool {
 	passPrefixes := []string{
+		"code review passed:",
 		"no issues",
 		"no findings",
 		"i didn't find any issues",

--- a/internal/storage/verdict_test.go
+++ b/internal/storage/verdict_test.go
@@ -594,6 +594,13 @@ var verdictTests = []verdictTestCase{
 		output: "No issues found. I checked for bugs, security issues, testing gaps, regressions, and code quality concerns.",
 		want:   VerdictPass,
 	},
+	{
+		name: "PassPhraseWins/synthesis pass summary overrides stale fail header",
+		output: "Review #12345 project-a\nVerdict: Fail\n\n" +
+			"2 reviewers: agent-a F, agent-b P\n\n" +
+			"Code review passed: no Medium, High, or Critical findings were identified.",
+		want: VerdictPass,
+	},
 
 	// Failures should come from clear structured findings or from the absence of a
 	// clear pass phrase. We intentionally avoid sentence-level caveat parsing.


### PR DESCRIPTION
CI panel synthesis can retain a stale fail header even when its final summary explicitly says the code review passed. The verdict parser only recognized older pass phrases, so clean panel reviews could appear failed in the TUI and other consumers.

Treat the synthesis summary as a deterministic pass signal at the shared parser boundary while preserving structured severity findings as higher-priority failures. Synthetic regression coverage captures the contradictory header-and-summary shape without exposing review-specific metadata.