### PR TITLE
Reject tautological test recommendations in review prompts

### DIFF
--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -73,6 +73,12 @@ Check the manifests for each changed file's language, including every language a
 - Python: pyproject.toml, requirements.txt, uv/pixi lockfiles.
 - Other languages: the equivalent manifests (Cargo.toml, pom.xml, build.gradle, Gemfile).`
 
+// antiTestSlopInstruction keeps reviewers from recommending tests that cannot
+// detect a behavioral regression because their assertions restate the code.
+const antiTestSlopInstruction = `
+
+IMPORTANT: Do not report a missing test when the only proposed test would be tautological. In particular, do not recommend tests that merely match source code against a regex, check that code text is present, or restate a constant's configured or literal value. Test recommendations must exercise observable behavior, meaningful invariants, failure modes, or integration boundaries, with assertions that are not trivially true by construction.`
+
 // HistoricalReviewContext holds a commit SHA and its associated review (if any) plus responses.
 type HistoricalReviewContext struct {
 	SHA       string

--- a/internal/prompt/prompt_body_templates.go
+++ b/internal/prompt/prompt_body_templates.go
@@ -255,7 +255,12 @@ func templateContextFromAddressView(view addressPromptView) TemplateContext {
 }
 
 func templateContextFromSystemView(view systemPromptView) TemplateContext {
-	return TemplateContext{System: &SystemTemplateContext{NoSkillsInstruction: view.NoSkillsInstruction, ToolchainVerificationInstruction: view.ToolchainVerificationInstruction, CurrentDate: view.CurrentDate}}
+	return TemplateContext{System: &SystemTemplateContext{
+		NoSkillsInstruction:              view.NoSkillsInstruction,
+		AntiTestSlopInstruction:          view.AntiTestSlopInstruction,
+		ToolchainVerificationInstruction: view.ToolchainVerificationInstruction,
+		CurrentDate:                      view.CurrentDate,
+	}}
 }
 
 func renderSinglePromptContext(ctx TemplateContext) (string, error) {

--- a/internal/prompt/template_context.go
+++ b/internal/prompt/template_context.go
@@ -349,6 +349,7 @@ func (c AddressTemplateContext) Clone() AddressTemplateContext {
 
 type SystemTemplateContext struct {
 	NoSkillsInstruction              string
+	AntiTestSlopInstruction          string
 	ToolchainVerificationInstruction string
 	CurrentDate                      string
 }

--- a/internal/prompt/templates.go
+++ b/internal/prompt/templates.go
@@ -38,6 +38,7 @@ func getSystemPrompt(agentName string, promptType string, now func() time.Time) 
 	if _, err := templateFS.ReadFile("templates/" + tmplName); err == nil {
 		body, err := renderSystemPrompt(tmplName, systemPromptView{
 			NoSkillsInstruction:              noSkillsInstruction,
+			AntiTestSlopInstruction:          antiTestSlopInstruction,
 			ToolchainVerificationInstruction: toolchainVerificationInstruction,
 			CurrentDate:                      now().UTC().Format("2006-01-02"),
 		})
@@ -72,6 +73,7 @@ func getSystemPrompt(agentName string, promptType string, now func() time.Time) 
 
 	body, err := renderSystemPrompt(fallbackName, systemPromptView{
 		NoSkillsInstruction:              noSkillsInstruction,
+		AntiTestSlopInstruction:          antiTestSlopInstruction,
 		ToolchainVerificationInstruction: toolchainVerificationInstruction,
 		CurrentDate:                      now().UTC().Format("2006-01-02"),
 	})

--- a/internal/prompt/templates/claude-code_review.md.gotmpl
+++ b/internal/prompt/templates/claude-code_review.md.gotmpl
@@ -25,6 +25,6 @@ Do not include any front matter such as "Reviewing the diff..." or "I'm checking
 4. **Regressions**: Changes that might break existing functionality.
 5. **Code quality**: Duplication, overly complex logic, unclear naming.
 
-Do not review the commit message. Focus only on the code changes in the diff.{{.System.NoSkillsInstruction}}{{.System.ToolchainVerificationInstruction}}
+Do not review the commit message. Focus only on the code changes in the diff.{{.System.NoSkillsInstruction}}{{.System.AntiTestSlopInstruction}}{{.System.ToolchainVerificationInstruction}}
 
 Current date: {{.System.CurrentDate}} (UTC)

--- a/internal/prompt/templates/codex_review.md.gotmpl
+++ b/internal/prompt/templates/codex_review.md.gotmpl
@@ -26,6 +26,6 @@ Do not include any front matter such as "Reviewing the diff..." or "I'm checking
 4. **Regressions**: Changes that might break existing functionality.
 5. **Code quality**: Duplication, overly complex logic, unclear naming.
 
-Do not review the commit message. Focus only on the code changes in the diff.{{.System.NoSkillsInstruction}}{{.System.ToolchainVerificationInstruction}}
+Do not review the commit message. Focus only on the code changes in the diff.{{.System.NoSkillsInstruction}}{{.System.AntiTestSlopInstruction}}{{.System.ToolchainVerificationInstruction}}
 
 Current date: {{.System.CurrentDate}} (UTC)

--- a/internal/prompt/templates/default_design_review.md.gotmpl
+++ b/internal/prompt/templates/default_design_review.md.gotmpl
@@ -23,6 +23,6 @@ After reviewing, provide:
 4. Any missing considerations not covered by the design
 5. A verdict: Pass or Fail with brief justification
 
-If you find no issues, state "No issues found." on its own line after the summary.{{.System.NoSkillsInstruction}}{{.System.ToolchainVerificationInstruction}}
+If you find no issues, state "No issues found." on its own line after the summary.{{.System.NoSkillsInstruction}}{{.System.AntiTestSlopInstruction}}{{.System.ToolchainVerificationInstruction}}
 
 Current date: {{.System.CurrentDate}} (UTC)

--- a/internal/prompt/templates/default_dirty.md.gotmpl
+++ b/internal/prompt/templates/default_dirty.md.gotmpl
@@ -27,6 +27,6 @@ After reviewing, provide:
 
 Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file or diff-level when the issue is an omission or spans a range), the severity must match the impact you described, and no two findings should contradict each other. Drop any finding that fails these checks.
 
-If you find no issues, state "No issues found." on its own line after the summary.{{.System.NoSkillsInstruction}}{{.System.ToolchainVerificationInstruction}}
+If you find no issues, state "No issues found." on its own line after the summary.{{.System.NoSkillsInstruction}}{{.System.AntiTestSlopInstruction}}{{.System.ToolchainVerificationInstruction}}
 
 Current date: {{.System.CurrentDate}} (UTC)

--- a/internal/prompt/templates/default_lookahead.md.gotmpl
+++ b/internal/prompt/templates/default_lookahead.md.gotmpl
@@ -34,6 +34,6 @@ For each finding, provide:
 Before finalizing, verify your review: every finding must name the future input and the earlier timestamp it leaks into, reference the narrowest applicable location (line number when possible, file-level when the issue spans a range), and have a severity matching the impact described. Drop any finding where the inputs are in fact available at the time of use, or where the leaking path never reaches a point-in-time output.
 
 If you find no look-ahead issues, state "No issues found." on its own line after the summary.
-Do not report unrelated code quality or style issues unless they cause a temporal-correctness defect.{{.System.NoSkillsInstruction}}{{.System.ToolchainVerificationInstruction}}
+Do not report unrelated code quality or style issues unless they cause a temporal-correctness defect.{{.System.NoSkillsInstruction}}{{.System.AntiTestSlopInstruction}}{{.System.ToolchainVerificationInstruction}}
 
 Current date: {{.System.CurrentDate}} (UTC)

--- a/internal/prompt/templates/default_range.md.gotmpl
+++ b/internal/prompt/templates/default_range.md.gotmpl
@@ -32,6 +32,6 @@ After reviewing, provide:
 
 Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file or diff-level when the issue is an omission or spans a range), the severity must match the impact you described, and no two findings should contradict each other. Drop any finding that fails these checks.
 
-If you find no issues, state "No issues found." on its own line after the summary.{{.System.NoSkillsInstruction}}{{.System.ToolchainVerificationInstruction}}
+If you find no issues, state "No issues found." on its own line after the summary.{{.System.NoSkillsInstruction}}{{.System.AntiTestSlopInstruction}}{{.System.ToolchainVerificationInstruction}}
 
 Current date: {{.System.CurrentDate}} (UTC)

--- a/internal/prompt/templates/default_review.md.gotmpl
+++ b/internal/prompt/templates/default_review.md.gotmpl
@@ -32,6 +32,6 @@ After reviewing, provide:
 
 Before finalizing, verify your review: every finding must reference the narrowest applicable location (line number when possible, file or diff-level when the issue is an omission or spans a range), the severity must match the impact you described, and no two findings should contradict each other. Drop any finding that fails these checks.
 
-If you find no issues, state "No issues found." on its own line after the summary.{{.System.NoSkillsInstruction}}{{.System.ToolchainVerificationInstruction}}
+If you find no issues, state "No issues found." on its own line after the summary.{{.System.NoSkillsInstruction}}{{.System.AntiTestSlopInstruction}}{{.System.ToolchainVerificationInstruction}}
 
 Current date: {{.System.CurrentDate}} (UTC)

--- a/internal/prompt/templates/default_security.md.gotmpl
+++ b/internal/prompt/templates/default_security.md.gotmpl
@@ -51,6 +51,6 @@ Before reporting, verify:
 Do not emit low-severity defense-in-depth findings. Drop the finding if those answers are vague or rely only on "this could be more secure."
 
 If you find no security issues, state "No issues found." on its own line after the summary.
-Do not report code quality or style issues unless they have security implications.{{.System.NoSkillsInstruction}}{{.System.ToolchainVerificationInstruction}}
+Do not report code quality or style issues unless they have security implications.{{.System.NoSkillsInstruction}}{{.System.AntiTestSlopInstruction}}{{.System.ToolchainVerificationInstruction}}
 
 Current date: {{.System.CurrentDate}} (UTC)

--- a/internal/prompt/templates/gemini_review.md.gotmpl
+++ b/internal/prompt/templates/gemini_review.md.gotmpl
@@ -24,6 +24,6 @@ Do NOT build the project, run the test suite, or execute the code while reviewin
 4. **Regressions**: Changes that might break existing functionality.
 5. **Code quality**: Duplication, overly complex logic, unclear naming.
 
-Do not review the commit message. Focus ONLY on the code changes in the diff.{{.System.NoSkillsInstruction}}{{.System.ToolchainVerificationInstruction}}
+Do not review the commit message. Focus ONLY on the code changes in the diff.{{.System.NoSkillsInstruction}}{{.System.AntiTestSlopInstruction}}{{.System.ToolchainVerificationInstruction}}
 
 Current date: {{.System.CurrentDate}} (UTC)

--- a/internal/prompt/templates_test.go
+++ b/internal/prompt/templates_test.go
@@ -341,6 +341,58 @@ func TestGetSystemPrompt_ToolchainVerificationInstruction(t *testing.T) {
 	}
 }
 
+func TestGetSystemPrompt_AntiTestSlopInstruction(t *testing.T) {
+	fixedTime := time.Date(2030, 6, 15, 0, 0, 0, 0, time.UTC)
+	mockNow := func() time.Time { return fixedTime }
+
+	reviewPrompts := []struct {
+		name    string
+		agent   string
+		command string
+	}{
+		{name: "Codex review", agent: "codex", command: "review"},
+		{name: "Claude review", agent: "claude-code", command: "review"},
+		{name: "Gemini review", agent: "gemini", command: "review"},
+		{name: "Default review", agent: "test", command: "review"},
+		{name: "Range review", agent: "codex", command: "range"},
+		{name: "Dirty review", agent: "claude-code", command: "dirty"},
+		{name: "Security review", agent: "test", command: "security"},
+		{name: "Design review", agent: "test", command: "design-review"},
+		{name: "Lookahead review", agent: "test", command: "lookahead"},
+	}
+
+	for _, tt := range reviewPrompts {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			got := getSystemPrompt(tt.agent, tt.command, mockNow)
+
+			assert.Contains(got, "only proposed test would be tautological")
+			assert.Contains(got, "match source code against a regex")
+			assert.Contains(got, "check that code text is present")
+			assert.Contains(got, "constant's configured or literal value")
+			assert.Contains(got, "observable behavior, meaningful invariants, failure modes, or integration boundaries")
+			assert.Contains(got, "not trivially true by construction")
+		})
+	}
+
+	nonReviewPrompts := []struct {
+		name    string
+		agent   string
+		command string
+	}{
+		{name: "Address", agent: "claude-code", command: "address"},
+		{name: "Run", agent: "gemini", command: "run"},
+	}
+
+	for _, tt := range nonReviewPrompts {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getSystemPrompt(tt.agent, tt.command, mockNow)
+
+			assert.NotContains(t, got, "only proposed test would be tautological")
+		})
+	}
+}
+
 func TestGetSystemPrompt_Exported(t *testing.T) {
 	assert := assert.New(t)
 	before := time.Now().UTC().Truncate(24 * time.Hour)

--- a/internal/prompt/testdata/golden/design_review.golden
+++ b/internal/prompt/testdata/golden/design_review.golden
@@ -30,6 +30,8 @@ IMPORTANT: You are being invoked by roborev to perform this review directly. Do 
 Return only the final review content. Do NOT include process narration, progress updates, or front matter such as "Reviewing the diff..." or "I'm checking...".
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
 
+IMPORTANT: Do not report a missing test when the only proposed test would be tautological. In particular, do not recommend tests that merely match source code against a regex, check that code text is present, or restate a constant's configured or literal value. Test recommendations must exercise observable behavior, meaningful invariants, failure modes, or integration boundaries, with assertions that are not trivially true by construction.
+
 IMPORTANT: Judge whether a feature or API exists from the project's toolchain and dependency manifests, not your own memory, which may be stale. This cuts both ways: do not flag valid recent features as broken, and do not miss calls to APIs that genuinely do not exist for the project's versions.
 
 Check the manifests for each changed file's language, including every language a multi-language change touches. Common ones:

--- a/internal/prompt/testdata/golden/dirty_review.golden
+++ b/internal/prompt/testdata/golden/dirty_review.golden
@@ -34,6 +34,8 @@ IMPORTANT: You are being invoked by roborev to perform this review directly. Do 
 Return only the final review content. Do NOT include process narration, progress updates, or front matter such as "Reviewing the diff..." or "I'm checking...".
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
 
+IMPORTANT: Do not report a missing test when the only proposed test would be tautological. In particular, do not recommend tests that merely match source code against a regex, check that code text is present, or restate a constant's configured or literal value. Test recommendations must exercise observable behavior, meaningful invariants, failure modes, or integration boundaries, with assertions that are not trivially true by construction.
+
 IMPORTANT: Judge whether a feature or API exists from the project's toolchain and dependency manifests, not your own memory, which may be stale. This cuts both ways: do not flag valid recent features as broken, and do not miss calls to APIs that genuinely do not exist for the project's versions.
 
 Check the manifests for each changed file's language, including every language a multi-language change touches. Common ones:

--- a/internal/prompt/testdata/golden/dirty_truncated.golden
+++ b/internal/prompt/testdata/golden/dirty_truncated.golden
@@ -34,6 +34,8 @@ IMPORTANT: You are being invoked by roborev to perform this review directly. Do 
 Return only the final review content. Do NOT include process narration, progress updates, or front matter such as "Reviewing the diff..." or "I'm checking...".
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
 
+IMPORTANT: Do not report a missing test when the only proposed test would be tautological. In particular, do not recommend tests that merely match source code against a regex, check that code text is present, or restate a constant's configured or literal value. Test recommendations must exercise observable behavior, meaningful invariants, failure modes, or integration boundaries, with assertions that are not trivially true by construction.
+
 IMPORTANT: Judge whether a feature or API exists from the project's toolchain and dependency manifests, not your own memory, which may be stale. This cuts both ways: do not flag valid recent features as broken, and do not miss calls to APIs that genuinely do not exist for the project's versions.
 
 Check the manifests for each changed file's language, including every language a multi-language change touches. Common ones:

--- a/internal/prompt/testdata/golden/lookahead_review.golden
+++ b/internal/prompt/testdata/golden/lookahead_review.golden
@@ -41,6 +41,8 @@ IMPORTANT: You are being invoked by roborev to perform this review directly. Do 
 Return only the final review content. Do NOT include process narration, progress updates, or front matter such as "Reviewing the diff..." or "I'm checking...".
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
 
+IMPORTANT: Do not report a missing test when the only proposed test would be tautological. In particular, do not recommend tests that merely match source code against a regex, check that code text is present, or restate a constant's configured or literal value. Test recommendations must exercise observable behavior, meaningful invariants, failure modes, or integration boundaries, with assertions that are not trivially true by construction.
+
 IMPORTANT: Judge whether a feature or API exists from the project's toolchain and dependency manifests, not your own memory, which may be stale. This cuts both ways: do not flag valid recent features as broken, and do not miss calls to APIs that genuinely do not exist for the project's versions.
 
 Check the manifests for each changed file's language, including every language a multi-language change touches. Common ones:

--- a/internal/prompt/testdata/golden/previous_reviews_with_comments.golden
+++ b/internal/prompt/testdata/golden/previous_reviews_with_comments.golden
@@ -39,6 +39,8 @@ IMPORTANT: You are being invoked by roborev to perform this review directly. Do 
 Return only the final review content. Do NOT include process narration, progress updates, or front matter such as "Reviewing the diff..." or "I'm checking...".
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
 
+IMPORTANT: Do not report a missing test when the only proposed test would be tautological. In particular, do not recommend tests that merely match source code against a regex, check that code text is present, or restate a constant's configured or literal value. Test recommendations must exercise observable behavior, meaningful invariants, failure modes, or integration boundaries, with assertions that are not trivially true by construction.
+
 IMPORTANT: Judge whether a feature or API exists from the project's toolchain and dependency manifests, not your own memory, which may be stale. This cuts both ways: do not flag valid recent features as broken, and do not miss calls to APIs that genuinely do not exist for the project's versions.
 
 Check the manifests for each changed file's language, including every language a multi-language change touches. Common ones:

--- a/internal/prompt/testdata/golden/range_truncated.golden
+++ b/internal/prompt/testdata/golden/range_truncated.golden
@@ -39,6 +39,8 @@ IMPORTANT: You are being invoked by roborev to perform this review directly. Do 
 Return only the final review content. Do NOT include process narration, progress updates, or front matter such as "Reviewing the diff..." or "I'm checking...".
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
 
+IMPORTANT: Do not report a missing test when the only proposed test would be tautological. In particular, do not recommend tests that merely match source code against a regex, check that code text is present, or restate a constant's configured or literal value. Test recommendations must exercise observable behavior, meaningful invariants, failure modes, or integration boundaries, with assertions that are not trivially true by construction.
+
 IMPORTANT: Judge whether a feature or API exists from the project's toolchain and dependency manifests, not your own memory, which may be stale. This cuts both ways: do not flag valid recent features as broken, and do not miss calls to APIs that genuinely do not exist for the project's versions.
 
 Check the manifests for each changed file's language, including every language a multi-language change touches. Common ones:

--- a/internal/prompt/testdata/golden/range_truncated_codex_in_range.golden
+++ b/internal/prompt/testdata/golden/range_truncated_codex_in_range.golden
@@ -33,6 +33,8 @@ IMPORTANT: You are being invoked by roborev to perform this review directly. Do 
 Return only the final review content. Do NOT include process narration, progress updates, or front matter such as "Reviewing the diff..." or "I'm checking...".
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
 
+IMPORTANT: Do not report a missing test when the only proposed test would be tautological. In particular, do not recommend tests that merely match source code against a regex, check that code text is present, or restate a constant's configured or literal value. Test recommendations must exercise observable behavior, meaningful invariants, failure modes, or integration boundaries, with assertions that are not trivially true by construction.
+
 IMPORTANT: Judge whether a feature or API exists from the project's toolchain and dependency manifests, not your own memory, which may be stale. This cuts both ways: do not flag valid recent features as broken, and do not miss calls to APIs that genuinely do not exist for the project's versions.
 
 Check the manifests for each changed file's language, including every language a multi-language change touches. Common ones:

--- a/internal/prompt/testdata/golden/range_with_in_range_reviews.golden
+++ b/internal/prompt/testdata/golden/range_with_in_range_reviews.golden
@@ -39,6 +39,8 @@ IMPORTANT: You are being invoked by roborev to perform this review directly. Do 
 Return only the final review content. Do NOT include process narration, progress updates, or front matter such as "Reviewing the diff..." or "I'm checking...".
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
 
+IMPORTANT: Do not report a missing test when the only proposed test would be tautological. In particular, do not recommend tests that merely match source code against a regex, check that code text is present, or restate a constant's configured or literal value. Test recommendations must exercise observable behavior, meaningful invariants, failure modes, or integration boundaries, with assertions that are not trivially true by construction.
+
 IMPORTANT: Judge whether a feature or API exists from the project's toolchain and dependency manifests, not your own memory, which may be stale. This cuts both ways: do not flag valid recent features as broken, and do not miss calls to APIs that genuinely do not exist for the project's versions.
 
 Check the manifests for each changed file's language, including every language a multi-language change touches. Common ones:

--- a/internal/prompt/testdata/golden/security_review.golden
+++ b/internal/prompt/testdata/golden/security_review.golden
@@ -58,6 +58,8 @@ IMPORTANT: You are being invoked by roborev to perform this review directly. Do 
 Return only the final review content. Do NOT include process narration, progress updates, or front matter such as "Reviewing the diff..." or "I'm checking...".
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
 
+IMPORTANT: Do not report a missing test when the only proposed test would be tautological. In particular, do not recommend tests that merely match source code against a regex, check that code text is present, or restate a constant's configured or literal value. Test recommendations must exercise observable behavior, meaningful invariants, failure modes, or integration boundaries, with assertions that are not trivially true by construction.
+
 IMPORTANT: Judge whether a feature or API exists from the project's toolchain and dependency manifests, not your own memory, which may be stale. This cuts both ways: do not flag valid recent features as broken, and do not miss calls to APIs that genuinely do not exist for the project's versions.
 
 Check the manifests for each changed file's language, including every language a multi-language change touches. Common ones:

--- a/internal/prompt/testdata/golden/single_review_claude_code.golden
+++ b/internal/prompt/testdata/golden/single_review_claude_code.golden
@@ -32,6 +32,8 @@ IMPORTANT: You are being invoked by roborev to perform this review directly. Do 
 Return only the final review content. Do NOT include process narration, progress updates, or front matter such as "Reviewing the diff..." or "I'm checking...".
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
 
+IMPORTANT: Do not report a missing test when the only proposed test would be tautological. In particular, do not recommend tests that merely match source code against a regex, check that code text is present, or restate a constant's configured or literal value. Test recommendations must exercise observable behavior, meaningful invariants, failure modes, or integration boundaries, with assertions that are not trivially true by construction.
+
 IMPORTANT: Judge whether a feature or API exists from the project's toolchain and dependency manifests, not your own memory, which may be stale. This cuts both ways: do not flag valid recent features as broken, and do not miss calls to APIs that genuinely do not exist for the project's versions.
 
 Check the manifests for each changed file's language, including every language a multi-language change touches. Common ones:

--- a/internal/prompt/testdata/golden/single_review_codex.golden
+++ b/internal/prompt/testdata/golden/single_review_codex.golden
@@ -33,6 +33,8 @@ IMPORTANT: You are being invoked by roborev to perform this review directly. Do 
 Return only the final review content. Do NOT include process narration, progress updates, or front matter such as "Reviewing the diff..." or "I'm checking...".
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
 
+IMPORTANT: Do not report a missing test when the only proposed test would be tautological. In particular, do not recommend tests that merely match source code against a regex, check that code text is present, or restate a constant's configured or literal value. Test recommendations must exercise observable behavior, meaningful invariants, failure modes, or integration boundaries, with assertions that are not trivially true by construction.
+
 IMPORTANT: Judge whether a feature or API exists from the project's toolchain and dependency manifests, not your own memory, which may be stale. This cuts both ways: do not flag valid recent features as broken, and do not miss calls to APIs that genuinely do not exist for the project's versions.
 
 Check the manifests for each changed file's language, including every language a multi-language change touches. Common ones:

--- a/internal/prompt/testdata/golden/single_review_default.golden
+++ b/internal/prompt/testdata/golden/single_review_default.golden
@@ -39,6 +39,8 @@ IMPORTANT: You are being invoked by roborev to perform this review directly. Do 
 Return only the final review content. Do NOT include process narration, progress updates, or front matter such as "Reviewing the diff..." or "I'm checking...".
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
 
+IMPORTANT: Do not report a missing test when the only proposed test would be tautological. In particular, do not recommend tests that merely match source code against a regex, check that code text is present, or restate a constant's configured or literal value. Test recommendations must exercise observable behavior, meaningful invariants, failure modes, or integration boundaries, with assertions that are not trivially true by construction.
+
 IMPORTANT: Judge whether a feature or API exists from the project's toolchain and dependency manifests, not your own memory, which may be stale. This cuts both ways: do not flag valid recent features as broken, and do not miss calls to APIs that genuinely do not exist for the project's versions.
 
 Check the manifests for each changed file's language, including every language a multi-language change touches. Common ones:

--- a/internal/prompt/testdata/golden/single_review_gemini.golden
+++ b/internal/prompt/testdata/golden/single_review_gemini.golden
@@ -31,6 +31,8 @@ IMPORTANT: You are being invoked by roborev to perform this review directly. Do 
 Return only the final review content. Do NOT include process narration, progress updates, or front matter such as "Reviewing the diff..." or "I'm checking...".
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
 
+IMPORTANT: Do not report a missing test when the only proposed test would be tautological. In particular, do not recommend tests that merely match source code against a regex, check that code text is present, or restate a constant's configured or literal value. Test recommendations must exercise observable behavior, meaningful invariants, failure modes, or integration boundaries, with assertions that are not trivially true by construction.
+
 IMPORTANT: Judge whether a feature or API exists from the project's toolchain and dependency manifests, not your own memory, which may be stale. This cuts both ways: do not flag valid recent features as broken, and do not miss calls to APIs that genuinely do not exist for the project's versions.
 
 Check the manifests for each changed file's language, including every language a multi-language change touches. Common ones:

--- a/internal/prompt/testdata/golden/single_truncated_diff.golden
+++ b/internal/prompt/testdata/golden/single_truncated_diff.golden
@@ -39,6 +39,8 @@ IMPORTANT: You are being invoked by roborev to perform this review directly. Do 
 Return only the final review content. Do NOT include process narration, progress updates, or front matter such as "Reviewing the diff..." or "I'm checking...".
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
 
+IMPORTANT: Do not report a missing test when the only proposed test would be tautological. In particular, do not recommend tests that merely match source code against a regex, check that code text is present, or restate a constant's configured or literal value. Test recommendations must exercise observable behavior, meaningful invariants, failure modes, or integration boundaries, with assertions that are not trivially true by construction.
+
 IMPORTANT: Judge whether a feature or API exists from the project's toolchain and dependency manifests, not your own memory, which may be stale. This cuts both ways: do not flag valid recent features as broken, and do not miss calls to APIs that genuinely do not exist for the project's versions.
 
 Check the manifests for each changed file's language, including every language a multi-language change touches. Common ones:

--- a/internal/prompt/testdata/golden/single_truncated_diff_codex.golden
+++ b/internal/prompt/testdata/golden/single_truncated_diff_codex.golden
@@ -33,6 +33,8 @@ IMPORTANT: You are being invoked by roborev to perform this review directly. Do 
 Return only the final review content. Do NOT include process narration, progress updates, or front matter such as "Reviewing the diff..." or "I'm checking...".
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
 
+IMPORTANT: Do not report a missing test when the only proposed test would be tautological. In particular, do not recommend tests that merely match source code against a regex, check that code text is present, or restate a constant's configured or literal value. Test recommendations must exercise observable behavior, meaningful invariants, failure modes, or integration boundaries, with assertions that are not trivially true by construction.
+
 IMPORTANT: Judge whether a feature or API exists from the project's toolchain and dependency manifests, not your own memory, which may be stale. This cuts both ways: do not flag valid recent features as broken, and do not miss calls to APIs that genuinely do not exist for the project's versions.
 
 Check the manifests for each changed file's language, including every language a multi-language change touches. Common ones:
@@ -55,8 +57,4 @@ Current date: GOLDEN_DATE (UTC)
 
 ### Diff
 
-(Diff too large to include inline)
-
-For Codex in read-only review mode, inspect the commit locally before writing findings.
-- `git show --stat --summary 2be73528b9660e76b0c7fd72ee3255fd6e84257a --`
-- `git show --format=medium --unified=80 2be73528b9660e76b0c7fd72ee3255fd6e84257a --`
+(Diff too large; for Codex run `git show 2be73528b9660e76b0c7fd72ee3255fd6e84257a --` locally.)

--- a/internal/prompt/testdata/golden/single_with_additional_context.golden
+++ b/internal/prompt/testdata/golden/single_with_additional_context.golden
@@ -39,6 +39,8 @@ IMPORTANT: You are being invoked by roborev to perform this review directly. Do 
 Return only the final review content. Do NOT include process narration, progress updates, or front matter such as "Reviewing the diff..." or "I'm checking...".
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
 
+IMPORTANT: Do not report a missing test when the only proposed test would be tautological. In particular, do not recommend tests that merely match source code against a regex, check that code text is present, or restate a constant's configured or literal value. Test recommendations must exercise observable behavior, meaningful invariants, failure modes, or integration boundaries, with assertions that are not trivially true by construction.
+
 IMPORTANT: Judge whether a feature or API exists from the project's toolchain and dependency manifests, not your own memory, which may be stale. This cuts both ways: do not flag valid recent features as broken, and do not miss calls to APIs that genuinely do not exist for the project's versions.
 
 Check the manifests for each changed file's language, including every language a multi-language change touches. Common ones:

--- a/internal/prompt/testdata/golden/single_with_guidelines.golden
+++ b/internal/prompt/testdata/golden/single_with_guidelines.golden
@@ -39,6 +39,8 @@ IMPORTANT: You are being invoked by roborev to perform this review directly. Do 
 Return only the final review content. Do NOT include process narration, progress updates, or front matter such as "Reviewing the diff..." or "I'm checking...".
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
 
+IMPORTANT: Do not report a missing test when the only proposed test would be tautological. In particular, do not recommend tests that merely match source code against a regex, check that code text is present, or restate a constant's configured or literal value. Test recommendations must exercise observable behavior, meaningful invariants, failure modes, or integration boundaries, with assertions that are not trivially true by construction.
+
 IMPORTANT: Judge whether a feature or API exists from the project's toolchain and dependency manifests, not your own memory, which may be stale. This cuts both ways: do not flag valid recent features as broken, and do not miss calls to APIs that genuinely do not exist for the project's versions.
 
 Check the manifests for each changed file's language, including every language a multi-language change touches. Common ones:

--- a/internal/prompt/testdata/golden/single_with_previous_reviews.golden
+++ b/internal/prompt/testdata/golden/single_with_previous_reviews.golden
@@ -39,6 +39,8 @@ IMPORTANT: You are being invoked by roborev to perform this review directly. Do 
 Return only the final review content. Do NOT include process narration, progress updates, or front matter such as "Reviewing the diff..." or "I'm checking...".
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
 
+IMPORTANT: Do not report a missing test when the only proposed test would be tautological. In particular, do not recommend tests that merely match source code against a regex, check that code text is present, or restate a constant's configured or literal value. Test recommendations must exercise observable behavior, meaningful invariants, failure modes, or integration boundaries, with assertions that are not trivially true by construction.
+
 IMPORTANT: Judge whether a feature or API exists from the project's toolchain and dependency manifests, not your own memory, which may be stale. This cuts both ways: do not flag valid recent features as broken, and do not miss calls to APIs that genuinely do not exist for the project's versions.
 
 Check the manifests for each changed file's language, including every language a multi-language change touches. Common ones:

--- a/internal/prompt/testdata/golden/single_with_severity_filter.golden
+++ b/internal/prompt/testdata/golden/single_with_severity_filter.golden
@@ -39,6 +39,8 @@ IMPORTANT: You are being invoked by roborev to perform this review directly. Do 
 Return only the final review content. Do NOT include process narration, progress updates, or front matter such as "Reviewing the diff..." or "I'm checking...".
 If you use tools while reviewing, finish all tool use before emitting the final review, and put the final review only after the last tool call.
 
+IMPORTANT: Do not report a missing test when the only proposed test would be tautological. In particular, do not recommend tests that merely match source code against a regex, check that code text is present, or restate a constant's configured or literal value. Test recommendations must exercise observable behavior, meaningful invariants, failure modes, or integration boundaries, with assertions that are not trivially true by construction.
+
 IMPORTANT: Judge whether a feature or API exists from the project's toolchain and dependency manifests, not your own memory, which may be stale. This cuts both ways: do not flag valid recent features as broken, and do not miss calls to APIs that genuinely do not exist for the project's versions.
 
 Check the manifests for each changed file's language, including every language a multi-language change touches. Common ones:


### PR DESCRIPTION
Roborev reviewers can flag missing tests even when the only suggested coverage mirrors source text or a literal configuration value. Those tests cannot detect a behavioral regression and turn otherwise useful reviews into noise.

This adds one shared anti-test-slop instruction to standard, range, dirty, security, design, lookahead, and agent-specific review prompts. It rejects source-regex, code-text-presence, and constant-reflection tests, and requires recommendations to exercise observable behavior, meaningful invariants, failure modes, or integration boundaries. Address and run prompts remain unchanged.

The instruction flows through `SystemTemplateContext` so every review surface uses consistent wording. The prompt-assembly test covers provider and review-type routing plus the non-review exclusions, while the goldens show the complete emitted prompt changes. The larger preamble makes one size-constrained Codex fixture select its existing compact local-inspection fallback.
