### PR TITLE
sync: support ${file:/path} password references in postgres_url

### DIFF
--- a/docs/advanced/postgres-sync.md
+++ b/docs/advanced/postgres-sync.md
@@ -79,11 +79,12 @@ Alternatively, keep the password in a file and reference its absolute path:
 postgres_url = "postgres://roborev:${file:/run/secrets/roborev-postgres-password}@host:5432/db"
 ```
 
-roborev trims leading and trailing whitespace from the file contents before
-substituting them into the URL. Ensure the account running the daemon can read
-the file, and restrict the file's permissions to that account. If the file is
-missing or unreadable, configuration validation warns about it and the reference
-expands to an empty value, causing the PostgreSQL connection to fail.
+Store the raw password in the file; roborev trims leading and trailing
+whitespace and percent-encodes URL-reserved characters before substituting it
+into the URL. Ensure the account running the daemon can read the file, and
+restrict the file's permissions to that account. If the file is missing or
+unreadable, configuration validation warns about it and the reference expands to
+an empty value, causing the PostgreSQL connection to fail.
 
 File references and environment variables can be used together in the same URL.
 Restart the daemon after changing either form of sync configuration.

--- a/docs/advanced/postgres-sync.md
+++ b/docs/advanced/postgres-sync.md
@@ -59,7 +59,7 @@ roborev sync now       # Trigger immediate sync
 
 Jobs in `queued` or `running` states remain local-only until they complete.
 
-## Environment Variable Expansion
+## Credential Expansion
 
 Sensitive values can reference environment variables:
 
@@ -72,6 +72,21 @@ Set the password in your shell:
 ```bash
 export ROBOREV_PG_PASS="secret"
 ```
+
+Alternatively, keep the password in a file and reference its absolute path:
+
+```toml
+postgres_url = "postgres://roborev:${file:/run/secrets/roborev-postgres-password}@host:5432/db"
+```
+
+roborev trims leading and trailing whitespace from the file contents before
+substituting them into the URL. Ensure the account running the daemon can read
+the file, and restrict the file's permissions to that account. If the file is
+missing or unreadable, configuration validation warns about it and the reference
+expands to an empty value, causing the PostgreSQL connection to fail.
+
+File references and environment variables can be used together in the same URL.
+Restart the daemon after changing either form of sync configuration.
 
 ## Changing Sync Servers
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1147,6 +1148,22 @@ func TestSyncConfigPostgresURLExpandedFileRef(t *testing.T) {
 	t.Run("file ref is read and trimmed", func(t *testing.T) {
 		cfg := SyncConfig{PostgresURL: "postgres://user:${file:" + pwFile + "}@localhost:5432/db"}
 		assert.Equal(t, "postgres://user:s3cr3t@localhost:5432/db", cfg.PostgresURLExpanded())
+	})
+
+	t.Run("file ref escapes reserved URL characters", func(t *testing.T) {
+		reservedPWFile := filepath.Join(dir, "reserved.pw")
+		require.NoError(t, os.WriteFile(reservedPWFile, []byte("p/a#s?s%@word:\n"), 0o600))
+
+		cfg := SyncConfig{PostgresURL: "postgres://user:${file:" + reservedPWFile + "}@localhost:5432/db"}
+		expanded := cfg.PostgresURLExpanded()
+		assert.Equal(t, "postgres://user:p%2Fa%23s%3Fs%25%40word%3A@localhost:5432/db", expanded)
+
+		parsed, err := url.Parse(expanded)
+		require.NoError(t, err)
+		require.NotNil(t, parsed.User)
+		password, present := parsed.User.Password()
+		require.True(t, present)
+		assert.Equal(t, "p/a#s?s%@word:", password)
 	})
 
 	t.Run("file ref and env var expand together", func(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1139,6 +1139,40 @@ func TestSyncConfigPostgresURLExpanded(t *testing.T) {
 	})
 }
 
+func TestSyncConfigPostgresURLExpandedFileRef(t *testing.T) {
+	dir := t.TempDir()
+	pwFile := filepath.Join(dir, "pg.pw")
+	require.NoError(t, os.WriteFile(pwFile, []byte("s3cr3t\n"), 0o600))
+
+	t.Run("file ref is read and trimmed", func(t *testing.T) {
+		cfg := SyncConfig{PostgresURL: "postgres://user:${file:" + pwFile + "}@localhost:5432/db"}
+		assert.Equal(t, "postgres://user:s3cr3t@localhost:5432/db", cfg.PostgresURLExpanded())
+	})
+
+	t.Run("file ref and env var expand together", func(t *testing.T) {
+		t.Setenv("PG_HOST", "hub.example")
+		cfg := SyncConfig{PostgresURL: "postgres://user:${file:" + pwFile + "}@${PG_HOST}:5432/db"}
+		assert.Equal(t, "postgres://user:s3cr3t@hub.example:5432/db", cfg.PostgresURLExpanded())
+	})
+
+	t.Run("unreadable file ref becomes empty (fails at dial, no leak)", func(t *testing.T) {
+		cfg := SyncConfig{PostgresURL: "postgres://user:${file:" + filepath.Join(dir, "missing") + "}@localhost:5432/db"}
+		assert.Equal(t, "postgres://user:@localhost:5432/db", cfg.PostgresURLExpanded())
+	})
+
+	t.Run("Validate warns when the password file is missing", func(t *testing.T) {
+		cfg := SyncConfig{Enabled: true, PostgresURL: "postgres://user:${file:" + filepath.Join(dir, "nope") + "}@localhost:5432/db"}
+		warnings := cfg.Validate()
+		require.Len(t, warnings, 1)
+		assert.Contains(t, warnings[0], "file that cannot be read")
+	})
+
+	t.Run("Validate is quiet when the file exists", func(t *testing.T) {
+		cfg := SyncConfig{Enabled: true, PostgresURL: "postgres://user:${file:" + pwFile + "}@localhost:5432/db"}
+		assert.Empty(t, cfg.Validate())
+	})
+}
+
 func TestSyncConfigGetRepoDisplayName(t *testing.T) {
 	t.Run("nil receiver returns empty", func(t *testing.T) {
 		var cfg *SyncConfig

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -3,6 +3,7 @@
 package config
 
 import (
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -15,10 +16,10 @@ type SyncConfig struct {
 
 	// PostgresURL is the connection string for PostgreSQL.
 	// Supports ${VAR} environment-variable expansion and ${file:/path}
-	// references whose (trimmed) file contents are substituted — the latter
-	// lets a credential live in a 0600 file instead of inline in this config,
-	// and lets a daemon started outside the process that set the env still
-	// resolve the password.
+	// references whose (trimmed) file contents are URL-encoded and substituted
+	// as the password — the latter lets a credential live in a 0600 file instead
+	// of inline in this config, and lets a daemon started outside the process
+	// that set the env still resolve the password.
 	PostgresURL string `toml:"postgres_url" sensitive:"true"`
 
 	// Interval is how often to sync (e.g., "5m", "1h"). Default: 1h
@@ -36,10 +37,11 @@ type SyncConfig struct {
 }
 
 // PostgresURLExpanded returns the PostgreSQL URL with ${file:/path} references
-// resolved to the trimmed file contents and ${VAR} environment variables
-// expanded. Returns empty string if URL is not set. A ${file:/path} that cannot
-// be read (like an unset ${VAR}) expands to empty, so the connection fails at
-// dial time rather than the reference leaking through verbatim.
+// resolved to the trimmed, URL-encoded password file contents and ${VAR}
+// environment variables expanded. Returns empty string if URL is not set. A
+// ${file:/path} that cannot be read (like an unset ${VAR}) expands to empty, so
+// the connection fails at dial time rather than the reference leaking through
+// verbatim.
 func (c *SyncConfig) PostgresURLExpanded() string {
 	if c.PostgresURL == "" {
 		return ""
@@ -50,7 +52,8 @@ func (c *SyncConfig) PostgresURLExpanded() string {
 			if err != nil {
 				return ""
 			}
-			return strings.TrimSpace(string(b))
+			password := strings.TrimSpace(string(b))
+			return strings.TrimPrefix(url.UserPassword("", password).String(), ":")
 		}
 		return os.Getenv(key)
 	})

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -14,7 +14,11 @@ type SyncConfig struct {
 	Enabled bool `toml:"enabled"`
 
 	// PostgresURL is the connection string for PostgreSQL.
-	// Supports environment variable expansion via ${VAR} syntax.
+	// Supports ${VAR} environment-variable expansion and ${file:/path}
+	// references whose (trimmed) file contents are substituted — the latter
+	// lets a credential live in a 0600 file instead of inline in this config,
+	// and lets a daemon started outside the process that set the env still
+	// resolve the password.
 	PostgresURL string `toml:"postgres_url" sensitive:"true"`
 
 	// Interval is how often to sync (e.g., "5m", "1h"). Default: 1h
@@ -31,13 +35,25 @@ type SyncConfig struct {
 	RepoNames map[string]string `toml:"repo_names"`
 }
 
-// PostgresURLExpanded returns the PostgreSQL URL with environment variables expanded.
-// Returns empty string if URL is not set.
+// PostgresURLExpanded returns the PostgreSQL URL with ${file:/path} references
+// resolved to the trimmed file contents and ${VAR} environment variables
+// expanded. Returns empty string if URL is not set. A ${file:/path} that cannot
+// be read (like an unset ${VAR}) expands to empty, so the connection fails at
+// dial time rather than the reference leaking through verbatim.
 func (c *SyncConfig) PostgresURLExpanded() string {
 	if c.PostgresURL == "" {
 		return ""
 	}
-	return os.ExpandEnv(c.PostgresURL)
+	return os.Expand(c.PostgresURL, func(key string) string {
+		if path, ok := strings.CutPrefix(key, "file:"); ok {
+			b, err := os.ReadFile(strings.TrimSpace(path))
+			if err != nil {
+				return ""
+			}
+			return strings.TrimSpace(string(b))
+		}
+		return os.Getenv(key)
+	})
 }
 
 // GetRepoDisplayName returns the configured display name for a repo identity,
@@ -63,18 +79,23 @@ func (c *SyncConfig) Validate() []string {
 		return warnings
 	}
 
-	// Check for environment variable references where the var is not set
-	// os.ExpandEnv replaces ${VAR} with empty string if VAR is not set
+	// Flag references that will expand to empty: an unset ${VAR}, or a
+	// ${file:/path} whose file cannot be read. Both leave the URL without a
+	// resolved value (typically the password) and the connection fails at dial.
 	if strings.Contains(c.PostgresURL, "${") {
 		re := regexp.MustCompile(`\$\{([^}]+)\}`)
-		matches := re.FindAllStringSubmatch(c.PostgresURL, -1)
-		for _, match := range matches {
-			if len(match) > 1 {
-				varName := match[1]
-				if os.Getenv(varName) == "" {
-					warnings = append(warnings, "sync.postgres_url may contain unexpanded environment variables")
-					break // Only one warning needed
+		for _, match := range re.FindAllStringSubmatch(c.PostgresURL, -1) {
+			if len(match) < 2 {
+				continue
+			}
+			if path, ok := strings.CutPrefix(match[1], "file:"); ok {
+				if _, err := os.Stat(strings.TrimSpace(path)); err != nil {
+					warnings = append(warnings, "sync.postgres_url references a file that cannot be read: "+strings.TrimSpace(path))
+					break
 				}
+			} else if os.Getenv(match[1]) == "" {
+				warnings = append(warnings, "sync.postgres_url may contain unexpanded environment variables")
+				break
 			}
 		}
 	}


### PR DESCRIPTION
# sync: support `${file:/path}` password references in `postgres_url`

## Why

I run the kenn suite self-hosted. kata, agentsview, middleman and roborev are
always-on services on one box on my private network, and a handful of
workstations across macOS, Windows and Linux work against them. roborev in that
setup stays local-first exactly as designed: every workstation runs its own
daemon driven by post-commit hooks, and the only shared piece is `[sync]`,
pushing reviews into the central Postgres so the fleet has one view of what was
reviewed.

That means the same sync credential has to be resolvable on every machine, by
whichever roborev daemon happens to be running there. `${VAR}` cannot do that,
and the reason is not configuration, it is process scope.

**The env var reaches only the process that was started with it.** My installer
writes the global `[sync]` config and runs the daemon as a managed service, with
`ROBOREV_PG_PASSWORD` injected into that process. But on a developer
workstation, a roborev daemon is very often already listening on :7373: the user
started it, or a previous session left it up. My supervisor deliberately defers
to that daemon rather than competing for the port, which is the right call, and
the cost is that the daemon actually doing the reviewing never saw the env var.
It reads the same global `config.toml`, resolves `${ROBOREV_PG_PASSWORD}` to
empty, hands `postgres://roborev:@host:5433/roborev` to the pool, and fails
auth. The reviews keep working locally, so nothing looks broken. The machine
just quietly stops appearing in the central database.

**The alternative is putting the password on disk, on every machine.** That is
what I ship today: resolve the secret at enroll time and embed it in the DSN
written into roborev's global config. It works for any daemon on the host, which
is the whole point, but now the plaintext credential sits in `config.toml` on
every workstation in the fleet, it is the same value on all of them, and
rotating it means re-running enroll everywhere to rewrite each config.

Neither option is a self-hosting problem I can solve outside roborev. One scopes
the secret to a process I do not control, the other scopes it to a file roborev
owns and rewrites.

`${file:/path}` gives a third shape that fits a self-hosted fleet. The
credential lives in one 0600 file per machine that any daemon on that host can
read regardless of who started it. The config holds a path instead of a secret,
so the same config is safe to hand to every machine. Rotation is a write to that
file: `PostgresURLExpanded()` is called in `SyncWorker.connect`, so the new value
is picked up on the next connect, with no config rewrite and no re-enroll.

This is config plumbing, not a secrets manager. It composes with whatever
already places the file (a systemd or launchd credential, a Vault or 1Password
fetch at install time), and `${VAR}` keeps working unchanged for anyone whose
daemon does inherit the env.

## What changed

- `PostgresURLExpanded()` resolves `${file:/path}` to the trimmed file contents
  alongside `${VAR}` env expansion, in a single `os.Expand` pass, so a URL can
  mix both (`postgres://user:${file:/etc/roborev/pg.pw}@${PG_HOST}:5432/db`).
- An unreadable `${file:/path}` expands to empty, matching the existing
  behaviour for an unset `${VAR}`. The connection then fails at dial rather than
  the literal reference leaking into a DSN or an error string.
- `Validate()` warns up front when a referenced file is missing, so a bad path
  surfaces at config time instead of only in sync logs.

Closes #994.
