### PR TITLE
sync: add skip_backfill to adopt a new target without pushing history

### DIFF
--- a/docs/advanced/postgres-sync.md
+++ b/docs/advanced/postgres-sync.md
@@ -22,6 +22,7 @@ enabled = true
 postgres_url = "postgres://roborev:${ROBOREV_PG_PASS}@nas.tailnet:5432/roborev"
 interval = "1h"           # Sync interval (default: 1h)
 machine_name = "laptop"   # Friendly name for this machine
+skip_backfill = false     # Adopt a new target without pushing history
 ```
 
 !!! note
@@ -84,6 +85,28 @@ roborev automatically detects this and performs a full resync:
 - If different, all local `synced_at` timestamps and pull cursors are cleared
 - This triggers a complete bidirectional sync: all local data is pushed, and all
     remote data is pulled
+
+### Adopting a Target Without Pushing History
+
+The default repopulates a replaced database, which is usually what you want.
+When the target is a database **shared with other people**, it is usually not:
+pushing your whole local history uploads every review on the machine, including
+work unrelated to that team, to everyone with read access.
+
+Set `skip_backfill = true` to adopt a target and sync only what changes from
+that point on:
+
+```toml
+[sync]
+skip_backfill = true
+```
+
+- Applies when a target is adopted: either a different database, or the first
+    time sync is enabled on a machine that already has local history
+- Affects the **push** direction only. Pull cursors are still reset, because
+    receiving what the target already holds is the point of joining it
+- Existing local rows are marked as already synced rather than deleted, so
+    editing one later still syncs it normally
 
 This means you can safely:
 

--- a/docs/advanced/postgres-sync.md
+++ b/docs/advanced/postgres-sync.md
@@ -86,6 +86,16 @@ roborev automatically detects this and performs a full resync:
 - This triggers a complete bidirectional sync: all local data is pushed, and all
     remote data is pulled
 
+This means you can safely:
+
+- Switch between PostgreSQL servers (e.g., dev to prod)
+- Reset/recreate your PostgreSQL database
+- Sync the same local database to multiple PostgreSQL instances over time
+
+The sync will never be left in an inconsistent state where it thinks data was
+synced but the target database doesn't have it. That guarantee describes the
+default; `skip_backfill` below deliberately trades it away.
+
 ### Adopting a Target Without Pushing History
 
 The default repopulates a replaced database, which is usually what you want.
@@ -105,17 +115,10 @@ skip_backfill = true
     time sync is enabled on a machine that already has local history
 - Affects the **push** direction only. Pull cursors are still reset, because
     receiving what the target already holds is the point of joining it
-- Existing local rows are marked as already synced rather than deleted, so
-    editing one later still syncs it normally
-
-This means you can safely:
-
-- Switch between PostgreSQL servers (e.g., dev to prod)
-- Reset/recreate your PostgreSQL database
-- Sync the same local database to multiple PostgreSQL instances over time
-
-The sync will never be left in an inconsistent state where it thinks data was
-synced but the target database doesn't have it.
+- Existing local rows are marked as already synced rather than deleted. Their
+    reviews and comments stay local for this target, because pushing a child
+    whose parent was never uploaded would reference a job the target has never
+    seen. Work created after adoption syncs normally
 
 ## See Also
 

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -26,6 +26,12 @@ type SyncConfig struct {
 	// ConnectTimeout is the connection timeout (e.g., "5s"). Default: 5s
 	ConnectTimeout string `toml:"connect_timeout"`
 
+	// SkipBackfill adopts a NEW sync target without pushing pre-existing local
+	// rows to it: only work created from that point on is synced. Existing
+	// targets are unaffected. Use when the target database is shared with
+	// others and the local history should not be disclosed to them.
+	SkipBackfill bool `toml:"skip_backfill"`
+
 	// RepoNames provides custom display names for synced repos by identity.
 	// Example: {"git@github.com:org/repo.git": "my-project"}
 	RepoNames map[string]string `toml:"repo_names"`

--- a/internal/storage/sync.go
+++ b/internal/storage/sync.go
@@ -189,6 +189,28 @@ func (db *DB) ClearAllSyncedAt() error {
 	return nil
 }
 
+// MarkAllSyncedNow stamps synced_at on every local row that has none, so a
+// newly connected database receives only what changes from here on. It is the
+// inverse of ClearAllSyncedAt and is used when adopting a new sync target
+// without backfilling: pushing an entire local history into a database shared
+// with other people discloses unrelated local work.
+//
+// Rows are stamped rather than deleted or flagged, so the existing push
+// selection (synced_at IS NULL OR updated_at > synced_at) needs no change: a
+// stamped row that is edited later still moves updated_at past synced_at and
+// syncs normally.
+func (db *DB) MarkAllSyncedNow() error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, table := range []string{"review_jobs", "reviews", "responses"} {
+		if _, err := db.Exec(
+			`UPDATE `+table+` SET synced_at = ? WHERE synced_at IS NULL`, now,
+		); err != nil {
+			return fmt.Errorf("mark %s synced: %w", table, err)
+		}
+	}
+	return nil
+}
+
 // BackfillRepoIdentities computes and sets identity for repos that don't have one.
 // Uses config.ResolveRepoIdentity to ensure consistency with new repo creation.
 // Returns the number of repos backfilled.

--- a/internal/storage/sync.go
+++ b/internal/storage/sync.go
@@ -213,7 +213,11 @@ func (db *DB) ClearAllSyncedAt() error {
 // created_at.
 func (db *DB) MarkAllSyncedNow() error {
 	for _, q := range []string{
-		`UPDATE review_jobs SET synced_at = updated_at`,
+		// Only jobs the push query would consider: a non-terminal job left
+		// unstamped keeps synced_at NULL, which already holds its children back,
+		// rather than becoming an unpushable parent that looks synced.
+		`UPDATE review_jobs SET synced_at = updated_at
+		  WHERE status IN ('done', 'failed', 'canceled', 'skipped')`,
 		`UPDATE reviews SET synced_at = updated_at`,
 		`UPDATE responses SET synced_at = created_at`,
 	} {
@@ -230,6 +234,44 @@ func (db *DB) MarkAllSyncedNow() error {
 	return db.SetSyncState(
 		SyncStateAdoptedMaxJobID, strconv.FormatInt(maxJobID.Int64, 10),
 	)
+}
+
+// HasSyncHistory reports whether this database shows evidence of having synced
+// before: a pull cursor, or any locally stamped row. Used to tell a genuine
+// first adoption from an upgrade that predates target-id tracking.
+func (db *DB) HasSyncHistory() (bool, error) {
+	for _, key := range []string{
+		SyncStateLastJobCursor, SyncStateLastReviewCursor, SyncStateLastResponseID,
+	} {
+		v, err := db.GetSyncState(key)
+		if err != nil {
+			return false, err
+		}
+		if v != "" {
+			return true, nil
+		}
+	}
+	var n int
+	if err := db.QueryRow(
+		`SELECT EXISTS (SELECT 1 FROM review_jobs WHERE synced_at IS NOT NULL)`,
+	).Scan(&n); err != nil {
+		return false, fmt.Errorf("check synced rows: %w", err)
+	}
+	return n == 1, nil
+}
+
+// adoptionBoundary reports the highest job id covered by the last adoption
+// stamp. Zero means no adoption has occurred, which disables the guard below.
+func (db *DB) adoptionBoundary() int64 {
+	raw, err := db.GetSyncState(SyncStateAdoptedMaxJobID)
+	if err != nil || raw == "" {
+		return 0
+	}
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return id
 }
 
 // BackfillRepoIdentities computes and sets identity for repos that don't have one.
@@ -477,34 +519,7 @@ func (db *DB) GetJobsToSync(machineID string, limit int) ([]SyncableJob, error) 
 		WHERE j.status IN ('done', 'failed', 'canceled', 'skipped')
 		AND j.source_machine_id = ?
 		AND j.uuid IS NOT NULL
-		AND (
-			j.synced_at IS NULL
-			OR `+sqliteNormalizedTimestampExpr("j.updated_at")+` > `+sqliteNormalizedTimestampExpr("j.synced_at")+`
-			-- Children are only eligible once their parent job counts as synced
-			-- (see GetReviewsToSync / GetCommentsToSync). After an adoption
-			-- stamp that is true for parents this target has never seen, so a
-			-- later edit to an old review would push a child whose parent is
-			-- absent and violate the job_uuid foreign key. Carry the parent up
-			-- in the same cycle: jobs are pushed before reviews and comments.
-			-- Scoped to adoption-stamped ids, so a normally-synced parent with a
-			-- pending child (the steady state) is NOT re-pushed.
-			OR (j.id <= COALESCE((
-				SELECT CAST(value AS INTEGER) FROM sync_state
-				WHERE key = 'adopted_max_job_id'
-			), 0) AND (
-			EXISTS (
-				SELECT 1 FROM reviews rv
-				WHERE rv.job_id = j.id AND rv.uuid IS NOT NULL
-				AND rv.updated_by_machine_id = j.source_machine_id
-				AND (rv.synced_at IS NULL OR `+sqliteNormalizedTimestampExpr("rv.updated_at")+` > `+sqliteNormalizedTimestampExpr("rv.synced_at")+`)
-			)
-			OR EXISTS (
-				SELECT 1 FROM responses rs
-				WHERE rs.job_id = j.id AND rs.uuid IS NOT NULL
-				AND rs.source_machine_id = j.source_machine_id
-				AND rs.synced_at IS NULL
-			)))
-		)
+		AND (j.synced_at IS NULL OR `+sqliteNormalizedTimestampExpr("j.updated_at")+` > `+sqliteNormalizedTimestampExpr("j.synced_at")+`)
 		ORDER BY j.id
 		LIMIT ?
 	`, machineID, limit)
@@ -698,6 +713,7 @@ type SyncableReview struct {
 // GetReviewsToSync returns reviews modified locally that need to be pushed.
 // Only returns reviews whose parent job has already been synced.
 func (db *DB) GetReviewsToSync(machineID string, limit int) ([]SyncableReview, error) {
+	adoptedMaxJobID := db.adoptionBoundary()
 	rows, err := db.Query(`
 		SELECT
 			r.id, r.uuid, r.job_id, j.uuid,
@@ -709,10 +725,16 @@ func (db *DB) GetReviewsToSync(machineID string, limit int) ([]SyncableReview, e
 		AND r.uuid IS NOT NULL
 		AND j.uuid IS NOT NULL
 		AND j.synced_at IS NOT NULL
+		-- Adoption stamps a parent as synced without ever pushing it, so its
+		-- children must not be pushed either: they would reference a job the
+		-- target has never seen and violate the job_uuid foreign key. Pre-
+		-- adoption children stay local for this target, which is what
+		-- skip_backfill asks for; work created after adoption syncs normally.
+		AND j.id > ?
 		AND (r.synced_at IS NULL OR `+sqliteNormalizedTimestampExpr("r.updated_at")+` > `+sqliteNormalizedTimestampExpr("r.synced_at")+`)
 		ORDER BY r.id
 		LIMIT ?
-	`, machineID, limit)
+	`, machineID, adoptedMaxJobID, limit)
 	if err != nil {
 		return nil, fmt.Errorf("query reviews to sync: %w", err)
 	}
@@ -780,6 +802,7 @@ type SyncableResponse struct {
 // GetCommentsToSync returns comments created locally that need to be pushed.
 // Only returns comments whose parent job has already been synced.
 func (db *DB) GetCommentsToSync(machineID string, limit int) ([]SyncableResponse, error) {
+	adoptedMaxJobID := db.adoptionBoundary()
 	rows, err := db.Query(`
 		SELECT
 			r.id, r.uuid, r.job_id, j.uuid,
@@ -791,9 +814,15 @@ func (db *DB) GetCommentsToSync(machineID string, limit int) ([]SyncableResponse
 		AND j.uuid IS NOT NULL
 		AND r.synced_at IS NULL
 		AND j.synced_at IS NOT NULL
+		-- Adoption stamps a parent as synced without ever pushing it, so its
+		-- children must not be pushed either: they would reference a job the
+		-- target has never seen and violate the job_uuid foreign key. Pre-
+		-- adoption children stay local for this target, which is what
+		-- skip_backfill asks for; work created after adoption syncs normally.
+		AND j.id > ?
 		ORDER BY r.id
 		LIMIT ?
-	`, machineID, limit)
+	`, machineID, adoptedMaxJobID, limit)
 	if err != nil {
 		return nil, fmt.Errorf("query responses to sync: %w", err)
 	}

--- a/internal/storage/sync.go
+++ b/internal/storage/sync.go
@@ -23,7 +23,12 @@ const (
 	// "predates this target", not "pushed to this target"; monotonic ids avoid
 	// comparing the mixed-format timestamps synced_at can hold.
 	SyncStateAdoptedMaxJobID = "adopted_max_job_id"
-	SyncStateDatabaseID      = "database_id" // Stable identity of this local SQLite database
+	// SyncStateAdoptedAt is when that stamp was applied. A parent below the id
+	// boundary counts as absent from the target only while its synced_at still
+	// predates this: a job that was queued at adoption, or a stamped one that
+	// was later edited, is pushed for real afterwards and releases its children.
+	SyncStateAdoptedAt  = "adopted_at"
+	SyncStateDatabaseID = "database_id" // Stable identity of this local SQLite database
 )
 
 // GetSyncState retrieves a value from the sync_state table.
@@ -180,6 +185,12 @@ func (db *DB) BackfillSourceMachineID() error {
 // This is used when syncing to a new Postgres database to ensure
 // all data gets re-synced.
 func (db *DB) ClearAllSyncedAt() error {
+	// The boundary describes one adoption of one target. Leaving it behind after
+	// a full re-sync would re-push the parent jobs while permanently excluding
+	// their reviews and comments, landing the target with bodyless jobs.
+	if err := db.ClearAdoptionBoundary(); err != nil {
+		return err
+	}
 	// Clear synced_at on review_jobs
 	if _, err := db.Exec(`UPDATE review_jobs SET synced_at = NULL`); err != nil {
 		return fmt.Errorf("clear review_jobs synced_at: %w", err)
@@ -231,8 +242,13 @@ func (db *DB) MarkAllSyncedNow() error {
 	if err := db.QueryRow(`SELECT MAX(id) FROM review_jobs`).Scan(&maxJobID); err != nil {
 		return fmt.Errorf("read adopted max job id: %w", err)
 	}
-	return db.SetSyncState(
+	if err := db.SetSyncState(
 		SyncStateAdoptedMaxJobID, strconv.FormatInt(maxJobID.Int64, 10),
+	); err != nil {
+		return err
+	}
+	return db.SetSyncState(
+		SyncStateAdoptedAt, time.Now().UTC().Format(time.RFC3339),
 	)
 }
 
@@ -260,18 +276,35 @@ func (db *DB) HasSyncHistory() (bool, error) {
 	return n == 1, nil
 }
 
-// adoptionBoundary reports the highest job id covered by the last adoption
-// stamp. Zero means no adoption has occurred, which disables the guard below.
-func (db *DB) adoptionBoundary() int64 {
+// ClearAdoptionBoundary forgets the last adoption stamp, so the child guard
+// stops applying. Called whenever the reconciliation for a target is something
+// other than stamping it.
+func (db *DB) ClearAdoptionBoundary() error {
+	for _, key := range []string{SyncStateAdoptedMaxJobID, SyncStateAdoptedAt} {
+		if err := db.SetSyncState(key, ""); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// adoptionBoundary reports the last adoption stamp: the highest job id it
+// covered and when it happened. A zero id means no adoption is in effect, which
+// disables the child guard entirely.
+func (db *DB) adoptionBoundary() (maxJobID int64, adoptedAt string) {
 	raw, err := db.GetSyncState(SyncStateAdoptedMaxJobID)
 	if err != nil || raw == "" {
-		return 0
+		return 0, ""
 	}
 	id, err := strconv.ParseInt(raw, 10, 64)
 	if err != nil {
-		return 0
+		return 0, ""
 	}
-	return id
+	at, err := db.GetSyncState(SyncStateAdoptedAt)
+	if err != nil || at == "" {
+		return 0, ""
+	}
+	return id, at
 }
 
 // BackfillRepoIdentities computes and sets identity for repos that don't have one.
@@ -713,7 +746,7 @@ type SyncableReview struct {
 // GetReviewsToSync returns reviews modified locally that need to be pushed.
 // Only returns reviews whose parent job has already been synced.
 func (db *DB) GetReviewsToSync(machineID string, limit int) ([]SyncableReview, error) {
-	adoptedMaxJobID := db.adoptionBoundary()
+	adoptedMaxJobID, adoptedAt := db.adoptionBoundary()
 	rows, err := db.Query(`
 		SELECT
 			r.id, r.uuid, r.job_id, j.uuid,
@@ -727,14 +760,15 @@ func (db *DB) GetReviewsToSync(machineID string, limit int) ([]SyncableReview, e
 		AND j.synced_at IS NOT NULL
 		-- Adoption stamps a parent as synced without ever pushing it, so its
 		-- children must not be pushed either: they would reference a job the
-		-- target has never seen and violate the job_uuid foreign key. Pre-
-		-- adoption children stay local for this target, which is what
-		-- skip_backfill asks for; work created after adoption syncs normally.
-		AND j.id > ?
+		-- target has never seen and violate the job_uuid foreign key. The guard
+		-- lifts as soon as the parent is pushed for real, which covers a job
+		-- that was still queued at adoption and a stamped one that was later
+		-- edited. Work created after adoption is past the id boundary already.
+		AND NOT (j.id <= ? AND `+sqliteNormalizedTimestampExpr("j.synced_at")+` <= datetime(?))
 		AND (r.synced_at IS NULL OR `+sqliteNormalizedTimestampExpr("r.updated_at")+` > `+sqliteNormalizedTimestampExpr("r.synced_at")+`)
 		ORDER BY r.id
 		LIMIT ?
-	`, machineID, adoptedMaxJobID, limit)
+	`, machineID, adoptedMaxJobID, adoptedAt, limit)
 	if err != nil {
 		return nil, fmt.Errorf("query reviews to sync: %w", err)
 	}
@@ -802,7 +836,7 @@ type SyncableResponse struct {
 // GetCommentsToSync returns comments created locally that need to be pushed.
 // Only returns comments whose parent job has already been synced.
 func (db *DB) GetCommentsToSync(machineID string, limit int) ([]SyncableResponse, error) {
-	adoptedMaxJobID := db.adoptionBoundary()
+	adoptedMaxJobID, adoptedAt := db.adoptionBoundary()
 	rows, err := db.Query(`
 		SELECT
 			r.id, r.uuid, r.job_id, j.uuid,
@@ -816,13 +850,14 @@ func (db *DB) GetCommentsToSync(machineID string, limit int) ([]SyncableResponse
 		AND j.synced_at IS NOT NULL
 		-- Adoption stamps a parent as synced without ever pushing it, so its
 		-- children must not be pushed either: they would reference a job the
-		-- target has never seen and violate the job_uuid foreign key. Pre-
-		-- adoption children stay local for this target, which is what
-		-- skip_backfill asks for; work created after adoption syncs normally.
-		AND j.id > ?
+		-- target has never seen and violate the job_uuid foreign key. The guard
+		-- lifts as soon as the parent is pushed for real, which covers a job
+		-- that was still queued at adoption and a stamped one that was later
+		-- edited. Work created after adoption is past the id boundary already.
+		AND NOT (j.id <= ? AND `+sqliteNormalizedTimestampExpr("j.synced_at")+` <= datetime(?))
 		ORDER BY r.id
 		LIMIT ?
-	`, machineID, adoptedMaxJobID, limit)
+	`, machineID, adoptedMaxJobID, adoptedAt, limit)
 	if err != nil {
 		return nil, fmt.Errorf("query responses to sync: %w", err)
 	}

--- a/internal/storage/sync.go
+++ b/internal/storage/sync.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -17,7 +18,12 @@ const (
 	SyncStateLastReviewCursor = "last_review_cursor" // Composite cursor for reviews (updated_at,id)
 	SyncStateLastResponseID   = "last_response_id"   // inserted_at/id cursor of last synced response
 	SyncStateSyncTargetID     = "sync_target_id"     // Database ID of last synced Postgres
-	SyncStateDatabaseID       = "database_id"        // Stable identity of this local SQLite database
+	// SyncStateAdoptedMaxJobID is the highest review_jobs.id stamped by
+	// MarkAllSyncedNow. Rows at or below it carry a synced_at that means
+	// "predates this target", not "pushed to this target"; monotonic ids avoid
+	// comparing the mixed-format timestamps synced_at can hold.
+	SyncStateAdoptedMaxJobID = "adopted_max_job_id"
+	SyncStateDatabaseID      = "database_id" // Stable identity of this local SQLite database
 )
 
 // GetSyncState retrieves a value from the sync_state table.
@@ -189,26 +195,41 @@ func (db *DB) ClearAllSyncedAt() error {
 	return nil
 }
 
-// MarkAllSyncedNow stamps synced_at on every local row that has none, so a
-// newly connected database receives only what changes from here on. It is the
-// inverse of ClearAllSyncedAt and is used when adopting a new sync target
-// without backfilling: pushing an entire local history into a database shared
-// with other people discloses unrelated local work.
+// MarkAllSyncedNow marks every local row as already synced, so a newly adopted
+// target receives only what changes from here on. It is the inverse of
+// ClearAllSyncedAt and is used when adopting a target without backfilling:
+// pushing an entire local history into a database shared with other people
+// discloses unrelated local work.
 //
-// Rows are stamped rather than deleted or flagged, so the existing push
-// selection (synced_at IS NULL OR updated_at > synced_at) needs no change: a
-// stamped row that is edited later still moves updated_at past synced_at and
-// syncs normally.
+// Rows are stamped from their OWN updated_at rather than wall-clock now, for two
+// reasons. It covers rows that were synced to a previous target and edited since
+// (a stale non-NULL synced_at with a newer updated_at), which a NULL-only stamp
+// would leave pending and push. And it keeps the comparison on one clock: these
+// timestamps have second granularity, so stamping "now" lets an edit made in the
+// same second compare equal to the stamp and never sync at all. Stamping the row
+// with its own updated_at means any later edit moves updated_at strictly past
+// synced_at and syncs normally. Responses carry no updated_at (they are
+// append-only and their eligibility is just a NULL check), so they take
+// created_at.
 func (db *DB) MarkAllSyncedNow() error {
-	now := time.Now().UTC().Format(time.RFC3339)
-	for _, table := range []string{"review_jobs", "reviews", "responses"} {
-		if _, err := db.Exec(
-			`UPDATE `+table+` SET synced_at = ? WHERE synced_at IS NULL`, now,
-		); err != nil {
-			return fmt.Errorf("mark %s synced: %w", table, err)
+	for _, q := range []string{
+		`UPDATE review_jobs SET synced_at = updated_at`,
+		`UPDATE reviews SET synced_at = updated_at`,
+		`UPDATE responses SET synced_at = created_at`,
+	} {
+		if _, err := db.Exec(q); err != nil {
+			return fmt.Errorf("mark rows synced: %w", err)
 		}
 	}
-	return nil
+	// Remember how far the stamp reached, so a child edited later can tell that
+	// its parent only LOOKS synced and carry it up (see GetJobsToSync).
+	var maxJobID sql.NullInt64
+	if err := db.QueryRow(`SELECT MAX(id) FROM review_jobs`).Scan(&maxJobID); err != nil {
+		return fmt.Errorf("read adopted max job id: %w", err)
+	}
+	return db.SetSyncState(
+		SyncStateAdoptedMaxJobID, strconv.FormatInt(maxJobID.Int64, 10),
+	)
 }
 
 // BackfillRepoIdentities computes and sets identity for repos that don't have one.
@@ -456,7 +477,34 @@ func (db *DB) GetJobsToSync(machineID string, limit int) ([]SyncableJob, error) 
 		WHERE j.status IN ('done', 'failed', 'canceled', 'skipped')
 		AND j.source_machine_id = ?
 		AND j.uuid IS NOT NULL
-		AND (j.synced_at IS NULL OR `+sqliteNormalizedTimestampExpr("j.updated_at")+` > `+sqliteNormalizedTimestampExpr("j.synced_at")+`)
+		AND (
+			j.synced_at IS NULL
+			OR `+sqliteNormalizedTimestampExpr("j.updated_at")+` > `+sqliteNormalizedTimestampExpr("j.synced_at")+`
+			-- Children are only eligible once their parent job counts as synced
+			-- (see GetReviewsToSync / GetCommentsToSync). After an adoption
+			-- stamp that is true for parents this target has never seen, so a
+			-- later edit to an old review would push a child whose parent is
+			-- absent and violate the job_uuid foreign key. Carry the parent up
+			-- in the same cycle: jobs are pushed before reviews and comments.
+			-- Scoped to adoption-stamped ids, so a normally-synced parent with a
+			-- pending child (the steady state) is NOT re-pushed.
+			OR (j.id <= COALESCE((
+				SELECT CAST(value AS INTEGER) FROM sync_state
+				WHERE key = 'adopted_max_job_id'
+			), 0) AND (
+			EXISTS (
+				SELECT 1 FROM reviews rv
+				WHERE rv.job_id = j.id AND rv.uuid IS NOT NULL
+				AND rv.updated_by_machine_id = j.source_machine_id
+				AND (rv.synced_at IS NULL OR `+sqliteNormalizedTimestampExpr("rv.updated_at")+` > `+sqliteNormalizedTimestampExpr("rv.synced_at")+`)
+			)
+			OR EXISTS (
+				SELECT 1 FROM responses rs
+				WHERE rs.job_id = j.id AND rs.uuid IS NOT NULL
+				AND rs.source_machine_id = j.source_machine_id
+				AND rs.synced_at IS NULL
+			)))
+		)
 		ORDER BY j.id
 		LIMIT ?
 	`, machineID, limit)

--- a/internal/storage/sync_ordering_test.go
+++ b/internal/storage/sync_ordering_test.go
@@ -725,14 +725,12 @@ func TestMarkAllSyncedNow(t *testing.T) {
 	_, err := h.db.AddCommentToJob(job.ID, "user", "test response")
 	require.NoError(t, err)
 
-	// Pre-existing work is pending: this is what a full backfill would push.
 	jobs, err := h.db.GetJobsToSync(h.machineID, 100)
 	require.NoError(t, err)
 	require.NotEmpty(t, jobs, "the job must be pending before the stamp")
 
 	require.NoError(t, h.db.MarkAllSyncedNow())
 
-	// Nothing pre-existing is offered to the new target.
 	jobs, err = h.db.GetJobsToSync(h.machineID, 100)
 	require.NoError(t, err)
 	assert.Empty(t, jobs, "stamped history must not be pushed to a new target")
@@ -749,4 +747,75 @@ func TestMarkAllSyncedNow(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, jobs, 1, "work created after the stamp must still sync")
 	assert.Equal(t, fresh.ID, jobs[0].ID)
+}
+
+// A row synced to a PREVIOUS target and edited since carries a stale non-NULL
+// synced_at with a newer updated_at. Stamping only NULL rows would leave it
+// pending and push it to the new target, which is the history the adopter asked
+// not to disclose.
+func TestMarkAllSyncedNowCoversStalePendingRows(t *testing.T) {
+	h := newSyncTestHelper(t)
+	job := h.createCompletedJob("stale-pending-sha")
+
+	// Synced to the old target, then edited locally.
+	h.setJobTimestamps(job.ID,
+		sql.NullString{String: "2026-01-01 00:00:00", Valid: true},
+		"2026-06-01 00:00:00")
+	pending, err := h.db.GetJobsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	require.NotEmpty(t, pending, "a locally edited row must be pending before adoption")
+
+	require.NoError(t, h.db.MarkAllSyncedNow())
+
+	pending, err = h.db.GetJobsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	assert.Empty(t, pending, "a stale pending row must not survive adoption")
+}
+
+// Stamping from the row's own updated_at keeps the comparison on one clock.
+// Stamping wall-clock now would let an edit in the same second compare equal to
+// the stamp and never sync, because these timestamps are second-granular.
+func TestMarkAllSyncedNowStampsFromUpdatedAt(t *testing.T) {
+	h := newSyncTestHelper(t)
+	job := h.createCompletedJob("same-second-sha")
+	h.setJobTimestamps(job.ID, sql.NullString{}, "2026-06-01 00:00:00")
+
+	require.NoError(t, h.db.MarkAllSyncedNow())
+
+	var syncedAt sql.NullString
+	require.NoError(t, h.db.QueryRow(
+		`SELECT synced_at FROM review_jobs WHERE id = ?`, job.ID).Scan(&syncedAt))
+	require.True(t, syncedAt.Valid)
+	assert.Equal(t, "2026-06-01 00:00:00", syncedAt.String,
+		"the stamp must be the row's own updated_at, not wall-clock now")
+}
+
+// Children are only eligible once their parent job counts as synced. An
+// adoption stamp makes that true for parents the new target has never seen, so
+// editing an old review must carry its parent up in the same cycle rather than
+// pushing a child whose parent is absent (a job_uuid foreign-key violation).
+func TestAdoptedParentIsPushedWithItsPendingChild(t *testing.T) {
+	h := newSyncTestHelper(t)
+	job := h.createCompletedJob("orphan-child-sha")
+	require.NoError(t, h.db.MarkAllSyncedNow())
+
+	jobs, err := h.db.GetJobsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	require.Empty(t, jobs, "nothing is pending immediately after adoption")
+
+	// Edit a pre-adoption review: it becomes eligible, so its parent must too.
+	review, err := h.db.GetReviewByJobID(job.ID)
+	require.NoError(t, err)
+	h.setReviewTimestamps(review.ID,
+		sql.NullString{String: "2026-01-01 00:00:00", Valid: true},
+		"2026-06-01 00:00:00")
+
+	pendingReviews, err := h.db.GetReviewsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	require.NotEmpty(t, pendingReviews, "the edited review must be pending")
+
+	jobs, err = h.db.GetJobsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	require.Len(t, jobs, 1, "the parent job must be pushed alongside its pending child")
+	assert.Equal(t, job.ID, jobs[0].ID)
 }

--- a/internal/storage/sync_ordering_test.go
+++ b/internal/storage/sync_ordering_test.go
@@ -715,3 +715,38 @@ func TestSyncOrder_FullWorkflow(t *testing.T) {
 
 	assert.Len(t, responses, 3)
 }
+
+// MarkAllSyncedNow is the inverse of ClearAllSyncedAt: after it, a newly
+// adopted sync target receives only work created from that point on.
+func TestMarkAllSyncedNow(t *testing.T) {
+	h := newSyncTestHelper(t)
+
+	job := h.createCompletedJob("skip-backfill-sha")
+	_, err := h.db.AddCommentToJob(job.ID, "user", "test response")
+	require.NoError(t, err)
+
+	// Pre-existing work is pending: this is what a full backfill would push.
+	jobs, err := h.db.GetJobsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	require.NotEmpty(t, jobs, "the job must be pending before the stamp")
+
+	require.NoError(t, h.db.MarkAllSyncedNow())
+
+	// Nothing pre-existing is offered to the new target.
+	jobs, err = h.db.GetJobsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	assert.Empty(t, jobs, "stamped history must not be pushed to a new target")
+	reviews, err := h.db.GetReviewsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	assert.Empty(t, reviews)
+	comments, err := h.db.GetCommentsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	assert.Empty(t, comments)
+
+	// New work still syncs: the stamp is a floor, not a mute.
+	fresh := h.createCompletedJob("after-the-stamp-sha")
+	jobs, err = h.db.GetJobsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	require.Len(t, jobs, 1, "work created after the stamp must still sync")
+	assert.Equal(t, fresh.ID, jobs[0].ID)
+}

--- a/internal/storage/sync_ordering_test.go
+++ b/internal/storage/sync_ordering_test.go
@@ -826,3 +826,89 @@ func TestAdoptionHoldsPreAdoptionChildren(t *testing.T) {
 	require.Len(t, reviews, 1, "post-adoption children must sync normally")
 	assert.Equal(t, freshReview.ID, reviews[0].ID)
 }
+
+// The boundary describes one adoption of one target. A later full re-sync
+// re-pushes the parent jobs, so leaving it in place would permanently exclude
+// their reviews and comments and land the target with bodyless jobs.
+func TestClearAllSyncedAtForgetsTheAdoptionBoundary(t *testing.T) {
+	h := newSyncTestHelper(t)
+	job := h.createCompletedJob("boundary-lifetime-sha")
+	require.NoError(t, h.db.MarkAllSyncedNow())
+
+	review, err := h.db.GetReviewByJobID(job.ID)
+	require.NoError(t, err)
+	h.setReviewTimestamps(review.ID, sql.NullString{}, "2026-06-01 00:00:00")
+	reviews, err := h.db.GetReviewsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	require.Empty(t, reviews, "the guard must apply while the adoption stands")
+
+	// Switching to a replaced target re-pushes everything, so the guard must go.
+	// The child still waits for its parent to actually land, as it always does,
+	// but once the parent is pushed the boundary must no longer exclude it.
+	require.NoError(t, h.db.ClearAllSyncedAt())
+	require.NoError(t, h.db.MarkJobSynced(job.ID))
+	reviews, err = h.db.GetReviewsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	require.Len(t, reviews, 1, "a full re-sync must not leave children excluded")
+}
+
+// A job still queued at adoption is never stamped, so when it completes and is
+// pushed for real its children must follow. The id boundary alone would block
+// them forever, because the job's id predates the adoption.
+func TestQueuedAtAdoptionReleasesItsChildrenOncePushed(t *testing.T) {
+	h := newSyncTestHelper(t)
+	job := h.createCompletedJob("queued-at-adoption-sha")
+	// Look like a job that was not terminal at adoption: no stamp of its own.
+	require.NoError(t, h.db.MarkAllSyncedNow())
+	h.setJobTimestamps(job.ID, sql.NullString{}, "2026-06-01 00:00:00")
+
+	review, err := h.db.GetReviewByJobID(job.ID)
+	require.NoError(t, err)
+	h.setReviewTimestamps(review.ID, sql.NullString{}, "2026-06-01 00:00:00")
+
+	// Pushed for real after adoption: synced_at moves past the adoption time.
+	h.setJobTimestamps(job.ID,
+		sql.NullString{String: "2099-01-01 00:00:00", Valid: true},
+		"2026-06-01 00:00:00")
+
+	reviews, err := h.db.GetReviewsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	require.Len(t, reviews, 1, "a parent pushed after adoption must release its children")
+	assert.Equal(t, review.ID, reviews[0].ID)
+}
+
+// HasSyncHistory decides whether an unrecorded target id is a genuine first
+// adoption or an upgrade from a version that predates target tracking.
+func TestHasSyncHistory(t *testing.T) {
+	t.Run("empty database has no history", func(t *testing.T) {
+		h := newSyncTestHelper(t)
+		got, err := h.db.HasSyncHistory()
+		require.NoError(t, err)
+		assert.False(t, got)
+	})
+
+	t.Run("a pull cursor counts as history", func(t *testing.T) {
+		h := newSyncTestHelper(t)
+		require.NoError(t, h.db.SetSyncState(SyncStateLastJobCursor, "42"))
+		got, err := h.db.HasSyncHistory()
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	t.Run("a stamped row counts as history", func(t *testing.T) {
+		h := newSyncTestHelper(t)
+		job := h.createCompletedJob("history-sha")
+		require.NoError(t, h.db.MarkJobSynced(job.ID))
+		got, err := h.db.HasSyncHistory()
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	t.Run("unsynced rows alone are not history", func(t *testing.T) {
+		h := newSyncTestHelper(t)
+		h.createCompletedJob("unsynced-sha")
+		got, err := h.db.HasSyncHistory()
+		require.NoError(t, err)
+		assert.False(t, got)
+	})
+}

--- a/internal/storage/sync_ordering_test.go
+++ b/internal/storage/sync_ordering_test.go
@@ -790,32 +790,39 @@ func TestMarkAllSyncedNowStampsFromUpdatedAt(t *testing.T) {
 		"the stamp must be the row's own updated_at, not wall-clock now")
 }
 
-// Children are only eligible once their parent job counts as synced. An
-// adoption stamp makes that true for parents the new target has never seen, so
-// editing an old review must carry its parent up in the same cycle rather than
-// pushing a child whose parent is absent (a job_uuid foreign-key violation).
-func TestAdoptedParentIsPushedWithItsPendingChild(t *testing.T) {
+// Adoption stamps a parent as synced without ever pushing it, so its children
+// must not be pushed either: they would reference a job the target has never
+// seen and violate the job_uuid foreign key. Pre-adoption children stay local
+// for this target; work created after adoption syncs normally.
+func TestAdoptionHoldsPreAdoptionChildren(t *testing.T) {
 	h := newSyncTestHelper(t)
-	job := h.createCompletedJob("orphan-child-sha")
+	old := h.createCompletedJob("pre-adoption-sha")
 	require.NoError(t, h.db.MarkAllSyncedNow())
 
-	jobs, err := h.db.GetJobsToSync(h.machineID, 100)
-	require.NoError(t, err)
-	require.Empty(t, jobs, "nothing is pending immediately after adoption")
-
-	// Edit a pre-adoption review: it becomes eligible, so its parent must too.
-	review, err := h.db.GetReviewByJobID(job.ID)
+	// Edit a pre-adoption review: pending on its own terms, but its parent was
+	// never pushed to this target.
+	review, err := h.db.GetReviewByJobID(old.ID)
 	require.NoError(t, err)
 	h.setReviewTimestamps(review.ID,
 		sql.NullString{String: "2026-01-01 00:00:00", Valid: true},
 		"2026-06-01 00:00:00")
 
-	pendingReviews, err := h.db.GetReviewsToSync(h.machineID, 100)
+	reviews, err := h.db.GetReviewsToSync(h.machineID, 100)
 	require.NoError(t, err)
-	require.NotEmpty(t, pendingReviews, "the edited review must be pending")
+	assert.Empty(t, reviews, "a child whose parent was never pushed must be held")
+	_, err = h.db.AddCommentToJob(old.ID, "user", "post-adoption comment")
+	require.NoError(t, err)
+	comments, err := h.db.GetCommentsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	assert.Empty(t, comments, "comments on a pre-adoption job must be held too")
 
-	jobs, err = h.db.GetJobsToSync(h.machineID, 100)
+	// Work created after adoption is unaffected.
+	fresh := h.createCompletedJob("post-adoption-sha")
+	require.NoError(t, h.db.MarkJobSynced(fresh.ID))
+	freshReview, err := h.db.GetReviewByJobID(fresh.ID)
 	require.NoError(t, err)
-	require.Len(t, jobs, 1, "the parent job must be pushed alongside its pending child")
-	assert.Equal(t, job.ID, jobs[0].ID)
+	reviews, err = h.db.GetReviewsToSync(h.machineID, 100)
+	require.NoError(t, err)
+	require.Len(t, reviews, 1, "post-adoption children must sync normally")
+	assert.Equal(t, freshReview.ID, reviews[0].ID)
 }

--- a/internal/storage/syncworker.go
+++ b/internal/storage/syncworker.go
@@ -374,9 +374,6 @@ func (w *SyncWorker) run(stopCh, doneCh chan struct{}, interval, connectTimeout 
 	}
 }
 
-// connect establishes the PostgreSQL connection.
-// Serialized by connectMu to prevent concurrent connection attempts.
-// Returns (true, nil) if a new connection was made, (false, nil) if already connected.
 // adoptionAction is what adopting a sync target means for the PUSH direction.
 type adoptionAction int
 
@@ -396,19 +393,35 @@ const (
 // is then pointed at a shared database must not upload all of it. It does NOT
 // clear, because there is no previous target whose state needs discarding and
 // clearing would re-push rows a pre-target-tracking version already sent.
-func adoptionActionFor(lastTargetID, dbID string, skipBackfill bool) adoptionAction {
+func adoptionActionFor(
+	lastTargetID, dbID string, skipBackfill, syncedBefore bool,
+) adoptionAction {
 	if lastTargetID == dbID {
+		return adoptionNone
+	}
+	if lastTargetID == "" {
+		// No recorded target is normally a first adoption, but it is also what
+		// an upgrade from a version that predates target tracking looks like.
+		// Evidence of previous syncing means this is that upgrade, reconnecting
+		// to the SAME database, so stamping would discard genuinely pending
+		// rows and clearing would re-push everything.
+		if syncedBefore {
+			return adoptionNone
+		}
+		if skipBackfill {
+			return adoptionStamp
+		}
 		return adoptionNone
 	}
 	if skipBackfill {
 		return adoptionStamp
 	}
-	if lastTargetID == "" {
-		return adoptionNone
-	}
 	return adoptionClear
 }
 
+// connect establishes the PostgreSQL connection.
+// Serialized by connectMu to prevent concurrent connection attempts.
+// Returns (true, nil) if a new connection was made, (false, nil) if already connected.
 func (w *SyncWorker) connect(timeout time.Duration) (bool, error) {
 	w.connectMu.Lock()
 	defer w.connectMu.Unlock()
@@ -463,7 +476,14 @@ func (w *SyncWorker) connect(timeout time.Duration) (bool, error) {
 	// database would otherwise upload all of it. Only the PUSH direction is
 	// affected; pull cursors are reset either way, because receiving what the
 	// target already holds is the point of adopting it.
-	if act := adoptionActionFor(lastTargetID, dbID, w.cfg.SkipBackfill); act != adoptionNone {
+	syncedBefore, err := w.db.HasSyncHistory()
+	if err != nil {
+		pool.Close()
+		return false, fmt.Errorf("check sync history: %w", err)
+	}
+	if act := adoptionActionFor(
+		lastTargetID, dbID, w.cfg.SkipBackfill, syncedBefore,
+	); act != adoptionNone {
 		oldID, newID := lastTargetID, dbID
 		if oldID == "" {
 			oldID = "none"

--- a/internal/storage/syncworker.go
+++ b/internal/storage/syncworker.go
@@ -481,9 +481,8 @@ func (w *SyncWorker) connect(timeout time.Duration) (bool, error) {
 		pool.Close()
 		return false, fmt.Errorf("check sync history: %w", err)
 	}
-	if act := adoptionActionFor(
-		lastTargetID, dbID, w.cfg.SkipBackfill, syncedBefore,
-	); act != adoptionNone {
+	act := adoptionActionFor(lastTargetID, dbID, w.cfg.SkipBackfill, syncedBefore)
+	if lastTargetID != dbID {
 		oldID, newID := lastTargetID, dbID
 		if oldID == "" {
 			oldID = "none"
@@ -510,8 +509,19 @@ func (w *SyncWorker) connect(timeout time.Duration) (bool, error) {
 				pool.Close()
 				return false, fmt.Errorf("clear synced_at: %w", err)
 			}
+		default:
+			// Nothing to reconcile on the push side, but any boundary from a
+			// previous adoption describes a target we are no longer talking to
+			// and would otherwise keep excluding children forever.
+			if err := w.db.ClearAdoptionBoundary(); err != nil {
+				pool.Close()
+				return false, fmt.Errorf("clear adoption boundary: %w", err)
+			}
 		}
-		// Also clear pull cursors so we pull all data from the new database
+		// Pull cursors belong to the target that issued them, so they are reset
+		// whenever the target changes, independent of what the push side does.
+		// Keeping them across an upgrade that never recorded a target id would
+		// permanently skip every remote row below the old cursors.
 		for _, key := range []string{SyncStateLastJobCursor, SyncStateLastReviewCursor, SyncStateLastResponseID} {
 			if err := w.db.SetSyncState(key, ""); err != nil {
 				pool.Close()

--- a/internal/storage/syncworker.go
+++ b/internal/storage/syncworker.go
@@ -433,10 +433,22 @@ func (w *SyncWorker) connect(timeout time.Duration) (bool, error) {
 		if len(newID) > 8 {
 			newID = newID[:8]
 		}
-		log.Printf("Sync: detected new Postgres database (was %s, now %s), clearing sync state for full re-sync", oldID, newID)
-		if err := w.db.ClearAllSyncedAt(); err != nil {
-			pool.Close()
-			return false, fmt.Errorf("clear synced_at: %w", err)
+		// Adopting a new target either re-pushes everything (the default, so a
+		// replaced database is repopulated) or starts from now. Only the PUSH
+		// direction is affected; pull cursors are reset either way, because
+		// receiving what the new target already holds is the point of joining it.
+		if w.cfg.SkipBackfill {
+			log.Printf("Sync: detected new Postgres database (was %s, now %s), starting from now (skip_backfill); existing local history is not pushed", oldID, newID)
+			if err := w.db.MarkAllSyncedNow(); err != nil {
+				pool.Close()
+				return false, fmt.Errorf("mark synced: %w", err)
+			}
+		} else {
+			log.Printf("Sync: detected new Postgres database (was %s, now %s), clearing sync state for full re-sync", oldID, newID)
+			if err := w.db.ClearAllSyncedAt(); err != nil {
+				pool.Close()
+				return false, fmt.Errorf("clear synced_at: %w", err)
+			}
 		}
 		// Also clear pull cursors so we pull all data from the new database
 		for _, key := range []string{SyncStateLastJobCursor, SyncStateLastReviewCursor, SyncStateLastResponseID} {

--- a/internal/storage/syncworker.go
+++ b/internal/storage/syncworker.go
@@ -377,6 +377,38 @@ func (w *SyncWorker) run(stopCh, doneCh chan struct{}, interval, connectTimeout 
 // connect establishes the PostgreSQL connection.
 // Serialized by connectMu to prevent concurrent connection attempts.
 // Returns (true, nil) if a new connection was made, (false, nil) if already connected.
+// adoptionAction is what adopting a sync target means for the PUSH direction.
+type adoptionAction int
+
+const (
+	// adoptionNone: same target as last time, nothing to reconcile.
+	adoptionNone adoptionAction = iota
+	// adoptionStamp: mark local rows as already synced so the target receives
+	// only what changes from here on (skip_backfill).
+	adoptionStamp
+	// adoptionClear: drop the watermarks so a REPLACED database is repopulated.
+	adoptionClear
+)
+
+// adoptionActionFor decides how a target change is reconciled. A first-ever
+// adoption (no recorded target) still stamps under skip_backfill, because that
+// is the common case: a machine that has been reviewing locally for months and
+// is then pointed at a shared database must not upload all of it. It does NOT
+// clear, because there is no previous target whose state needs discarding and
+// clearing would re-push rows a pre-target-tracking version already sent.
+func adoptionActionFor(lastTargetID, dbID string, skipBackfill bool) adoptionAction {
+	if lastTargetID == dbID {
+		return adoptionNone
+	}
+	if skipBackfill {
+		return adoptionStamp
+	}
+	if lastTargetID == "" {
+		return adoptionNone
+	}
+	return adoptionClear
+}
+
 func (w *SyncWorker) connect(timeout time.Duration) (bool, error) {
 	w.connectMu.Lock()
 	defer w.connectMu.Unlock()
@@ -424,26 +456,35 @@ func (w *SyncWorker) connect(timeout time.Duration) (bool, error) {
 		return false, fmt.Errorf("get sync target ID: %w", err)
 	}
 
-	if lastTargetID != "" && lastTargetID != dbID {
-		// Different database - clear all synced_at and pull cursors for full re-sync
+	// Adopting a target covers two cases: switching to a DIFFERENT database, and
+	// enabling sync for the first time (no recorded target). Both matter for
+	// skip_backfill, and the first-time case is the common one: a machine that
+	// has been reviewing locally for months and is then pointed at a shared
+	// database would otherwise upload all of it. Only the PUSH direction is
+	// affected; pull cursors are reset either way, because receiving what the
+	// target already holds is the point of adopting it.
+	if act := adoptionActionFor(lastTargetID, dbID, w.cfg.SkipBackfill); act != adoptionNone {
 		oldID, newID := lastTargetID, dbID
-		if len(oldID) > 8 {
+		if oldID == "" {
+			oldID = "none"
+		} else if len(oldID) > 8 {
 			oldID = oldID[:8]
 		}
 		if len(newID) > 8 {
 			newID = newID[:8]
 		}
-		// Adopting a new target either re-pushes everything (the default, so a
-		// replaced database is repopulated) or starts from now. Only the PUSH
-		// direction is affected; pull cursors are reset either way, because
-		// receiving what the new target already holds is the point of joining it.
-		if w.cfg.SkipBackfill {
-			log.Printf("Sync: detected new Postgres database (was %s, now %s), starting from now (skip_backfill); existing local history is not pushed", oldID, newID)
+		switch act {
+		case adoptionStamp:
+			log.Printf("Sync: adopting Postgres database (was %s, now %s), starting from now (skip_backfill); existing local history is not pushed", oldID, newID)
 			if err := w.db.MarkAllSyncedNow(); err != nil {
 				pool.Close()
 				return false, fmt.Errorf("mark synced: %w", err)
 			}
-		} else {
+		case adoptionClear:
+			// A REPLACED database has to be repopulated, so the default clears
+			// the watermarks. Not done on first adoption: there is no previous
+			// target whose state needs discarding, and clearing would re-push
+			// rows a pre-target-tracking version already sent.
 			log.Printf("Sync: detected new Postgres database (was %s, now %s), clearing sync state for full re-sync", oldID, newID)
 			if err := w.db.ClearAllSyncedAt(); err != nil {
 				pool.Close()

--- a/internal/storage/syncworker_adoption_test.go
+++ b/internal/storage/syncworker_adoption_test.go
@@ -20,18 +20,22 @@ func TestAdoptionActionFor(t *testing.T) {
 		lastTargetID string
 		dbID         string
 		skipBackfill bool
+		syncedBefore bool
 		want         adoptionAction
 	}{
-		{"first adoption with skip_backfill stamps", "", newTarget, true, adoptionStamp},
-		{"first adoption without skip_backfill does nothing", "", newTarget, false, adoptionNone},
-		{"changed target with skip_backfill stamps", oldTarget, newTarget, true, adoptionStamp},
-		{"changed target without skip_backfill clears", oldTarget, newTarget, false, adoptionClear},
-		{"same target does nothing", newTarget, newTarget, false, adoptionNone},
-		{"same target with skip_backfill does nothing", newTarget, newTarget, true, adoptionNone},
+		{"first adoption with skip_backfill stamps", "", newTarget, true, false, adoptionStamp},
+		{"first adoption without skip_backfill does nothing", "", newTarget, false, false, adoptionNone},
+		{"upgrade with sync history is not a first adoption", "", newTarget, true, true, adoptionNone},
+		{"changed target with skip_backfill stamps", oldTarget, newTarget, true, true, adoptionStamp},
+		{"changed target without skip_backfill clears", oldTarget, newTarget, false, true, adoptionClear},
+		{"same target does nothing", newTarget, newTarget, false, true, adoptionNone},
+		{"same target with skip_backfill does nothing", newTarget, newTarget, true, true, adoptionNone},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, adoptionActionFor(tc.lastTargetID, tc.dbID, tc.skipBackfill))
+			assert.Equal(t, tc.want, adoptionActionFor(
+				tc.lastTargetID, tc.dbID, tc.skipBackfill, tc.syncedBefore,
+			))
 		})
 	}
 }

--- a/internal/storage/syncworker_adoption_test.go
+++ b/internal/storage/syncworker_adoption_test.go
@@ -1,0 +1,37 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Adopting a sync target must pick the right push-direction reconciliation.
+// The first-ever adoption (no recorded target) is the case that matters most:
+// it is when a machine with existing local history is first pointed at a
+// shared database.
+func TestAdoptionActionFor(t *testing.T) {
+	const (
+		oldTarget = "db-aaaa"
+		newTarget = "db-bbbb"
+	)
+	cases := []struct {
+		name         string
+		lastTargetID string
+		dbID         string
+		skipBackfill bool
+		want         adoptionAction
+	}{
+		{"first adoption with skip_backfill stamps", "", newTarget, true, adoptionStamp},
+		{"first adoption without skip_backfill does nothing", "", newTarget, false, adoptionNone},
+		{"changed target with skip_backfill stamps", oldTarget, newTarget, true, adoptionStamp},
+		{"changed target without skip_backfill clears", oldTarget, newTarget, false, adoptionClear},
+		{"same target does nothing", newTarget, newTarget, false, adoptionNone},
+		{"same target with skip_backfill does nothing", newTarget, newTarget, true, adoptionNone},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, adoptionActionFor(tc.lastTargetID, tc.dbID, tc.skipBackfill))
+		})
+	}
+}


### PR DESCRIPTION
*** Alternate Solution Found ***

Closing this: it is the wrong approach.