### PR TITLE
Honor configured commands in check-agents

### DIFF
--- a/cmd/roborev/check_agents.go
+++ b/cmd/roborev/check_agents.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"go.kenn.io/roborev/internal/agent"
+	"go.kenn.io/roborev/internal/config"
 )
 
 func checkAgentsCmd() *cobra.Command {
@@ -35,6 +36,11 @@ Examples:
   roborev check-agents --timeout 30     # 30 second timeout per agent
   roborev check-agents --large-prompt   # Test with 33KB+ prompt (Windows limit check)`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.LoadGlobal()
+			if err != nil {
+				return fmt.Errorf("load global config: %w", err)
+			}
+
 			names := agent.Available()
 			sort.Strings(names)
 
@@ -61,21 +67,10 @@ Examples:
 					continue
 				}
 
-				if !agent.IsAvailable(name) {
-					a, _ := agent.Get(name)
-					cmdName := ""
-					if a != nil {
-						if ca, ok := a.(agent.CommandAgent); ok {
-							cmdName = ca.CommandName()
-						}
-					}
-					fmt.Printf("  - %-14s %s (not found in PATH)\n", name, cmdName)
+				a, err := agent.GetAvailableExactWithConfig(repoPath, name, cfg)
+				if err != nil {
+					fmt.Printf("  - %-14s %s\n", name, err)
 					skipped++
-					continue
-				}
-
-				a, _ := agent.GetAvailable(name)
-				if a == nil {
 					continue
 				}
 

--- a/cmd/roborev/check_agents_test.go
+++ b/cmd/roborev/check_agents_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.kenn.io/roborev/internal/testutil"
+)
+
+func TestCheckAgentsHonorsConfiguredCodexCommand(t *testing.T) {
+	setupConfigEnv(t, "codex_cmd = 'codex-proxy'\n", "")
+	t.Cleanup(testutil.MockExecutable(t, "codex", 1))
+	t.Cleanup(testutil.MockExecutable(t, "codex-proxy", 1))
+
+	cmd := checkAgentsCmd()
+	cmd.SetArgs([]string{"--agent", "codex", "--timeout", "1"})
+	output := captureOutput(t, cmd.Execute)
+
+	assert.Regexp(t, `(?m)^  \? codex\s+codex-proxy \(`, output)
+}


### PR DESCRIPTION
`roborev check-agents` bypassed configured command overrides and smoke-tested canonical agent binaries. Installations that route Codex or other agents through wrappers could therefore receive unrelated authentication or quota failures from a binary their actual jobs never use.

This makes health checks resolve each requested agent through the existing config-aware exact-agent path. The smoke test now exercises the configured command and will not silently fall back to a different agent, keeping diagnostics aligned with real job execution.

<sup>generated by a clanker</sup>