### PR TITLE
Bootstrap reusable CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_call:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/windows-migration.yml
+++ b/.github/workflows/windows-migration.yml
@@ -3,6 +3,7 @@ name: Windows Migration
 # Temporary: keep this isolated while validating the v0.56 -> current Windows
 # daemon migration path. Remove after the migration window closes, target 2026-08.
 on:
+  workflow_call:
   push:
     branches: [main]
   pull_request:


### PR DESCRIPTION
## Summary

- make the existing CI workflow callable from a later main-pinned dispatcher
- retain the current pull-request trigger and GitHub-hosted execution during the bootstrap phase

This preserves full pull-request validation while the runner-routing change is reviewed and landed separately.
