### PR TITLE
Stop shipping completed jobs' prompts and outputs in job listings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Test with coverage
         # -p 1 serializes package execution to avoid ROBOREV_DATA_DIR race conditions
         # between tests in different packages that modify this environment variable
-        run: go test -race -shuffle=on -tags integration -p 1 -coverprofile=coverage.out ./...
+        run: go test -timeout 30m -race -shuffle=on -tags integration -p 1 -coverprofile=coverage.out ./...
 
       - name: Upload coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0

--- a/cmd/roborev/tui/fetch.go
+++ b/cmd/roborev/tui/fetch.go
@@ -167,6 +167,10 @@ func listJobsQuery(values neturl.Values) *daemonclient.ListJobsQuery {
 		typed := daemonclient.ListJobsQueryHideClassifyJobs(value)
 		query.HideClassifyJobs = &typed
 	}
+	if value := values.Get("omit_prompt"); value != "" {
+		typed := daemonclient.ListJobsQueryOmitPrompt(value)
+		query.OmitPrompt = &typed
+	}
 	setStringParam("repo_prefix", &query.RepoPrefix)
 	setIntParam("limit", &query.Limit)
 	setIntParam("offset", &query.Offset)
@@ -216,6 +220,11 @@ func (m model) fetchJobs() tea.Cmd {
 		// Exclude fix jobs — they belong in the Tasks view, not the queue
 		params.Set("exclude_job_type", "fix")
 
+		// Metadata-only rows: completed jobs' prompts are never rendered
+		// from the queue and dominate the payload. Queued/running jobs
+		// keep their prompt server-side for the prompt view.
+		params.Set("omit_prompt", "true")
+
 		// Hide auto-design-router byproducts (classify rows + skipped design
 		// rows) unless the user opted in via show_classify_jobs. Resolved at
 		// fetch time so single-repo filters honor that repo's override.
@@ -260,6 +269,7 @@ func (m model) fetchMoreJobs() tea.Cmd {
 		params := neturl.Values{}
 		params.Set("limit", "50")
 		params.Set("offset", fmt.Sprintf("%d", offset))
+		params.Set("omit_prompt", "true")
 		for _, path := range m.activeRepoFilter {
 			params.Add("repo", path)
 		}
@@ -772,7 +782,7 @@ func (m model) fetchPanelMembers(runUUID string) tea.Cmd {
 	baseURL := m.endpoint.BaseURL()
 	client := m.client
 	return func() tea.Msg {
-		url := fmt.Sprintf("%s/api/jobs?panel_run=%s&limit=0", baseURL, neturl.QueryEscape(runUUID))
+		url := fmt.Sprintf("%s/api/jobs?panel_run=%s&limit=0&omit_prompt=true", baseURL, neturl.QueryEscape(runUUID))
 		resp, err := client.Get(url)
 		if err != nil {
 			return panelMembersMsg{runUUID: runUUID, err: err}
@@ -1047,6 +1057,7 @@ func (m model) fetchFixJobs() tea.Cmd {
 		params := neturl.Values{}
 		params.Set("job_type", "fix")
 		params.Set("limit", "200")
+		params.Set("omit_prompt", "true")
 
 		result, err := m.loadJobsPage(params)
 		if err != nil {

--- a/cmd/roborev/tui/fetch_test.go
+++ b/cmd/roborev/tui/fetch_test.go
@@ -5,10 +5,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	neturl "net/url"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/storage"
 )
 
 func TestListJobsParamsRepeatedRepo(t *testing.T) {
@@ -71,4 +74,55 @@ func TestFetchJobsMultiRepoUsesRepeatedRepoAndPaginates(t *testing.T) {
 	)
 	assert.NotEqual("0", jobsQuery.Get("limit"),
 		"multi-repo paginates instead of loading every job")
+}
+
+// Queue/task/panel listings never render completed jobs' prompts, so every
+// list fetch must request metadata-only rows: full prompts are ~91% of the
+// payload and repeated polls were the daemon's main allocation driver.
+// Detail views (single job, /api/review) still fetch the full record.
+func TestListFetchesRequestMetadataOnlyRows(t *testing.T) {
+	assert := assert.New(t)
+
+	var mu sync.Mutex
+	queries := make(map[string]neturl.Values)
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/jobs" {
+				mu.Lock()
+				key := "list"
+				switch {
+				case r.URL.Query().Get("panel_run") != "":
+					key = "panel"
+				case r.URL.Query().Get("job_type") == "fix":
+					key = "fix"
+				case r.URL.Query().Get("offset") != "":
+					key = "more"
+				}
+				queries[key] = r.URL.Query()
+				mu.Unlock()
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"jobs": []any{}, "has_more": false,
+			})
+		},
+	))
+	defer ts.Close()
+
+	m := newModel(testEndpointFromURL(ts.URL), withExternalIODisabled())
+
+	_, ok := fetchJobsMessage(t, m).(jobsMsg)
+	require.True(t, ok)
+	m.jobs = []storage.ReviewJob{{ID: 1}}
+	m.fetchMoreJobs()()
+	m.fetchFixJobs()()
+	m.fetchPanelMembers("panel-run-uuid")()
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, key := range []string{"list", "more", "fix", "panel"} {
+		require.Contains(t, queries, key, "%s fetch should have hit /api/jobs", key)
+		assert.Equal("true", queries[key].Get("omit_prompt"),
+			"%s fetch must request metadata-only rows", key)
+	}
 }

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -950,10 +950,14 @@ const limitNotProvided = -999999
 // stripJobPrompts clears the large prompt and diff payloads from listed jobs
 // for omit_prompt=true callers. Metadata-only consumers such as the agent hook
 // daemon poll job lists on every hook event; shipping full prompts to them
-// costs tens of megabytes of encode/decode per request.
+// costs tens of megabytes of encode/decode per request. Queued/running jobs
+// keep their prompt — the active set is small and it is the only way to see
+// what a not-yet-reviewed job was asked, matching ListJobs' WithoutPrompt.
 func stripJobPrompts(jobs []storage.ReviewJob) {
 	for i := range jobs {
-		jobs[i].Prompt = ""
+		if jobs[i].Status != storage.JobStatusQueued && jobs[i].Status != storage.JobStatusRunning {
+			jobs[i].Prompt = ""
+		}
 		jobs[i].DiffContent = nil
 	}
 }

--- a/internal/daemon/server_jobs_test.go
+++ b/internal/daemon/server_jobs_test.go
@@ -2689,11 +2689,22 @@ func TestListJobsOmitPrompt(t *testing.T) {
 	repo, err := db.GetOrCreateRepo("/test/omit-prompt-repo")
 	require.NoError(t, err)
 	diff := "diff --git a/f b/f"
-	_, err = db.EnqueueJob(storage.EnqueueOpts{
+	doneJob, err := db.EnqueueJob(storage.EnqueueOpts{
 		RepoID:      repo.ID,
-		GitRef:      "dirty",
+		GitRef:      "done-ref",
 		Agent:       "test",
 		Prompt:      "a very large stored prompt",
+		DiffContent: diff,
+	})
+	require.NoError(t, err)
+	_, err = db.ClaimJob("worker-omit")
+	require.NoError(t, err)
+	require.NoError(t, db.CompleteJob(doneJob.ID, "test", "a very large stored prompt", "No issues found."))
+	queuedJob, err := db.EnqueueJob(storage.EnqueueOpts{
+		RepoID:      repo.ID,
+		GitRef:      "queued-ref",
+		Agent:       "test",
+		Prompt:      "a queued prompt",
 		DiffContent: diff,
 	})
 	require.NoError(t, err)
@@ -2717,27 +2728,48 @@ func TestListJobsOmitPrompt(t *testing.T) {
 		return *resp.JSON200.Jobs
 	}
 
+	jobByID := func(t *testing.T, jobs []daemonclient.ReviewJob, id int64) daemonclient.ReviewJob {
+		t.Helper()
+		for _, j := range jobs {
+			if j.Id == id {
+				return j
+			}
+		}
+		t.Fatalf("job %d not in listing", id)
+		return daemonclient.ReviewJob{}
+	}
+
 	t.Run("default includes prompt", func(t *testing.T) {
 		jobs := listJobs(t, &daemonclient.ListJobsParams{Repo: &repoFilter})
+		require.Len(t, jobs, 2)
+		done := jobByID(t, jobs, doneJob.ID)
+		require.NotNil(t, done.Prompt)
+		assert.Equal("a very large stored prompt", *done.Prompt)
+	})
+
+	t.Run("omit_prompt=true strips terminal jobs, keeps queued", func(t *testing.T) {
+		jobs := listJobs(t, &daemonclient.ListJobsParams{Repo: &repoFilter, OmitPrompt: &omit})
+		require.Len(t, jobs, 2)
+		done := jobByID(t, jobs, doneJob.ID)
+		assert.Nil(done.Prompt)
+		assert.Nil(done.DiffContent)
+		queued := jobByID(t, jobs, queuedJob.ID)
+		require.NotNil(t, queued.Prompt)
+		assert.Equal("a queued prompt", *queued.Prompt)
+	})
+
+	t.Run("omit_prompt=true strips prompt on terminal single-job lookup", func(t *testing.T) {
+		jobs := listJobs(t, &daemonclient.ListJobsParams{Id: &doneJob.ID, OmitPrompt: &omit})
+		require.Len(t, jobs, 1)
+		assert.Nil(jobs[0].Prompt)
+		assert.Nil(jobs[0].DiffContent)
+	})
+
+	t.Run("omit_prompt=true keeps prompt on queued single-job lookup", func(t *testing.T) {
+		jobs := listJobs(t, &daemonclient.ListJobsParams{Id: &queuedJob.ID, OmitPrompt: &omit})
 		require.Len(t, jobs, 1)
 		require.NotNil(t, jobs[0].Prompt)
-		assert.Equal("a very large stored prompt", *jobs[0].Prompt)
-	})
-
-	t.Run("omit_prompt=true strips prompt and diff content", func(t *testing.T) {
-		jobs := listJobs(t, &daemonclient.ListJobsParams{Repo: &repoFilter, OmitPrompt: &omit})
-		require.Len(t, jobs, 1)
-		assert.Nil(jobs[0].Prompt)
-		assert.Nil(jobs[0].DiffContent)
-	})
-
-	t.Run("omit_prompt=true strips prompt on single-job lookup", func(t *testing.T) {
-		all := listJobs(t, &daemonclient.ListJobsParams{Repo: &repoFilter})
-		require.Len(t, all, 1)
-		jobs := listJobs(t, &daemonclient.ListJobsParams{Id: &all[0].Id, OmitPrompt: &omit})
-		require.Len(t, jobs, 1)
-		assert.Nil(jobs[0].Prompt)
-		assert.Nil(jobs[0].DiffContent)
+		assert.Equal("a queued prompt", *jobs[0].Prompt)
 	})
 }
 

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -698,6 +698,24 @@ func TestCostOptionsFromInput(t *testing.T) {
 	assert.Error(err)
 }
 
+func TestStripJobPromptsKeepsActiveJobs(t *testing.T) {
+	assert := assert.New(t)
+	diff := "diff"
+	jobs := []storage.ReviewJob{
+		{Status: storage.JobStatusQueued, Prompt: "queued prompt"},
+		{Status: storage.JobStatusRunning, Prompt: "running prompt"},
+		{Status: storage.JobStatusDone, Prompt: "done prompt", DiffContent: &diff},
+	}
+	stripJobPrompts(jobs)
+
+	assert.Equal("queued prompt", jobs[0].Prompt,
+		"queued jobs keep the prompt: it is the only way to see what was asked")
+	assert.Equal("running prompt", jobs[1].Prompt,
+		"running jobs keep the prompt for the TUI prompt view")
+	assert.Empty(jobs[2].Prompt, "terminal jobs are stripped")
+	assert.Nil(jobs[2].DiffContent, "diff content is always stripped")
+}
+
 func TestServerServesPprof(t *testing.T) {
 	assert := assert.New(t)
 	server, _, _ := newTestServer(t)

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -98,7 +98,7 @@ type ListJobsInput struct {
 	ExcludeJobType     string   `query:"exclude_job_type" doc:"Exclude jobs of this type"`
 	HideClassifyJobs   string   `query:"hide_classify_jobs" doc:"Hide auto-design-router rows (job_type=classify and status=skipped)" enum:"true,false,"`
 	PanelRun           string   `query:"panel_run" doc:"Return all jobs (members + synthesis) of one panel run"`
-	OmitPrompt         string   `query:"omit_prompt" doc:"Omit prompt and diff content from returned jobs (metadata-only listing)" enum:"true,false,"`
+	OmitPrompt         string   `query:"omit_prompt" doc:"Omit prompt and diff content from returned jobs (metadata-only listing; queued/running jobs keep their prompt)" enum:"true,false,"`
 	RepoPrefix         string   `query:"repo_prefix" doc:"Filter repos by path prefix"`
 	Limit              int      `query:"limit" default:"-999999" doc:"Max results (default 50, 0=unlimited, max 10000)"`
 	Offset             int      `query:"offset" default:"-1" doc:"Skip N results (requires limit>0)"`

--- a/internal/daemon_client/client.gen.go
+++ b/internal/daemon_client/client.gen.go
@@ -1187,7 +1187,7 @@ type ListJobsParams struct {
 	// PanelRun Return all jobs (members + synthesis) of one panel run
 	PanelRun *string `form:"panel_run,omitempty" json:"panel_run,omitempty"`
 
-	// OmitPrompt Omit prompt and diff content from returned jobs (metadata-only listing)
+	// OmitPrompt Omit prompt and diff content from returned jobs (metadata-only listing; queued/running jobs keep their prompt)
 	OmitPrompt *ListJobsParamsOmitPrompt `form:"omit_prompt,omitempty" json:"omit_prompt,omitempty"`
 
 	// RepoPrefix Filter repos by path prefix

--- a/internal/daemon_client/openapi-3.0.json
+++ b/internal/daemon_client/openapi-3.0.json
@@ -4149,12 +4149,12 @@
             }
           },
           {
-            "description": "Omit prompt and diff content from returned jobs (metadata-only listing)",
+            "description": "Omit prompt and diff content from returned jobs (metadata-only listing; queued/running jobs keep their prompt)",
             "explode": false,
             "in": "query",
             "name": "omit_prompt",
             "schema": {
-              "description": "Omit prompt and diff content from returned jobs (metadata-only listing)",
+              "description": "Omit prompt and diff content from returned jobs (metadata-only listing; queued/running jobs keep their prompt)",
               "enum": [
                 "true",
                 "false",

--- a/internal/storage/db_filter_test.go
+++ b/internal/storage/db_filter_test.go
@@ -1208,23 +1208,82 @@ func TestListJobsWithoutPrompt(t *testing.T) {
 	defer db.Close()
 	repo, err := db.GetOrCreateRepo("/tmp/without-prompt-repo")
 	require.NoError(t, err)
-	_, err = db.EnqueueJob(EnqueueOpts{
+
+	// Oldest job: claimed and completed → terminal, prompt must be stripped.
+	doneJob, err := db.EnqueueJob(EnqueueOpts{
 		RepoID: repo.ID,
-		GitRef: "dirty",
+		GitRef: "done-ref",
 		Agent:  "test",
-		Prompt: "a large stored prompt",
+		Prompt: "done prompt",
+	})
+	require.NoError(t, err)
+	claimJob(t, db, "worker-1")
+	require.NoError(t, db.CompleteJob(doneJob.ID, "test", "done prompt", "No issues found."))
+
+	// Second job: claimed → running, prompt must survive the metadata listing
+	// (the TUI prompt view reads it straight from the queue rows).
+	runningJob, err := db.EnqueueJob(EnqueueOpts{
+		RepoID: repo.ID,
+		GitRef: "running-ref",
+		Agent:  "test",
+		Prompt: "running prompt",
+	})
+	require.NoError(t, err)
+	claimJob(t, db, "worker-2")
+
+	// Third job: stays queued, prompt must also survive.
+	queuedJob, err := db.EnqueueJob(EnqueueOpts{
+		RepoID: repo.ID,
+		GitRef: "queued-ref",
+		Agent:  "test",
+		Prompt: "queued prompt",
 	})
 	require.NoError(t, err)
 
 	withPrompt, err := db.ListJobs("", repo.RootPath, 0, 0)
 	require.NoError(t, err)
-	require.Len(t, withPrompt, 1)
-	assert.Equal("a large stored prompt", withPrompt[0].Prompt, "default listing keeps the prompt")
+	require.Len(t, withPrompt, 3)
+	for _, j := range withPrompt {
+		assert.NotEmpty(j.Prompt, "default listing keeps every prompt")
+	}
 
 	withoutPrompt, err := db.ListJobs("", repo.RootPath, 0, 0, WithoutPrompt())
 	require.NoError(t, err)
-	require.Len(t, withoutPrompt, 1)
-	assert.Empty(withoutPrompt[0].Prompt, "WithoutPrompt must not hydrate the prompt column")
-	assert.Equal(withPrompt[0].ID, withoutPrompt[0].ID, "same job either way")
-	assert.Equal(withPrompt[0].GitRef, withoutPrompt[0].GitRef, "other fields still hydrated")
+	require.Len(t, withoutPrompt, 3)
+	byID := make(map[int64]ReviewJob, len(withoutPrompt))
+	for _, j := range withoutPrompt {
+		byID[j.ID] = j
+	}
+	assert.Empty(byID[doneJob.ID].Prompt, "terminal jobs must not hydrate the prompt column")
+	assert.Equal("running prompt", byID[runningJob.ID].Prompt, "running jobs keep the prompt")
+	assert.Equal("queued prompt", byID[queuedJob.ID].Prompt, "queued jobs keep the prompt")
+	assert.Equal("done-ref", byID[doneJob.ID].GitRef, "other fields still hydrated")
+}
+
+func TestListJobsParsesVerdictWhenVerdictBoolNull(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo := createRepo(t, db, filepath.Join(t.TempDir(), "null-verdict-list-repo"))
+
+	job, err := db.EnqueueJob(EnqueueOpts{RepoID: repo.ID, GitRef: "nullverdict123", Agent: "codex"})
+	require.NoError(t, err, "EnqueueJob failed: %v")
+
+	_, err = db.ClaimJob("worker-0")
+	require.NoError(t, err, "ClaimJob failed: %v")
+
+	err = db.CompleteJob(job.ID, "codex", "review prompt", "- Medium — Bug in line 42\nSummary: found issues.")
+	require.NoError(t, err, "CompleteJob failed: %v")
+
+	// Legacy rows (e.g. synced from an older machine) can lack verdict_bool;
+	// the listing must still fall back to parsing the output text.
+	_, err = db.Exec(`UPDATE reviews SET verdict_bool = NULL WHERE job_id = ?`, job.ID)
+	require.NoError(t, err, "clear verdict_bool failed: %v")
+
+	jobs, err := db.ListJobs("", "", 50, 0)
+	require.NoError(t, err, "ListJobs failed: %v")
+
+	require.Len(t, jobs, 1)
+	require.NotNil(t, jobs[0].Verdict)
+	assert.Equal(t, "F", *jobs[0].Verdict)
 }

--- a/internal/storage/db_job_test.go
+++ b/internal/storage/db_job_test.go
@@ -2044,3 +2044,22 @@ func TestEnqueuePostCommitJobAllowsCanceledReplacement(t *testing.T) {
 	assert.Nil(t, again)
 	assert.True(t, duplicate)
 }
+
+// Listings treat a non-NULL verdict_bool as proof that a non-empty review
+// output exists (so they can skip reading the output column). An empty-output
+// completion must therefore leave verdict_bool NULL, matching CompleteJob.
+func TestCompleteFixJobEmptyOutputLeavesVerdictNull(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo := createRepo(t, db, "/tmp/fix-empty-output-repo")
+	commit := createCommit(t, db, repo.ID, "fix123")
+	job := enqueueJob(t, db, repo.ID, commit.ID, "fix123")
+	claimJob(t, db, "w1")
+
+	require.NoError(t, db.CompleteFixJob(job.ID, "codex", "p", "", "patch content"))
+
+	var vb sql.NullInt64
+	require.NoError(t, db.QueryRow(`SELECT verdict_bool FROM reviews WHERE job_id = ?`, job.ID).Scan(&vb))
+	assert.False(t, vb.Valid, "empty output must not store a verdict")
+}

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -660,10 +660,16 @@ func (db *DB) CompleteFixJob(jobID int64, agent, prompt, output, patch string) e
 		return nil // Job was canceled
 	}
 
-	verdictBool := verdictToBool(ParseVerdict(finalOutput))
+	// Only store a verdict for non-empty output, matching CompleteJob:
+	// listings treat a non-NULL verdict_bool as proof that a non-empty
+	// review output exists and skip reading the output column.
+	var verdictBoolVal any
+	if finalOutput != "" {
+		verdictBoolVal = verdictToBool(ParseVerdict(finalOutput))
+	}
 	_, err = conn.ExecContext(ctx,
 		`INSERT INTO reviews (job_id, agent, prompt, output, verdict_bool, uuid, updated_by_machine_id, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		jobID, agent, prompt, finalOutput, verdictBool, reviewUUID, machineID, now)
+		jobID, agent, prompt, finalOutput, verdictBoolVal, reviewUUID, machineID, now)
 	if err != nil {
 		return err
 	}
@@ -1237,13 +1243,18 @@ func (db *DB) ListJobs(statusFilter string, repoFilter string, limit, offset int
 	// The review output is only needed to parse a verdict for legacy rows
 	// where verdict_bool is NULL (e.g. synced from older machines); rows with
 	// a stored verdict skip the large TEXT payload and pass the existence
-	// flag instead.
+	// flag instead. Both expressions must stay lazy CASEs: evaluating
+	// rv.output at all (even just != '') materializes the full text, so the
+	// flag returns 1 straight from verdict_bool — writers and the startup
+	// backfill guarantee a non-NULL verdict implies a non-empty output.
 	query := `
 		SELECT j.id, j.repo_id, j.commit_id, j.git_ref, j.branch, j.ci_base_branch, j.session_id, j.agent, j.reasoning, j.status, j.enqueued_at,
 		       j.started_at, j.finished_at, j.worker_id, j.error, ` + promptExpr + `, j.retry_count,
 		       COALESCE(j.agentic, 0), COALESCE(j.prompt_prebuilt, 0), r.root_path, r.name, c.subject, rv.closed,
 		       CASE WHEN rv.verdict_bool IS NULL THEN rv.output ELSE '' END,
-		       rv.verdict_bool, COALESCE(rv.output != '', 0), j.source_machine_id, j.uuid, j.model, j.job_type, j.review_type, j.patch_id, COALESCE(j.output_prefix, ''),
+		       rv.verdict_bool,
+		       CASE WHEN rv.verdict_bool IS NOT NULL THEN 1 ELSE COALESCE(rv.output != '', 0) END,
+		       j.source_machine_id, j.uuid, j.model, j.job_type, j.review_type, j.patch_id, COALESCE(j.output_prefix, ''),
 		       j.parent_job_id, j.provider, j.requested_model, j.requested_provider, j.token_usage, COALESCE(j.worktree_path, ''),
 		       j.command_line, j.dirty_files, COALESCE(j.min_severity, ''), COALESCE(j.backup_agent, ''), COALESCE(j.backup_model, ''),
 		       COALESCE(j.skip_reason, ''), COALESCE(j.source, ''),

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -1053,10 +1053,12 @@ func WithClosed(closed bool) ListJobsOption {
 	return func(o *listJobsOptions) { o.closed = &closed }
 }
 
-// WithoutPrompt selects an empty string in place of the prompt column so
-// metadata-only listings never read the stored prompts. Prompts embed full
-// diffs, so on repos with a long review history hydrating them costs tens of
-// megabytes of SQLite reads and string allocations per listing.
+// WithoutPrompt selects an empty string in place of the prompt column for
+// terminal jobs so metadata-only listings never read their stored prompts.
+// Prompts embed full diffs, so on repos with a long review history hydrating
+// them costs tens of megabytes of SQLite reads and string allocations per
+// listing. Queued/running jobs keep their prompt: the active set is small and
+// the TUI prompt view renders it straight from list rows.
 func WithoutPrompt() ListJobsOption {
 	return func(o *listJobsOptions) { o.omitPrompt = true }
 }
@@ -1224,18 +1226,24 @@ func buildJobFilterClause(statusFilter, repoFilter string, o listJobsOptions) (s
 // ListJobs returns jobs with optional status, repo, branch, and closed filters.
 func (db *DB) ListJobs(statusFilter string, repoFilter string, limit, offset int, opts ...ListJobsOption) ([]ReviewJob, error) {
 	options := collectListJobsOptions(opts...)
-	// Metadata-only listings select a constant instead of the prompt column;
-	// the scan still binds the same positional field, it just never touches
-	// the large TEXT payload.
+	// Metadata-only listings skip the prompt column for terminal jobs; the
+	// scan still binds the same positional field, it just never touches the
+	// large TEXT payload. Queued/running rows keep their prompt: the active
+	// set is small and the TUI prompt view reads it straight from list rows.
 	promptExpr := "j.prompt"
 	if options.omitPrompt {
-		promptExpr = "''"
+		promptExpr = "CASE WHEN j.status IN ('queued', 'running') THEN j.prompt ELSE '' END"
 	}
+	// The review output is only needed to parse a verdict for legacy rows
+	// where verdict_bool is NULL (e.g. synced from older machines); rows with
+	// a stored verdict skip the large TEXT payload and pass the existence
+	// flag instead.
 	query := `
 		SELECT j.id, j.repo_id, j.commit_id, j.git_ref, j.branch, j.ci_base_branch, j.session_id, j.agent, j.reasoning, j.status, j.enqueued_at,
 		       j.started_at, j.finished_at, j.worker_id, j.error, ` + promptExpr + `, j.retry_count,
-		       COALESCE(j.agentic, 0), COALESCE(j.prompt_prebuilt, 0), r.root_path, r.name, c.subject, rv.closed, rv.output,
-		       rv.verdict_bool, j.source_machine_id, j.uuid, j.model, j.job_type, j.review_type, j.patch_id, COALESCE(j.output_prefix, ''),
+		       COALESCE(j.agentic, 0), COALESCE(j.prompt_prebuilt, 0), r.root_path, r.name, c.subject, rv.closed,
+		       CASE WHEN rv.verdict_bool IS NULL THEN rv.output ELSE '' END,
+		       rv.verdict_bool, COALESCE(rv.output != '', 0), j.source_machine_id, j.uuid, j.model, j.job_type, j.review_type, j.patch_id, COALESCE(j.output_prefix, ''),
 		       j.parent_job_id, j.provider, j.requested_model, j.requested_provider, j.token_usage, COALESCE(j.worktree_path, ''),
 		       j.command_line, j.dirty_files, COALESCE(j.min_severity, ''), COALESCE(j.backup_agent, ''), COALESCE(j.backup_model, ''),
 		       COALESCE(j.skip_reason, ''), COALESCE(j.source, ''),
@@ -1271,12 +1279,13 @@ func (db *DB) ListJobs(statusFilter string, repoFilter string, limit, offset int
 		var j ReviewJob
 		var output sql.NullString
 		var verdictBool sql.NullInt64
+		var hasOutput bool
 		var fields reviewJobScanFields
 
 		err := rows.Scan(&j.ID, &j.RepoID, &fields.CommitID, &j.GitRef, &fields.Branch, &fields.CIBaseBranch, &fields.SessionID, &j.Agent, &j.Reasoning, &j.Status, &fields.EnqueuedAt,
 			&fields.StartedAt, &fields.FinishedAt, &fields.WorkerID, &fields.Error, &fields.Prompt, &j.RetryCount,
 			&fields.Agentic, &fields.PromptPrebuilt, &j.RepoPath, &j.RepoName, &fields.CommitSubject, &fields.Closed, &output,
-			&verdictBool, &fields.SourceMachineID, &fields.UUID, &fields.Model, &fields.JobType, &fields.ReviewType, &fields.PatchID, &fields.OutputPrefix,
+			&verdictBool, &hasOutput, &fields.SourceMachineID, &fields.UUID, &fields.Model, &fields.JobType, &fields.ReviewType, &fields.PatchID, &fields.OutputPrefix,
 			&fields.ParentJobID, &fields.Provider, &fields.RequestedModel, &fields.RequestedProvider, &fields.TokenUsage, &fields.WorktreePath,
 			&fields.CommandLine, &fields.DirtyFiles, &fields.MinSeverity, &fields.BackupAgent, &fields.BackupModel,
 			&fields.SkipReason, &fields.Source,
@@ -1285,9 +1294,7 @@ func (db *DB) ListJobs(statusFilter string, repoFilter string, limit, offset int
 			return nil, err
 		}
 		applyReviewJobScan(&j, fields)
-		if output.Valid {
-			applyJobVerdict(&j, verdictBool, output.String)
-		}
+		applyJobVerdict(&j, verdictBool, output.String, hasOutput)
 
 		jobs = append(jobs, j)
 	}
@@ -1893,7 +1900,7 @@ func (db *DB) GetPanelMembers(panelRunUUID string) ([]ReviewJob, error) {
 		}
 		applyReviewJobScan(&j, fields)
 		if output.Valid {
-			applyJobVerdict(&j, verdictBool, output.String)
+			applyJobVerdict(&j, verdictBool, output.String, output.String != "")
 		}
 		jobs = append(jobs, j)
 	}
@@ -1943,7 +1950,7 @@ func (db *DB) GetSynthesisJob(panelRunUUID string) (*ReviewJob, error) {
 	}
 	applyReviewJobScan(&j, fields)
 	if output.Valid {
-		applyJobVerdict(&j, verdictBool, output.String)
+		applyJobVerdict(&j, verdictBool, output.String, output.String != "")
 	}
 	return &j, nil
 }

--- a/internal/storage/repos.go
+++ b/internal/storage/repos.go
@@ -548,7 +548,7 @@ func (db *DB) GetRepoStats(repoID int64) (*RepoStats, error) {
 			continue
 		}
 
-		applyJobVerdict(&job, verdictBool, output)
+		applyJobVerdict(&job, verdictBool, output, output != "")
 		if job.Verdict != nil {
 			if *job.Verdict == verdictPass {
 				stats.PassedReviews++

--- a/internal/storage/reviews.go
+++ b/internal/storage/reviews.go
@@ -38,7 +38,7 @@ func (db *DB) GetReviewByJobID(jobID int64) (*Review, error) {
 	}
 	applyReviewScan(&r, reviewFields)
 	applyReviewJobScan(&job, jobFields)
-	applyJobVerdict(&job, reviewFields.VerdictBool, r.Output)
+	applyJobVerdict(&job, reviewFields.VerdictBool, r.Output, r.Output != "")
 
 	r.Job = &job
 
@@ -373,7 +373,7 @@ func (db *DB) GetJobsWithReviewsByIDs(jobIDs []int64) (map[int64]JobWithReview, 
 
 		if entry, ok := result[r.JobID]; ok {
 			entry.Review = &r
-			applyJobVerdict(&entry.Job, fields.VerdictBool, r.Output)
+			applyJobVerdict(&entry.Job, fields.VerdictBool, r.Output, r.Output != "")
 			result[r.JobID] = entry
 		}
 	}

--- a/internal/storage/summary.go
+++ b/internal/storage/summary.go
@@ -495,8 +495,20 @@ func summaryFailures(q querier, where string, args []any) (FailureStats, error) 
 }
 
 // BackfillVerdictBool populates verdict_bool for reviews that have output
-// but a NULL verdict_bool. Returns the number of rows updated.
+// but a NULL verdict_bool, and clears verdict_bool on empty-output rows
+// (written by older CompleteFixJob versions). Listings rely on a non-NULL
+// verdict_bool implying a non-empty output so they can skip reading the
+// output column. Returns the number of rows updated.
 func (db *DB) BackfillVerdictBool() (int, error) {
+	cleared, err := db.Exec(`UPDATE reviews SET verdict_bool = NULL WHERE verdict_bool IS NOT NULL AND output = ''`)
+	if err != nil {
+		return 0, err
+	}
+	clearedCount, err := cleared.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+
 	rows, err := db.Query(`
 		SELECT rv.id, rv.output
 		FROM reviews rv
@@ -528,7 +540,7 @@ func (db *DB) BackfillVerdictBool() (int, error) {
 	}
 
 	if len(updates) == 0 {
-		return 0, nil
+		return int(clearedCount), nil
 	}
 
 	tx, err := db.Begin()
@@ -552,7 +564,7 @@ func (db *DB) BackfillVerdictBool() (int, error) {
 	if err := tx.Commit(); err != nil {
 		return 0, err
 	}
-	return len(updates), nil
+	return len(updates) + int(clearedCount), nil
 }
 
 // categorizeError maps error messages to categories.

--- a/internal/storage/summary_test.go
+++ b/internal/storage/summary_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"database/sql"
 	"testing"
 	"time"
 
@@ -464,6 +465,36 @@ func TestBackfillVerdictBool(t *testing.T) {
 	count, err = db.BackfillVerdictBool()
 	require.NoError(t, err)
 	assert.Equal(t, 0, count)
+}
+
+// Older CompleteFixJob stored verdict_bool even for empty outputs. Listings
+// rely on non-NULL verdict_bool implying a non-empty output, so the startup
+// backfill pass must clear those legacy rows.
+func TestBackfillVerdictBoolClearsEmptyOutputVerdicts(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo := createRepo(t, db, "/tmp/backfill-clear-repo")
+	commit := createCommit(t, db, repo.ID, "clear123")
+	job := enqueueJob(t, db, repo.ID, commit.ID, "clear123")
+	claimJob(t, db, "w1")
+	require.NoError(t, db.CompleteJob(job.ID, "codex", "p", "No issues found."))
+
+	// Simulate a legacy empty-output row that still carries a verdict.
+	_, err := db.Exec(`UPDATE reviews SET output = '', verdict_bool = 0 WHERE job_id = ?`, job.ID)
+	require.NoError(t, err)
+
+	count, err := db.BackfillVerdictBool()
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	var vb sql.NullInt64
+	require.NoError(t, db.QueryRow(`SELECT verdict_bool FROM reviews WHERE job_id = ?`, job.ID).Scan(&vb))
+	assert.False(t, vb.Valid, "empty-output rows must not keep a verdict")
+
+	count, err = db.BackfillVerdictBool()
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "normalization is idempotent")
 }
 
 func TestPercentile(t *testing.T) {

--- a/internal/storage/verdict.go
+++ b/internal/storage/verdict.go
@@ -40,8 +40,12 @@ func applyReviewVerdict(review *Review, verdictBool sql.NullInt64) {
 	}
 }
 
-func applyJobVerdict(job *ReviewJob, verdictBool sql.NullInt64, output string) {
-	if output == "" || job.Error != "" || job.IsTaskJob() {
+// applyJobVerdict derives the job's verdict from the stored verdict_bool,
+// falling back to parsing the review output. hasReview reports whether a
+// non-empty review output exists; callers that skip hydrating the output for
+// rows with a stored verdict pass the existence flag from SQL instead.
+func applyJobVerdict(job *ReviewJob, verdictBool sql.NullInt64, output string, hasReview bool) {
+	if !hasReview || job.Error != "" || job.IsTaskJob() {
 		return
 	}
 	verdict := verdictFromBoolOrParse(verdictBool, output)

--- a/pkg/client/generated/enums.go
+++ b/pkg/client/generated/enums.go
@@ -83,7 +83,7 @@ func (l ListJobsQueryHideClassifyJobs) Validate() error {
 	}
 }
 
-// ListJobsQueryOmitPrompt Omit prompt and diff content from returned jobs (metadata-only listing)
+// ListJobsQueryOmitPrompt Omit prompt and diff content from returned jobs (metadata-only listing; queued/running jobs keep their prompt)
 type ListJobsQueryOmitPrompt string
 
 const (

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -160,7 +160,7 @@ type ListJobsQuery struct {
 	// PanelRun Return all jobs (members + synthesis) of one panel run
 	PanelRun *string `json:"panel_run,omitempty"`
 
-	// OmitPrompt Omit prompt and diff content from returned jobs (metadata-only listing)
+	// OmitPrompt Omit prompt and diff content from returned jobs (metadata-only listing; queued/running jobs keep their prompt)
 	OmitPrompt *ListJobsQueryOmitPrompt `json:"omit_prompt,omitempty"`
 
 	// RepoPrefix Filter repos by path prefix

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -3041,12 +3041,12 @@ paths:
           schema:
             description: Return all jobs (members + synthesis) of one panel run
             type: string
-        - description: Omit prompt and diff content from returned jobs (metadata-only listing)
+        - description: Omit prompt and diff content from returned jobs (metadata-only listing; queued/running jobs keep their prompt)
           explode: false
           in: query
           name: omit_prompt
           schema:
-            description: Omit prompt and diff content from returned jobs (metadata-only listing)
+            description: Omit prompt and diff content from returned jobs (metadata-only listing; queued/running jobs keep their prompt)
             enum:
               - "true"
               - "false"


### PR DESCRIPTION
## Summary

Profiling the daemon (`/debug/pprof/heap` + `vmmap`) showed its resident memory is dominated by `/api/jobs` responses, not by anything it actually retains: live heap idles around 12MB, but every listed job carried its full stored prompt (which embeds the diff, ~34KB average on my database) plus the entire review output. A single unpaginated listing of a 6k-job database produced a 211MB JSON body and ballooned the daemon past 2GB of transient heap; on macOS those freed pages stay in reported RSS (`MADV_FREE`), so each burst permanently ratcheted the baseline shown by process monitors. The TUI polls listings every 15s and never renders a completed job's prompt from them, so nearly all of that payload was dead weight.

- Metadata listings (`omit_prompt=true` / `WithoutPrompt`) now skip the prompt column for terminal jobs at the SQL level. Queued/running jobs keep their prompt: the active set is small and it is the only way the TUI prompt view can show what a not-yet-reviewed job was asked.
- The review `output` column is only hydrated for legacy rows where `verdict_bool` is NULL (e.g. synced from older machines); rows with a stored verdict pass an existence flag instead, so verdict badges render identically without shipping the full review text per row.
- The TUI passes `omit_prompt=true` on all list fetches (queue, pagination, tasks, panel members). Detail views are unchanged: single-job lookups without the flag and `/api/review` still return the full record.
- `stripJobPrompts` (the single-job `omit_prompt` path) matches the same terminal-only semantics, and both OpenAPI specs/clients are regenerated for the doc update.

A 50-job listing drops from ~813KB to ~70KB, and the pathological all-jobs listing from 211MB to ~8MB, removing the burst source behind the creeping RSS baseline. Validated by profiling a live daemon before/after concurrent `limit=0` listings (45MB → 2.9GB RSS with live heap back at 12MB after GC) and measuring listing payloads with and without `omit_prompt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sup>generated by a clanker</sup>