### PR TITLE
fix: read agentsview's new cost shape

### DIFF
--- a/cmd/roborev/tui/queue_test.go
+++ b/cmd/roborev/tui/queue_test.go
@@ -862,6 +862,22 @@ func TestTUIQueueCollapsedPanelShowsAggregatedMemberCost(t *testing.T) {
 	assert.Contains(t, out, "~$0.35", "collapsed parent row shows summed member costs")
 }
 
+func TestTUIQueueCostCellDistinguishesMissingAmountFromZero(t *testing.T) {
+	m := model{}
+
+	drifted := storage.ReviewJob{
+		TokenUsage: `{"total_output_tokens":200,"has_cost":true}`,
+	}
+	assert.Empty(t, m.jobCostCell(drifted),
+		"a cost flag without an amount must not render as a free run")
+
+	free := storage.ReviewJob{
+		TokenUsage: `{"cost_usd":0,"has_cost":true}`,
+	}
+	assert.Equal(t, "~$0.00", m.jobCostCell(free),
+		"an explicit zero remains a priced free run")
+}
+
 func TestTUIQueueCollapsedPanelShowsSummaryCostBeforeExpansion(t *testing.T) {
 	parent := makeJob(10, withRef("syn"), withStatus(storage.JobStatusDone),
 		withSynthesis("R", storage.PanelSummary{

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -988,8 +988,32 @@ The endpoint should return JSON compatible with
 ```
 
 `has_token_data` and `has_cost` are required booleans. When `has_token_data` is
-true, token counts are required. When `has_cost` is true, `cost_usd` is
-required. A `404` response is treated as no usage data for that session.
+true, token counts are required. A `404` response is treated as no usage data
+for that session.
+
+When `has_cost` is true, the cost must arrive in one of two shapes. Either
+`cost_usd` as a float, or the integer envelope agentsview adopted in v0.39.0:
+
+```json
+{
+  "total_output_tokens": 4762,
+  "peak_context_tokens": 70092,
+  "has_token_data": true,
+  "cost": { "microdollars": 131767 },
+  "has_cost": true,
+  "cost_source": "computed"
+}
+```
+
+roborev accepts either and prefers `cost_usd` when both are present. When using
+the envelope, omit `cost_usd` rather than sending it as `null` — the published
+schema types it as a plain number. roborev itself tolerates an explicit `null`
+and treats it as absent, but that leniency is deliberate defensiveness, not part
+of the contract.
+
+A session priced at exactly zero must send an explicit `0` (or `0`
+microdollars); absent is not the same as free. Flagging `has_cost` with neither
+field is a schema error.
 
 ### Agentic Mode
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1005,11 +1005,11 @@ When `has_cost` is true, the cost must arrive in one of two shapes. Either
 }
 ```
 
-roborev accepts either and prefers `cost_usd` when both are present. When using
-the envelope, omit `cost_usd` rather than sending it as `null` — the published
-schema types it as a plain number. roborev itself tolerates an explicit `null`
-and treats it as absent, but that leniency is deliberate defensiveness, not part
-of the contract.
+roborev accepts either and prefers the `cost` envelope when both are present.
+When using the envelope, omit `cost_usd` rather than sending it as `null` — the
+published schema types it as a plain number. roborev itself tolerates an
+explicit `null` and treats it as absent, but that leniency is deliberate
+defensiveness, not part of the contract.
 
 A session priced at exactly zero must send an explicit `0` (or `0`
 microdollars); absent is not the same as free. Flagging `has_cost` with neither

--- a/internal/backfill/tokens.go
+++ b/internal/backfill/tokens.go
@@ -1,6 +1,7 @@
 package backfill
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"go.kenn.io/roborev/internal/storage"
@@ -102,6 +103,9 @@ func MergeTokenUsage(existingJSON string, fetched *tokens.Usage) *tokens.Usage {
 	if merged.CachedInputTokens == 0 {
 		merged.CachedInputTokens = existing.CachedInputTokens
 	}
+	if merged.CacheCreationTokens == 0 {
+		merged.CacheCreationTokens = existing.CacheCreationTokens
+	}
 	if merged.UsageSource == "" {
 		merged.UsageSource = existing.UsageSource
 	}
@@ -111,16 +115,47 @@ func MergeTokenUsage(existingJSON string, fetched *tokens.Usage) *tokens.Usage {
 	if merged.EventOffset == 0 {
 		merged.EventOffset = existing.EventOffset
 	}
-	if !merged.HasCost && existing.HasCost {
+	// Keep whichever side actually carries dollars rather than the freshest one:
+	// a re-fetch can come back unpriced (agentsview flagging has_cost with no
+	// amount), and letting that overwrite a real recorded figure would lose
+	// spend that was already measured.
+	//
+	// Gating on hasRecordedCost means a stored flag with no amount is never
+	// carried forward. Such a row is exactly what this repair removes, and
+	// resurrecting the flag would keep it in the priced numerator at $0. A
+	// freshly fetched $0 still survives, since that is a real free run rather
+	// than an amount that went missing.
+	if hasRecordedCost(existingJSON) && (!merged.HasCost || merged.CostUSD == 0) {
 		merged.CostUSD = existing.CostUSD
 		merged.HasCost = true
 	}
 	return &merged
 }
 
-func NeedsTokenCostBackfill(tokenUsage string) bool {
+// hasRecordedCost reports whether a row carries an actual dollar figure, not
+// just the has_cost flag. The two came apart when agentsview v0.39.0 moved cost
+// into a microdollar envelope roborev could not yet read: the flag was stored,
+// the amount was lost, and the row silently priced itself at $0.
+//
+// Presence of the cost_usd key is what separates the two, which is why Usage
+// serializes it unconditionally. A row recording an explicit 0 is a real free
+// run and is left alone; a row flagged priced with no amount at all is the
+// drifted shape and needs re-fetching.
+func hasRecordedCost(tokenUsage string) bool {
 	usage := tokens.ParseJSON(tokenUsage)
-	return usage == nil || !usage.HasCost
+	if usage == nil || !usage.HasCost {
+		return false
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(tokenUsage), &raw); err != nil {
+		return false
+	}
+	amount, ok := raw["cost_usd"]
+	return ok && string(amount) != "null"
+}
+
+func NeedsTokenCostBackfill(tokenUsage string) bool {
+	return !hasRecordedCost(tokenUsage)
 }
 
 func NeedsTokenUsageBackfill(tokenUsage string) bool {
@@ -130,9 +165,10 @@ func NeedsTokenUsageBackfill(tokenUsage string) bool {
 	}
 	hasTokenCounts := usage.InputTokens != 0 ||
 		usage.CachedInputTokens != 0 ||
+		usage.CacheCreationTokens != 0 ||
 		usage.OutputTokens != 0 ||
 		usage.PeakContextTokens != 0
-	return !hasTokenCounts || !usage.HasCost
+	return !hasTokenCounts || !hasRecordedCost(tokenUsage)
 }
 
 func ApplyTokenUsage(

--- a/internal/backfill/tokens.go
+++ b/internal/backfill/tokens.go
@@ -1,7 +1,6 @@
 package backfill
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"go.kenn.io/roborev/internal/storage"
@@ -143,15 +142,7 @@ func MergeTokenUsage(existingJSON string, fetched *tokens.Usage) *tokens.Usage {
 // drifted shape and needs re-fetching.
 func hasRecordedCost(tokenUsage string) bool {
 	usage := tokens.ParseJSON(tokenUsage)
-	if usage == nil || !usage.HasCost {
-		return false
-	}
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(tokenUsage), &raw); err != nil {
-		return false
-	}
-	amount, ok := raw["cost_usd"]
-	return ok && string(amount) != "null"
+	return usage != nil && usage.HasCost
 }
 
 func NeedsTokenCostBackfill(tokenUsage string) bool {

--- a/internal/backfill/tokens_test.go
+++ b/internal/backfill/tokens_test.go
@@ -1,0 +1,143 @@
+package backfill
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/tokens"
+)
+
+// driftedUsage is the exact token_usage shape agentsview v0.39.0 produced once
+// it moved cost into a microdollar envelope roborev could not read: the priced
+// flag survived, the dollar figure did not.
+const driftedUsage = `{"input_tokens":275361,"cached_input_tokens":204672,` +
+	`"total_output_tokens":2257,"peak_context_tokens":64393,"has_cost":true,` +
+	`"usage_source":"job_log_turn_completed","thread_id":"t-1","event_offset":1}`
+
+func TestNeedsTokenCostBackfill(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.True(NeedsTokenCostBackfill(""), "no usage at all needs backfill")
+	assert.True(
+		NeedsTokenCostBackfill(`{"total_output_tokens":300}`),
+		"usage without a cost flag needs backfill",
+	)
+	assert.True(
+		NeedsTokenCostBackfill(driftedUsage),
+		"priced flag with no dollar amount needs backfill",
+	)
+	assert.False(
+		NeedsTokenCostBackfill(`{"has_cost":true,"cost_usd":0.42}`),
+		"a real recorded cost is already backfilled",
+	)
+	assert.False(
+		NeedsTokenCostBackfill(`{"has_cost":true,"cost_usd":0}`),
+		"an explicit $0 is a real free run, not a lost amount",
+	)
+	assert.True(
+		NeedsTokenCostBackfill(`{"has_cost":true,"cost_usd":null}`),
+		"a null amount is absent, not $0",
+	)
+}
+
+// A genuine free run must survive a merge intact rather than being re-flagged
+// as unpriced, which would drop it back out of the priced numerator.
+func TestMergeTokenUsageKeepsExplicitZeroCost(t *testing.T) {
+	existing := `{"total_output_tokens":300,"has_cost":true,"cost_usd":0}`
+	fetched := &tokens.Usage{OutputTokens: 300}
+
+	merged := MergeTokenUsage(existing, fetched)
+	require.NotNil(t, merged)
+	assert.True(t, merged.HasCost, "an explicit $0 stays priced")
+	assert.Zero(t, merged.CostUSD)
+}
+
+func TestNeedsTokenUsageBackfill(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.True(
+		NeedsTokenUsageBackfill(driftedUsage),
+		"complete token counts do not excuse a missing dollar amount",
+	)
+	assert.True(
+		NeedsTokenUsageBackfill(`{"has_cost":true,"cost_usd":0.42}`),
+		"cost without token counts still needs backfill",
+	)
+	assert.False(
+		NeedsTokenUsageBackfill(
+			`{"total_output_tokens":300,"has_cost":true,"cost_usd":0.42}`,
+		),
+		"counts plus a real cost is complete",
+	)
+	assert.False(
+		NeedsTokenUsageBackfill(
+			`{"cache_creation_tokens":512,"has_cost":true,"cost_usd":0.42}`,
+		),
+		"cache-creation tokens count as token data",
+	)
+}
+
+// The drifted rows are the whole point of the backfill, so they must survive
+// both candidate filters used by `roborev backfill-tokens`.
+func TestTokenCandidatesIncludesDriftedCostRow(t *testing.T) {
+	started := time.Now()
+	job := storage.ReviewJob{
+		ID:         5297,
+		Status:     storage.JobStatusDone,
+		SessionID:  "019fb0c3-3c66-7e52-aa96-2935983320f3",
+		StartedAt:  &started,
+		TokenUsage: driftedUsage,
+	}
+
+	require.Len(t, TokenCandidates([]storage.ReviewJob{job}), 1)
+	require.Len(t, LogTokenCandidates([]storage.ReviewJob{job}), 1)
+}
+
+func TestMergeTokenUsageKeepsRecordedCostOverUnpricedFetch(t *testing.T) {
+	existing := `{"total_output_tokens":300,"has_cost":true,"cost_usd":1.23}`
+	fetched := &tokens.Usage{OutputTokens: 300, HasCost: true, CostUSD: 0}
+
+	merged := MergeTokenUsage(existing, fetched)
+	require.NotNil(t, merged)
+	assert.True(t, merged.HasCost)
+	assert.InDelta(t, 1.23, merged.CostUSD, 1e-9,
+		"a fresh $0 must not overwrite real recorded spend")
+}
+
+func TestMergeTokenUsageTakesFetchedCostOverDriftedZero(t *testing.T) {
+	fetched := &tokens.Usage{HasCost: true, CostUSD: 0.598641}
+
+	merged := MergeTokenUsage(driftedUsage, fetched)
+	require.NotNil(t, merged)
+	assert.True(t, merged.HasCost)
+	assert.InDelta(t, 0.598641, merged.CostUSD, 1e-9)
+	assert.Equal(t, int64(2257), merged.OutputTokens,
+		"token counts carry over from the existing row")
+	assert.Equal(t, int64(64393), merged.PeakContextTokens)
+}
+
+// A drifted row must not have its bare has_cost flag carried forward when no
+// side has dollars: that is the $0-priced state the repair exists to remove, and
+// resurrecting it keeps the row in the priced numerator at $0.
+func TestMergeTokenUsageDropsUnpricedCostFlag(t *testing.T) {
+	fetched := &tokens.Usage{OutputTokens: 2257, PeakContextTokens: 64393}
+
+	merged := MergeTokenUsage(driftedUsage, fetched)
+	require.NotNil(t, merged)
+	assert.False(t, merged.HasCost,
+		"a cost flag with no dollars anywhere must not survive the merge")
+	assert.Zero(t, merged.CostUSD)
+}
+
+func TestMergeTokenUsageCarriesCacheCreationTokens(t *testing.T) {
+	existing := `{"cache_creation_tokens":8192,"total_output_tokens":300}`
+	fetched := &tokens.Usage{HasCost: true, CostUSD: 0.42}
+
+	merged := MergeTokenUsage(existing, fetched)
+	require.NotNil(t, merged)
+	assert.Equal(t, int64(8192), merged.CacheCreationTokens)
+}

--- a/internal/daemon/panel_posting_test.go
+++ b/internal/daemon/panel_posting_test.go
@@ -192,6 +192,22 @@ func TestPanelCommitStatus(t *testing.T) {
 	}
 }
 
+func TestPanelTotalCostExcludesFlagWithoutAmount(t *testing.T) {
+	synth := &storage.ReviewJob{
+		TokenUsage: `{"total_output_tokens":200,"has_cost":true}`,
+	}
+	members := []storage.BatchReviewResult{
+		{TokenUsage: `{"cost_usd":0.11,"has_cost":true}`},
+		{TokenUsage: `{"peak_context_tokens":100,"has_cost":true}`},
+	}
+
+	cost, priced, total := panelTotalCost(synth, members)
+	assert.InDelta(t, 0.11, cost, 1e-9)
+	assert.Equal(t, 1, priced,
+		"amount-less flags must not make panel pricing look complete")
+	assert.Equal(t, 3, total)
+}
+
 // TestSynthesisCompletedPostsOnce verifies a synthesis review.completed posts
 // the persisted review exactly once even under duplicate event delivery (the
 // posting CAS is idempotent) and finalizes the panel row (posted_at set).

--- a/internal/storage/cost.go
+++ b/internal/storage/cost.go
@@ -26,7 +26,14 @@ type CostOptions struct {
 // hasCost is the SQL predicate for a row carrying a recorded dollar cost. It
 // gates the priced numerator (jobs_with_cost) and total_usd. Requires
 // review_jobs aliased as "j".
-const hasCost = "json_valid(j.token_usage) AND json_extract(j.token_usage, '$.has_cost')"
+//
+// The flag alone is not enough: rows written while agentsview reported cost in a
+// shape roborev could not read carry has_cost with no cost_usd, and counting
+// them would report $0 spend at full coverage while real money went unrecorded.
+// json_extract yields NULL for both an absent key and an explicit null, while a
+// genuine free run stores 0 and still counts.
+const hasCost = "json_valid(j.token_usage) AND json_extract(j.token_usage, '$.has_cost') " +
+	"AND json_extract(j.token_usage, '$.cost_usd') IS NOT NULL"
 
 // agentRanByUsage is the fallback agent-ran signal: a token_usage blob that
 // records real consumption — a cost flag, output tokens, peak context, or a
@@ -38,6 +45,7 @@ const agentRanByUsage = "json_valid(j.token_usage) AND (" +
 	"json_extract(j.token_usage, '$.has_cost') " +
 	"OR json_extract(j.token_usage, '$.total_output_tokens') > 0 " +
 	"OR json_extract(j.token_usage, '$.peak_context_tokens') > 0 " +
+	"OR json_extract(j.token_usage, '$.cache_creation_tokens') > 0 " +
 	"OR json_extract(j.token_usage, '$.cost_usd') > 0)"
 
 // costEligible is the shared eligibility predicate: a terminal job where an

--- a/internal/storage/cost_test.go
+++ b/internal/storage/cost_test.go
@@ -217,6 +217,68 @@ func TestGetCostAggregateIncludesPricedRowsWithoutMarker(t *testing.T) {
 	assert.True(c.Complete, "coverage is complete when the only row is priced")
 }
 
+// TestGetCostAggregateExcludesFlaggedRowsWithNoAmount guards the SQL side of
+// the agentsview v0.39.0 drift: a row flagged has_cost but carrying no cost_usd
+// has no dollars to contribute, so counting it as priced would report $0 spend
+// and full coverage while real money went unrecorded. An explicit $0 is a real
+// free run and must still count.
+func TestGetCostAggregateExcludesFlaggedRowsWithNoAmount(t *testing.T) {
+	assert := assert.New(t)
+	db := openTestDB(t)
+	t.Cleanup(func() { db.Close() })
+
+	repo := createRepo(t, db, "/tmp/cost-no-amount")
+	commit := createCommit(t, db, repo.ID, "no-amount-sha")
+
+	drifted := enqueueJob(t, db, repo.ID, commit.ID, "no-amount-sha")
+	setJobStatus(t, db, drifted.ID, JobStatusDone)
+	seedCost(t, db, drifted.ID, `{"peak_context_tokens":100,"has_cost":true}`)
+
+	opts := CostOptions{RepoPaths: []string{repo.RootPath}}
+	c, err := db.GetCostAggregate(opts)
+	require.NoError(t, err)
+	assert.Equal(1, c.JobsTotal, "the row still proves an agent ran")
+	assert.Equal(0, c.JobsWithCost, "a flag with no amount is not priced")
+	assert.InDelta(0.0, c.TotalUSD, 0.0001)
+	assert.False(c.Complete, "coverage is not complete while dollars are missing")
+
+	free := enqueueJob(t, db, repo.ID, commit.ID, "no-amount-sha")
+	setJobStatus(t, db, free.ID, JobStatusDone)
+	seedCost(t, db, free.ID, `{"peak_context_tokens":100,"cost_usd":0,"has_cost":true}`)
+
+	c, err = db.GetCostAggregate(opts)
+	require.NoError(t, err)
+	assert.Equal(2, c.JobsTotal)
+	assert.Equal(1, c.JobsWithCost, "an explicit $0 is a priced free run")
+	assert.InDelta(0.0, c.TotalUSD, 0.0001)
+}
+
+// TestGetCostAggregateIncludesCacheWriteOnlyRowsWithoutMarker extends the
+// agentRanByUsage fallback to cache-creation tokens. A marker-less row whose
+// only recorded consumption is cache writes still proves an agent ran, so
+// leaving it out of the denominator would overstate coverage.
+func TestGetCostAggregateIncludesCacheWriteOnlyRowsWithoutMarker(t *testing.T) {
+	assert := assert.New(t)
+	db := openTestDB(t)
+	t.Cleanup(func() { db.Close() })
+
+	repo := createRepo(t, db, "/tmp/cost-cache-write")
+	commit := createCommit(t, db, repo.ID, "cache-write-sha")
+	job := enqueueJob(t, db, repo.ID, commit.ID, "cache-write-sha")
+	setJobStatus(t, db, job.ID, JobStatusDone)
+
+	sessionID := "sess-cache-write"
+	setJobSession(t, db, job.ID, sessionID)
+	require.NoError(t, db.SaveJobTokenUsage(
+		job.ID, sessionID, `{"cache_creation_tokens":8192}`))
+
+	c, err := db.GetCostAggregate(CostOptions{RepoPaths: []string{repo.RootPath}})
+	require.NoError(t, err)
+	assert.Equal(1, c.JobsTotal, "cache writes prove an agent ran")
+	assert.Equal(0, c.JobsWithCost, "the row carries no cost")
+	assert.False(c.Complete, "an unpriced eligible row leaves coverage partial")
+}
+
 // TestGetCostAggregateRerunClearsStaleCost guards against attributing a prior
 // run's spend to a re-run job. Re-enqueuing must clear token_usage and the
 // agent_invoked marker, so a second run that reports no cost is counted as

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -2017,6 +2017,12 @@ type PanelSummary struct {
 	FirstStartedAt      *time.Time `json:"first_started_at,omitempty"`
 }
 
+// memberHasCost is the priced-row predicate for panel members: the unaliased
+// counterpart of hasCost in cost.go, and subject to the same rule that a
+// has_cost flag with no cost_usd carries no dollars and is not priced.
+const memberHasCost = "json_valid(token_usage) AND json_extract(token_usage, '$.has_cost') " +
+	"AND json_extract(token_usage, '$.cost_usd') IS NOT NULL"
+
 // GetPanelSummaries computes the member breakdown for each given panel run in
 // one GROUP BY aggregate (no per-row N+1). Runs with no member rows are
 // absent from the returned map.
@@ -2038,8 +2044,8 @@ func (db *DB) GetPanelSummaries(runUUIDs []string) (map[string]PanelSummary, err
 		       COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0),
 		       COALESCE(SUM(CASE WHEN status = 'canceled' THEN 1 ELSE 0 END), 0),
 		       COALESCE(SUM(CASE WHEN status = 'skipped' THEN 1 ELSE 0 END), 0),
-		       COALESCE(SUM(CASE WHEN json_valid(token_usage) AND json_extract(token_usage, '$.has_cost') THEN 1 ELSE 0 END), 0),
-		       COALESCE(SUM(CASE WHEN json_valid(token_usage) AND json_extract(token_usage, '$.has_cost') THEN json_extract(token_usage, '$.cost_usd') ELSE 0 END), 0),
+		       COALESCE(SUM(CASE WHEN `+memberHasCost+` THEN 1 ELSE 0 END), 0),
+		       COALESCE(SUM(CASE WHEN `+memberHasCost+` THEN json_extract(token_usage, '$.cost_usd') ELSE 0 END), 0),
 		       MIN(started_at)
 		FROM review_jobs
 		WHERE panel_role = 'member' AND panel_run_uuid IN (%s)

--- a/internal/storage/panels_test.go
+++ b/internal/storage/panels_test.go
@@ -432,6 +432,33 @@ func TestReviewHydrationIncludesPanelFields(t *testing.T) {
 	assert.Equal("branch_final", bySHA.Job.PanelName)
 }
 
+// TestGetPanelSummariesExcludesMembersWithNoCostAmount mirrors the cost
+// aggregate guard for panel rollups: a member flagged has_cost with no cost_usd
+// contributes no dollars, so counting it as priced would report the panel's
+// member cost as complete while real spend went unrecorded.
+func TestGetPanelSummariesExcludesMembersWithNoCostAmount(t *testing.T) {
+	assert := assert.New(t)
+	db := openTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	repo := createRepo(t, db, "/tmp/panel-no-amount")
+
+	_, members := enqueuePanelRun(t, db, repo.ID, "run-drift", 2)
+	setStatus(t, db, members[0].ID, JobStatusDone)
+	setStatus(t, db, members[1].ID, JobStatusDone)
+	seedCost(t, db, members[0].ID, `{"cost_usd":0.30,"has_cost":true}`)
+	seedCost(t, db, members[1].ID, `{"peak_context_tokens":100,"has_cost":true}`)
+
+	got, err := db.GetPanelSummaries([]string{"run-drift"})
+	require.NoError(t, err)
+
+	sum := got["run-drift"]
+	assert.Equal(2, sum.MembersTotal)
+	assert.Equal(1, sum.MembersWithCost, "a flag with no amount is not priced")
+	assert.InDelta(0.30, sum.MembersCostUSD, 0.000001)
+	assert.False(sum.MembersCostComplete,
+		"member cost is not complete while dollars are missing")
+}
+
 func TestGetPanelSummaries(t *testing.T) {
 	assert := assert.New(t)
 	db := openTestDB(t)

--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -434,6 +434,20 @@ func ParseJSON(data string) *Usage {
 	if err := json.Unmarshal([]byte(data), &u); err != nil {
 		return nil
 	}
+	// Historical rows written during the agentsview cost-shape transition can
+	// carry has_cost without cost_usd. Normalize that drift at the parse
+	// boundary so every consumer agrees that HasCost means an amount was
+	// actually recorded. A non-nil RawMessage preserves an explicit zero while
+	// treating both an absent key and JSON null as unpriced.
+	if u.HasCost {
+		var raw struct {
+			CostUSD *json.RawMessage `json:"cost_usd"`
+		}
+		if err := json.Unmarshal([]byte(data), &raw); err != nil ||
+			raw.CostUSD == nil {
+			u.HasCost = false
+		}
+	}
 	if !u.HasUsageData() {
 		return nil
 	}

--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -22,15 +22,25 @@ import (
 // Stored as JSON in the review_jobs.token_usage column.
 // Fields align with agentsview's session-usage output.
 type Usage struct {
-	InputTokens       int64   `json:"input_tokens,omitempty"`
-	CachedInputTokens int64   `json:"cached_input_tokens,omitempty"`
-	OutputTokens      int64   `json:"total_output_tokens,omitempty"`
-	PeakContextTokens int64   `json:"peak_context_tokens,omitempty"`
-	CostUSD           float64 `json:"cost_usd,omitempty"`
-	HasCost           bool    `json:"has_cost,omitempty"`
-	UsageSource       string  `json:"usage_source,omitempty"`
-	ThreadID          string  `json:"thread_id,omitempty"`
-	EventOffset       int64   `json:"event_offset,omitempty"`
+	InputTokens int64 `json:"input_tokens,omitempty"`
+	// CachedInputTokens counts cache *reads*. Note the provider difference:
+	// OpenAI's input_tokens includes cached_input_tokens, while Anthropic
+	// reports the two as disjoint sets.
+	CachedInputTokens int64 `json:"cached_input_tokens,omitempty"`
+	// CacheCreationTokens counts tokens written into the prompt cache, which
+	// is priced separately from cache reads.
+	CacheCreationTokens int64 `json:"cache_creation_tokens,omitempty"`
+	OutputTokens        int64 `json:"total_output_tokens,omitempty"`
+	PeakContextTokens   int64 `json:"peak_context_tokens,omitempty"`
+	// CostUSD is written unconditionally. Omitting a zero would make a run
+	// priced at exactly $0 byte-identical to the drifted rows that recorded
+	// has_cost with no amount, which is the ambiguity this field exists to
+	// resolve.
+	CostUSD     float64 `json:"cost_usd"`
+	HasCost     bool    `json:"has_cost,omitempty"`
+	UsageSource string  `json:"usage_source,omitempty"`
+	ThreadID    string  `json:"thread_id,omitempty"`
+	EventOffset int64   `json:"event_offset,omitempty"`
 }
 
 // FetchConfig configures session usage lookup. When Endpoint is set,
@@ -49,29 +59,52 @@ type FetchConfig struct {
 // `agentsview session usage <id> --format json` and the deprecated
 // `agentsview token-use <id>` command.
 type agentsviewResponse struct {
-	SessionID         string  `json:"session_id"`
-	Agent             string  `json:"agent"`
-	Project           string  `json:"project"`
-	OutputTokens      int64   `json:"total_output_tokens"`
-	PeakContextTokens int64   `json:"peak_context_tokens"`
-	HasTokenData      bool    `json:"has_token_data"`
-	CostUSD           float64 `json:"cost_usd"`
-	HasCost           bool    `json:"has_cost"`
+	SessionID         string        `json:"session_id"`
+	Agent             string        `json:"agent"`
+	Project           string        `json:"project"`
+	OutputTokens      int64         `json:"total_output_tokens"`
+	PeakContextTokens int64         `json:"peak_context_tokens"`
+	HasTokenData      bool          `json:"has_token_data"`
+	CostUSD           *float64      `json:"cost_usd"`
+	Cost              *costEnvelope `json:"cost"`
+	HasCost           bool          `json:"has_cost"`
+}
+
+// costEnvelope is the integer-cost shape agentsview adopted in v0.39.0:
+// `"cost": {"microdollars": 131767}`. Microdollars is a pointer so an explicit
+// null is distinguishable from a genuine zero-cost run.
+type costEnvelope struct {
+	Microdollars *int64 `json:"microdollars,omitempty"`
+}
+
+// resolveCostUSD converts either cost shape to dollars, reporting whether a
+// cost was actually present. An explicit `"cost_usd": null` is absent, not $0;
+// a real 0 (or 0 microdollars) is a valid free run. The float field wins when
+// both are populated, since it is the more explicit of the two.
+func resolveCostUSD(costUSD *float64, cost *costEnvelope) (float64, bool) {
+	if costUSD != nil {
+		return *costUSD, true
+	}
+	if cost != nil && cost.Microdollars != nil {
+		return float64(*cost.Microdollars) / 1e6, true
+	}
+	return 0, false
 }
 
 // SessionUsagePayload is the JSON shape returned by AgentsView's
 // session-usage API and accepted by roborev's token backfill endpoint.
 type SessionUsagePayload struct {
-	SessionID         string   `json:"session_id"`
-	Agent             string   `json:"agent,omitempty"`
-	Project           string   `json:"project,omitempty"`
-	InputTokens       *int64   `json:"input_tokens,omitempty"`
-	CachedInputTokens *int64   `json:"cached_input_tokens,omitempty"`
-	OutputTokens      *int64   `json:"total_output_tokens,omitempty"`
-	PeakContextTokens *int64   `json:"peak_context_tokens,omitempty"`
-	HasTokenData      *bool    `json:"has_token_data"`
-	CostUSD           *float64 `json:"cost_usd,omitempty"`
-	HasCost           *bool    `json:"has_cost"`
+	SessionID         string        `json:"session_id"`
+	Agent             string        `json:"agent,omitempty"`
+	Project           string        `json:"project,omitempty"`
+	InputTokens       *int64        `json:"input_tokens,omitempty"`
+	CachedInputTokens *int64        `json:"cached_input_tokens,omitempty"`
+	OutputTokens      *int64        `json:"total_output_tokens,omitempty"`
+	PeakContextTokens *int64        `json:"peak_context_tokens,omitempty"`
+	HasTokenData      *bool         `json:"has_token_data"`
+	CostUSD           *float64      `json:"cost_usd,omitempty"`
+	Cost              *costEnvelope `json:"cost,omitempty"`
+	HasCost           *bool         `json:"has_cost"`
 }
 
 // FormatSummary returns a compact human-readable summary like
@@ -86,26 +119,25 @@ func (u Usage) FormatSummary() string {
 		inputLabel = "in"
 	}
 	hasTokens := inputTokens != 0 || u.OutputTokens != 0 ||
-		u.CachedInputTokens != 0
+		u.CachedInputTokens != 0 || u.CacheCreationTokens != 0
 	if !hasTokens {
 		// No token counts: show the cost alone when present.
 		return u.FormatCost()
 	}
-	s := fmt.Sprintf(
-		"%s %s · %s out",
-		formatCount(inputTokens),
-		inputLabel,
-		formatCount(u.OutputTokens),
-	)
+	// Cache reads and cache writes are priced differently, so they are
+	// reported separately rather than summed.
+	var notes []string
 	if u.CachedInputTokens != 0 {
-		s = fmt.Sprintf(
-			"%s %s (%s cached) · %s out",
-			formatCount(inputTokens),
-			inputLabel,
-			formatCount(u.CachedInputTokens),
-			formatCount(u.OutputTokens),
-		)
+		notes = append(notes, formatCount(u.CachedInputTokens)+" cached")
 	}
+	if u.CacheCreationTokens != 0 {
+		notes = append(notes, formatCount(u.CacheCreationTokens)+" written")
+	}
+	s := fmt.Sprintf("%s %s", formatCount(inputTokens), inputLabel)
+	if len(notes) > 0 {
+		s += " (" + strings.Join(notes, ", ") + ")"
+	}
+	s += " · " + formatCount(u.OutputTokens) + " out"
 	if cost := u.FormatCost(); cost != "" {
 		s += " · " + cost
 	}
@@ -198,15 +230,22 @@ func fetchForSessionCLI(
 		return nil, fmt.Errorf("parse agentsview output: %w", err)
 	}
 
-	if resp.OutputTokens == 0 && resp.PeakContextTokens == 0 &&
-		!resp.HasCost {
+	// A has_cost flag with no accompanying amount carries no dollars, so it is
+	// not treated as cost data: recording it would price the review at $0 and
+	// silently deflate every aggregate it lands in.
+	costUSD, hasCost := 0.0, false
+	if resp.HasCost {
+		costUSD, hasCost = resolveCostUSD(resp.CostUSD, resp.Cost)
+	}
+
+	if resp.OutputTokens == 0 && resp.PeakContextTokens == 0 && !hasCost {
 		return nil, nil
 	}
 	return &Usage{
 		OutputTokens:      resp.OutputTokens,
 		PeakContextTokens: resp.PeakContextTokens,
-		CostUSD:           resp.CostUSD,
-		HasCost:           resp.HasCost,
+		CostUSD:           costUSD,
+		HasCost:           hasCost,
 	}, nil
 }
 
@@ -370,10 +409,13 @@ func UsageFromSessionPayload(resp SessionUsagePayload) (*Usage, error) {
 		}
 	}
 	if *resp.HasCost {
-		if resp.CostUSD == nil {
-			return nil, fmt.Errorf("usage endpoint schema: missing cost_usd")
+		costUSD, ok := resolveCostUSD(resp.CostUSD, resp.Cost)
+		if !ok {
+			return nil, fmt.Errorf(
+				"usage endpoint schema: missing cost_usd or cost.microdollars",
+			)
 		}
-		usage.CostUSD = *resp.CostUSD
+		usage.CostUSD = costUSD
 		usage.HasCost = true
 	}
 	if !usage.HasUsageData() {
@@ -402,6 +444,7 @@ func ParseJSON(data string) *Usage {
 func (u Usage) HasUsageData() bool {
 	return u.InputTokens != 0 ||
 		u.CachedInputTokens != 0 ||
+		u.CacheCreationTokens != 0 ||
 		u.OutputTokens != 0 ||
 		u.PeakContextTokens != 0 ||
 		u.HasCost
@@ -428,9 +471,13 @@ func ParseCodexUsageJSONL(r io.Reader) (*Usage, error) {
 		Type     string `json:"type"`
 		ThreadID string `json:"thread_id,omitempty"`
 		Usage    struct {
-			InputTokens       int64 `json:"input_tokens"`
-			CachedInputTokens int64 `json:"cached_input_tokens"`
-			OutputTokens      int64 `json:"output_tokens"`
+			InputTokens int64 `json:"input_tokens"`
+			// OpenAI's input_tokens is inclusive of cached_input_tokens; the
+			// two are not disjoint. Stored as-is to stay faithful to the
+			// source event.
+			CachedInputTokens     int64 `json:"cached_input_tokens"`
+			CacheWriteInputTokens int64 `json:"cache_write_input_tokens"`
+			OutputTokens          int64 `json:"output_tokens"`
 		} `json:"usage,omitempty"`
 	}
 
@@ -450,12 +497,13 @@ func ParseCodexUsageJSONL(r io.Reader) (*Usage, error) {
 					}
 					if ev.Type == "turn.completed" {
 						u := Usage{
-							InputTokens:       ev.Usage.InputTokens,
-							CachedInputTokens: ev.Usage.CachedInputTokens,
-							OutputTokens:      ev.Usage.OutputTokens,
-							UsageSource:       "job_log_turn_completed",
-							ThreadID:          threadID,
-							EventOffset:       offset,
+							InputTokens:         ev.Usage.InputTokens,
+							CachedInputTokens:   ev.Usage.CachedInputTokens,
+							CacheCreationTokens: ev.Usage.CacheWriteInputTokens,
+							OutputTokens:        ev.Usage.OutputTokens,
+							UsageSource:         "job_log_turn_completed",
+							ThreadID:            threadID,
+							EventOffset:         offset,
 						}
 						if ev.ThreadID != "" {
 							u.ThreadID = ev.ThreadID

--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -79,14 +79,14 @@ type costEnvelope struct {
 
 // resolveCostUSD converts either cost shape to dollars, reporting whether a
 // cost was actually present. An explicit `"cost_usd": null` is absent, not $0;
-// a real 0 (or 0 microdollars) is a valid free run. The float field wins when
-// both are populated, since it is the more explicit of the two.
+// a real 0 (or 0 microdollars) is a valid free run. The microdollar envelope
+// wins when both are populated because it is the current agentsview format.
 func resolveCostUSD(costUSD *float64, cost *costEnvelope) (float64, bool) {
-	if costUSD != nil {
-		return *costUSD, true
-	}
 	if cost != nil && cost.Microdollars != nil {
 		return float64(*cost.Microdollars) / 1e6, true
+	}
+	if costUSD != nil {
+		return *costUSD, true
 	}
 	return 0, false
 }

--- a/internal/tokens/tokens_test.go
+++ b/internal/tokens/tokens_test.go
@@ -138,6 +138,27 @@ func TestParseJSON(t *testing.T) {
 		assert.InDelta(t, 0.05, u.CostUSD, 1e-9)
 	})
 
+	t.Run("cost flag without amount is unpriced", func(t *testing.T) {
+		u := ParseJSON(`{"total_output_tokens":200,"has_cost":true}`)
+		require.NotNil(t, u)
+		assert.False(t, u.HasCost)
+	})
+
+	t.Run("null cost amount is unpriced", func(t *testing.T) {
+		u := ParseJSON(
+			`{"total_output_tokens":200,"cost_usd":null,"has_cost":true}`,
+		)
+		require.NotNil(t, u)
+		assert.False(t, u.HasCost)
+	})
+
+	t.Run("explicit zero cost remains priced", func(t *testing.T) {
+		u := ParseJSON(`{"cost_usd":0,"has_cost":true}`)
+		require.NotNil(t, u)
+		assert.True(t, u.HasCost)
+		assert.Zero(t, u.CostUSD)
+	})
+
 	t.Run("codex input buckets", func(t *testing.T) {
 		u := ParseJSON(
 			`{"input_tokens":79150,"cached_input_tokens":2560,` +

--- a/internal/tokens/tokens_test.go
+++ b/internal/tokens/tokens_test.go
@@ -592,11 +592,11 @@ func TestUsageFromSessionPayloadCostShapes(t *testing.T) {
 			wantUSD:  0.598641,
 		},
 		{
-			name: "both present prefers explicit cost_usd",
+			name: "both present prefers microdollar envelope",
 			body: `{"has_token_data":false,"cost_usd":0.42,` +
 				`"cost":{"microdollars":999999},"has_cost":true}`,
 			wantCost: true,
-			wantUSD:  0.42,
+			wantUSD:  0.999999,
 		},
 		{
 			name:     "zero microdollars is a valid free run",

--- a/internal/tokens/tokens_test.go
+++ b/internal/tokens/tokens_test.go
@@ -2,6 +2,7 @@ package tokens
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -69,6 +70,21 @@ func TestFormatSummary(t *testing.T) {
 			"cost only",
 			Usage{CostUSD: 0.05, HasCost: true},
 			"~$0.05",
+		},
+		{
+			"cache writes are reported alongside reads",
+			Usage{
+				InputTokens: 24594, CachedInputTokens: 1408,
+				CacheCreationTokens: 8192, OutputTokens: 290,
+			},
+			"24.6k in (1.4k cached, 8.2k written) · 290 out",
+		},
+		{
+			// Cache writes alone are real consumption, so the summary must
+			// not collapse to an empty string.
+			"cache writes alone still summarize",
+			Usage{CacheCreationTokens: 512},
+			"0 ctx (512 written) · 0 out",
 		},
 	}
 
@@ -161,6 +177,33 @@ func TestParseCodexUsageJSONL(t *testing.T) {
 	assert.Equal(t, "job_log_turn_completed", usage.UsageSource)
 	assert.Equal(t, "thread-123", usage.ThreadID)
 	assert.Positive(t, usage.EventOffset)
+}
+
+// Codex reports cache-creation tokens separately from cache reads. The field
+// exists as of codex-cli 0.146.0 and must not be folded into
+// cached_input_tokens, which counts cache *reads*.
+func TestParseCodexUsageJSONLCapturesCacheWriteTokens(t *testing.T) {
+	log := `{"type":"turn.completed","usage":{"input_tokens":24594,` +
+		`"cached_input_tokens":1408,"cache_write_input_tokens":8192,` +
+		`"output_tokens":290,"reasoning_output_tokens":158}}` + "\n"
+
+	usage, err := ParseCodexUsageJSONL(strings.NewReader(log))
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	assert.Equal(t, int64(24594), usage.InputTokens)
+	assert.Equal(t, int64(1408), usage.CachedInputTokens)
+	assert.Equal(t, int64(8192), usage.CacheCreationTokens)
+	assert.Equal(t, int64(290), usage.OutputTokens)
+}
+
+// A turn that only wrote cache still consumed tokens, so it is usage data.
+func TestParseCodexUsageJSONLCacheWriteAloneIsUsage(t *testing.T) {
+	usage, err := ParseCodexUsageJSONL(strings.NewReader(
+		`{"type":"turn.completed","usage":{"cache_write_input_tokens":512}}` + "\n",
+	))
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	assert.Equal(t, int64(512), usage.CacheCreationTokens)
 }
 
 func TestParseCodexUsageJSONLIgnoresMissingUsage(t *testing.T) {
@@ -517,6 +560,152 @@ func TestFetchForSessionWithConfigRequiresAgentsviewWhenRequested(t *testing.T) 
 	assert.Contains(t, err.Error(), "agentsview lookup")
 }
 
+// agentsview v0.39.0 moved the cost from a "cost_usd" float to a
+// "cost": {"microdollars": N} envelope. Both shapes must decode, and a null
+// cost_usd must never be read as a valid $0.
+func TestUsageFromSessionPayloadCostShapes(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		wantErr   string
+		wantCost  bool
+		wantUSD   float64
+		wantNoUse bool
+	}{
+		{
+			name:     "legacy cost_usd float",
+			body:     `{"has_token_data":false,"cost_usd":0.42,"has_cost":true}`,
+			wantCost: true,
+			wantUSD:  0.42,
+		},
+		{
+			name:     "microdollar envelope",
+			body:     `{"has_token_data":false,"cost":{"microdollars":131767},"has_cost":true}`,
+			wantCost: true,
+			wantUSD:  0.131767,
+		},
+		{
+			name: "null cost_usd falls back to microdollars",
+			body: `{"has_token_data":false,"cost_usd":null,` +
+				`"cost":{"microdollars":598641},"has_cost":true}`,
+			wantCost: true,
+			wantUSD:  0.598641,
+		},
+		{
+			name: "both present prefers explicit cost_usd",
+			body: `{"has_token_data":false,"cost_usd":0.42,` +
+				`"cost":{"microdollars":999999},"has_cost":true}`,
+			wantCost: true,
+			wantUSD:  0.42,
+		},
+		{
+			name:     "zero microdollars is a valid free run",
+			body:     `{"has_token_data":false,"cost":{"microdollars":0},"has_cost":true}`,
+			wantCost: true,
+			wantUSD:  0,
+		},
+		{
+			name:     "zero cost_usd is a valid free run",
+			body:     `{"has_token_data":false,"cost_usd":0,"has_cost":true}`,
+			wantCost: true,
+			wantUSD:  0,
+		},
+		{
+			name:    "has_cost with neither field is a schema error",
+			body:    `{"has_token_data":false,"has_cost":true}`,
+			wantErr: "missing cost",
+		},
+		{
+			name: "null microdollars is not a valid zero",
+			body: `{"has_token_data":false,"cost":{"microdollars":null},` +
+				`"has_cost":true}`,
+			wantErr: "missing cost",
+		},
+		{
+			name:      "no cost and no tokens means no usage",
+			body:      `{"has_token_data":false,"has_cost":false}`,
+			wantNoUse: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var payload SessionUsagePayload
+			require.NoError(t, json.Unmarshal([]byte(tt.body), &payload))
+
+			usage, err := UsageFromSessionPayload(payload)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Nil(t, usage)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantNoUse {
+				assert.Nil(t, usage)
+				return
+			}
+			require.NotNil(t, usage)
+			assert.Equal(t, tt.wantCost, usage.HasCost)
+			assert.InDelta(t, tt.wantUSD, usage.CostUSD, 1e-9)
+		})
+	}
+}
+
+func TestFetchForSessionCLIParsesMicrodollarCost(t *testing.T) {
+	installFakeAgentsview(t, `#!/bin/sh
+if [ "$1" = "session" ] && [ "$2" = "usage" ]; then
+  echo '{"session_id":"s","agent":"codex","total_output_tokens":4762,"peak_context_tokens":70092,"has_token_data":true,"cost_usd":null,"cost":{"microdollars":598641},"has_cost":true,"cost_source":"computed"}'
+  exit 0
+fi
+echo "unexpected args: $@" >&2
+exit 99
+`)
+
+	usage, err := FetchForSession(context.Background(), "s")
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	assert.Equal(t, int64(4762), usage.OutputTokens)
+	assert.Equal(t, int64(70092), usage.PeakContextTokens)
+	assert.True(t, usage.HasCost)
+	assert.InDelta(t, 0.598641, usage.CostUSD, 1e-9)
+}
+
+// An unpriced session must not be recorded as a $0 review: dropping the cost
+// flag keeps it out of the priced numerator instead of deflating the total.
+func TestFetchForSessionCLIHasCostWithoutAmountDropsCost(t *testing.T) {
+	installFakeAgentsview(t, `#!/bin/sh
+if [ "$1" = "session" ] && [ "$2" = "usage" ]; then
+  echo '{"session_id":"s","agent":"codex","total_output_tokens":300,"peak_context_tokens":5000,"has_token_data":true,"has_cost":true}'
+  exit 0
+fi
+echo "unexpected args: $@" >&2
+exit 99
+`)
+
+	usage, err := FetchForSession(context.Background(), "s")
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	assert.Equal(t, int64(300), usage.OutputTokens)
+	assert.False(t, usage.HasCost)
+	assert.Zero(t, usage.CostUSD)
+}
+
+func TestFetchForSessionCLIHasCostWithoutAmountOrTokensMeansNoUsage(t *testing.T) {
+	installFakeAgentsview(t, `#!/bin/sh
+if [ "$1" = "session" ] && [ "$2" = "usage" ]; then
+  echo '{"session_id":"s","agent":"codex","has_token_data":false,"has_cost":true}'
+  exit 0
+fi
+echo "unexpected args: $@" >&2
+exit 99
+`)
+
+	usage, err := FetchForSession(context.Background(), "s")
+	require.NoError(t, err)
+	assert.Nil(t, usage)
+}
+
 func TestToJSON(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		assert.Empty(t, ToJSON(nil))
@@ -532,6 +721,14 @@ func TestToJSON(t *testing.T) {
 		require.NotNil(t, got)
 		assert.Equal(t, orig.PeakContextTokens, got.PeakContextTokens)
 		assert.Equal(t, orig.OutputTokens, got.OutputTokens)
+	})
+
+	// A run priced at exactly $0 must persist the amount, not just the flag.
+	// Dropping it would make a real free run byte-identical to the drifted
+	// rows that recorded has_cost with no dollars.
+	t.Run("explicit zero cost survives serialization", func(t *testing.T) {
+		s := ToJSON(&Usage{OutputTokens: 300, CostUSD: 0, HasCost: true})
+		assert.Contains(t, s, `"cost_usd":0`)
 	})
 
 	t.Run("round trip with cost", func(t *testing.T) {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -184,6 +184,10 @@ type CostAggregate struct {
 	TotalUsd     float64 `json:"total_usd"`
 }
 
+type CostEnvelope struct {
+	Microdollars *int64 `json:"microdollars,omitempty"`
+}
+
 type DaemonStatus struct {
 	// Schema A URL to the JSON Schema for this object.
 	Schema              *string           `json:"$schema,omitempty"`
@@ -1442,20 +1446,35 @@ func (r ReviewJob) Validate() error {
 }
 
 type SessionUsagePayload struct {
-	Agent             *string  `json:"agent,omitempty"`
-	CachedInputTokens *int64   `json:"cached_input_tokens,omitempty"`
-	CostUsd           *float64 `json:"cost_usd,omitempty"`
-	HasCost           *bool    `json:"has_cost,omitempty"`
-	HasTokenData      *bool    `json:"has_token_data,omitempty"`
-	InputTokens       *int64   `json:"input_tokens,omitempty"`
-	PeakContextTokens *int64   `json:"peak_context_tokens,omitempty"`
-	Project           *string  `json:"project,omitempty"`
-	SessionID         string   `json:"session_id" validate:"required"`
-	TotalOutputTokens *int64   `json:"total_output_tokens,omitempty"`
+	Agent             *string       `json:"agent,omitempty"`
+	CachedInputTokens *int64        `json:"cached_input_tokens,omitempty"`
+	Cost              *CostEnvelope `json:"cost,omitempty"`
+	CostUsd           *float64      `json:"cost_usd,omitempty"`
+	HasCost           *bool         `json:"has_cost,omitempty"`
+	HasTokenData      *bool         `json:"has_token_data,omitempty"`
+	InputTokens       *int64        `json:"input_tokens,omitempty"`
+	PeakContextTokens *int64        `json:"peak_context_tokens,omitempty"`
+	Project           *string       `json:"project,omitempty"`
+	SessionID         string        `json:"session_id" validate:"required"`
+	TotalOutputTokens *int64        `json:"total_output_tokens,omitempty"`
 }
 
 func (s SessionUsagePayload) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(s))
+	var errors runtime.ValidationErrors
+	if s.Cost != nil {
+		if v, ok := any(s.Cost).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Cost", err)
+			}
+		}
+	}
+	if err := typesValidator.Var(s.SessionID, "required"); err != nil {
+		errors = errors.Append("SessionID", err)
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
 }
 
 type ShutdownOutputBody struct {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -299,6 +299,13 @@ components:
         - jobs_total
         - complete
       type: object
+    CostEnvelope:
+      additionalProperties: false
+      properties:
+        microdollars:
+          format: int64
+          type: integer
+      type: object
     DaemonStatus:
       additionalProperties: false
       properties:
@@ -2033,6 +2040,8 @@ components:
         cached_input_tokens:
           format: int64
           type: integer
+        cost:
+          $ref: "#/components/schemas/CostEnvelope"
         cost_usd:
           format: double
           type: number


### PR DESCRIPTION
Agentsview v0.39.0 moved session costs from the `cost_usd` field to a `cost.microdollars` envelope. Roborev still read only the old shape, so affected reviews appeared priced but recorded no amount and quietly undercounted spend.

This change accepts both cost shapes, re-fetches affected rows during token backfill, and excludes amount-less flags from cost coverage. It also records Codex cache-write tokens so usage totals remain complete.