### PR TITLE
Resume interrupted work after agent Stop hooks

### DIFF
--- a/internal/agenthook/output.go
+++ b/internal/agenthook/output.go
@@ -2,7 +2,7 @@ package agenthook
 
 import "strings"
 
-const postToolUseContinuationInstruction = "If Roborev issues are found, fix them, " +
+const continuationInstruction = "If Roborev issues are found, fix them, " +
 	"then continue the task you were doing before this hook interrupted you."
 
 func BuildOutput(input Input, resp Response) map[string]any {
@@ -13,20 +13,20 @@ func BuildOutput(input Input, resp Response) map[string]any {
 		return map[string]any{
 			"hookSpecificOutput": map[string]any{
 				"hookEventName":     "PostToolUse",
-				"additionalContext": postToolUseAdditionalContext(resp.Reason),
+				"additionalContext": withContinuationInstruction(resp.Reason),
 			},
 		}
 	}
 	return map[string]any{
 		"decision": "block",
-		"reason":   resp.Reason,
+		"reason":   withContinuationInstruction(resp.Reason),
 	}
 }
 
-func postToolUseAdditionalContext(reason string) string {
+func withContinuationInstruction(reason string) string {
 	reason = strings.TrimSpace(reason)
 	if reason == "" {
-		return postToolUseContinuationInstruction
+		return continuationInstruction
 	}
-	return reason + " " + postToolUseContinuationInstruction
+	return reason + " " + continuationInstruction
 }

--- a/internal/agenthook/output_test.go
+++ b/internal/agenthook/output_test.go
@@ -14,8 +14,8 @@ func TestBuildOutputForStopBlocks(t *testing.T) {
 	})
 
 	assert.Equal(t, "block", output["decision"])
-	assert.Equal(t, "Invoke $roborev-fix.", output["reason"])
-	assert.NotContains(t, output["reason"], "continue the task")
+	assert.Contains(t, output["reason"], "Invoke $roborev-fix.")
+	assert.Contains(t, output["reason"], "continue the task")
 }
 
 func TestBuildOutputForPostToolUseAddsContext(t *testing.T) {


### PR DESCRIPTION
Codex treats a blocking Stop hook reason as a new user prompt. Roborev currently sends only the review-fix instruction, which can divert multi-turn work that paused at a specification, approval, or implementation checkpoint.

This appends the same continuation framing already used by PostToolUse to Stop responses. The original reason remains intact, while Codex is explicitly told to return to the interrupted task after addressing review findings.

The change is limited to prompt construction; trigger thresholds, review discovery, and hook state behavior are unchanged. The main logic and regression coverage are in `internal/agenthook/output.go` and `internal/agenthook/output_test.go`.
