### PR TITLE
feat(agent-hook): add workspace-scoped snoozing

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ leaving Markdown tables unchanged. Use `make check-renovate-config` to validate
 | `roborev analyze <type>` | Run code analysis with optional auto-fix |
 | `roborev agent-hook install` | Install optional Codex/Claude agent harness hooks |
 | `roborev agent-hook install --agent droid` | Install optional Factory Droid harness hooks |
+| `roborev snooze` | Silence Agent Hook reminders in the current worktree and branch |
+| `roborev snooze off` | Resume Agent Hook reminders in the current worktree and branch |
 | `roborev compact` | Verify and consolidate open review findings |
 | `roborev show [sha]` | Display review for commit |
 | `roborev export reviews` | Export completed reviews as JSON |

--- a/cmd/roborev/main.go
+++ b/cmd/roborev/main.go
@@ -47,6 +47,7 @@ func main() {
 	rootCmd.AddCommand(enqueueCmd()) // hidden alias for backward compatibility
 	rootCmd.AddCommand(waitCmd())
 	rootCmd.AddCommand(statusCmd())
+	rootCmd.AddCommand(snoozeCmd())
 	rootCmd.AddCommand(pauseCmd())
 	rootCmd.AddCommand(unpauseCmd())
 	rootCmd.AddCommand(listCmd())

--- a/cmd/roborev/snooze.go
+++ b/cmd/roborev/snooze.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	gitrepo "go.kenn.io/kit/git/repo"
+
+	"go.kenn.io/roborev/internal/daemon"
+)
+
+const defaultAgentHookSnooze = 8 * time.Hour
+
+func snoozeCmd() *cobra.Command {
+	duration := defaultAgentHookSnooze
+	cmd := &cobra.Command{
+		Use:   "snooze [on|off]",
+		Short: "Temporarily silence agent-hook reminders in this workspace",
+		Long: `Temporarily silence agent-hook reminders for the current worktree and branch.
+
+Reviews continue to enqueue and run while the agent hook is snoozed. With no
+action, snooze behaves like "on". Use "off" to resume reminders immediately.`,
+		Args:                  cobra.MaximumNArgs(1),
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			action := "on"
+			if len(args) == 1 {
+				action = strings.ToLower(strings.TrimSpace(args[0]))
+			}
+			if action != "on" && action != "off" {
+				return fmt.Errorf("action must be on or off")
+			}
+			if action == "off" && cmd.Flags().Changed("duration") {
+				return fmt.Errorf("--duration cannot be used with snooze off")
+			}
+			if duration <= 0 {
+				return fmt.Errorf("snooze duration must be positive")
+			}
+			return runSnooze(cmd, action == "on", duration)
+		},
+	}
+	cmd.Flags().DurationVarP(
+		&duration, "duration", "d", defaultAgentHookSnooze,
+		"how long to silence agent-hook reminders (for example 30m or 8h)",
+	)
+	return cmd
+}
+
+func runSnooze(cmd *cobra.Command, enabled bool, duration time.Duration) error {
+	repoPath, worktreePath, branch, err := currentSnoozeScope(cmd.Context())
+	if err != nil {
+		return err
+	}
+	if err := ensureDaemon(); err != nil {
+		return err
+	}
+
+	req := daemon.AgentHookSnoozeRequest{
+		RepoPath:     repoPath,
+		WorktreePath: worktreePath,
+		Branch:       branch,
+		Enabled:      enabled,
+	}
+	if enabled {
+		req.SnoozedUntil = time.Now().Add(duration).UTC()
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("encode agent hook snooze: %w", err)
+	}
+	ep := getDaemonEndpoint()
+	httpReq, err := http.NewRequestWithContext(
+		cmd.Context(), http.MethodPost,
+		ep.BaseURL()+"/api/agent-hook/snooze", bytes.NewReader(body),
+	)
+	if err != nil {
+		return fmt.Errorf("create agent hook snooze request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := ep.HTTPClient(5 * time.Second).Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("update agent hook snooze: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		message, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf(
+			"update agent hook snooze: daemon returned %s: %s",
+			resp.Status, strings.TrimSpace(string(message)),
+		)
+	}
+
+	label := branch
+	if label == "" {
+		label = "detached HEAD"
+	} else {
+		label = fmt.Sprintf("branch %q", branch)
+	}
+	if enabled {
+		fmt.Fprintf(
+			cmd.OutOrStdout(),
+			"Agent hook snoozed for %s on %s. Reviews will continue to run.\n",
+			formatSnoozeDuration(duration), label,
+		)
+	} else {
+		fmt.Fprintf(cmd.OutOrStdout(), "Agent hook resumed on %s.\n", label)
+	}
+	return nil
+}
+
+func currentSnoozeScope(ctx context.Context) (string, string, string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", "", "", fmt.Errorf("get current directory: %w", err)
+	}
+	worktreePath, err := gitrepo.Root(ctx, cwd)
+	if err != nil || worktreePath == "" {
+		return "", "", "", fmt.Errorf("not inside a git repository")
+	}
+	repoPath, err := gitrepo.MainRoot(ctx, worktreePath)
+	if err != nil {
+		return "", "", "", fmt.Errorf("resolve main repository: %w", err)
+	}
+	if repoPath == "" {
+		return "", "", "", fmt.Errorf("resolve main repository: empty path")
+	}
+	return repoPath, worktreePath,
+		gitrepo.CurrentBranch(ctx, worktreePath), nil
+}
+
+func formatSnoozeDuration(duration time.Duration) string {
+	if duration%time.Hour == 0 {
+		return fmt.Sprintf("%dh", int64(duration/time.Hour))
+	}
+	if duration%time.Minute == 0 {
+		return fmt.Sprintf("%dm", int64(duration/time.Minute))
+	}
+	return duration.String()
+}

--- a/cmd/roborev/snooze_test.go
+++ b/cmd/roborev/snooze_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/daemon"
+)
+
+func TestSnoozeCommandSetsAndClearsCurrentWorkspace(t *testing.T) {
+	assert := assert.New(t)
+	repo := NewGitTestRepo(t)
+	repo.CommitFile("main.go", "package main\n", "initial")
+	repo.Run("checkout", "-b", "feature/snooze")
+
+	requests := make(chan daemon.AgentHookSnoozeRequest, 2)
+	NewMockDaemon(t, MockRefineHooks{
+		OnUnhandled: func(w http.ResponseWriter, r *http.Request, _ *mockRefineState) bool {
+			if r.URL.Path != "/api/agent-hook/snooze" {
+				return false
+			}
+			var req daemon.AgentHookSnoozeRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			requests <- req
+			respondJSON(w, http.StatusOK, map[string]any{"snoozed": req.Enabled})
+			return true
+		},
+	})
+	chdir(t, repo.Dir)
+
+	started := time.Now()
+	var onOutput bytes.Buffer
+	on := snoozeCmd()
+	on.SetOut(&onOutput)
+	on.SetArgs([]string{"on"})
+	require.NoError(t, on.Execute())
+	onRequest := <-requests
+	assert.True(onRequest.Enabled)
+	assert.Equal(repo.Dir, onRequest.RepoPath)
+	assert.Equal(repo.Dir, onRequest.WorktreePath)
+	assert.Equal("feature/snooze", onRequest.Branch)
+	assert.WithinDuration(started.Add(defaultAgentHookSnooze), onRequest.SnoozedUntil, 5*time.Second)
+	assert.Contains(onOutput.String(), "Reviews will continue to run")
+
+	var offOutput bytes.Buffer
+	off := snoozeCmd()
+	off.SetOut(&offOutput)
+	off.SetArgs([]string{"off"})
+	require.NoError(t, off.Execute())
+	offRequest := <-requests
+	assert.False(offRequest.Enabled)
+	assert.Equal("feature/snooze", offRequest.Branch)
+	assert.True(offRequest.SnoozedUntil.IsZero())
+	assert.Contains(offOutput.String(), "Agent hook resumed")
+}

--- a/docs/agent-hook.md
+++ b/docs/agent-hook.md
@@ -71,6 +71,31 @@ stay off unless `commit_threshold` is set above `0`. Failed-review counts are
 scoped to the current git branch. Older jobs without a stored branch are
 included, matching `roborev fix` discovery.
 
+## Snoozing Reminders
+
+Silence Agent Hook reminders temporarily when a session needs a longer stretch
+of implementation work:
+
+```bash
+roborev snooze                 # defaults to eight hours
+roborev snooze on --duration 2h
+roborev snooze off             # resume immediately
+```
+
+The snooze is scoped to the current linked worktree and branch. Switching
+branches or working in another checkout does not inherit it. The deadline is
+stored as local workspace state in roborev's SQLite database and expires
+automatically.
+
+Snoozing affects only the coding-agent harness reminder. Post-commit reviews
+continue to enqueue, workers continue processing them, and failed reviews keep
+accumulating for later attention. The hook advances its local commit baselines
+while snoozed so it does not emit a catch-up reminder for every commit made
+during the quiet period.
+
+The bundled `/roborev-snooze` skill (or `$roborev-snooze` in Codex) exposes both
+the `on` and `off` operations from an agent session.
+
 ## Quick Start
 
 The reminder tells the agent to run the `$roborev-fix` skill, so install

--- a/docs/guides/agent-skills.md
+++ b/docs/guides/agent-skills.md
@@ -97,9 +97,9 @@ before roborev receives the path. Custom destinations are not tracked by
     description still requires explicit roborev invocation. See the
     [syntax table](#agent-specific-syntax) for more examples.
 
-    Factory supports `disable-model-invocation`, but the current bundled
-    Droid-derived definitions do not set that available machine-readable policy.
-    They rely on description and body guardrails instead.
+    Factory supports `disable-model-invocation`. The bundled `/roborev-snooze`
+    definition sets that policy, so only a human can trigger it. Other Droid-derived
+    definitions rely on description and body guardrails.
 
 ### Review a commit
 

--- a/docs/guides/agent-skills.md
+++ b/docs/guides/agent-skills.md
@@ -57,6 +57,7 @@ before roborev receives the path. Custom destinations are not tracked by
 | `/roborev-fix [job_id...]` | Discover and fix all open review findings in one pass |
 | `/roborev-refine [--since ...] [--branch ...] [--max-iterations ...]` | Iterative review-fix-review loop until all reviews pass |
 | `/roborev-respond <job_id> [message]` | Add a response to document changes |
+| `/roborev-snooze [on\|off] [duration]` | Silence or resume Agent Hook reminders for the current worktree and branch |
 
 ## Usage
 
@@ -178,6 +179,20 @@ Run the same future-data leakage check across all commits on the current branch:
 The skill compares the branch with its merge base by default, or with the branch
 specified by `--base`, and waits to present the result inline.
 
+### Snooze Agent Hook reminders
+
+Keep reviews running while temporarily silencing the mid-session Agent Hook
+instruction:
+
+```text
+/roborev-snooze on
+/roborev-snooze on 2h
+/roborev-snooze off
+```
+
+The skill maps a custom duration to `roborev snooze on --duration <duration>`.
+It never pauses queue processing or disables post-commit review enqueueing.
+
 ### Fix all open reviews at once
 
 The most powerful skill is `/roborev-fix`. With no arguments it discovers all
@@ -250,11 +265,11 @@ which can produce better results than the CLI's isolated worktree approach.
 
 | Agent | Syntax |
 |-------|--------|
-| Claude Code, personal install | `/roborev-review`, `/roborev-review-branch`, `/roborev-design-review`, `/roborev-design-review-branch`, `/roborev-lookahead-review`, `/roborev-lookahead-review-branch`, `/roborev-fix`, `/roborev-refine`, `/roborev-respond` |
-| Claude Code, plugin install | `/roborev:roborev-review`, `/roborev:roborev-review-branch`, `/roborev:roborev-design-review`, `/roborev:roborev-design-review-branch`, `/roborev:roborev-lookahead-review`, `/roborev:roborev-lookahead-review-branch`, `/roborev:roborev-fix`, `/roborev:roborev-refine`, `/roborev:roborev-respond` |
-| Factory Droid | `/roborev-review`, `/roborev-review-branch`, `/roborev-design-review`, `/roborev-design-review-branch`, `/roborev-lookahead-review`, `/roborev-lookahead-review-branch`, `/roborev-fix`, `/roborev-refine`, `/roborev-respond` |
-| Codex, personal install | `$roborev-review`, `$roborev-review-branch`, `$roborev-design-review`, `$roborev-design-review-branch`, `$roborev-lookahead-review`, `$roborev-lookahead-review-branch`, `$roborev-fix`, `$roborev-refine`, `$roborev-respond` |
-| Codex, plugin install | `$roborev:roborev-review`, `$roborev:roborev-review-branch`, `$roborev:roborev-design-review`, `$roborev:roborev-design-review-branch`, `$roborev:roborev-lookahead-review`, `$roborev:roborev-lookahead-review-branch`, `$roborev:roborev-fix`, `$roborev:roborev-refine`, `$roborev:roborev-respond` |
+| Claude Code, personal install | `/roborev-review`, `/roborev-review-branch`, `/roborev-design-review`, `/roborev-design-review-branch`, `/roborev-lookahead-review`, `/roborev-lookahead-review-branch`, `/roborev-fix`, `/roborev-refine`, `/roborev-respond`, `/roborev-snooze` |
+| Claude Code, plugin install | `/roborev:roborev-review`, `/roborev:roborev-review-branch`, `/roborev:roborev-design-review`, `/roborev:roborev-design-review-branch`, `/roborev:roborev-lookahead-review`, `/roborev:roborev-lookahead-review-branch`, `/roborev:roborev-fix`, `/roborev:roborev-refine`, `/roborev:roborev-respond`, `/roborev:roborev-snooze` |
+| Factory Droid | `/roborev-review`, `/roborev-review-branch`, `/roborev-design-review`, `/roborev-design-review-branch`, `/roborev-lookahead-review`, `/roborev-lookahead-review-branch`, `/roborev-fix`, `/roborev-refine`, `/roborev-respond`, `/roborev-snooze` |
+| Codex, personal install | `$roborev-review`, `$roborev-review-branch`, `$roborev-design-review`, `$roborev-design-review-branch`, `$roborev-lookahead-review`, `$roborev-lookahead-review-branch`, `$roborev-fix`, `$roborev-refine`, `$roborev-respond`, `$roborev-snooze` |
+| Codex, plugin install | `$roborev:roborev-review`, `$roborev:roborev-review-branch`, `$roborev:roborev-design-review`, `$roborev:roborev-design-review-branch`, `$roborev:roborev-lookahead-review`, `$roborev:roborev-lookahead-review-branch`, `$roborev:roborev-fix`, `$roborev:roborev-refine`, `$roborev:roborev-respond`, `$roborev:roborev-snooze` |
 
 Codex can also invoke either installation by selecting the skill in its
 structured skill picker. Skill descriptions intentionally state only the

--- a/internal/agenthook/state.go
+++ b/internal/agenthook/state.go
@@ -32,14 +32,16 @@ type hookScope struct {
 	Branch              string
 	WorktreeKey         string
 	CandidateLineageKey string
+	SnoozedUntil        time.Time
 	Tracked             bool
 }
 
 type trackedRepoResolution struct {
-	Tracked  bool
-	RootPath string
-	Identity string
-	Name     string
+	Tracked      bool
+	RootPath     string
+	Identity     string
+	Name         string
+	SnoozedUntil time.Time
 }
 
 type gitScope struct {
@@ -146,6 +148,9 @@ func (s *StateStore) recordStop(req Request) (Response, error) {
 			Skipped:               true,
 		}, nil
 	}
+	if scope.SnoozedUntil.After(time.Now()) {
+		return s.recordSnoozed(req, scope)
+	}
 	failedReviewCount, haveFailedReviewCount := countOpenFailedReviews(
 		context.Background(), scope.TrackedRepoRoot, scope.Branch, scope.Head, req.RoborevServerAddr,
 	)
@@ -241,6 +246,9 @@ func (s *StateStore) recordPreToolUse(req Request) (Response, error) {
 			Skipped:               true,
 		}, nil
 	}
+	if scope.SnoozedUntil.After(time.Now()) {
+		return s.recordSnoozed(req, scope)
+	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -292,6 +300,9 @@ func (s *StateStore) recordPostToolUse(req Request) (Response, error) {
 			FailedReviewThreshold: req.FailedReviewThreshold,
 			Skipped:               true,
 		}, nil
+	}
+	if scope.SnoozedUntil.After(time.Now()) {
+		return s.recordSnoozed(req, scope)
 	}
 
 	failedReviewCount, haveFailedReviewCount := 0, false
@@ -428,6 +439,43 @@ func (s *StateStore) recordPostToolUse(req Request) (Response, error) {
 		resp.Reason = buildCommitReason(req, triggeringCommitCount, scope.WorktreeRoot)
 	}
 	return resp, nil
+}
+
+// recordSnoozed advances the checkout baselines without accumulating reminder
+// thresholds. Reviews keep running in the main daemon; only this agent-facing
+// hook response is suppressed. Advancing HEAD prevents commits made during the
+// snooze from producing an immediate catch-up reminder after it expires.
+func (s *StateStore) recordSnoozed(req Request, scope hookScope) (Response, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	st := s.sessions[req.Event.SessionID]
+	lineageKey := ensureLineageKey(&st, scope)
+	keys := uniqueStrings(append(
+		[]string{scope.WorktreeKey},
+		commitSequenceKeys(scope, lineageKey)...,
+	))
+	recordSequenceHeads(&st, scope, keys)
+	resetPromptCountersForKeys(&st, keys)
+	delete(st.FailedReviewTriggeredCounts, lineageKey)
+	st.FailedReviewCount = 0
+	st.LastCWD = req.Event.CWD
+	st.LastSeenAt = time.Now().UTC()
+	s.sessions[req.Event.SessionID] = st
+	if err := s.saveLocked(); err != nil {
+		return Response{}, err
+	}
+
+	return Response{
+		SessionID:             req.Event.SessionID,
+		Count:                 st.Count,
+		Threshold:             req.Threshold,
+		CommitCount:           st.CommitCount,
+		CommitThreshold:       req.CommitThreshold,
+		FailedReviewThreshold: req.FailedReviewThreshold,
+		ReminderPromptCount:   st.ReminderPromptCount,
+		Skipped:               true,
+	}, nil
 }
 
 func hasActionableFailedReviews(count int, ok bool) bool {
@@ -767,12 +815,16 @@ func resolveHookScope(ctx context.Context, cwd, configuredAddr string) (hookScop
 	}
 	trackedRoot := mainRepoRoot(gitInfo)
 	tracked := true
-	if resolved, known := resolveTrackedRepo(ctx, gitInfo.WorktreeRoot, configuredAddr); known {
+	var snoozedUntil time.Time
+	if resolved, known := resolveTrackedRepo(
+		ctx, gitInfo.WorktreeRoot, gitInfo.Branch, configuredAddr,
+	); known {
 		if !resolved.Tracked {
 			tracked = false
 		} else if strings.TrimSpace(resolved.RootPath) != "" {
 			trackedRoot = strings.TrimSpace(resolved.RootPath)
 		}
+		snoozedUntil = resolved.SnoozedUntil
 	}
 	return hookScope{
 		WorktreeRoot:    gitInfo.WorktreeRoot,
@@ -783,11 +835,14 @@ func resolveHookScope(ctx context.Context, cwd, configuredAddr string) (hookScop
 		CandidateLineageKey: lineageSequenceKey(
 			trackedRoot, gitInfo.Branch, gitInfo.WorktreeRoot, gitInfo.Head,
 		),
-		Tracked: tracked,
+		SnoozedUntil: snoozedUntil,
+		Tracked:      tracked,
 	}, true
 }
 
-func resolveTrackedRepo(ctx context.Context, path, configuredAddr string) (trackedRepoResolution, bool) {
+func resolveTrackedRepo(
+	ctx context.Context, path, branch, configuredAddr string,
+) (trackedRepoResolution, bool) {
 	ep, ok := roborevEndpoint(configuredAddr)
 	if !ok {
 		return trackedRepoResolution{}, false
@@ -795,6 +850,7 @@ func resolveTrackedRepo(ctx context.Context, path, configuredAddr string) (track
 	client := ep.HTTPClient(2 * time.Second)
 	values := url.Values{}
 	values.Set("path", path)
+	values.Set("branch", branch)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ep.BaseURL()+"/api/repos/resolve?"+values.Encode(), nil)
 	if err != nil {
 		return trackedRepoResolution{}, false
@@ -810,9 +866,10 @@ func resolveTrackedRepo(ctx context.Context, path, configuredAddr string) (track
 	var out struct {
 		Tracked *bool `json:"tracked"`
 		Repo    *struct {
-			RootPath string `json:"root_path"`
-			Identity string `json:"identity"`
-			Name     string `json:"name"`
+			RootPath              string     `json:"root_path"`
+			Identity              string     `json:"identity"`
+			Name                  string     `json:"name"`
+			AgentHookSnoozedUntil *time.Time `json:"agent_hook_snoozed_until,omitempty"`
 		} `json:"repo,omitempty"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
@@ -826,6 +883,9 @@ func resolveTrackedRepo(ctx context.Context, path, configuredAddr string) (track
 		resolved.RootPath = out.Repo.RootPath
 		resolved.Identity = out.Repo.Identity
 		resolved.Name = out.Repo.Name
+		if out.Repo.AgentHookSnoozedUntil != nil {
+			resolved.SnoozedUntil = *out.Repo.AgentHookSnoozedUntil
+		}
 	}
 	return resolved, true
 }

--- a/internal/agenthook/state.go
+++ b/internal/agenthook/state.go
@@ -174,14 +174,18 @@ func (s *StateStore) recordStop(req Request) (Response, error) {
 
 	now := time.Now().UTC()
 	st.Count++
-	st.StopCountSincePrompt++
+	if st.StopCountsSincePrompt == nil {
+		st.StopCountsSincePrompt = map[string]int{}
+	}
+	st.StopCountsSincePrompt[lineageKey]++
+	stopCountSincePrompt := st.StopCountsSincePrompt[lineageKey]
 	st.LastTurnID = req.Event.TurnID
 	st.LastCWD = req.Event.CWD
 	st.LastSeenAt = now
 	recordSequenceHeads(&st, scope, []string{scope.WorktreeKey})
 
 	actionableReviews := hasActionableFailedReviews(failedReviewCount, haveFailedReviewCount)
-	stopTriggered := thresholdReady(st.StopCountSincePrompt, req.Threshold) && actionableReviews
+	stopTriggered := thresholdReady(stopCountSincePrompt, req.Threshold) && actionableReviews
 	if stopTriggered {
 		st.TriggeredAt = now
 	}
@@ -214,7 +218,7 @@ func (s *StateStore) recordStop(req Request) (Response, error) {
 		resp.Reason = buildFailedReviewReason(req, st)
 	case stopTriggered:
 		resp.TriggeredBy = "stop"
-		resp.Reason = buildStopReason(req, st)
+		resp.Reason = buildStopReason(req, stopCountSincePrompt)
 	}
 	return resp, nil
 }
@@ -452,7 +456,7 @@ func (s *StateStore) recordSnoozed(req Request, scope hookScope) (Response, erro
 	st := s.sessions[req.Event.SessionID]
 	lineageKey := ensureLineageKey(&st, scope)
 	keys := uniqueStrings(append(
-		[]string{scope.WorktreeKey},
+		[]string{scope.WorktreeKey, lineageKey},
 		commitSequenceKeys(scope, lineageKey)...,
 	))
 	recordSequenceHeads(&st, scope, keys)
@@ -490,13 +494,11 @@ func isShellCommandTool(toolName string) bool {
 	return toolName == "" || toolName == "Bash" || toolName == ExecuteMatcher
 }
 
-// resetPromptCounters restarts the per-prompt counters after a reminder fires.
-// StopCountSincePrompt is session-wide, but commit counts are cleared only for
-// the checkout being prompted so a prompt in one repo or branch cannot discard a
-// deferred commit reminder owed to another.
+// resetPromptCountersForKeys restarts the per-workspace counters after a
+// reminder fires without discarding progress owed to another repo or branch.
 func resetPromptCountersForKeys(st *SessionState, keys []string) {
-	st.StopCountSincePrompt = 0
 	for _, key := range uniqueStrings(keys) {
+		delete(st.StopCountsSincePrompt, key)
 		delete(st.CommitCountsSincePrompt, key)
 		delete(st.CommitSHAsSincePrompt, key)
 	}
@@ -525,7 +527,9 @@ func commitSequenceKeys(scope hookScope, lineageKey string) []string {
 }
 
 func promptResetKeys(scope hookScope, lineageKey string) []string {
-	return commitSequenceKeys(scope, lineageKey)
+	return uniqueStrings(append(
+		[]string{lineageKey}, commitSequenceKeys(scope, lineageKey)...,
+	))
 }
 
 func recordSequenceHeads(st *SessionState, scope hookScope, keys []string) {
@@ -668,8 +672,8 @@ func applyFailedReviewTrigger(
 	return true
 }
 
-func buildStopReason(req Request, st SessionState) string {
-	return buildPromptReason(req, fmt.Sprintf("%s reached.", countPhrase(st.Count, "Stop hook", "Stop hooks")))
+func buildStopReason(req Request, count int) string {
+	return buildPromptReason(req, fmt.Sprintf("%s reached.", countPhrase(count, "Stop hook", "Stop hooks")))
 }
 
 // buildCommitReason describes the commit reminder for the checkout that triggered

--- a/internal/agenthook/state_test.go
+++ b/internal/agenthook/state_test.go
@@ -310,7 +310,7 @@ func TestBuildHookReasonsAreCompactOneLine(t *testing.T) {
 	assert.NotContains(failed, "/Users/wesm")
 	assert.NotContains(failed, "continue the task")
 
-	stop := buildStopReason(req, st)
+	stop := buildStopReason(req, st.Count)
 	assert.Equal("Invoke the $roborev-fix skill now. 4 Stop hooks reached.", stop)
 	assert.NotContains(stop, "\n")
 	assert.NotContains(stop, req.Event.SessionID)
@@ -994,7 +994,7 @@ func TestRecordStopSuppressesReminderWhileWorkspaceIsSnoozed(t *testing.T) {
 		path: filepath.Join(t.TempDir(), "state.json"),
 		sessions: map[string]SessionState{
 			"session-1": {
-				StopCountSincePrompt:        3,
+				StopCountsSincePrompt:       map[string]int{branchKey: 3},
 				CommitSHAsSincePrompt:       map[string][]string{branchKey: {"old-head"}},
 				FailedReviewTriggeredCounts: map[string]int{branchKey: 1},
 			},
@@ -1017,12 +1017,75 @@ func TestRecordStopSuppressesReminderWhileWorkspaceIsSnoozed(t *testing.T) {
 	assert.False(resp.Triggered)
 	assert.Equal(0, jobRequests, "snoozed hooks should not poll or count reviews")
 	state := store.sessions["session-1"]
-	assert.Zero(state.StopCountSincePrompt)
+	assert.Empty(state.StopCountsSincePrompt)
 	assert.Zero(state.ReminderPromptCount)
 	assert.Empty(state.CommitSHAsSincePrompt)
 	assert.Empty(state.FailedReviewTriggeredCounts)
 	assert.Equal(head, state.RepoHeads[worktreeKey])
 	assert.Equal(head, state.RepoHeads[branchKey])
+}
+
+func TestStopReminderProgressIsScopedAcrossSnoozedWorkspaces(t *testing.T) {
+	assert := assert.New(t)
+	repoA := testutil.NewGitRepo(t)
+	repoA.CommitFile("a.go", "package a\n", "initial A")
+	repoB := testutil.NewGitRepo(t)
+	repoB.CommitFile("b.go", "package b\n", "initial B")
+
+	var snoozeA atomic.Bool
+	closed := false
+	verdict := "F"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/repos/resolve" {
+			root := r.URL.Query().Get("path")
+			repo := map[string]any{
+				"root_path": root,
+				"name":      filepath.Base(root),
+			}
+			if root == repoA.Path() && snoozeA.Load() {
+				repo["agent_hook_snoozed_until"] = time.Now().Add(time.Hour).UTC()
+			}
+			assert.NoError(json.NewEncoder(w).Encode(map[string]any{
+				"tracked": true,
+				"repo":    repo,
+			}))
+			return
+		}
+		assert.NoError(json.NewEncoder(w).Encode(jobsResponse{
+			Jobs: []storage.ReviewJob{
+				{Status: storage.JobStatusDone, Closed: &closed, Verdict: &verdict, Branch: "main"},
+			},
+		}))
+	}))
+	t.Cleanup(server.Close)
+
+	store := &StateStore{
+		path:     filepath.Join(t.TempDir(), "state.json"),
+		sessions: map[string]SessionState{},
+	}
+	record := func(cwd string) Response {
+		resp, err := store.Record(Request{
+			Event: Input{
+				SessionID:     "session-1",
+				CWD:           cwd,
+				HookEventName: "Stop",
+			},
+			Threshold:             2,
+			FailedReviewThreshold: 0,
+			Instruction:           "Run roborev fix.",
+			RoborevServerAddr:     server.URL,
+		})
+		require.NoError(t, err)
+		return resp
+	}
+
+	assert.False(record(repoA.Path()).Triggered)
+	assert.False(record(repoB.Path()).Triggered,
+		"repo A Stop progress must not trigger repo B")
+	snoozeA.Store(true)
+	assert.True(record(repoA.Path()).Skipped)
+	assert.True(record(repoB.Path()).Triggered,
+		"snoozing repo A must preserve repo B Stop progress")
 }
 
 func TestRecordPreToolUseBaselinesUntrackedRepoForLaterPostCommitRegistration(t *testing.T) {

--- a/internal/agenthook/state_test.go
+++ b/internal/agenthook/state_test.go
@@ -963,6 +963,68 @@ func TestRecordStopSkipsUntrackedRepo(t *testing.T) {
 	assert.Empty(store.sessions, "untracked repos should not mutate hook state")
 }
 
+func TestRecordStopSuppressesReminderWhileWorkspaceIsSnoozed(t *testing.T) {
+	assert := assert.New(t)
+	repo := testutil.NewGitRepo(t)
+	head := repo.CommitFile("main.go", "package main\n", "initial")
+
+	jobRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/repos/resolve" {
+			assert.Equal(repo.Path(), r.URL.Query().Get("path"))
+			assert.Equal("main", r.URL.Query().Get("branch"))
+			assert.NoError(json.NewEncoder(w).Encode(map[string]any{
+				"tracked": true,
+				"repo": map[string]any{
+					"root_path":                repo.Path(),
+					"name":                     filepath.Base(repo.Path()),
+					"agent_hook_snoozed_until": time.Now().Add(time.Hour).UTC(),
+				},
+			}))
+			return
+		}
+		jobRequests++
+		http.Error(w, "review lookup should be suppressed", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	worktreeKey := worktreeSequenceKey(repo.Path(), repo.Path())
+	branchKey := repoHeadKey(repo.Path(), "main")
+	store := &StateStore{
+		path: filepath.Join(t.TempDir(), "state.json"),
+		sessions: map[string]SessionState{
+			"session-1": {
+				StopCountSincePrompt:        3,
+				CommitSHAsSincePrompt:       map[string][]string{branchKey: {"old-head"}},
+				FailedReviewTriggeredCounts: map[string]int{branchKey: 1},
+			},
+		},
+	}
+	resp, err := store.Record(Request{
+		Event: Input{
+			SessionID:     "session-1",
+			CWD:           repo.Path(),
+			HookEventName: "Stop",
+		},
+		Threshold:             1,
+		FailedReviewThreshold: 1,
+		Instruction:           "Run roborev fix.",
+		RoborevServerAddr:     server.URL,
+	})
+
+	require.NoError(t, err)
+	assert.True(resp.Skipped)
+	assert.False(resp.Triggered)
+	assert.Equal(0, jobRequests, "snoozed hooks should not poll or count reviews")
+	state := store.sessions["session-1"]
+	assert.Zero(state.StopCountSincePrompt)
+	assert.Zero(state.ReminderPromptCount)
+	assert.Empty(state.CommitSHAsSincePrompt)
+	assert.Empty(state.FailedReviewTriggeredCounts)
+	assert.Equal(head, state.RepoHeads[worktreeKey])
+	assert.Equal(head, state.RepoHeads[branchKey])
+}
+
 func TestRecordPreToolUseBaselinesUntrackedRepoForLaterPostCommitRegistration(t *testing.T) {
 	assert := assert.New(t)
 	repo := testutil.NewGitRepo(t)

--- a/internal/agenthook/types.go
+++ b/internal/agenthook/types.go
@@ -63,7 +63,7 @@ type Response struct {
 
 type SessionState struct {
 	Count                       int                 `json:"count"`
-	StopCountSincePrompt        int                 `json:"stop_count_since_prompt,omitempty"`
+	StopCountsSincePrompt       map[string]int      `json:"stop_counts_since_prompt,omitempty"`
 	CommitCount                 int                 `json:"commit_count,omitempty"`
 	CommitCountsSincePrompt     map[string]int      `json:"commit_counts_since_prompt,omitempty"`
 	CommitSHAsSincePrompt       map[string][]string `json:"commit_shas_since_prompt,omitempty"`

--- a/internal/daemon/routes.go
+++ b/internal/daemon/routes.go
@@ -122,6 +122,13 @@ func (s *Server) registerHumaAPI(mux *http.ServeMux) huma.API {
 			o.Tags = []string{"repos"}
 		})
 
+	huma.Post(api, "/api/agent-hook/snooze", s.humaSetAgentHookSnooze,
+		func(o *huma.Operation) {
+			o.OperationID = "set-agent-hook-snooze"
+			o.Summary = "Set or clear an agent-hook workspace snooze"
+			o.Tags = []string{"agent-hook"}
+		})
+
 	huma.Get(api, "/api/branches", s.humaListBranches,
 		func(o *huma.Operation) {
 			o.OperationID = "list-branches"

--- a/internal/daemon/routes_test.go
+++ b/internal/daemon/routes_test.go
@@ -787,6 +787,7 @@ func TestHumaOpenAPISpec(t *testing.T) {
 		"/api/comments":          "get",
 		"/api/repos":             "get",
 		"/api/repos/resolve":     "get",
+		"/api/agent-hook/snooze": "post",
 		"/api/branches":          "get",
 		"/api/status":            "get",
 		"/api/summary":           "get",

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -1483,6 +1483,65 @@ func (s *Server) humaResolveRepo(
 		Identity: repo.Identity,
 		Name:     repo.Name,
 	}
+	snooze, err := s.db.ActiveAgentHookSnooze(
+		repo.RootPath, path, input.Branch, time.Now(),
+	)
+	if err != nil {
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("lookup agent hook snooze: %v", err),
+		)
+	}
+	if snooze != nil {
+		resp.Body.Repo.AgentHookSnoozedUntil = &snooze.SnoozedUntil
+	}
+	return resp, nil
+}
+
+func (s *Server) humaSetAgentHookSnooze(
+	_ context.Context, input *AgentHookSnoozeInput,
+) (*AgentHookSnoozeOutput, error) {
+	req := input.Body
+	if strings.TrimSpace(req.RepoPath) == "" ||
+		strings.TrimSpace(req.WorktreePath) == "" {
+		return nil, huma.Error400BadRequest(
+			"repo_path and worktree_path are required",
+		)
+	}
+
+	resp := &AgentHookSnoozeOutput{}
+	if !req.Enabled {
+		err := s.db.ClearAgentHookSnooze(
+			req.RepoPath, req.WorktreePath, req.Branch,
+		)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, huma.Error404NotFound("repository is not tracked")
+		}
+		if err != nil {
+			return nil, huma.Error500InternalServerError(
+				fmt.Sprintf("clear agent hook snooze: %v", err),
+			)
+		}
+		return resp, nil
+	}
+
+	if !req.SnoozedUntil.After(time.Now()) {
+		return nil, huma.Error400BadRequest(
+			"snoozed_until must be in the future",
+		)
+	}
+	snooze, err := s.db.SetAgentHookSnooze(
+		req.RepoPath, req.WorktreePath, req.Branch, req.SnoozedUntil,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, huma.Error404NotFound("repository is not tracked")
+	}
+	if err != nil {
+		return nil, huma.Error500InternalServerError(
+			fmt.Sprintf("set agent hook snooze: %v", err),
+		)
+	}
+	resp.Body.Snoozed = true
+	resp.Body.SnoozedUntil = &snooze.SnoozedUntil
 	return resp, nil
 }
 

--- a/internal/daemon/server_agent_hook_snooze_test.go
+++ b/internal/daemon/server_agent_hook_snooze_test.go
@@ -1,0 +1,80 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gitrepo "go.kenn.io/kit/git/repo"
+
+	"go.kenn.io/roborev/internal/testutil"
+)
+
+func TestAgentHookSnoozeAPIUpdatesResolveMetadata(t *testing.T) {
+	assert := assert.New(t)
+	server, db, _ := newTestServer(t)
+	repo := testutil.NewTestRepo(t)
+	mainRoot, err := gitrepo.MainRoot(context.Background(), repo.Root)
+	require.NoError(t, err)
+	_, err = db.GetOrCreateRepo(mainRoot)
+	require.NoError(t, err)
+	until := time.Now().Add(2 * time.Hour).UTC().Round(0)
+
+	setBody, err := json.Marshal(AgentHookSnoozeRequest{
+		RepoPath:     mainRoot,
+		WorktreePath: repo.Root,
+		Branch:       "feature/api",
+		Enabled:      true,
+		SnoozedUntil: until,
+	})
+	require.NoError(t, err)
+	set := serveHuma(
+		t, server, http.MethodPost, "/api/agent-hook/snooze", setBody,
+	)
+	require.Equal(t, http.StatusOK, set.Code, set.Body.String())
+
+	resolvePath := "/api/repos/resolve?path=" + url.QueryEscape(repo.Root) +
+		"&branch=" + url.QueryEscape("feature/api")
+	resolved := serveHuma(t, server, http.MethodGet, resolvePath, nil)
+	require.Equal(t, http.StatusOK, resolved.Code)
+	var metadata ResolveRepoOutput
+	require.NoError(t, json.Unmarshal(resolved.Body.Bytes(), &metadata.Body))
+	require.NotNil(t, metadata.Body.Repo)
+	require.NotNil(t, metadata.Body.Repo.AgentHookSnoozedUntil)
+	assert.Equal(until, *metadata.Body.Repo.AgentHookSnoozedUntil)
+
+	other := serveHuma(
+		t, server, http.MethodGet,
+		"/api/repos/resolve?path="+url.QueryEscape(repo.Root)+"&branch=other",
+		nil,
+	)
+	require.Equal(t, http.StatusOK, other.Code)
+	var otherMetadata ResolveRepoOutput
+	require.NoError(t, json.Unmarshal(other.Body.Bytes(), &otherMetadata.Body))
+	require.NotNil(t, otherMetadata.Body.Repo)
+	assert.Nil(otherMetadata.Body.Repo.AgentHookSnoozedUntil)
+
+	offBody, err := json.Marshal(AgentHookSnoozeRequest{
+		RepoPath:     mainRoot,
+		WorktreePath: repo.Root,
+		Branch:       "feature/api",
+		Enabled:      false,
+	})
+	require.NoError(t, err)
+	off := serveHuma(
+		t, server, http.MethodPost, "/api/agent-hook/snooze", offBody,
+	)
+	require.Equal(t, http.StatusOK, off.Code, off.Body.String())
+
+	resumed := serveHuma(t, server, http.MethodGet, resolvePath, nil)
+	require.Equal(t, http.StatusOK, resumed.Code)
+	var resumedMetadata ResolveRepoOutput
+	require.NoError(t, json.Unmarshal(resumed.Body.Bytes(), &resumedMetadata.Body))
+	require.NotNil(t, resumedMetadata.Body.Repo)
+	assert.Nil(resumedMetadata.Body.Repo.AgentHookSnoozedUntil)
+}

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"time"
+
 	"go.kenn.io/roborev/internal/backfill"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/tokens"
@@ -321,14 +323,16 @@ type ListReposOutput struct {
 
 // ResolveRepoInput holds query parameters for resolving a tracked repo.
 type ResolveRepoInput struct {
-	Path string `query:"path" doc:"Absolute path or path inside a repository"`
+	Path   string `query:"path" doc:"Absolute path or path inside a repository"`
+	Branch string `query:"branch" doc:"Current branch for agent-hook snooze lookup"`
 }
 
 // ResolvedRepo is the tracked repo metadata returned by GET /api/repos/resolve.
 type ResolvedRepo struct {
-	RootPath string `json:"root_path"`
-	Identity string `json:"identity"`
-	Name     string `json:"name"`
+	RootPath              string     `json:"root_path"`
+	Identity              string     `json:"identity"`
+	Name                  string     `json:"name"`
+	AgentHookSnoozedUntil *time.Time `json:"agent_hook_snoozed_until,omitempty"`
 }
 
 // ResolveRepoOutput is the response for GET /api/repos/resolve.
@@ -336,6 +340,27 @@ type ResolveRepoOutput struct {
 	Body struct {
 		Tracked bool          `json:"tracked"`
 		Repo    *ResolvedRepo `json:"repo,omitempty"`
+	}
+}
+
+// AgentHookSnoozeRequest updates the local agent-hook snooze for one checkout
+// and branch. Enabled=false clears the record.
+type AgentHookSnoozeRequest struct {
+	RepoPath     string    `json:"repo_path"`
+	WorktreePath string    `json:"worktree_path"`
+	Branch       string    `json:"branch,omitempty"`
+	Enabled      bool      `json:"enabled"`
+	SnoozedUntil time.Time `json:"snoozed_until,omitempty"`
+}
+
+type AgentHookSnoozeInput struct {
+	Body AgentHookSnoozeRequest
+}
+
+type AgentHookSnoozeOutput struct {
+	Body struct {
+		Snoozed      bool       `json:"snoozed"`
+		SnoozedUntil *time.Time `json:"snoozed_until,omitempty"`
 	}
 }
 

--- a/internal/daemon_client/client.gen.go
+++ b/internal/daemon_client/client.gen.go
@@ -163,6 +163,25 @@ type AddCommentRequest struct {
 	Sha       *string `json:"sha,omitempty"`
 }
 
+// AgentHookSnoozeOutputBody defines model for AgentHookSnoozeOutputBody.
+type AgentHookSnoozeOutputBody struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema       *string    `json:"$schema,omitempty"`
+	Snoozed      bool       `json:"snoozed"`
+	SnoozedUntil *time.Time `json:"snoozed_until,omitempty"`
+}
+
+// AgentHookSnoozeRequest defines model for AgentHookSnoozeRequest.
+type AgentHookSnoozeRequest struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema       *string    `json:"$schema,omitempty"`
+	Branch       *string    `json:"branch,omitempty"`
+	Enabled      bool       `json:"enabled"`
+	RepoPath     string     `json:"repo_path"`
+	SnoozedUntil *time.Time `json:"snoozed_until,omitempty"`
+	WorktreePath string     `json:"worktree_path"`
+}
+
 // AgentStats defines model for AgentStats.
 type AgentStats struct {
 	Agent              string  `json:"agent"`
@@ -256,6 +275,11 @@ type CostAggregate struct {
 	JobsTotal    int64   `json:"jobs_total"`
 	JobsWithCost int64   `json:"jobs_with_cost"`
 	TotalUsd     float64 `json:"total_usd"`
+}
+
+// CostEnvelope defines model for CostEnvelope.
+type CostEnvelope struct {
+	Microdollars *int64 `json:"microdollars,omitempty"`
 }
 
 // DaemonStatus defines model for DaemonStatus.
@@ -841,9 +865,10 @@ type ResolveRepoOutputBody struct {
 
 // ResolvedRepo defines model for ResolvedRepo.
 type ResolvedRepo struct {
-	Identity string `json:"identity"`
-	Name     string `json:"name"`
-	RootPath string `json:"root_path"`
+	AgentHookSnoozedUntil *time.Time `json:"agent_hook_snoozed_until,omitempty"`
+	Identity              string     `json:"identity"`
+	Name                  string     `json:"name"`
+	RootPath              string     `json:"root_path"`
 }
 
 // Response defines model for Response.
@@ -943,16 +968,17 @@ type ReviewJob struct {
 
 // SessionUsagePayload defines model for SessionUsagePayload.
 type SessionUsagePayload struct {
-	Agent             *string  `json:"agent,omitempty"`
-	CachedInputTokens *int64   `json:"cached_input_tokens,omitempty"`
-	CostUsd           *float64 `json:"cost_usd,omitempty"`
-	HasCost           *bool    `json:"has_cost"`
-	HasTokenData      *bool    `json:"has_token_data"`
-	InputTokens       *int64   `json:"input_tokens,omitempty"`
-	PeakContextTokens *int64   `json:"peak_context_tokens,omitempty"`
-	Project           *string  `json:"project,omitempty"`
-	SessionId         string   `json:"session_id"`
-	TotalOutputTokens *int64   `json:"total_output_tokens,omitempty"`
+	Agent             *string       `json:"agent,omitempty"`
+	CachedInputTokens *int64        `json:"cached_input_tokens,omitempty"`
+	Cost              *CostEnvelope `json:"cost,omitempty"`
+	CostUsd           *float64      `json:"cost_usd,omitempty"`
+	HasCost           *bool         `json:"has_cost"`
+	HasTokenData      *bool         `json:"has_token_data"`
+	InputTokens       *int64        `json:"input_tokens,omitempty"`
+	PeakContextTokens *int64        `json:"peak_context_tokens,omitempty"`
+	Project           *string       `json:"project,omitempty"`
+	SessionId         string        `json:"session_id"`
+	TotalOutputTokens *int64        `json:"total_output_tokens,omitempty"`
 }
 
 // ShutdownOutputBody defines model for ShutdownOutputBody.
@@ -1228,6 +1254,9 @@ type ListReposParams struct {
 type ResolveRepoParams struct {
 	// Path Absolute path or path inside a repository
 	Path *string `form:"path,omitempty" json:"path,omitempty"`
+
+	// Branch Current branch for agent-hook snooze lookup
+	Branch *string `form:"branch,omitempty" json:"branch,omitempty"`
 }
 
 // GetReviewParams defines parameters for GetReview.
@@ -1268,6 +1297,9 @@ type SyncNowParams struct {
 	// Stream Stream sync progress as NDJSON when set to 1
 	Stream *string `form:"stream,omitempty" json:"stream,omitempty"`
 }
+
+// SetAgentHookSnoozeJSONRequestBody defines body for SetAgentHookSnooze for application/json ContentType.
+type SetAgentHookSnoozeJSONRequestBody = AgentHookSnoozeRequest
 
 // AddCommentJSONRequestBody defines body for AddComment for application/json ContentType.
 type AddCommentJSONRequestBody = AddCommentRequest
@@ -1383,6 +1415,11 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 type ClientInterface interface {
 	// ListActivity request
 	ListActivity(ctx context.Context, params *ListActivityParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SetAgentHookSnoozeWithBody request with any body
+	SetAgentHookSnoozeWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	SetAgentHookSnooze(ctx context.Context, body SetAgentHookSnoozeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListBranches request
 	ListBranches(ctx context.Context, params *ListBranchesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1518,6 +1555,30 @@ type ClientInterface interface {
 
 func (c *Client) ListActivity(ctx context.Context, params *ListActivityParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListActivityRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SetAgentHookSnoozeWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetAgentHookSnoozeRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SetAgentHookSnooze(ctx context.Context, body SetAgentHookSnoozeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetAgentHookSnoozeRequest(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2149,6 +2210,46 @@ func NewListActivityRequest(server string, params *ListActivityParams) (*http.Re
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewSetAgentHookSnoozeRequest calls the generic SetAgentHookSnooze builder with application/json body
+func NewSetAgentHookSnoozeRequest(server string, body SetAgentHookSnoozeJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewSetAgentHookSnoozeRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewSetAgentHookSnoozeRequestWithBody generates requests for SetAgentHookSnooze with any type of body
+func NewSetAgentHookSnoozeRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/agent-hook/snooze")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -3805,6 +3906,22 @@ func NewResolveRepoRequest(server string, params *ResolveRepoParams) (*http.Requ
 
 		}
 
+		if params.Branch != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "branch", *params.Branch, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		queryURL.RawQuery = queryValues.Encode()
 	}
 
@@ -4283,6 +4400,11 @@ type ClientWithResponsesInterface interface {
 	// ListActivityWithResponse request
 	ListActivityWithResponse(ctx context.Context, params *ListActivityParams, reqEditors ...RequestEditorFn) (*ListActivityResponse, error)
 
+	// SetAgentHookSnoozeWithBodyWithResponse request with any body
+	SetAgentHookSnoozeWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetAgentHookSnoozeResponse, error)
+
+	SetAgentHookSnoozeWithResponse(ctx context.Context, body SetAgentHookSnoozeJSONRequestBody, reqEditors ...RequestEditorFn) (*SetAgentHookSnoozeResponse, error)
+
 	// ListBranchesWithResponse request
 	ListBranchesWithResponse(ctx context.Context, params *ListBranchesParams, reqEditors ...RequestEditorFn) (*ListBranchesResponse, error)
 
@@ -4432,6 +4554,29 @@ func (r ListActivityResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ListActivityResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type SetAgentHookSnoozeResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *AgentHookSnoozeOutputBody
+	ApplicationproblemJSONDefault *ErrorModel
+}
+
+// Status returns HTTPResponse.Status
+func (r SetAgentHookSnoozeResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SetAgentHookSnoozeResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -5261,6 +5406,23 @@ func (c *ClientWithResponses) ListActivityWithResponse(ctx context.Context, para
 	return ParseListActivityResponse(rsp)
 }
 
+// SetAgentHookSnoozeWithBodyWithResponse request with arbitrary body returning *SetAgentHookSnoozeResponse
+func (c *ClientWithResponses) SetAgentHookSnoozeWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetAgentHookSnoozeResponse, error) {
+	rsp, err := c.SetAgentHookSnoozeWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSetAgentHookSnoozeResponse(rsp)
+}
+
+func (c *ClientWithResponses) SetAgentHookSnoozeWithResponse(ctx context.Context, body SetAgentHookSnoozeJSONRequestBody, reqEditors ...RequestEditorFn) (*SetAgentHookSnoozeResponse, error) {
+	rsp, err := c.SetAgentHookSnooze(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSetAgentHookSnoozeResponse(rsp)
+}
+
 // ListBranchesWithResponse request returning *ListBranchesResponse
 func (c *ClientWithResponses) ListBranchesWithResponse(ctx context.Context, params *ListBranchesParams, reqEditors ...RequestEditorFn) (*ListBranchesResponse, error) {
 	rsp, err := c.ListBranches(ctx, params, reqEditors...)
@@ -5696,6 +5858,39 @@ func ParseListActivityResponse(rsp *http.Response) (*ListActivityResponse, error
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest ActivityOutputBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSetAgentHookSnoozeResponse parses an HTTP response from a SetAgentHookSnoozeWithResponse call
+func ParseSetAgentHookSnoozeResponse(rsp *http.Response) (*SetAgentHookSnoozeResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SetAgentHookSnoozeResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AgentHookSnoozeOutputBody
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/daemon_client/openapi-3.0.json
+++ b/internal/daemon_client/openapi-3.0.json
@@ -85,6 +85,63 @@
         ],
         "type": "object"
       },
+      "AgentHookSnoozeOutputBody": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/AgentHookSnoozeOutputBody.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "snoozed": {
+            "type": "boolean"
+          },
+          "snoozed_until": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "snoozed"
+        ],
+        "type": "object"
+      },
+      "AgentHookSnoozeRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/AgentHookSnoozeRequest.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "branch": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "repo_path": {
+            "type": "string"
+          },
+          "snoozed_until": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "worktree_path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "repo_path",
+          "worktree_path",
+          "enabled"
+        ],
+        "type": "object"
+      },
       "AgentStats": {
         "additionalProperties": false,
         "properties": {
@@ -386,6 +443,16 @@
           "jobs_total",
           "complete"
         ],
+        "type": "object"
+      },
+      "CostEnvelope": {
+        "additionalProperties": false,
+        "properties": {
+          "microdollars": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
         "type": "object"
       },
       "DaemonStatus": {
@@ -2296,6 +2363,10 @@
       "ResolvedRepo": {
         "additionalProperties": false,
         "properties": {
+          "agent_hook_snoozed_until": {
+            "format": "date-time",
+            "type": "string"
+          },
           "identity": {
             "type": "string"
           },
@@ -2645,6 +2716,9 @@
           "cached_input_tokens": {
             "format": "int64",
             "type": "integer"
+          },
+          "cost": {
+            "$ref": "#/components/schemas/CostEnvelope"
           },
           "cost_usd": {
             "format": "double",
@@ -3004,6 +3078,47 @@
         "summary": "List recent daemon activity",
         "tags": [
           "daemon"
+        ]
+      }
+    },
+    "/api/agent-hook/snooze": {
+      "post": {
+        "operationId": "set-agent-hook-snooze",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentHookSnoozeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentHookSnoozeOutputBody"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Set or clear an agent-hook workspace snooze",
+        "tags": [
+          "agent-hook"
         ]
       }
     },
@@ -4518,6 +4633,16 @@
             "name": "path",
             "schema": {
               "description": "Absolute path or path inside a repository",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Current branch for agent-hook snooze lookup",
+            "explode": false,
+            "in": "query",
+            "name": "branch",
+            "schema": {
+              "description": "Current branch for agent-hook snooze lookup",
               "type": "string"
             }
           }

--- a/internal/skills/claude/roborev-snooze/SKILL.md
+++ b/internal/skills/claude/roborev-snooze/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: roborev-snooze
+description: Use only when the user explicitly invokes /roborev-snooze
+disable-model-invocation: true
+---
+
+# roborev-snooze
+
+Temporarily silence or resume roborev Agent Hook reminders for the current
+worktree and branch. Reviews continue to enqueue and run while reminders are
+snoozed.
+
+## Usage
+
+```text
+/roborev-snooze [on|off] [duration]
+```
+
+`on` is the default action and the duration defaults to eight hours. A duration
+uses Go duration syntax such as `30m`, `2h`, or `12h`.
+
+## Explicit invocation only
+
+Invocation must be explicit: literal personal `/roborev-snooze`, or structured
+Claude Code skill selection.
+Requests such as “silence review notifications” without one of these explicit
+mechanisms must use native behavior and must not run roborev.
+
+## Instructions
+
+This skill requires you to execute the matching command and report its result.
+Defer to project-level CLAUDE.md instructions when they conflict with these
+steps.
+
+- With no action, or with `on`, run `roborev snooze on`. If the user supplied a
+  duration, add `--duration <duration>`.
+- With `off`, run `roborev snooze off`.
+- Do not pause the review queue, disable post-commit hooks, or change review
+  configuration. Snooze affects only Agent Hook reminders in the current
+  worktree and branch.
+- If the command fails because the current directory is not a tracked Git
+  repository, report that error without trying to register or initialize it.
+
+Examples:
+
+```bash
+roborev snooze on
+roborev snooze on --duration 2h
+roborev snooze off
+```

--- a/internal/skills/codex/roborev-snooze/SKILL.md
+++ b/internal/skills/codex/roborev-snooze/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: roborev-snooze
+description: Use only when the user explicitly invokes $roborev-snooze
+---
+
+# roborev-snooze
+
+Temporarily silence or resume roborev Agent Hook reminders for the current
+worktree and branch. Reviews continue to enqueue and run while reminders are
+snoozed.
+
+## Usage
+
+```text
+$roborev-snooze [on|off] [duration]
+```
+
+`on` is the default action and the duration defaults to eight hours. A duration
+uses Go duration syntax such as `30m`, `2h`, or `12h`.
+
+## Explicit invocation only
+
+Invocation must be explicit: literal personal `$roborev-snooze`, plugin
+`$roborev:roborev-snooze`, or structured Codex skill selection.
+Requests such as “silence review notifications” without one of these explicit
+mechanisms must use native behavior and must not run roborev.
+
+## Instructions
+
+This skill requires you to execute the matching command and report its result.
+Defer to project-level CLAUDE.md instructions when they conflict with these
+steps.
+
+- With no action, or with `on`, run `roborev snooze on`. If the user supplied a
+  duration, add `--duration <duration>`.
+- With `off`, run `roborev snooze off`.
+- Do not pause the review queue, disable post-commit hooks, or change review
+  configuration. Snooze affects only Agent Hook reminders in the current
+  worktree and branch.
+- If the command fails because the current directory is not a tracked Git
+  repository, report that error without trying to register or initialize it.
+
+Examples:
+
+```bash
+roborev snooze on
+roborev snooze on --duration 2h
+roborev snooze off
+```

--- a/internal/skills/codex/roborev-snooze/agents/openai.yaml
+++ b/internal/skills/codex/roborev-snooze/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/internal/skills/derive.go
+++ b/internal/skills/derive.go
@@ -44,17 +44,24 @@ var derivedClaudeSkills = []string{
 func skillDerivations() []skillDerivation {
 	derivations := make([]skillDerivation, 0, len(derivedDroidSkills)+len(derivedClaudeSkills))
 	for _, skillName := range derivedDroidSkills {
-		derivations = append(derivations, skillDerivation{
-			TargetAgent: AgentDroid,
-			SkillName:   skillName,
-			Replacements: []stringReplacement{
-				{
-					Old: ", plugin\n`$roborev:" + skillName + "`, or structured Codex skill selection",
-					New: ", or structured\nFactory skill selection",
-				},
-				{Old: "$roborev", New: "/roborev"},
-				{Old: "CLAUDE.md", New: "AGENTS.md"},
+		replacements := []stringReplacement{
+			{
+				Old: ", plugin\n`$roborev:" + skillName + "`, or structured Codex skill selection",
+				New: ", or structured\nFactory skill selection",
 			},
+			{Old: "$roborev", New: "/roborev"},
+			{Old: "CLAUDE.md", New: "AGENTS.md"},
+		}
+		if skillName == "roborev-snooze" {
+			replacements = append([]stringReplacement{{
+				Old: "invokes $" + skillName + "\n---",
+				New: "invokes /" + skillName + "\ndisable-model-invocation: true\n---",
+			}}, replacements...)
+		}
+		derivations = append(derivations, skillDerivation{
+			TargetAgent:  AgentDroid,
+			SkillName:    skillName,
+			Replacements: replacements,
 		})
 	}
 	for _, skillName := range derivedClaudeSkills {

--- a/internal/skills/derive.go
+++ b/internal/skills/derive.go
@@ -31,12 +31,14 @@ var derivedDroidSkills = []string{
 	"roborev-respond",
 	"roborev-review",
 	"roborev-review-branch",
+	"roborev-snooze",
 }
 
 var derivedClaudeSkills = []string{
 	"roborev-fix",
 	"roborev-refine",
 	"roborev-respond",
+	"roborev-snooze",
 }
 
 func skillDerivations() []skillDerivation {

--- a/internal/skills/droid/roborev-snooze/SKILL.md
+++ b/internal/skills/droid/roborev-snooze/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: roborev-snooze
+description: Use only when the user explicitly invokes /roborev-snooze
+---
+
+# roborev-snooze
+
+Temporarily silence or resume roborev Agent Hook reminders for the current
+worktree and branch. Reviews continue to enqueue and run while reminders are
+snoozed.
+
+## Usage
+
+```text
+/roborev-snooze [on|off] [duration]
+```
+
+`on` is the default action and the duration defaults to eight hours. A duration
+uses Go duration syntax such as `30m`, `2h`, or `12h`.
+
+## Explicit invocation only
+
+Invocation must be explicit: literal personal `/roborev-snooze`, or structured
+Factory skill selection.
+Requests such as “silence review notifications” without one of these explicit
+mechanisms must use native behavior and must not run roborev.
+
+## Instructions
+
+This skill requires you to execute the matching command and report its result.
+Defer to project-level AGENTS.md instructions when they conflict with these
+steps.
+
+- With no action, or with `on`, run `roborev snooze on`. If the user supplied a
+  duration, add `--duration <duration>`.
+- With `off`, run `roborev snooze off`.
+- Do not pause the review queue, disable post-commit hooks, or change review
+  configuration. Snooze affects only Agent Hook reminders in the current
+  worktree and branch.
+- If the command fails because the current directory is not a tracked Git
+  repository, report that error without trying to register or initialize it.
+
+Examples:
+
+```bash
+roborev snooze on
+roborev snooze on --duration 2h
+roborev snooze off
+```

--- a/internal/skills/droid/roborev-snooze/SKILL.md
+++ b/internal/skills/droid/roborev-snooze/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: roborev-snooze
 description: Use only when the user explicitly invokes /roborev-snooze
+disable-model-invocation: true
 ---
 
 # roborev-snooze

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -74,6 +74,7 @@ func TestCodexSkillsEmbedInvocationPolicies(t *testing.T) {
 		"roborev-respond",
 		"roborev-review",
 		"roborev-review-branch",
+		"roborev-snooze",
 	}
 	assert.ElementsMatch(t, wantSkills, expectedSkillDirNamesForAgent(t, AgentCodex))
 
@@ -93,7 +94,7 @@ func TestCodexSkillDescriptionsRequireExplicitInvocation(t *testing.T) {
 	require.True(t, ok)
 	skills, err := embeddedSkillsForAgent(spec)
 	require.NoError(t, err)
-	require.Len(t, skills, 9)
+	require.Len(t, skills, 10)
 
 	for _, skill := range skills {
 		wantDescription := "Use only when the user explicitly invokes $" + skill.DirName
@@ -110,7 +111,7 @@ func TestCodexSkillBodiesAcceptEveryExplicitInvocationPath(t *testing.T) {
 	require.True(t, ok)
 	skills, err := embeddedSkillsForAgent(spec)
 	require.NoError(t, err)
-	require.Len(t, skills, 9)
+	require.Len(t, skills, 10)
 
 	for _, skill := range skills {
 		content := string(skill.Content)
@@ -137,7 +138,7 @@ func TestClaudeSkillDescriptionsRequireExplicitInvocation(t *testing.T) {
 	require.True(t, ok)
 	skills, err := embeddedSkillsForAgent(spec)
 	require.NoError(t, err)
-	require.Len(t, skills, 9)
+	require.Len(t, skills, 10)
 
 	for _, skill := range skills {
 		wantDescription := "Use only when the user explicitly invokes /" + skill.DirName
@@ -154,7 +155,7 @@ func TestDroidSkillDescriptionsRequireExplicitInvocation(t *testing.T) {
 	require.True(t, ok)
 	skills, err := embeddedSkillsForAgent(spec)
 	require.NoError(t, err)
-	require.Len(t, skills, 9)
+	require.Len(t, skills, 10)
 
 	for _, skill := range skills {
 		wantDescription := "Use only when the user explicitly invokes /" + skill.DirName
@@ -177,7 +178,7 @@ func TestClaudeSkillsEmbedExplicitInvocationPolicy(t *testing.T) {
 	require.True(t, ok)
 	skills, err := embeddedSkillsForAgent(spec)
 	require.NoError(t, err)
-	require.Len(t, skills, 9)
+	require.Len(t, skills, 10)
 
 	for _, skill := range skills {
 		content := strings.ReplaceAll(string(skill.Content), "\r\n", "\n")
@@ -200,7 +201,7 @@ func TestClaudeSkillBodiesAcceptEveryExplicitInvocationPath(t *testing.T) {
 	require.True(t, ok)
 	skills, err := embeddedSkillsForAgent(spec)
 	require.NoError(t, err)
-	require.Len(t, skills, 9)
+	require.Len(t, skills, 10)
 
 	for _, skill := range skills {
 		content := string(skill.Content)
@@ -900,7 +901,7 @@ func TestDroidSkillsUseDroidAdaptations(t *testing.T) {
 func TestDerivedSkillFilesAreCurrent(t *testing.T) {
 	derived, err := renderDerivedSkills(os.DirFS("."))
 	require.NoError(t, err)
-	require.Len(t, derived, 12)
+	require.Len(t, derived, 14)
 
 	for relPath, want := range derived {
 		got, err := os.ReadFile(filepath.FromSlash(relPath))

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -921,7 +921,13 @@ func TestDerivedExplicitInvocationWordingUsesTargetAgent(t *testing.T) {
 		assert.NotContains(t, text, "roborev:", "%s retains Codex plugin namespace", relPath)
 		if strings.HasPrefix(relPath, "droid/") {
 			assert.Contains(t, text, "`/"+skillName+"`, or structured Factory skill selection", relPath)
-			assert.NotContains(t, text, "disable-model-invocation", "%s must not carry the Claude-only frontmatter policy", relPath)
+			if skillName == "roborev-snooze" {
+				assert.Contains(t, text, "disable-model-invocation: true",
+					"roborev-snooze must be human-triggered only")
+			} else {
+				assert.NotContains(t, text, "disable-model-invocation",
+					"%s must not carry model-invocation policy", relPath)
+			}
 		} else {
 			assert.Contains(t, text, "`/"+skillName+"`, or structured Claude Code skill selection", relPath)
 			if skillName == "roborev-fix" {

--- a/internal/storage/agent_hook_snooze.go
+++ b/internal/storage/agent_hook_snooze.go
@@ -1,0 +1,115 @@
+package storage
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// AgentHookSnooze is a local agent-hook suppression window for one checkout
+// and branch.
+type AgentHookSnooze struct {
+	RepoPath     string    `json:"repo_path"`
+	WorktreePath string    `json:"worktree_path"`
+	Branch       string    `json:"branch"`
+	SnoozedUntil time.Time `json:"snoozed_until"`
+}
+
+// SetAgentHookSnooze creates or replaces the snooze for a tracked repository's
+// current worktree and branch.
+func (db *DB) SetAgentHookSnooze(
+	repoPath, worktreePath, branch string, until time.Time,
+) (*AgentHookSnooze, error) {
+	repo, err := db.GetRepoByPath(repoPath)
+	if err != nil {
+		return nil, err
+	}
+	normalizedWorktree, err := normalizeRepoPath(worktreePath)
+	if err != nil {
+		return nil, fmt.Errorf("normalize worktree path: %w", err)
+	}
+	until = until.UTC()
+	_, err = db.Exec(`
+		INSERT INTO agent_hook_snoozes
+			(repo_id, worktree_path, branch, snoozed_until, updated_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(repo_id, worktree_path, branch) DO UPDATE SET
+			snoozed_until = excluded.snoozed_until,
+			updated_at = excluded.updated_at`,
+		repo.ID, normalizedWorktree, branch,
+		until.Format(time.RFC3339Nano), time.Now().UTC().Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("set agent hook snooze: %w", err)
+	}
+	return &AgentHookSnooze{
+		RepoPath:     repo.RootPath,
+		WorktreePath: normalizedWorktree,
+		Branch:       branch,
+		SnoozedUntil: until,
+	}, nil
+}
+
+// ClearAgentHookSnooze removes the snooze for one checkout and branch. It is
+// idempotent so `roborev snooze off` is safe when no snooze is active.
+func (db *DB) ClearAgentHookSnooze(repoPath, worktreePath, branch string) error {
+	repo, err := db.GetRepoByPath(repoPath)
+	if err != nil {
+		return err
+	}
+	normalizedWorktree, err := normalizeRepoPath(worktreePath)
+	if err != nil {
+		return fmt.Errorf("normalize worktree path: %w", err)
+	}
+	_, err = db.Exec(`
+		DELETE FROM agent_hook_snoozes
+		WHERE repo_id = ? AND worktree_path = ? AND branch = ?`,
+		repo.ID, normalizedWorktree, branch,
+	)
+	if err != nil {
+		return fmt.Errorf("clear agent hook snooze: %w", err)
+	}
+	return nil
+}
+
+// ActiveAgentHookSnooze returns the active snooze for one checkout and branch,
+// or nil when none exists or its deadline has passed.
+func (db *DB) ActiveAgentHookSnooze(
+	repoPath, worktreePath, branch string, now time.Time,
+) (*AgentHookSnooze, error) {
+	repo, err := db.GetRepoByPath(repoPath)
+	if err != nil {
+		return nil, err
+	}
+	normalizedWorktree, err := normalizeRepoPath(worktreePath)
+	if err != nil {
+		return nil, fmt.Errorf("normalize worktree path: %w", err)
+	}
+	var untilRaw string
+	err = db.QueryRow(`
+		SELECT snoozed_until
+		FROM agent_hook_snoozes
+		WHERE repo_id = ? AND worktree_path = ? AND branch = ?`,
+		repo.ID, normalizedWorktree, branch,
+	).Scan(&untilRaw)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get agent hook snooze: %w", err)
+	}
+	until, err := time.Parse(time.RFC3339Nano, untilRaw)
+	if err != nil {
+		return nil, fmt.Errorf("parse agent hook snooze deadline: %w", err)
+	}
+	if !until.After(now) {
+		return nil, nil
+	}
+	return &AgentHookSnooze{
+		RepoPath:     repo.RootPath,
+		WorktreePath: normalizedWorktree,
+		Branch:       branch,
+		SnoozedUntil: until,
+	}, nil
+}

--- a/internal/storage/agent_hook_snooze_test.go
+++ b/internal/storage/agent_hook_snooze_test.go
@@ -1,0 +1,77 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentHookSnoozeIsScopedAndExpires(t *testing.T) {
+	assert := assert.New(t)
+	db := openTestDB(t)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	repoPath := filepath.Join(t.TempDir(), "repo")
+	_, err := db.GetOrCreateRepo(repoPath)
+	require.NoError(t, err)
+	worktreePath := filepath.Join(t.TempDir(), "worktree")
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	until := now.Add(8 * time.Hour)
+
+	set, err := db.SetAgentHookSnooze(
+		repoPath, worktreePath, "feature/snooze", until,
+	)
+	require.NoError(t, err)
+	assert.Equal("feature/snooze", set.Branch)
+	assert.Equal(until, set.SnoozedUntil)
+
+	active, err := db.ActiveAgentHookSnooze(
+		repoPath, worktreePath, "feature/snooze", now,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, active)
+	assert.Equal(until, active.SnoozedUntil)
+
+	otherBranch, err := db.ActiveAgentHookSnooze(
+		repoPath, worktreePath, "other", now,
+	)
+	require.NoError(t, err)
+	assert.Nil(otherBranch, "a snooze must not follow the worktree to another branch")
+
+	expired, err := db.ActiveAgentHookSnooze(
+		repoPath, worktreePath, "feature/snooze", until,
+	)
+	require.NoError(t, err)
+	assert.Nil(expired)
+
+	require.NoError(t, db.ClearAgentHookSnooze(
+		repoPath, worktreePath, "feature/snooze",
+	))
+	cleared, err := db.ActiveAgentHookSnooze(
+		repoPath, worktreePath, "feature/snooze", now,
+	)
+	require.NoError(t, err)
+	assert.Nil(cleared)
+}
+
+func TestOpenAddsAgentHookSnoozesToExistingDatabase(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "existing.db")
+	db, err := Open(dbPath)
+	require.NoError(t, err)
+	_, err = db.Exec(`DROP TABLE agent_hook_snoozes`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	db, err = Open(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	repoPath := filepath.Join(t.TempDir(), "repo")
+	_, err = db.GetOrCreateRepo(repoPath)
+	require.NoError(t, err)
+	_, err = db.SetAgentHookSnooze(
+		repoPath, repoPath, "main", time.Now().Add(time.Hour),
+	)
+	require.NoError(t, err)
+}

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -157,6 +157,18 @@ CREATE TABLE IF NOT EXISTS daemon_state (
   updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+-- agent_hook_snoozes is local-only workspace state. It is deliberately not
+-- synced to PostgreSQL because worktree paths and snooze intent are specific to
+-- this machine.
+CREATE TABLE IF NOT EXISTS agent_hook_snoozes (
+  repo_id INTEGER NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+  worktree_path TEXT NOT NULL,
+  branch TEXT NOT NULL,
+  snoozed_until TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (repo_id, worktree_path, branch)
+);
+
 CREATE INDEX IF NOT EXISTS idx_review_jobs_status ON review_jobs(status);
 CREATE INDEX IF NOT EXISTS idx_review_jobs_repo ON review_jobs(repo_id);
 CREATE INDEX IF NOT EXISTS idx_review_jobs_git_ref ON review_jobs(git_ref);

--- a/internal/storage/repos.go
+++ b/internal/storage/repos.go
@@ -657,6 +657,15 @@ func (db *DB) DeleteRepo(repoID int64, cascade bool) error {
 		}
 	}
 
+	// SQLite foreign-key enforcement is connection-local and may be disabled,
+	// so repository lifecycle operations must clean up local snooze state
+	// explicitly rather than relying on ON DELETE CASCADE.
+	if _, err := conn.ExecContext(ctx,
+		`DELETE FROM agent_hook_snoozes WHERE repo_id = ?`, repoID,
+	); err != nil {
+		return err
+	}
+
 	// Delete the repo itself
 	result, err := conn.ExecContext(ctx, `DELETE FROM repos WHERE id = ?`, repoID)
 	if err != nil {
@@ -700,6 +709,37 @@ func (db *DB) MergeRepos(sourceRepoID, targetRepoID int64) (int64, error) {
 			}
 		}
 	}()
+
+	// Preserve machine-local Agent Hook snoozes when duplicate repository rows
+	// are consolidated. For an identical worktree/branch key, keep the later
+	// deadline so merging cannot shorten an active quiet period.
+	_, err = conn.ExecContext(ctx, `
+		INSERT INTO agent_hook_snoozes
+			(repo_id, worktree_path, branch, snoozed_until, updated_at)
+		SELECT ?, worktree_path, branch, snoozed_until, updated_at
+		FROM agent_hook_snoozes
+		WHERE repo_id = ?
+		ON CONFLICT(repo_id, worktree_path, branch) DO UPDATE SET
+			snoozed_until = CASE
+				WHEN julianday(excluded.snoozed_until) >
+					julianday(agent_hook_snoozes.snoozed_until)
+				THEN excluded.snoozed_until
+				ELSE agent_hook_snoozes.snoozed_until
+			END,
+			updated_at = CASE
+				WHEN julianday(excluded.updated_at) >
+					julianday(agent_hook_snoozes.updated_at)
+				THEN excluded.updated_at
+				ELSE agent_hook_snoozes.updated_at
+			END`, targetRepoID, sourceRepoID)
+	if err != nil {
+		return 0, err
+	}
+	if _, err := conn.ExecContext(ctx,
+		`DELETE FROM agent_hook_snoozes WHERE repo_id = ?`, sourceRepoID,
+	); err != nil {
+		return 0, err
+	}
 
 	// Move all commits from source to target
 	// Note: commits.sha is UNIQUE, so this will fail if both repos have

--- a/internal/storage/repos_test.go
+++ b/internal/storage/repos_test.go
@@ -670,13 +670,25 @@ func TestGetRepoStats(t *testing.T) {
 func TestDeleteRepo(t *testing.T) {
 	t.Run("delete empty repo", func(t *testing.T) {
 		db, repo := setupDBAndRepo(t, "delete-empty")
+		db.SetMaxOpenConns(1)
+		_, err := db.Exec(`PRAGMA foreign_keys = OFF`)
+		require.NoError(t, err)
+		_, err = db.SetAgentHookSnooze(
+			repo.RootPath, repo.RootPath, "main", time.Now().Add(time.Hour),
+		)
+		require.NoError(t, err)
 
-		err := db.DeleteRepo(repo.ID, false)
+		err = db.DeleteRepo(repo.ID, false)
 		require.NoError(t, err, "DeleteRepo failed: %v")
 
 		// Verify deleted
 		_, err = db.GetRepoByID(repo.ID)
 		require.Error(t, err)
+		var snoozeCount int
+		require.NoError(t, db.QueryRow(
+			`SELECT COUNT(*) FROM agent_hook_snoozes WHERE repo_id = ?`, repo.ID,
+		).Scan(&snoozeCount))
+		assert.Zero(t, snoozeCount)
 	})
 
 	t.Run("delete repo with jobs without cascade returns error", func(t *testing.T) {
@@ -819,6 +831,50 @@ func TestMergeRepos(t *testing.T) {
 		var orphanedCount int
 		db.QueryRow(`SELECT COUNT(*) FROM commits WHERE repo_id = ?`, source.ID).Scan(&orphanedCount)
 		assert.Equal(t, 0, orphanedCount)
+	})
+
+	t.Run("merge preserves source snoozes and later conflict deadline", func(t *testing.T) {
+		db := openTestDB(t)
+		defer db.Close()
+
+		source := createRepo(t, db, filepath.Join(t.TempDir(), "merge-snooze-source"))
+		target := createRepo(t, db, filepath.Join(t.TempDir(), "merge-snooze-target"))
+		sharedWorktree := filepath.Join(t.TempDir(), "shared-worktree")
+		uniqueWorktree := filepath.Join(t.TempDir(), "source-worktree")
+		now := time.Now().UTC()
+		sourceUntil := now.Add(8 * time.Hour)
+		_, err := db.SetAgentHookSnooze(
+			source.RootPath, sharedWorktree, "main", sourceUntil,
+		)
+		require.NoError(t, err)
+		_, err = db.SetAgentHookSnooze(
+			source.RootPath, uniqueWorktree, "feature", now.Add(4*time.Hour),
+		)
+		require.NoError(t, err)
+		_, err = db.SetAgentHookSnooze(
+			target.RootPath, sharedWorktree, "main", now.Add(2*time.Hour),
+		)
+		require.NoError(t, err)
+
+		_, err = db.MergeRepos(source.ID, target.ID)
+		require.NoError(t, err)
+
+		conflict, err := db.ActiveAgentHookSnooze(
+			target.RootPath, sharedWorktree, "main", now,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, conflict)
+		assert.Equal(t, sourceUntil, conflict.SnoozedUntil)
+		unique, err := db.ActiveAgentHookSnooze(
+			target.RootPath, uniqueWorktree, "feature", now,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, unique)
+		var sourceCount int
+		require.NoError(t, db.QueryRow(
+			`SELECT COUNT(*) FROM agent_hook_snoozes WHERE repo_id = ?`, source.ID,
+		).Scan(&sourceCount))
+		assert.Zero(t, sourceCount)
 	})
 }
 

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -35,6 +35,10 @@ type ClientInterface interface {
 	ListActivity(ctx context.Context, options *ListActivityRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListActivityResponse, error)
 	ListActivityWithResponse(ctx context.Context, options *ListActivityRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListActivityResp, error)
 
+	// SetAgentHookSnooze Set or clear an agent-hook workspace snooze
+	SetAgentHookSnooze(ctx context.Context, options *SetAgentHookSnoozeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SetAgentHookSnoozeResponse, error)
+	SetAgentHookSnoozeWithResponse(ctx context.Context, options *SetAgentHookSnoozeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SetAgentHookSnoozeResp, error)
+
 	// ListBranches List branches with job counts
 	ListBranches(ctx context.Context, options *ListBranchesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListBranchesResponse, error)
 	ListBranchesWithResponse(ctx context.Context, options *ListBranchesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListBranchesResp, error)
@@ -238,6 +242,70 @@ func (c *Client) ListActivity(ctx context.Context, options *ListActivityRequestO
 	}
 
 	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/activity")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// SetAgentHookSnooze Set or clear an agent-hook workspace snooze
+func (c *Client) SetAgentHookSnooze(ctx context.Context, options *SetAgentHookSnoozeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SetAgentHookSnoozeResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/agent-hook/snooze",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*SetAgentHookSnoozeResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(SetAgentHookSnoozeErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "SetAgentHookSnoozeErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(SetAgentHookSnoozeResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "SetAgentHookSnoozeResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/agent-hook/snooze")
 	if err != nil {
 		return nil, fmt.Errorf("error executing request: %w", err)
 	}
@@ -1910,7 +1978,8 @@ func (c *Client) ResolveRepo(ctx context.Context, options *ResolveRepoRequestOpt
 	var err error
 
 	queryEncoding := map[string]runtime.QueryEncoding{
-		"path": {Style: "form", Explode: &[]bool{false}[0]},
+		"branch": {Style: "form", Explode: &[]bool{false}[0]},
+		"path":   {Style: "form", Explode: &[]bool{false}[0]},
 	}
 	reqParams := runtime.RequestOptionsParameters{
 		RequestURL:    c.apiClient.GetBaseURL() + "/api/repos/resolve",

--- a/pkg/client/generated/client_options.go
+++ b/pkg/client/generated/client_options.go
@@ -50,6 +50,50 @@ func (o *ListActivityRequestOptions) GetHeader() (map[string]string, error) {
 	return nil, nil
 }
 
+// SetAgentHookSnoozeRequestOptions is the options needed to make a request to SetAgentHookSnooze.
+type SetAgentHookSnoozeRequestOptions struct {
+	Body *SetAgentHookSnoozeBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *SetAgentHookSnoozeRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *SetAgentHookSnoozeRequestOptions) GetPathParams() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetQuery returns the query params as a map.
+func (o *SetAgentHookSnoozeRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *SetAgentHookSnoozeRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *SetAgentHookSnoozeRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
 // ListBranchesRequestOptions is the options needed to make a request to ListBranches.
 type ListBranchesRequestOptions struct {
 	Query *ListBranchesQuery

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -59,6 +59,56 @@ func (c *Client) ListActivityWithResponse(ctx context.Context, options *ListActi
 	}
 }
 
+// SetAgentHookSnooze Set or clear an agent-hook workspace snooze
+func (c *Client) SetAgentHookSnoozeWithResponse(ctx context.Context, options *SetAgentHookSnoozeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SetAgentHookSnoozeResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/agent-hook/snooze",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/agent-hook/snooze")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &SetAgentHookSnoozeResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(SetAgentHookSnoozeResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SetAgentHookSnoozeResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
 // ListBranches List branches with job counts
 func (c *Client) ListBranchesWithResponse(ctx context.Context, options *ListBranchesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListBranchesResp, error) {
 	var err error

--- a/pkg/client/generated/payloads.go
+++ b/pkg/client/generated/payloads.go
@@ -2,6 +2,8 @@
 
 package generated
 
+type SetAgentHookSnoozeBody = AgentHookSnoozeRequest
+
 type AddCommentBody = AddCommentRequest
 
 type EnqueueJobBody = EnqueueRequest

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -223,6 +223,9 @@ type ListReposQuery struct {
 type ResolveRepoQuery struct {
 	// Path Absolute path or path inside a repository
 	Path *string `json:"path,omitempty"`
+
+	// Branch Current branch for agent-hook snooze lookup
+	Branch *string `json:"branch,omitempty"`
 }
 
 type GetReviewQuery struct {

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -15,6 +15,10 @@ type ListActivityResponse = ActivityOutputBody
 
 type ListActivityErrorResponse = ErrorModel
 
+type SetAgentHookSnoozeResponse = AgentHookSnoozeOutputBody
+
+type SetAgentHookSnoozeErrorResponse = ErrorModel
+
 type ListBranchesResponse = ListBranchesOutputBody
 
 type ListBranchesErrorResponse = ErrorModel
@@ -238,6 +242,13 @@ type ListActivityResp struct {
 	Body         []byte
 	StatusCode   int
 	JSON200      *ListActivityResponse
+}
+
+type SetAgentHookSnoozeResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *SetAgentHookSnoozeResponse
 }
 
 type ListBranchesResp struct {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -55,6 +55,27 @@ func (a AddCommentRequest) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(a))
 }
 
+type AgentHookSnoozeOutputBody struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema       *string    `json:"$schema,omitempty"`
+	Snoozed      bool       `json:"snoozed"`
+	SnoozedUntil *time.Time `json:"snoozed_until,omitempty"`
+}
+
+type AgentHookSnoozeRequest struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema       *string    `json:"$schema,omitempty"`
+	Branch       *string    `json:"branch,omitempty"`
+	Enabled      bool       `json:"enabled"`
+	RepoPath     string     `json:"repo_path" validate:"required"`
+	SnoozedUntil *time.Time `json:"snoozed_until,omitempty"`
+	WorktreePath string     `json:"worktree_path" validate:"required"`
+}
+
+func (a AgentHookSnoozeRequest) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(a))
+}
+
 type AgentStats struct {
 	Agent              string  `json:"agent" validate:"required"`
 	Errors             int64   `json:"errors"`
@@ -1283,9 +1304,10 @@ func (r ResolveRepoOutputBody) Validate() error {
 }
 
 type ResolvedRepo struct {
-	Identity string `json:"identity" validate:"required"`
-	Name     string `json:"name" validate:"required"`
-	RootPath string `json:"root_path" validate:"required"`
+	AgentHookSnoozedUntil *time.Time `json:"agent_hook_snoozed_until,omitempty"`
+	Identity              string     `json:"identity" validate:"required"`
+	Name                  string     `json:"name" validate:"required"`
+	RootPath              string     `json:"root_path" validate:"required"`
 }
 
 func (r ResolvedRepo) Validate() error {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -64,6 +64,50 @@ components:
         - commenter
         - comment
       type: object
+    AgentHookSnoozeOutputBody:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - https://example.com/AgentHookSnoozeOutputBody.json
+          format: uri
+          readOnly: true
+          type: string
+        snoozed:
+          type: boolean
+        snoozed_until:
+          format: date-time
+          type: string
+      required:
+        - snoozed
+      type: object
+    AgentHookSnoozeRequest:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - https://example.com/AgentHookSnoozeRequest.json
+          format: uri
+          readOnly: true
+          type: string
+        branch:
+          type: string
+        enabled:
+          type: boolean
+        repo_path:
+          type: string
+        snoozed_until:
+          format: date-time
+          type: string
+        worktree_path:
+          type: string
+      required:
+        - repo_path
+        - worktree_path
+        - enabled
+      type: object
     AgentStats:
       additionalProperties: false
       properties:
@@ -1784,6 +1828,9 @@ components:
     ResolvedRepo:
       additionalProperties: false
       properties:
+        agent_hook_snoozed_until:
+          format: date-time
+          type: string
         identity:
           type: string
         name:
@@ -2315,6 +2362,31 @@ paths:
       summary: List recent daemon activity
       tags:
         - daemon
+  /api/agent-hook/snooze:
+    post:
+      operationId: set-agent-hook-snooze
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AgentHookSnoozeRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentHookSnoozeOutputBody"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      summary: Set or clear an agent-hook workspace snooze
+      tags:
+        - agent-hook
   /api/branches:
     get:
       operationId: list-branches
@@ -3287,6 +3359,13 @@ paths:
           name: path
           schema:
             description: Absolute path or path inside a repository
+            type: string
+        - description: Current branch for agent-hook snooze lookup
+          explode: false
+          in: query
+          name: branch
+          schema:
+            description: Current branch for agent-hook snooze lookup
             type: string
       responses:
         "200":

--- a/skills/README.md
+++ b/skills/README.md
@@ -17,6 +17,7 @@ Skills are updated automatically when you run `roborev update`.
 | `/roborev-fix [job_id...]` | Fix all open review findings (or specific jobs) in one pass |
 | `/roborev-design-review <path-or-job-id>` | Review a design proposal for completeness and feasibility |
 | `/roborev-respond <job_id> [message]` | Add a response to a review |
+| `/roborev-snooze [on\|off] [duration]` | Silence or resume Agent Hook reminders in the current workspace |
 
 ## Example Workflow
 
@@ -51,5 +52,5 @@ After fixing, document what was done:
 
 | Agent | Invocation |
 |-------|------------|
-| Claude Code | `/roborev-fix`, `/roborev-design-review`, `/roborev-respond` |
-| Codex | `$roborev-fix`, `$roborev-design-review`, `$roborev-respond` |
+| Claude Code | `/roborev-fix`, `/roborev-design-review`, `/roborev-respond`, `/roborev-snooze` |
+| Codex | `$roborev-fix`, `$roborev-design-review`, `$roborev-respond`, `$roborev-snooze` |

--- a/skills/roborev-snooze.md
+++ b/skills/roborev-snooze.md
@@ -1,0 +1,22 @@
+# roborev-snooze
+
+Temporarily silence or resume roborev Agent Hook reminders for the current
+worktree and branch. Reviews continue to enqueue and run while reminders are
+snoozed.
+
+## Usage
+
+```text
+/roborev-snooze [on|off] [duration]
+```
+
+Run the matching command:
+
+```bash
+roborev snooze on                   # defaults to eight hours
+roborev snooze on --duration 2h     # custom duration
+roborev snooze off                  # resume immediately
+```
+
+Do not use `roborev pause`; that pauses review processing, while snooze affects
+only Agent Hook reminders.

--- a/skills/roborev-snooze.md
+++ b/skills/roborev-snooze.md
@@ -10,6 +10,9 @@ snoozed.
 /roborev-snooze [on|off] [duration]
 ```
 
+This skill is human-triggered only. Invoke it explicitly with the slash command;
+the model must not select it automatically.
+
 Run the matching command:
 
 ```bash


### PR DESCRIPTION
Agent Hook reminders are useful, but long implementation stretches need a quieter mode. Existing queue pausing is too broad because it stops the asynchronous reviews users still want running.

This adds `roborev snooze` / `roborev snooze on --duration <duration>` and `roborev snooze off`, with an eight-hour default. Snooze state is keyed to the current repository, linked worktree, and branch. It suppresses only Agent Hook reminders while reviews continue enqueueing, processing, and accumulating findings; hook baselines advance during the quiet period to avoid catch-up noise afterward.

The state remains local SQLite-only because worktree paths and snooze intent are machine-specific. Bundled Codex, Claude, and Droid skills expose both on and off operations, with machine-readable metadata that keeps snoozing human-triggered only. The README plus Agent Hook and agent-skills guides document the behavior.

<sup>generated by a clanker</sup>