### PR TITLE
test: characterize severity threshold marker verdict precedence

### DIFF
--- a/internal/storage/verdict_test.go
+++ b/internal/storage/verdict_test.go
@@ -738,9 +738,15 @@ var verdictTests = []verdictTestCase{
 		want:   VerdictPass,
 	},
 	{
-		name:   "ThresholdMarker/marker with chatty narration is fail",
-		output: "All findings are below medium severity.\n\nSEVERITY_THRESHOLD_MET\n\nNo code changes needed.",
-		want:   VerdictFail,
+		name: "ThresholdMarker/below-threshold prose with marker is fail",
+		output: "No internal contradictions found. Remaining observations are below " +
+			"the high severity threshold.\n\nSEVERITY_THRESHOLD_MET",
+		want: VerdictFail,
+	},
+	{
+		name:   "ThresholdMarker/recognized pass prose with marker is pass",
+		output: "No findings at or above high severity.\n\nSEVERITY_THRESHOLD_MET",
+		want:   VerdictPass,
 	},
 	{
 		name:   "ThresholdMarker/marker plus prose finding without severity label is fail",


### PR DESCRIPTION
Issue #987 describes semantically equivalent below-threshold reviews receiving different stored verdicts depending on the narration surrounding the threshold marker. Existing cases protected the marker-only safety rule but did not isolate the prose heuristic that still runs after marker-only recognition rejects a chatty response.

This adds paired characterization coverage: realistic below-threshold narration remains fail-closed, while a recognized No findings prefix passes even with the same marker. The contrast makes the current precedence explicit and gives a prompt-side fix a stable regression surface without weakening the parser against marker-bearing substantive findings.

This PR deliberately changes no production behavior; #987 remains open for resolving the prompt/parser contract.

<sup>generated by a clanker</sup>