### PR TITLE
Make daemon discovery sandbox-safe

### DIFF
--- a/cmd/roborev/daemon_lifecycle.go
+++ b/cmd/roborev/daemon_lifecycle.go
@@ -41,19 +41,22 @@ var (
 	// daemon may be mid-startup or briefly too busy to answer.
 	ensureProbeAttempts   = 3
 	ensureProbeRetryDelay = 1 * time.Second
+	probeDaemonForEnsure  = probeDaemonWithRetry
 
 	// daemonStartTimeout bounds how long startDaemon waits for a spawned
 	// daemon to become ready.
-	daemonStartTimeout      = 15 * time.Second
-	getAnyRunningDaemon     = daemon.GetAnyRunningDaemon
-	listAllRuntimes         = daemon.ListAllRuntimes
-	cleanupZombieDaemons    = daemon.CleanupZombieDaemons
-	isPIDAliveForUpdate     = isPIDAliveForUpdateDefault
-	restartDaemonForEnsure  = restartDaemon
-	startDaemonForEnsure    = startDaemon
-	stopDaemonForUpdate     = stopDaemon
-	killAllDaemonsForUpdate = killAllDaemons
-	startUpdatedDaemon      = func(binDir string) error {
+	daemonStartTimeout          = 15 * time.Second
+	getAnyRunningDaemon         = daemon.GetAnyRunningDaemon
+	getAnyRunningDaemonForStart = daemon.GetAnyRunningDaemonContext
+	listAllRuntimes             = daemon.ListAllRuntimes
+	cleanupZombieDaemons        = daemon.CleanupZombieDaemons
+	isPIDAliveForUpdate         = isPIDAliveForUpdateDefault
+	restartDaemonForEnsure      = restartDaemon
+	startDaemonForEnsure        = startDaemon
+	startDaemonDetached         = startDetachedDaemon
+	stopDaemonForUpdate         = stopDaemon
+	killAllDaemonsForUpdate     = killAllDaemons
+	startUpdatedDaemon          = func(binDir string) error {
 		newBinary := filepath.Join(binDir, "roborev")
 		if runtime.GOOS == "windows" {
 			newBinary += ".exe"
@@ -76,6 +79,8 @@ var (
 		return sigCh, func() { signal.Stop(sigCh) }
 	}
 )
+
+var errDaemonReady = errors.New("daemon ready")
 
 // ErrDaemonNotRunning indicates no daemon runtime file was found
 var ErrDaemonNotRunning = fmt.Errorf("daemon not running (no runtime file found)")
@@ -226,10 +231,17 @@ func ensureDaemon() error {
 	skipVersionCheck := os.Getenv("ROBOREV_SKIP_VERSION_CHECK") == "1"
 
 	// First check runtime files for any running daemon
-	if info, err := getAnyRunningDaemon(); err == nil {
+	info, discoveryErr := getAnyRunningDaemon()
+	if daemon.IsDaemonAccessDenied(discoveryErr) {
+		return discoveryErr
+	}
+	if discoveryErr == nil {
 		if !skipVersionCheck {
-			probe, err := probeDaemonWithRetry(info.Endpoint(), 2*time.Second)
+			probe, err := probeDaemonForEnsure(info.Endpoint(), 2*time.Second)
 			if err != nil {
+				if daemon.IsDaemonAccessDenied(err) {
+					return fmt.Errorf("%w: %w", daemon.ErrDaemonAccessDenied, err)
+				}
 				if verbose {
 					fmt.Printf("Daemon probe failed, restarting...\n")
 				}
@@ -256,7 +268,8 @@ func ensureDaemon() error {
 	// Try the configured default address for manual daemon runs that do not
 	// have a runtime file yet.
 	ep := getDaemonEndpoint()
-	if probe, err := daemon.ProbeDaemon(ep, 2*time.Second); err == nil {
+	probe, probeErr := probeDaemonForEnsure(ep, 2*time.Second)
+	if probeErr == nil {
 		if !skipVersionCheck {
 			if probe.Version == "" {
 				if verbose {
@@ -272,6 +285,9 @@ func ensureDaemon() error {
 			}
 		}
 		return nil
+	}
+	if daemon.IsDaemonAccessDenied(probeErr) {
+		return fmt.Errorf("%w: %w", daemon.ErrDaemonAccessDenied, probeErr)
 	}
 
 	// Legacy pre-kit daemons are invisible to kit discovery because they do
@@ -300,6 +316,14 @@ func startDaemon() error {
 		Store:    daemon.RuntimeStore(),
 		Discover: daemon.DiscoverOptions(1 * time.Second),
 		Start: func(ctx context.Context) error {
+			ready, err := discoverDaemonForStart(ctx)
+			if err != nil {
+				return err
+			}
+			if ready {
+				return errDaemonReady
+			}
+
 			exe, err := os.Executable()
 			if err != nil {
 				return fmt.Errorf("failed to find executable: %w", err)
@@ -309,20 +333,51 @@ func startDaemon() error {
 				return err
 			}
 			defer closeLogs()
-			return startDetachedDaemon(ctx, detachedDaemonOptions{
+			if err := startDaemonDetached(ctx, detachedDaemonOptions{
 				Executable:      exe,
 				Args:            []string{"daemon", "run"},
 				Env:             filterGitEnv(os.Environ()),
 				Stdout:          stdout,
 				Stderr:          stderr,
 				RefuseEphemeral: os.Getenv("ROBOREV_TEST_ALLOW_AUTOSTART") != "1",
-			})
+			}); err != nil {
+				return err
+			}
+
+			for {
+				ready, err := discoverDaemonForStart(ctx)
+				if err != nil {
+					return err
+				}
+				if ready {
+					return errDaemonReady
+				}
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(50 * time.Millisecond):
+				}
+			}
 		},
 	}
 	if _, _, err := manager.Ensure(context.Background(), daemonStartTimeout); err != nil {
+		if errors.Is(err, errDaemonReady) {
+			return nil
+		}
 		return fmt.Errorf("failed to start daemon: %w", err)
 	}
 	return nil
+}
+
+func discoverDaemonForStart(ctx context.Context) (bool, error) {
+	_, err := getAnyRunningDaemonForStart(ctx)
+	if err == nil {
+		return true, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+	return false, nil
 }
 
 func openDetachedDaemonLogs() (*os.File, *os.File, func(), error) {

--- a/cmd/roborev/daemon_lifecycle_test.go
+++ b/cmd/roborev/daemon_lifecycle_test.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -13,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/roborev/internal/daemon"
+	"go.kenn.io/roborev/internal/testenv"
 	"go.kenn.io/roborev/internal/version"
 )
 
@@ -179,4 +185,194 @@ func TestEnsureDaemonCleansZombiesBeforeColdStart(t *testing.T) {
 
 	require.NoError(t, ensureDaemon())
 	assert.Equal(t, []string{"cleanup:127.0.0.1:1", "start"}, calls)
+}
+
+func TestEnsureDaemonDoesNotRecoverFromAccessDeniedDiscovery(t *testing.T) {
+	t.Setenv("ROBOREV_SKIP_VERSION_CHECK", "")
+
+	origGet := getAnyRunningDaemon
+	origProbe := probeDaemonForEnsure
+	origCleanup := cleanupZombieDaemons
+	origRestart := restartDaemonForEnsure
+	origStart := startDaemonForEnsure
+	getAnyRunningDaemon = func() (*daemon.RuntimeInfo, error) {
+		return nil, daemon.ErrDaemonAccessDenied
+	}
+	probeCalls, cleanupCalls, restartCalls, startCalls := 0, 0, 0, 0
+	probeDaemonForEnsure = func(daemon.DaemonEndpoint, time.Duration) (*daemon.PingInfo, error) {
+		probeCalls++
+		return nil, nil
+	}
+	cleanupZombieDaemons = func(daemon.DaemonEndpoint) int { cleanupCalls++; return 0 }
+	restartDaemonForEnsure = func() error { restartCalls++; return nil }
+	startDaemonForEnsure = func() error { startCalls++; return nil }
+	t.Cleanup(func() {
+		getAnyRunningDaemon = origGet
+		probeDaemonForEnsure = origProbe
+		cleanupZombieDaemons = origCleanup
+		restartDaemonForEnsure = origRestart
+		startDaemonForEnsure = origStart
+	})
+
+	err := ensureDaemon()
+	require.ErrorIs(t, err, daemon.ErrDaemonAccessDenied)
+	assert.Zero(t, probeCalls)
+	assert.Zero(t, cleanupCalls)
+	assert.Zero(t, restartCalls)
+	assert.Zero(t, startCalls)
+}
+
+func TestEnsureDaemonDoesNotRestartAfterAccessDeniedVersionProbe(t *testing.T) {
+	t.Setenv("ROBOREV_SKIP_VERSION_CHECK", "")
+
+	origGet := getAnyRunningDaemon
+	origProbe := probeDaemonForEnsure
+	origRestart := restartDaemonForEnsure
+	origStart := startDaemonForEnsure
+	getAnyRunningDaemon = func() (*daemon.RuntimeInfo, error) {
+		return &daemon.RuntimeInfo{Network: "tcp", Address: "127.0.0.1:7373"}, nil
+	}
+	probeDaemonForEnsure = func(daemon.DaemonEndpoint, time.Duration) (*daemon.PingInfo, error) {
+		return nil, &net.OpError{Op: "dial", Net: "tcp", Err: syscall.EPERM}
+	}
+	restartCalls, startCalls := 0, 0
+	restartDaemonForEnsure = func() error { restartCalls++; return nil }
+	startDaemonForEnsure = func() error { startCalls++; return nil }
+	t.Cleanup(func() {
+		getAnyRunningDaemon = origGet
+		probeDaemonForEnsure = origProbe
+		restartDaemonForEnsure = origRestart
+		startDaemonForEnsure = origStart
+	})
+
+	err := ensureDaemon()
+	require.ErrorIs(t, err, daemon.ErrDaemonAccessDenied)
+	assert.Zero(t, restartCalls)
+	assert.Zero(t, startCalls)
+}
+
+func TestEnsureDaemonDoesNotColdStartAfterAccessDeniedDefaultProbe(t *testing.T) {
+	t.Setenv("ROBOREV_SKIP_VERSION_CHECK", "")
+
+	origServerAddr := serverAddr
+	origParsed := parsedServerEndpoint
+	origGet := getAnyRunningDaemon
+	origProbe := probeDaemonForEnsure
+	origCleanup := cleanupZombieDaemons
+	origStart := startDaemonForEnsure
+	serverAddr = ""
+	parsedServerEndpoint = nil
+	getAnyRunningDaemon = func() (*daemon.RuntimeInfo, error) { return nil, os.ErrNotExist }
+	probeDaemonForEnsure = func(daemon.DaemonEndpoint, time.Duration) (*daemon.PingInfo, error) {
+		return nil, &net.OpError{Op: "dial", Net: "tcp", Err: syscall.EACCES}
+	}
+	cleanupCalls, startCalls := 0, 0
+	cleanupZombieDaemons = func(daemon.DaemonEndpoint) int { cleanupCalls++; return 0 }
+	startDaemonForEnsure = func() error { startCalls++; return nil }
+	t.Cleanup(func() {
+		serverAddr = origServerAddr
+		parsedServerEndpoint = origParsed
+		getAnyRunningDaemon = origGet
+		probeDaemonForEnsure = origProbe
+		cleanupZombieDaemons = origCleanup
+		startDaemonForEnsure = origStart
+	})
+
+	err := ensureDaemon()
+	require.ErrorIs(t, err, daemon.ErrDaemonAccessDenied)
+	assert.Zero(t, cleanupCalls)
+	assert.Zero(t, startCalls)
+}
+
+func TestStartDaemonUsesAlternateAwareDiscoveryInsideStartLock(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix sockets are not supported on Windows")
+	}
+	testenv.SetDataDir(t)
+
+	primary := daemon.DaemonEndpoint{Network: "tcp", Address: "127.0.0.1:1"}
+	alternate := daemon.DaemonEndpoint{
+		Network: "unix",
+		Address: filepath.Join(t.TempDir(), "daemon.sock"),
+	}
+	require.NoError(t, daemon.WriteRuntime(primary, &alternate, version.Version))
+
+	origGet := getAnyRunningDaemonForStart
+	getAnyRunningDaemonForStart = func(context.Context) (*daemon.RuntimeInfo, error) {
+		return &daemon.RuntimeInfo{
+			PID:     os.Getpid(),
+			Network: alternate.Network,
+			Address: alternate.Address,
+			Version: version.Version,
+		}, nil
+	}
+	t.Cleanup(func() { getAnyRunningDaemonForStart = origGet })
+
+	require.NoError(t, startDaemon())
+}
+
+func TestStartDaemonDoesNotSpawnAfterAccessDeniedDiscoveryInsideStartLock(t *testing.T) {
+	testenv.SetDataDir(t)
+
+	origGet := getAnyRunningDaemonForStart
+	origStart := startDaemonDetached
+	spawnCalls := 0
+	getAnyRunningDaemonForStart = func(context.Context) (*daemon.RuntimeInfo, error) {
+		return nil, daemon.ErrDaemonAccessDenied
+	}
+	startDaemonDetached = func(context.Context, detachedDaemonOptions) error {
+		spawnCalls++
+		return nil
+	}
+	t.Cleanup(func() {
+		getAnyRunningDaemonForStart = origGet
+		startDaemonDetached = origStart
+	})
+
+	err := startDaemon()
+	require.ErrorIs(t, err, daemon.ErrDaemonAccessDenied)
+	assert.Zero(t, spawnCalls)
+}
+
+func TestStartDaemonUsesAlternateAwareDiscoveryWhileWaiting(t *testing.T) {
+	testenv.SetDataDir(t)
+
+	origGet := getAnyRunningDaemonForStart
+	origStart := startDaemonDetached
+	discoveryCalls := 0
+	spawnCalls := 0
+	getAnyRunningDaemonForStart = func(context.Context) (*daemon.RuntimeInfo, error) {
+		discoveryCalls++
+		if discoveryCalls == 1 {
+			return nil, os.ErrNotExist
+		}
+		return &daemon.RuntimeInfo{
+			PID:     os.Getpid(),
+			Network: "unix",
+			Address: filepath.Join(t.TempDir(), "daemon.sock"),
+			Version: version.Version,
+		}, nil
+	}
+	startDaemonDetached = func(context.Context, detachedDaemonOptions) error {
+		spawnCalls++
+		return nil
+	}
+	t.Cleanup(func() {
+		getAnyRunningDaemonForStart = origGet
+		startDaemonDetached = origStart
+	})
+
+	require.NoError(t, startDaemon())
+	assert.Equal(t, 1, spawnCalls)
+}
+
+func TestDiscoverDaemonForStartHonorsCanceledContext(t *testing.T) {
+	testenv.SetDataDir(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	ready, err := discoverDaemonForStart(ctx)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.False(t, ready)
 }

--- a/cmd/roborev/main_test_helpers_test.go
+++ b/cmd/roborev/main_test_helpers_test.go
@@ -167,7 +167,7 @@ func NewMockDaemon(t *testing.T, hooks MockRefineHooks) *MockDaemon {
 	require.NoError(t, os.MkdirAll(tmpDir, 0o755), "failed to create data dir")
 	mockAddr := ts.URL[7:] // strip "http://"
 	require.NoError(t,
-		daemon.WriteRuntime(daemon.DaemonEndpoint{Network: "tcp", Address: mockAddr}, version.Version),
+		daemon.WriteRuntime(daemon.DaemonEndpoint{Network: "tcp", Address: mockAddr}, nil, version.Version),
 		"failed to write daemon runtime")
 
 	origServerAddr := serverAddr

--- a/cmd/roborev/status.go
+++ b/cmd/roborev/status.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -11,9 +12,12 @@ import (
 	"github.com/spf13/cobra"
 	gitrepo "go.kenn.io/kit/git/repo"
 
+	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/githook"
 	"go.kenn.io/roborev/internal/storage"
 )
+
+var statusEnsureDaemon = ensureDaemon
 
 type statusJSONResult struct {
 	Running bool                  `json:"running"`
@@ -48,7 +52,22 @@ func statusCmd() *cobra.Command {
 			}
 
 			// Ensure daemon is running (and restart if version mismatch)
-			if err := ensureDaemon(); err != nil {
+			if err := statusEnsureDaemon(); err != nil {
+				if errors.Is(err, daemon.ErrDaemonAccessDenied) {
+					message := fmt.Sprintf(
+						"%v; if roborev is running in a sandbox, allow loopback or Unix socket access and retry",
+						err,
+					)
+					if jsonOutput {
+						return writeJSONResult(statusJSONResult{
+							Running: true,
+							Error:   message,
+						})
+					}
+					fmt.Println("Daemon: status unavailable")
+					fmt.Println(message)
+					return nil
+				}
 				if jsonOutput {
 					return writeJSONResult(statusJSONResult{Running: false})
 				}

--- a/cmd/roborev/status_test.go
+++ b/cmd/roborev/status_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/version"
 )
@@ -17,6 +18,44 @@ type statusJSONOutput struct {
 	Running bool                 `json:"running"`
 	Daemon  storage.DaemonStatus `json:"daemon"`
 	Jobs    []storage.ReviewJob  `json:"jobs,omitempty"`
+	Error   string               `json:"error,omitempty"`
+}
+
+func TestStatusCmdReportsAccessDeniedAsSandboxRestriction(t *testing.T) {
+	origEnsure := statusEnsureDaemon
+	statusEnsureDaemon = func() error { return daemon.ErrDaemonAccessDenied }
+	t.Cleanup(func() { statusEnsureDaemon = origEnsure })
+
+	output := captureStdout(t, func() {
+		cmd := statusCmd()
+		err := cmd.Execute()
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "Daemon: status unavailable")
+	assert.Contains(t, output, "sandbox")
+	assert.Contains(t, output, "loopback or Unix socket")
+	assert.NotContains(t, output, "Daemon: not running")
+	assert.NotContains(t, output, "Start with: roborev daemon start")
+}
+
+func TestStatusCmdJSONReportsAccessDeniedAsRunning(t *testing.T) {
+	origEnsure := statusEnsureDaemon
+	statusEnsureDaemon = func() error { return daemon.ErrDaemonAccessDenied }
+	t.Cleanup(func() { statusEnsureDaemon = origEnsure })
+
+	output := captureStdout(t, func() {
+		cmd := statusCmd()
+		cmd.SetArgs([]string{"--json"})
+		err := cmd.Execute()
+		require.NoError(t, err)
+	})
+
+	var parsed statusJSONOutput
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed))
+	assert.True(t, parsed.Running)
+	assert.Contains(t, parsed.Error, "sandbox")
+	assert.Contains(t, parsed.Error, "loopback or Unix socket")
 }
 
 func TestStatusCmdDoesNotReportNotRunningWhenStatusRequestTimesOut(t *testing.T) {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -782,6 +782,12 @@ roborev uninstall-hook           # Remove hook
 | `--json` | Emit daemon and queue status as JSON. Includes the active daemon endpoint as `network`, `address`, and `port` fields alongside queue counters and version fields |
 | `--force` | Overwrite an existing post-commit hook with a fresh one |
 
+If daemon access is denied, `roborev status` reports the status as unavailable
+and suggests allowing loopback or Unix-socket access when running in a sandbox.
+It does not treat permission denial as proof that the daemon is stopped, and it
+does not start or restart the daemon. JSON output keeps `running: true` and
+includes the access error.
+
 `pause` and `unpause` are daemon-wide queue controls. Pausing prevents workers
 from starting new queued jobs, but running jobs continue to completion. A paused
 queue survives daemon restarts and is shown in `roborev status` and the TUI. Use

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -794,6 +794,14 @@ loopback. This provides filesystem-level access control: the socket is created
 with `0600` permissions and its parent directory with `0700`, so only the owning
 user can connect.
 
+The default TCP daemon also tries to expose this private socket as an alternate
+endpoint. Clients can fall back to it when a sandbox blocks TCP loopback. This
+alternate is best-effort: if the socket cannot be created, the daemon warns and
+continues serving TCP. Its path is namespaced by the configured data directory
+and advertised through daemon runtime metadata, so isolated daemons do not
+replace one another's fallback. An explicit `server_addr = "unix://"`
+configuration remains socket-only.
+
 To enable Unix domain sockets, set `server_addr` to `unix://`:
 
 ```toml

--- a/internal/daemon/auxiliary_listener_unix.go
+++ b/internal/daemon/auxiliary_listener_unix.go
@@ -1,0 +1,66 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	kitdaemon "go.kenn.io/kit/daemon"
+
+	"go.kenn.io/roborev/internal/config"
+)
+
+func listenUnixEndpoint(ep DaemonEndpoint) (net.Listener, error) {
+	socketDir := filepath.Dir(ep.Address)
+	if err := os.MkdirAll(socketDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create socket directory: %w", err)
+	}
+	fi, err := os.Stat(socketDir)
+	if err != nil {
+		return nil, fmt.Errorf("stat socket directory: %w", err)
+	}
+	if perm := fi.Mode().Perm(); perm&0o077 != 0 {
+		return nil, fmt.Errorf(
+			"socket directory %s has unsafe permissions %o (must not be group/world accessible)",
+			socketDir, perm,
+		)
+	}
+
+	_ = os.Remove(ep.Address)
+	listener, err := ep.Listener()
+	if err != nil {
+		return nil, fmt.Errorf("listen on %s: %w", ep, err)
+	}
+	if err := os.Chmod(ep.Address, 0o600); err != nil {
+		_ = listener.Close()
+		_ = os.Remove(ep.Address)
+		return nil, fmt.Errorf("chmod socket: %w", err)
+	}
+	return listener, nil
+}
+
+func listenAuxiliaryEndpoint(primary DaemonEndpoint) (net.Listener, *DaemonEndpoint, error) {
+	if primary.IsUnix() {
+		return nil, nil, nil
+	}
+	endpoint := DaemonEndpoint{Network: "unix", Address: auxiliarySocketPath()}
+	listener, err := listenUnixEndpoint(endpoint)
+	if err != nil {
+		return nil, nil, err
+	}
+	return listener, &endpoint, nil
+}
+
+func auxiliarySocketPath() string {
+	dataDir := filepath.Clean(config.DataDir())
+	if absolute, err := filepath.Abs(dataDir); err == nil {
+		dataDir = absolute
+	}
+	sum := sha256.Sum256([]byte(dataDir))
+	service := fmt.Sprintf("%s-%x", daemonServiceName, sum[:8])
+	return kitdaemon.DefaultSocketPath(service)
+}

--- a/internal/daemon/auxiliary_listener_unix_test.go
+++ b/internal/daemon/auxiliary_listener_unix_test.go
@@ -1,0 +1,68 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListenAuxiliaryEndpointForTCP(t *testing.T) {
+	setShortRuntimeDir(t)
+
+	listener, endpoint, err := listenAuxiliaryEndpoint(DaemonEndpoint{
+		Network: "tcp",
+		Address: "127.0.0.1:7373",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, listener)
+	require.NotNil(t, endpoint)
+	t.Cleanup(func() { require.NoError(t, listener.Close()) })
+
+	assert.Equal(t, "unix", endpoint.Network)
+	info, err := os.Stat(endpoint.Address)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+	dirInfo, err := os.Stat(filepath.Dir(endpoint.Address))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), dirInfo.Mode().Perm())
+}
+
+func TestListenAuxiliaryEndpointSkipsUnixPrimary(t *testing.T) {
+	setShortRuntimeDir(t)
+
+	listener, endpoint, err := listenAuxiliaryEndpoint(DaemonEndpoint{
+		Network: "unix",
+		Address: DefaultSocketPath(),
+	})
+
+	require.NoError(t, err)
+	assert.Nil(t, listener)
+	assert.Nil(t, endpoint)
+}
+
+func TestListenAuxiliaryEndpointIsolatesDataDirectories(t *testing.T) {
+	setShortRuntimeDir(t)
+	primary := DaemonEndpoint{Network: "tcp", Address: "127.0.0.1:7373"}
+
+	t.Setenv("ROBOREV_DATA_DIR", t.TempDir())
+	firstListener, firstEndpoint, err := listenAuxiliaryEndpoint(primary)
+	require.NoError(t, err)
+	require.NotNil(t, firstListener)
+	require.NotNil(t, firstEndpoint)
+	t.Cleanup(func() { require.NoError(t, firstListener.Close()) })
+
+	t.Setenv("ROBOREV_DATA_DIR", t.TempDir())
+	secondListener, secondEndpoint, err := listenAuxiliaryEndpoint(primary)
+	require.NoError(t, err)
+	require.NotNil(t, secondListener)
+	require.NotNil(t, secondEndpoint)
+	t.Cleanup(func() { require.NoError(t, secondListener.Close()) })
+
+	assert.NotEqual(t, firstEndpoint.Address, secondEndpoint.Address)
+}

--- a/internal/daemon/auxiliary_listener_windows.go
+++ b/internal/daemon/auxiliary_listener_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package daemon
+
+import (
+	"fmt"
+	"net"
+)
+
+func listenUnixEndpoint(DaemonEndpoint) (net.Listener, error) {
+	return nil, fmt.Errorf("Unix sockets are not supported on Windows")
+}
+
+func listenAuxiliaryEndpoint(DaemonEndpoint) (net.Listener, *DaemonEndpoint, error) {
+	return nil, nil, nil
+}

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -3,12 +3,14 @@ package daemon
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	kitdaemon "go.kenn.io/kit/daemon"
@@ -16,16 +18,28 @@ import (
 	"go.kenn.io/roborev/internal/config"
 )
 
-const daemonServiceName = "roborev"
+const (
+	daemonServiceName          = "roborev"
+	runtimeAlternateNetworkKey = "alternate_network"
+	runtimeAlternateAddressKey = "alternate_address"
+)
+
+// ErrDaemonAccessDenied means a daemon runtime was found but local permissions
+// prevented every usable endpoint from being probed.
+var ErrDaemonAccessDenied = errors.New("daemon access denied")
+
+var probeRuntimeEndpoint = probeRuntimeRecord
 
 // RuntimeInfo stores daemon runtime state
 type RuntimeInfo struct {
-	PID        int    `json:"pid"`
-	Network    string `json:"network,omitempty"`
-	Address    string `json:"address"`
-	Service    string `json:"service,omitempty"`
-	Version    string `json:"version,omitempty"`
-	SourcePath string `json:"-"` // Path to the runtime file (not serialized, set by ListAllRuntimes)
+	PID              int    `json:"pid"`
+	Network          string `json:"network,omitempty"`
+	Address          string `json:"address"`
+	Service          string `json:"service,omitempty"`
+	Version          string `json:"version,omitempty"`
+	SourcePath       string `json:"-"` // Path to the runtime file (not serialized, set by ListAllRuntimes)
+	AlternateNetwork string `json:"-"`
+	AlternateAddress string `json:"-"`
 }
 
 // Endpoint returns a DaemonEndpoint for this runtime.
@@ -37,6 +51,31 @@ func (r RuntimeInfo) Endpoint() DaemonEndpoint {
 		Service: r.Service,
 		Version: r.Version,
 	}.Endpoint())
+}
+
+// Endpoints returns the primary endpoint followed by a valid distinct
+// alternate endpoint published in runtime metadata.
+func (r RuntimeInfo) Endpoints() []DaemonEndpoint {
+	primary := r.Endpoint()
+	endpoints := []DaemonEndpoint{primary}
+	if r.AlternateNetwork == "" || r.AlternateAddress == "" {
+		return endpoints
+	}
+
+	var raw string
+	switch r.AlternateNetwork {
+	case "tcp":
+		raw = r.AlternateAddress
+	case "unix":
+		raw = "unix://" + r.AlternateAddress
+	default:
+		return endpoints
+	}
+	alternate, err := ParseEndpoint(raw)
+	if err != nil || alternate == primary {
+		return endpoints
+	}
+	return append(endpoints, alternate)
 }
 
 // PingInfo is the minimal daemon identity payload used for liveness probes.
@@ -73,12 +112,14 @@ func DiscoverOptions(timeout time.Duration) kitdaemon.DiscoverOptions {
 func runtimeInfoFromRecord(rec kitdaemon.RuntimeRecord) *RuntimeInfo {
 	ep := daemonEndpointFromKit(rec.Endpoint())
 	return &RuntimeInfo{
-		PID:        rec.PID,
-		Network:    ep.Network,
-		Address:    ep.Address,
-		Service:    rec.Service,
-		Version:    rec.Version,
-		SourcePath: rec.SourcePath,
+		PID:              rec.PID,
+		Network:          ep.Network,
+		Address:          ep.Address,
+		Service:          rec.Service,
+		Version:          rec.Version,
+		SourcePath:       rec.SourcePath,
+		AlternateNetwork: rec.Metadata[runtimeAlternateNetworkKey],
+		AlternateAddress: rec.Metadata[runtimeAlternateAddressKey],
 	}
 }
 
@@ -107,8 +148,22 @@ func RuntimePathForPID(pid int) string {
 
 // WriteRuntime saves the daemon runtime info atomically.
 // Uses write-to-temp-then-rename to prevent readers from seeing partial writes.
-func WriteRuntime(ep DaemonEndpoint, version string) error {
-	rec := kitdaemon.NewRuntimeRecord(daemonServiceName, version, ep.kitEndpoint())
+func WriteRuntime(primary DaemonEndpoint, alternate *DaemonEndpoint, version string) error {
+	rec := kitdaemon.NewRuntimeRecord(daemonServiceName, version, primary.kitEndpoint())
+	if alternate != nil {
+		info := RuntimeInfo{
+			Network:          primary.Network,
+			Address:          primary.Address,
+			AlternateNetwork: alternate.Network,
+			AlternateAddress: alternate.Address,
+		}
+		if len(info.Endpoints()) == 2 {
+			rec.Metadata = map[string]string{
+				runtimeAlternateNetworkKey: alternate.Network,
+				runtimeAlternateAddressKey: alternate.Address,
+			}
+		}
+	}
 	_, err := runtimeStore().Write(rec)
 	return err
 }
@@ -218,23 +273,83 @@ func listLegacyRuntimes() []*RuntimeInfo {
 	return runtimes
 }
 
-// GetAnyRunningDaemon returns info about a responsive daemon.
-// Returns os.ErrNotExist if no responsive daemon is found.
-func GetAnyRunningDaemon() (*RuntimeInfo, error) {
-	rec, _, ok, err := kitdaemon.Discover(context.Background(), runtimeStore(), kitdaemon.DiscoverOptions{
-		Probe: kitdaemon.ProbeOptions{
-			ExpectedService: daemonServiceName,
-			Timeout:         time.Second,
-		},
+func probeRuntimeRecord(ctx context.Context, ep DaemonEndpoint) (*PingInfo, error) {
+	if ep.Address == "" {
+		return nil, fmt.Errorf("empty daemon address")
+	}
+	if !ep.IsUnix() && !isLoopbackAddr(ep.Address) {
+		return nil, fmt.Errorf("non-loopback daemon address: %s", ep.Address)
+	}
+	info, err := kitdaemon.Probe(ctx, ep.kitEndpoint(), kitdaemon.ProbeOptions{
+		ExpectedService: daemonServiceName,
+		Timeout:         time.Second,
 	})
 	if err != nil {
 		return nil, err
 	}
-	if ok {
-		return runtimeInfoFromRecord(rec), nil
-	}
+	return pingInfoFromKit(info), nil
+}
 
+// IsDaemonAccessDenied reports whether err is roborev's access-denied sentinel
+// or an operating-system permission error from a local endpoint probe.
+func IsDaemonAccessDenied(err error) bool {
+	return errors.Is(err, ErrDaemonAccessDenied) ||
+		errors.Is(err, os.ErrPermission) ||
+		errors.Is(err, syscall.EACCES) ||
+		errors.Is(err, syscall.EPERM)
+}
+
+func discoverRuntimeRecords(
+	ctx context.Context,
+	records []kitdaemon.RuntimeRecord,
+	probe func(context.Context, DaemonEndpoint) (*PingInfo, error),
+) (*RuntimeInfo, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	var deniedErr error
+	for _, rec := range records {
+		info := runtimeInfoFromRecord(rec)
+		primary := info.Endpoint()
+		for _, ep := range info.Endpoints() {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			ping, err := probe(ctx, ep)
+			if err == nil && ping != nil && ping.PID != 0 && ping.PID == rec.PID {
+				info.Network = ep.Network
+				info.Address = ep.Address
+				if ep != primary {
+					info.AlternateNetwork = primary.Network
+					info.AlternateAddress = primary.Address
+				}
+				return info, nil
+			}
+			if IsDaemonAccessDenied(err) {
+				deniedErr = fmt.Errorf("%w at %s: %w", ErrDaemonAccessDenied, ep, err)
+			}
+		}
+	}
+	if deniedErr != nil {
+		return nil, deniedErr
+	}
 	return nil, os.ErrNotExist
+}
+
+// GetAnyRunningDaemonContext returns info about a responsive daemon.
+// Returns os.ErrNotExist if no responsive daemon is found.
+func GetAnyRunningDaemonContext(ctx context.Context) (*RuntimeInfo, error) {
+	records, err := runtimeStore().List()
+	if err != nil {
+		return nil, err
+	}
+	return discoverRuntimeRecords(ctx, records, probeRuntimeEndpoint)
+}
+
+// GetAnyRunningDaemon returns info about a responsive daemon.
+// Returns os.ErrNotExist if no responsive daemon is found.
+func GetAnyRunningDaemon() (*RuntimeInfo, error) {
+	return GetAnyRunningDaemonContext(context.Background())
 }
 
 // ProbeDaemon validates that a daemon endpoint is serving the roborev daemon.
@@ -255,25 +370,49 @@ func ProbeDaemon(ep DaemonEndpoint, timeout time.Duration) (*PingInfo, error) {
 	return pingInfoFromKit(info), nil
 }
 
-// IsDaemonAlive checks if a daemon at the given endpoint is actually responding.
+// ProbeDaemonAlive checks if a daemon at the given endpoint is actually responding.
 // This is more reliable than checking PID and works cross-platform.
 // Only allows loopback addresses (for TCP) to prevent SSRF via malicious runtime files.
 // Uses retry logic to avoid misclassifying a slow or transiently failing daemon.
-func IsDaemonAlive(ep DaemonEndpoint) bool {
+func ProbeDaemonAlive(ep DaemonEndpoint) (bool, error) {
 	if ep.Address == "" {
-		return false
+		return false, nil
 	}
 
-	// Try up to 2 times with a short delay between attempts
+	var lastErr error
 	for attempt := range 2 {
 		if attempt > 0 {
 			time.Sleep(200 * time.Millisecond)
 		}
-		if _, err := ProbeDaemon(ep, 1*time.Second); err == nil {
-			return true
+		if _, err := probeRuntimeEndpoint(context.Background(), ep); err == nil {
+			return true, nil
+		} else if IsDaemonAccessDenied(err) {
+			return false, fmt.Errorf("%w at %s: %w", ErrDaemonAccessDenied, ep, err)
+		} else {
+			lastErr = err
 		}
 	}
-	return false
+	return false, lastErr
+}
+
+// IsDaemonAlive checks if a daemon at the given endpoint is actually responding.
+func IsDaemonAlive(ep DaemonEndpoint) bool {
+	alive, _ := ProbeDaemonAlive(ep)
+	return alive
+}
+
+func probeRuntimeAlive(info *RuntimeInfo) (bool, error) {
+	var deniedErr error
+	for _, ep := range info.Endpoints() {
+		alive, err := ProbeDaemonAlive(ep)
+		if alive {
+			return true, nil
+		}
+		if IsDaemonAccessDenied(err) {
+			deniedErr = err
+		}
+	}
+	return false, deniedErr
 }
 
 func parseDaemonBindAddr(addr string) (string, int, error) {
@@ -422,8 +561,11 @@ func CleanupZombieDaemons(target DaemonEndpoint) int {
 			continue
 		}
 
-		// Skip responsive daemons
-		if IsDaemonAlive(ep) {
+		alive, probeErr := probeRuntimeAlive(info)
+		if alive {
+			continue
+		}
+		if IsDaemonAccessDenied(probeErr) {
 			continue
 		}
 

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -1,7 +1,9 @@
 package daemon
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"net"
@@ -11,11 +13,13 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	kitdaemon "go.kenn.io/kit/daemon"
 
 	"go.kenn.io/roborev/internal/testenv"
 )
@@ -161,7 +165,12 @@ func TestRuntimeInfoReadWrite(t *testing.T) {
 
 	t.Run("WriteAndRead", func(t *testing.T) {
 		// Write runtime info
-		err := WriteRuntime(DaemonEndpoint{Network: "tcp", Address: defaultTestAddr}, "test-version")
+		alternate := DaemonEndpoint{Network: "tcp", Address: "127.0.0.1:7374"}
+		err := WriteRuntime(
+			DaemonEndpoint{Network: "tcp", Address: defaultTestAddr},
+			&alternate,
+			"test-version",
+		)
 		if err != nil {
 			require.Condition(t, func() bool {
 				return false
@@ -191,6 +200,8 @@ func TestRuntimeInfoReadWrite(t *testing.T) {
 				return false
 			}, "Expected version 'test-version', got '%s'", info.Version)
 		}
+		assert.Equal(t, "tcp", info.AlternateNetwork)
+		assert.Equal(t, alternate.Address, info.AlternateAddress)
 	})
 
 	t.Run("Remove", func(t *testing.T) {
@@ -490,6 +501,141 @@ func TestRuntimeInfo_Endpoint(t *testing.T) {
 	info = RuntimeInfo{PID: 1, Address: "127.0.0.1:7373", Network: ""}
 	ep = info.Endpoint()
 	assert.Equal("tcp", ep.Network)
+}
+
+func TestRuntimeInfoEndpoints(t *testing.T) {
+	t.Run("primary only", func(t *testing.T) {
+		info := RuntimeInfo{Network: "tcp", Address: defaultTestAddr}
+		assert.Equal(t, []DaemonEndpoint{{Network: "tcp", Address: defaultTestAddr}}, info.Endpoints())
+	})
+
+	t.Run("valid alternate", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Unix sockets are not supported on Windows")
+		}
+		alternatePath := "/tmp/rr-runtime-alt.sock"
+		info := RuntimeInfo{
+			Network:          "tcp",
+			Address:          defaultTestAddr,
+			AlternateNetwork: "unix",
+			AlternateAddress: alternatePath,
+		}
+		assert.Equal(t, []DaemonEndpoint{
+			{Network: "tcp", Address: defaultTestAddr},
+			{Network: "unix", Address: alternatePath},
+		}, info.Endpoints())
+	})
+
+	t.Run("incomplete alternate", func(t *testing.T) {
+		info := RuntimeInfo{
+			Network:          "tcp",
+			Address:          defaultTestAddr,
+			AlternateNetwork: "unix",
+		}
+		assert.Equal(t, []DaemonEndpoint{{Network: "tcp", Address: defaultTestAddr}}, info.Endpoints())
+	})
+
+	t.Run("non-loopback alternate", func(t *testing.T) {
+		info := RuntimeInfo{
+			Network:          "tcp",
+			Address:          defaultTestAddr,
+			AlternateNetwork: "tcp",
+			AlternateAddress: "192.0.2.1:7373",
+		}
+		assert.Equal(t, []DaemonEndpoint{{Network: "tcp", Address: defaultTestAddr}}, info.Endpoints())
+	})
+
+	t.Run("duplicate alternate", func(t *testing.T) {
+		info := RuntimeInfo{
+			Network:          "tcp",
+			Address:          defaultTestAddr,
+			AlternateNetwork: "tcp",
+			AlternateAddress: defaultTestAddr,
+		}
+		assert.Equal(t, []DaemonEndpoint{{Network: "tcp", Address: defaultTestAddr}}, info.Endpoints())
+	})
+}
+
+func TestDiscoverRuntimeRecords(t *testing.T) {
+	const alternateAddr = "127.0.0.1:7374"
+	record := kitdaemon.RuntimeRecord{
+		PID:     42,
+		Network: "tcp",
+		Address: defaultTestAddr,
+		Metadata: map[string]string{
+			runtimeAlternateNetworkKey: "tcp",
+			runtimeAlternateAddressKey: alternateAddr,
+		},
+	}
+	denied := &net.OpError{Op: "dial", Net: "tcp", Err: syscall.EPERM}
+
+	t.Run("falls back after primary access denied", func(t *testing.T) {
+		got, err := discoverRuntimeRecords(t.Context(), []kitdaemon.RuntimeRecord{record}, func(_ context.Context, ep DaemonEndpoint) (*PingInfo, error) {
+			if ep.Address == defaultTestAddr {
+				return nil, denied
+			}
+			return &PingInfo{OK: true, Service: daemonServiceName, PID: record.PID}, nil
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "tcp", got.Network)
+		assert.Equal(t, alternateAddr, got.Address)
+	})
+
+	t.Run("preserves access denied after every endpoint fails", func(t *testing.T) {
+		_, err := discoverRuntimeRecords(t.Context(), []kitdaemon.RuntimeRecord{record}, func(context.Context, DaemonEndpoint) (*PingInfo, error) {
+			return nil, denied
+		})
+
+		require.ErrorIs(t, err, ErrDaemonAccessDenied)
+	})
+
+	t.Run("ordinary failures mean not found", func(t *testing.T) {
+		_, err := discoverRuntimeRecords(t.Context(), []kitdaemon.RuntimeRecord{record}, func(context.Context, DaemonEndpoint) (*PingInfo, error) {
+			return nil, errors.New("connection refused")
+		})
+
+		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	for name, pingPID := range map[string]int{
+		"missing ping PID":    0,
+		"mismatched ping PID": record.PID + 1,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := discoverRuntimeRecords(t.Context(), []kitdaemon.RuntimeRecord{record}, func(context.Context, DaemonEndpoint) (*PingInfo, error) {
+				return &PingInfo{OK: true, Service: daemonServiceName, PID: pingPID}, nil
+			})
+
+			require.ErrorIs(t, err, os.ErrNotExist)
+		})
+	}
+}
+
+func TestCleanupZombieDaemonsPreservesAccessDeniedRuntime(t *testing.T) {
+	testenv.SetDataDir(t)
+	socketDir, err := os.MkdirTemp("/tmp", "rr-denied-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, os.RemoveAll(socketDir)) })
+	socketPath := filepath.Join(socketDir, "daemon.sock")
+	require.NoError(t, os.WriteFile(socketPath, nil, 0o600))
+
+	primary := DaemonEndpoint{Network: "tcp", Address: defaultTestAddr}
+	alternate := DaemonEndpoint{Network: "unix", Address: socketPath}
+	require.NoError(t, WriteRuntime(primary, &alternate, "test-version"))
+	runtimePath := RuntimePath()
+
+	origProbe := probeRuntimeEndpoint
+	probeRuntimeEndpoint = func(context.Context, DaemonEndpoint) (*PingInfo, error) {
+		return nil, &net.OpError{Op: "dial", Net: "local", Err: syscall.EPERM}
+	}
+	t.Cleanup(func() { probeRuntimeEndpoint = origProbe })
+
+	cleaned := CleanupZombieDaemons(primary)
+
+	assert.Zero(t, cleaned)
+	assert.FileExists(t, runtimePath)
+	assert.FileExists(t, socketPath)
 }
 
 func TestListAllRuntimesWithGlobMetacharacters(t *testing.T) {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -35,29 +35,30 @@ import (
 
 // Server is the HTTP API server for the daemon
 type Server struct {
-	db              *storage.DB
-	configWatcher   *ConfigWatcher
-	broadcaster     Broadcaster
-	workerPool      *WorkerPool
-	httpServer      *http.Server
-	syncWorker      *storage.SyncWorker
-	ciPoller        *CIPoller
-	hookRunner      *HookRunner
-	errorLog        *ErrorLog
-	activityLog     *ActivityLog
-	telemetry       telemetry.Client
-	telemetryOnce   sync.Once
-	telemetryStop   chan struct{}
-	startTime       time.Time
-	endpointMu      sync.Mutex // protects endpoint (written by Start, read by Stop)
-	endpoint        DaemonEndpoint
-	socketActivated bool // true if started via systemd socket activation
-	stopOnce        sync.Once
-	stopErr         error
-	sweepMu         sync.Mutex         // protects sweepCancel (written by Start, read by Stop)
-	sweepCancel     context.CancelFunc // cancels the panel sweep goroutine on Stop
-	shutdownCh      chan struct{}      // closed when /api/shutdown is requested
-	shutdownOnce    sync.Once
+	db                *storage.DB
+	configWatcher     *ConfigWatcher
+	broadcaster       Broadcaster
+	workerPool        *WorkerPool
+	httpServer        *http.Server
+	syncWorker        *storage.SyncWorker
+	ciPoller          *CIPoller
+	hookRunner        *HookRunner
+	errorLog          *ErrorLog
+	activityLog       *ActivityLog
+	telemetry         telemetry.Client
+	telemetryOnce     sync.Once
+	telemetryStop     chan struct{}
+	startTime         time.Time
+	endpointMu        sync.Mutex // protects endpoint (written by Start, read by Stop)
+	endpoint          DaemonEndpoint
+	alternateEndpoint *DaemonEndpoint
+	socketActivated   bool // true if started via systemd socket activation
+	stopOnce          sync.Once
+	stopErr           error
+	sweepMu           sync.Mutex         // protects sweepCancel (written by Start, read by Stop)
+	sweepCancel       context.CancelFunc // cancels the panel sweep goroutine on Stop
+	shutdownCh        chan struct{}      // closed when /api/shutdown is requested
+	shutdownOnce      sync.Once
 
 	// Cached machine ID to avoid INSERT on every status request
 	machineIDMu sync.Mutex
@@ -65,6 +66,11 @@ type Server struct {
 }
 
 const dailyTelemetryInterval = 24 * time.Hour
+
+var (
+	getSystemdListenerForServer      = getSystemdListener
+	listenAuxiliaryEndpointForServer = listenAuxiliaryEndpoint
+)
 
 // NewServer creates a new daemon server
 func NewServer(db *storage.DB, cfg *config.Config, configPath string) *Server {
@@ -153,7 +159,7 @@ func (s *Server) Start(ctx context.Context) error {
 	cfg := s.configWatcher.Config()
 
 	// Check for socket activation before falling back to the config
-	listener, ep, err := getSystemdListener()
+	listener, ep, err := getSystemdListenerForServer()
 	if err != nil {
 		return err
 	}
@@ -179,8 +185,15 @@ func (s *Server) Start(ctx context.Context) error {
 		}
 	}
 
-	// Check if a responsive daemon is still running after cleanup
-	if info, err := GetAnyRunningDaemon(); err == nil && IsDaemonAlive(info.Endpoint()) {
+	// Check if a responsive daemon is still running after cleanup.
+	info, discoveryErr := GetAnyRunningDaemon()
+	if IsDaemonAccessDenied(discoveryErr) {
+		if listener != nil {
+			_ = listener.Close()
+		}
+		return discoveryErr
+	}
+	if discoveryErr == nil && IsDaemonAlive(info.Endpoint()) {
 		if listener != nil {
 			_ = listener.Close()
 		}
@@ -202,30 +215,10 @@ func (s *Server) Start(ctx context.Context) error {
 		// Bind the listener before publishing runtime metadata so concurrent CLI
 		// invocations cannot race a half-started daemon and kill it as a zombie.
 		if ep.IsUnix() {
-			socketPath := ep.Address
-			socketDir := filepath.Dir(socketPath)
-			if err := os.MkdirAll(socketDir, 0o700); err != nil {
-				s.configWatcher.Stop()
-				return fmt.Errorf("create socket directory: %w", err)
-			}
-			// Verify the parent directory has safe permissions (owner-only)
-			if fi, err := os.Stat(socketDir); err == nil {
-				if perm := fi.Mode().Perm(); perm&0o077 != 0 {
-					s.configWatcher.Stop()
-					return fmt.Errorf("socket directory %s has unsafe permissions %o (must not be group/world accessible)", socketDir, perm)
-				}
-			}
-			// Remove stale socket from a previous run
-			os.Remove(socketPath)
-			listener, err = ep.Listener()
+			listener, err = listenUnixEndpoint(ep)
 			if err != nil {
 				s.configWatcher.Stop()
-				return fmt.Errorf("listen on %s: %w", ep, err)
-			}
-			if err := os.Chmod(socketPath, 0o600); err != nil {
-				_ = listener.Close()
-				s.configWatcher.Stop()
-				return fmt.Errorf("chmod socket: %w", err)
+				return err
 			}
 		} else {
 			// TCP: find an available port first
@@ -281,10 +274,50 @@ func (s *Server) Start(ctx context.Context) error {
 		return nil
 	}
 
+	var alternate *DaemonEndpoint
+	if !s.socketActivated {
+		auxListener, candidate, auxErr := listenAuxiliaryEndpointForServer(ep)
+		if auxErr != nil {
+			log.Printf("Warning: auxiliary Unix listener unavailable: %v", auxErr)
+		} else if auxListener != nil && candidate != nil {
+			auxServeErrCh := make(chan error, 1)
+			log.Printf("Starting auxiliary HTTP server on %s", candidate)
+			go func() {
+				auxServeErrCh <- s.httpServer.Serve(auxListener)
+			}()
+			auxReady, auxExited, readyErr := waitForServerReady(
+				ctx, *candidate, 2*time.Second, auxServeErrCh,
+			)
+			if readyErr != nil || !auxReady {
+				_ = auxListener.Close()
+				_ = os.Remove(candidate.Address)
+				if readyErr == nil {
+					readyErr = fmt.Errorf("listener exited before becoming ready")
+				}
+				log.Printf("Warning: auxiliary Unix listener unavailable: %v", readyErr)
+				if !auxExited {
+					_ = awaitServeExitOnUnreadyStartup(false, auxServeErrCh)
+				}
+			} else {
+				alternate = candidate
+				go func() {
+					serveErr := <-auxServeErrCh
+					if serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+						log.Printf("Auxiliary Unix listener stopped: %v", serveErr)
+					}
+				}()
+			}
+		}
+	}
+
+	s.endpointMu.Lock()
+	s.alternateEndpoint = alternate
+	s.endpointMu.Unlock()
+
 	s.startPanelSweep(ctx)
 
 	// Write runtime info only after the HTTP server is accepting requests.
-	if err := WriteRuntime(ep, version.Version); err != nil {
+	if err := WriteRuntime(ep, alternate, version.Version); err != nil {
 		log.Printf("Warning: failed to write runtime info: %v", err)
 	}
 
@@ -510,9 +543,13 @@ func (s *Server) stopOnce0() error {
 	// Clean up Unix domain socket (if we created it)
 	s.endpointMu.Lock()
 	ep := s.endpoint
+	alternate := s.alternateEndpoint
 	s.endpointMu.Unlock()
 	if ep.IsUnix() && !s.socketActivated {
 		os.Remove(ep.Address)
+	}
+	if alternate != nil {
+		os.Remove(alternate.Address)
 	}
 
 	// Stop CI poller

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -1,15 +1,20 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -175,6 +180,56 @@ func newTestActivityLog() *ActivityLog {
 	}
 }
 
+func setShortRuntimeDir(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix sockets are not supported on Windows")
+	}
+	dir, err := os.MkdirTemp("/tmp", "rr-xdg-*")
+	require.NoError(t, err)
+	require.NoError(t, os.Chmod(dir, 0o700))
+	t.Cleanup(func() { require.NoError(t, os.RemoveAll(dir)) })
+	t.Setenv("XDG_RUNTIME_DIR", dir)
+	return dir
+}
+
+func startServerAndWaitForRuntime(t *testing.T, server *Server) (<-chan error, *RuntimeInfo) {
+	t.Helper()
+	errCh := make(chan error, 1)
+	go func() { errCh <- server.Start(context.Background()) }()
+
+	var info *RuntimeInfo
+	var startErr error
+	require.Eventually(t, func() bool {
+		select {
+		case startErr = <-errCh:
+			return true
+		default:
+		}
+		var err error
+		info, err = ReadRuntime()
+		return err == nil
+	}, 5*time.Second, 10*time.Millisecond)
+	require.NoError(t, startErr)
+	require.NotNil(t, info)
+	return errCh, info
+}
+
+func stopTestServer(t *testing.T, server *Server, errCh <-chan error) {
+	t.Helper()
+	require.NoError(t, server.Stop())
+	var stopErr error
+	require.Eventually(t, func() bool {
+		select {
+		case stopErr = <-errCh:
+			return true
+		default:
+			return false
+		}
+	}, 5*time.Second, 10*time.Millisecond)
+	require.NoError(t, stopErr)
+}
+
 func TestServerStartRejectsNonLoopbackBindAddr(t *testing.T) {
 	tests := []struct {
 		name string
@@ -204,6 +259,32 @@ func TestServerStartRejectsNonLoopbackBindAddr(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestServerStartRejectsAccessDeniedExistingDaemon(t *testing.T) {
+	testenv.SetDataDir(t)
+	require.NoError(t, WriteRuntime(
+		DaemonEndpoint{Network: "tcp", Address: defaultTestAddr},
+		nil,
+		"test-version",
+	))
+
+	origProbe := probeRuntimeEndpoint
+	probeRuntimeEndpoint = func(context.Context, DaemonEndpoint) (*PingInfo, error) {
+		return nil, &net.OpError{Op: "dial", Net: "tcp", Err: syscall.EACCES}
+	}
+	t.Cleanup(func() { probeRuntimeEndpoint = origProbe })
+
+	db, _ := testutil.OpenTestDBWithDir(t)
+	cfg := config.DefaultConfig()
+	cfg.ServerAddr = "127.0.0.1:0"
+	server := NewServer(db, cfg, "")
+	t.Cleanup(func() { require.NoError(t, server.Close()) })
+
+	err := server.Start(t.Context())
+	require.ErrorIs(t, err, ErrDaemonAccessDenied)
+	assert.FileExists(t, RuntimePath())
+	assert.Empty(t, server.endpoint.Address)
 }
 
 func TestWaitForServerReadySurfacesServeError(t *testing.T) {
@@ -395,6 +476,92 @@ func TestServerStartSupportsIPv6LoopbackBindAddr(t *testing.T) {
 	require.Condition(t, func() bool {
 		return false
 	}, "timed out waiting for IPv6 daemon runtime")
+}
+
+func TestServerServesPrimaryAndAuxiliaryEndpoints(t *testing.T) {
+	testenv.SetDataDir(t)
+	setShortRuntimeDir(t)
+
+	db, _ := testutil.OpenTestDBWithDir(t)
+	cfg := config.DefaultConfig()
+	cfg.ServerAddr = "127.0.0.1:0"
+	server := NewServer(db, cfg, "")
+	errCh, info := startServerAndWaitForRuntime(t, server)
+
+	endpoints := info.Endpoints()
+	require.Len(t, endpoints, 2)
+	assert.Equal(t, "tcp", endpoints[0].Network)
+	assert.Equal(t, "unix", endpoints[1].Network)
+	for _, endpoint := range endpoints {
+		_, err := ProbeDaemon(endpoint, time.Second)
+		require.NoError(t, err)
+	}
+	assert.FileExists(t, endpoints[1].Address)
+
+	stopTestServer(t, server, errCh)
+	assert.NoFileExists(t, endpoints[1].Address)
+}
+
+func TestServerContinuesWhenAuxiliaryListenerFails(t *testing.T) {
+	testenv.SetDataDir(t)
+	setShortRuntimeDir(t)
+
+	origListen := listenAuxiliaryEndpointForServer
+	listenAuxiliaryEndpointForServer = func(DaemonEndpoint) (net.Listener, *DaemonEndpoint, error) {
+		return nil, nil, errors.New("synthetic auxiliary bind failure")
+	}
+	t.Cleanup(func() { listenAuxiliaryEndpointForServer = origListen })
+
+	origLogOutput := log.Writer()
+	var logOutput bytes.Buffer
+	log.SetOutput(&logOutput)
+	t.Cleanup(func() { log.SetOutput(origLogOutput) })
+
+	db, _ := testutil.OpenTestDBWithDir(t)
+	cfg := config.DefaultConfig()
+	cfg.ServerAddr = "127.0.0.1:0"
+	server := NewServer(db, cfg, "")
+	errCh, info := startServerAndWaitForRuntime(t, server)
+
+	assert.Len(t, info.Endpoints(), 1)
+	_, err := ProbeDaemon(info.Endpoint(), time.Second)
+	require.NoError(t, err)
+	assert.Contains(t, logOutput.String(), "auxiliary Unix listener")
+	assert.Contains(t, logOutput.String(), "synthetic auxiliary bind failure")
+
+	stopTestServer(t, server, errCh)
+}
+
+func TestServerSocketActivationSkipsAuxiliaryListener(t *testing.T) {
+	testenv.SetDataDir(t)
+	setShortRuntimeDir(t)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	endpoint := DaemonEndpoint{Network: "tcp", Address: listener.Addr().String()}
+	origSystemd := getSystemdListenerForServer
+	getSystemdListenerForServer = func() (net.Listener, DaemonEndpoint, error) {
+		return listener, endpoint, nil
+	}
+	t.Cleanup(func() { getSystemdListenerForServer = origSystemd })
+
+	origListen := listenAuxiliaryEndpointForServer
+	auxiliaryCalls := 0
+	listenAuxiliaryEndpointForServer = func(DaemonEndpoint) (net.Listener, *DaemonEndpoint, error) {
+		auxiliaryCalls++
+		return nil, nil, nil
+	}
+	t.Cleanup(func() { listenAuxiliaryEndpointForServer = origListen })
+
+	db, _ := testutil.OpenTestDBWithDir(t)
+	server := NewServer(db, config.DefaultConfig(), "")
+	errCh, info := startServerAndWaitForRuntime(t, server)
+
+	assert.Equal(t, endpoint, info.Endpoint())
+	assert.Len(t, info.Endpoints(), 1)
+	assert.Zero(t, auxiliaryCalls)
+
+	stopTestServer(t, server, errCh)
 }
 
 func TestNewServerAllowUnsafeAgents(t *testing.T) {

--- a/internal/skills/claude/roborev-design-review-branch/SKILL.md
+++ b/internal/skills/claude/roborev-design-review-branch/SKILL.md
@@ -21,6 +21,13 @@ Claude Code skill selection.
 Requests such as “review this branch's design” without one of these
 explicit mechanisms must use native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same Bash command with
+`dangerouslyDisableSandbox: true`. Do not start or restart the daemon because a sandboxed
+status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/claude/roborev-design-review/SKILL.md
+++ b/internal/skills/claude/roborev-design-review/SKILL.md
@@ -21,6 +21,13 @@ Claude Code skill selection.
 Requests such as “review this commit's design” without one of these explicit mechanisms
 must use native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same Bash command with
+`dangerouslyDisableSandbox: true`. Do not start or restart the daemon because a sandboxed
+status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/claude/roborev-fix/SKILL.md
+++ b/internal/skills/claude/roborev-fix/SKILL.md
@@ -25,6 +25,13 @@ an invocation.
 Requests such as “fix the open findings” without one of these explicit mechanisms must use native
 behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same Bash command with
+`dangerouslyDisableSandbox: true`. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill just because the user pasted existing review

--- a/internal/skills/claude/roborev-lookahead-review-branch/SKILL.md
+++ b/internal/skills/claude/roborev-lookahead-review-branch/SKILL.md
@@ -24,6 +24,13 @@ Claude Code skill selection.
 Requests such as “check this branch for future leakage” without one of these
 explicit mechanisms must use native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same Bash command with
+`dangerouslyDisableSandbox: true`. Do not start or restart the daemon because a sandboxed
+status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/claude/roborev-lookahead-review/SKILL.md
+++ b/internal/skills/claude/roborev-lookahead-review/SKILL.md
@@ -24,6 +24,13 @@ Claude Code skill selection.
 Requests such as “check this commit for peekahead” without one of these explicit
 mechanisms must use native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same Bash command with
+`dangerouslyDisableSandbox: true`. Do not start or restart the daemon because a sandboxed
+status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/claude/roborev-refine/SKILL.md
+++ b/internal/skills/claude/roborev-refine/SKILL.md
@@ -36,6 +36,13 @@ behavior and must not run roborev.
 This skill intentionally focuses on the current branch flow. It does not expose
 `roborev refine --all-branches` or `roborev refine --list`.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same Bash command with
+`dangerouslyDisableSandbox: true`. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/claude/roborev-respond/SKILL.md
+++ b/internal/skills/claude/roborev-respond/SKILL.md
@@ -21,6 +21,13 @@ Claude Code skill selection.
 Requests such as “respond to this review” without one of these explicit mechanisms must use
 native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same Bash command with
+`dangerouslyDisableSandbox: true`. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## IMPORTANT
 
 This skill requires you to **execute bash commands** to record the comment and close the review. The task is not complete until you run both commands and see confirmation output.

--- a/internal/skills/claude/roborev-review-branch/SKILL.md
+++ b/internal/skills/claude/roborev-review-branch/SKILL.md
@@ -21,6 +21,13 @@ Claude Code skill selection.
 Requests such as “review this branch” without one of these explicit mechanisms must use
 native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same Bash command with
+`dangerouslyDisableSandbox: true`. Do not start or restart the daemon because a sandboxed
+status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/claude/roborev-review/SKILL.md
+++ b/internal/skills/claude/roborev-review/SKILL.md
@@ -21,6 +21,13 @@ Claude Code skill selection.
 Requests such as “review this commit” without one of these explicit mechanisms must use native
 behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same Bash command with
+`dangerouslyDisableSandbox: true`. Do not start or restart the daemon because a sandboxed
+status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/claude/roborev-snooze/SKILL.md
+++ b/internal/skills/claude/roborev-snooze/SKILL.md
@@ -26,6 +26,13 @@ Claude Code skill selection.
 Requests such as “silence review notifications” without one of these explicit
 mechanisms must use native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same Bash command with
+`dangerouslyDisableSandbox: true`. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## Instructions
 
 This skill requires you to execute the matching command and report its result.

--- a/internal/skills/codex/roborev-design-review-branch/SKILL.md
+++ b/internal/skills/codex/roborev-design-review-branch/SKILL.md
@@ -20,6 +20,13 @@ Invocation must be explicit: literal personal `$roborev-design-review-branch`, p
 Requests such as “review this branch's design” without one of these
 explicit mechanisms must use native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+`sandbox_permissions: "require_escalated"`. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/codex/roborev-design-review/SKILL.md
+++ b/internal/skills/codex/roborev-design-review/SKILL.md
@@ -20,6 +20,13 @@ Invocation must be explicit: literal personal `$roborev-design-review`, plugin
 Requests such as “review this commit's design” without one of these explicit mechanisms
 must use native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+`sandbox_permissions: "require_escalated"`. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/codex/roborev-fix/SKILL.md
+++ b/internal/skills/codex/roborev-fix/SKILL.md
@@ -25,6 +25,13 @@ an invocation.
 Requests such as “fix the open findings” without one of these explicit mechanisms must use native
 behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+`sandbox_permissions: "require_escalated"`. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill just because the user pasted existing review

--- a/internal/skills/codex/roborev-lookahead-review-branch/SKILL.md
+++ b/internal/skills/codex/roborev-lookahead-review-branch/SKILL.md
@@ -23,6 +23,13 @@ Invocation must be explicit: literal personal `$roborev-lookahead-review-branch`
 Requests such as “check this branch for future leakage” without one of these
 explicit mechanisms must use native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+`sandbox_permissions: "require_escalated"`. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/codex/roborev-lookahead-review/SKILL.md
+++ b/internal/skills/codex/roborev-lookahead-review/SKILL.md
@@ -23,6 +23,13 @@ Invocation must be explicit: literal personal `$roborev-lookahead-review`, plugi
 Requests such as “check this commit for peekahead” without one of these explicit
 mechanisms must use native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+`sandbox_permissions: "require_escalated"`. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/codex/roborev-refine/SKILL.md
+++ b/internal/skills/codex/roborev-refine/SKILL.md
@@ -35,6 +35,13 @@ behavior and must not run roborev.
 This skill intentionally focuses on the current branch flow. It does not expose
 `roborev refine --all-branches` or `roborev refine --list`.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+`sandbox_permissions: "require_escalated"`. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/codex/roborev-respond/SKILL.md
+++ b/internal/skills/codex/roborev-respond/SKILL.md
@@ -20,6 +20,13 @@ Invocation must be explicit: literal personal `$roborev-respond`, plugin
 Requests such as “respond to this review” without one of these explicit mechanisms must use
 native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+`sandbox_permissions: "require_escalated"`. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## IMPORTANT
 
 This skill requires you to **execute bash commands** to record the comment and close the review. The task is not complete until you run both commands and see confirmation output.

--- a/internal/skills/codex/roborev-review-branch/SKILL.md
+++ b/internal/skills/codex/roborev-review-branch/SKILL.md
@@ -20,6 +20,13 @@ Invocation must be explicit: literal personal `$roborev-review-branch`, plugin
 Requests such as “review this branch” without one of these explicit mechanisms must use
 native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+`sandbox_permissions: "require_escalated"`. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/codex/roborev-review/SKILL.md
+++ b/internal/skills/codex/roborev-review/SKILL.md
@@ -20,6 +20,13 @@ Invocation must be explicit: literal personal `$roborev-review`, plugin
 Requests such as “review this commit” without one of these explicit mechanisms must use native
 behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+`sandbox_permissions: "require_escalated"`. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/codex/roborev-snooze/SKILL.md
+++ b/internal/skills/codex/roborev-snooze/SKILL.md
@@ -25,6 +25,13 @@ Invocation must be explicit: literal personal `$roborev-snooze`, plugin
 Requests such as “silence review notifications” without one of these explicit
 mechanisms must use native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+`sandbox_permissions: "require_escalated"`. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## Instructions
 
 This skill requires you to execute the matching command and report its result.

--- a/internal/skills/derive.go
+++ b/internal/skills/derive.go
@@ -71,6 +71,10 @@ func skillDerivations() []skillDerivation {
 			},
 			{Old: "$roborev", New: "/roborev"},
 			{Old: "CLAUDE.md", New: "AGENTS.md"},
+			{
+				Old: "`sandbox_permissions: \"require_escalated\"`",
+				New: "the runtime's supported sandbox escalation mechanism",
+			},
 		}
 		if skillName == "roborev-snooze" {
 			replacements = append([]stringReplacement{{
@@ -91,6 +95,11 @@ func skillDerivations() []skillDerivation {
 				New: ", or structured\nClaude Code skill selection",
 			},
 			{Old: "$roborev", New: "/roborev"},
+			{Old: "Retry the same command with", New: "Retry the same Bash command with"},
+			{
+				Old: "`sandbox_permissions: \"require_escalated\"`",
+				New: "`dangerouslyDisableSandbox: true`",
+			},
 		}
 		// roborev-fix must stay model-invocable: the agent-hook Stop hook
 		// instructs the Claude Code model to invoke it, and
@@ -118,6 +127,10 @@ func skillDerivations() []skillDerivation {
 			{Old: "$roborev", New: "/roborev"},
 			// Grok project rules use AGENTS.md (CLAUDE.md is a compatibility alias).
 			{Old: "CLAUDE.md", New: "AGENTS.md"},
+			{
+				Old: "`sandbox_permissions: \"require_escalated\"`",
+				New: "the runtime's supported sandbox escalation mechanism",
+			},
 		}
 		// Same model-invocation rules as Claude: roborev-fix stays invocable
 		// for agent-hook Stop; other skills are explicit-only.

--- a/internal/skills/droid/roborev-design-review-branch/SKILL.md
+++ b/internal/skills/droid/roborev-design-review-branch/SKILL.md
@@ -20,6 +20,13 @@ Factory skill selection.
 Requests such as “review this branch's design” without one of these
 explicit mechanisms must use native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+the runtime's supported sandbox escalation mechanism. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/droid/roborev-design-review/SKILL.md
+++ b/internal/skills/droid/roborev-design-review/SKILL.md
@@ -20,6 +20,13 @@ Factory skill selection.
 Requests such as “review this commit's design” without one of these explicit mechanisms
 must use native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+the runtime's supported sandbox escalation mechanism. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/droid/roborev-fix/SKILL.md
+++ b/internal/skills/droid/roborev-fix/SKILL.md
@@ -25,6 +25,13 @@ an invocation.
 Requests such as “fix the open findings” without one of these explicit mechanisms must use native
 behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+the runtime's supported sandbox escalation mechanism. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill just because the user pasted existing review

--- a/internal/skills/droid/roborev-lookahead-review-branch/SKILL.md
+++ b/internal/skills/droid/roborev-lookahead-review-branch/SKILL.md
@@ -23,6 +23,13 @@ Factory skill selection.
 Requests such as “check this branch for future leakage” without one of these
 explicit mechanisms must use native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+the runtime's supported sandbox escalation mechanism. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/droid/roborev-lookahead-review/SKILL.md
+++ b/internal/skills/droid/roborev-lookahead-review/SKILL.md
@@ -23,6 +23,13 @@ Factory skill selection.
 Requests such as “check this commit for peekahead” without one of these explicit
 mechanisms must use native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+the runtime's supported sandbox escalation mechanism. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/droid/roborev-refine/SKILL.md
+++ b/internal/skills/droid/roborev-refine/SKILL.md
@@ -35,6 +35,13 @@ behavior and must not run roborev.
 This skill intentionally focuses on the current branch flow. It does not expose
 `roborev refine --all-branches` or `roborev refine --list`.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+the runtime's supported sandbox escalation mechanism. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/droid/roborev-respond/SKILL.md
+++ b/internal/skills/droid/roborev-respond/SKILL.md
@@ -20,6 +20,13 @@ Factory skill selection.
 Requests such as “respond to this review” without one of these explicit mechanisms must use
 native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+the runtime's supported sandbox escalation mechanism. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## IMPORTANT
 
 This skill requires you to **execute bash commands** to record the comment and close the review. The task is not complete until you run both commands and see confirmation output.

--- a/internal/skills/droid/roborev-review-branch/SKILL.md
+++ b/internal/skills/droid/roborev-review-branch/SKILL.md
@@ -20,6 +20,13 @@ Factory skill selection.
 Requests such as “review this branch” without one of these explicit mechanisms must use
 native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+the runtime's supported sandbox escalation mechanism. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/droid/roborev-review/SKILL.md
+++ b/internal/skills/droid/roborev-review/SKILL.md
@@ -20,6 +20,13 @@ Factory skill selection.
 Requests such as “review this commit” without one of these explicit mechanisms must use native
 behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+the runtime's supported sandbox escalation mechanism. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/droid/roborev-snooze/SKILL.md
+++ b/internal/skills/droid/roborev-snooze/SKILL.md
@@ -26,6 +26,13 @@ Factory skill selection.
 Requests such as “silence review notifications” without one of these explicit
 mechanisms must use native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+the runtime's supported sandbox escalation mechanism. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## Instructions
 
 This skill requires you to execute the matching command and report its result.

--- a/internal/skills/grok/roborev-design-review-branch/SKILL.md
+++ b/internal/skills/grok/roborev-design-review-branch/SKILL.md
@@ -21,6 +21,13 @@ Grok Build skill selection.
 Requests such as “review this branch's design” without one of these
 explicit mechanisms must use native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+the runtime's supported sandbox escalation mechanism. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/grok/roborev-design-review/SKILL.md
+++ b/internal/skills/grok/roborev-design-review/SKILL.md
@@ -21,6 +21,13 @@ Grok Build skill selection.
 Requests such as “review this commit's design” without one of these explicit mechanisms
 must use native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+the runtime's supported sandbox escalation mechanism. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/grok/roborev-fix/SKILL.md
+++ b/internal/skills/grok/roborev-fix/SKILL.md
@@ -25,6 +25,13 @@ an invocation.
 Requests such as “fix the open findings” without one of these explicit mechanisms must use native
 behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+the runtime's supported sandbox escalation mechanism. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill just because the user pasted existing review

--- a/internal/skills/grok/roborev-lookahead-review-branch/SKILL.md
+++ b/internal/skills/grok/roborev-lookahead-review-branch/SKILL.md
@@ -24,6 +24,13 @@ Grok Build skill selection.
 Requests such as “check this branch for future leakage” without one of these
 explicit mechanisms must use native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+the runtime's supported sandbox escalation mechanism. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/grok/roborev-lookahead-review/SKILL.md
+++ b/internal/skills/grok/roborev-lookahead-review/SKILL.md
@@ -24,6 +24,13 @@ Grok Build skill selection.
 Requests such as “check this commit for peekahead” without one of these explicit
 mechanisms must use native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+the runtime's supported sandbox escalation mechanism. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/grok/roborev-refine/SKILL.md
+++ b/internal/skills/grok/roborev-refine/SKILL.md
@@ -36,6 +36,13 @@ behavior and must not run roborev.
 This skill intentionally focuses on the current branch flow. It does not expose
 `roborev refine --all-branches` or `roborev refine --list`.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+the runtime's supported sandbox escalation mechanism. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/grok/roborev-respond/SKILL.md
+++ b/internal/skills/grok/roborev-respond/SKILL.md
@@ -21,6 +21,13 @@ Grok Build skill selection.
 Requests such as “respond to this review” without one of these explicit mechanisms must use
 native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+the runtime's supported sandbox escalation mechanism. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## IMPORTANT
 
 This skill requires you to **execute bash commands** to record the comment and close the review. The task is not complete until you run both commands and see confirmation output.

--- a/internal/skills/grok/roborev-review-branch/SKILL.md
+++ b/internal/skills/grok/roborev-review-branch/SKILL.md
@@ -21,6 +21,13 @@ Grok Build skill selection.
 Requests such as “review this branch” without one of these explicit mechanisms must use
 native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+the runtime's supported sandbox escalation mechanism. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/grok/roborev-review/SKILL.md
+++ b/internal/skills/grok/roborev-review/SKILL.md
@@ -21,6 +21,13 @@ Grok Build skill selection.
 Requests such as “review this commit” without one of these explicit mechanisms must use native
 behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+the runtime's supported sandbox escalation mechanism. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## When NOT to invoke this skill
 
 Do NOT invoke this skill when the user is presenting or pasting existing review

--- a/internal/skills/grok/roborev-snooze/SKILL.md
+++ b/internal/skills/grok/roborev-snooze/SKILL.md
@@ -26,6 +26,13 @@ Grok Build skill selection.
 Requests such as “silence review notifications” without one of these explicit
 mechanisms must use native behavior and must not run roborev.
 
+## Sandbox access
+
+roborev uses a local daemon. If a command fails with `permission denied`, the sandbox may be
+blocking access to its loopback port or Unix socket. Retry the same command with
+the runtime's supported sandbox escalation mechanism. Do not start or restart the daemon because a
+sandboxed status probe cannot reach it.
+
 ## Instructions
 
 This skill requires you to execute the matching command and report its result.

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -223,6 +223,43 @@ func TestClaudeSkillBodiesAcceptEveryExplicitInvocationPath(t *testing.T) {
 	}
 }
 
+func TestAgentSkillsDocumentSandboxRecovery(t *testing.T) {
+	tests := []struct {
+		agent          Agent
+		parameter      string
+		otherParameter string
+	}{
+		{
+			agent:          AgentCodex,
+			parameter:      `sandbox_permissions: "require_escalated"`,
+			otherParameter: "dangerouslyDisableSandbox: true",
+		},
+		{
+			agent:          AgentClaude,
+			parameter:      "dangerouslyDisableSandbox: true",
+			otherParameter: `sandbox_permissions: "require_escalated"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.agent), func(t *testing.T) {
+			spec, ok := lookupAgent(tt.agent)
+			require.True(t, ok)
+			skills, err := embeddedSkillsForAgent(spec)
+			require.NoError(t, err)
+			require.Len(t, skills, 10)
+
+			for _, skill := range skills {
+				content := strings.Join(strings.Fields(string(skill.Content)), " ")
+				assert.Contains(t, content, "roborev uses a local daemon", skill.DirName)
+				assert.Contains(t, content, "Do not start or restart the daemon", skill.DirName)
+				assert.Contains(t, content, tt.parameter, skill.DirName)
+				assert.NotContains(t, content, tt.otherParameter, skill.DirName)
+			}
+		})
+	}
+}
+
 func TestPluginDefaultPromptsExplicitlyInvokeNamespacedSkills(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join("..", "..", ".codex-plugin", "plugin.json"))
 	require.NoError(t, err)
@@ -988,6 +1025,23 @@ func TestDerivedExplicitInvocationWordingUsesTargetAgent(t *testing.T) {
 			} else {
 				assert.Contains(t, text, "disable-model-invocation: true", "%s missing Claude frontmatter policy", relPath)
 			}
+		}
+	}
+}
+
+func TestDerivedSandboxWordingUsesTargetAgent(t *testing.T) {
+	derived, err := renderDerivedSkills(os.DirFS("."))
+	require.NoError(t, err)
+
+	for relPath, content := range derived {
+		text := strings.Join(strings.Fields(string(content)), " ")
+		if strings.HasPrefix(relPath, "droid/") || strings.HasPrefix(relPath, "grok/") {
+			assert.Contains(t, text, "runtime's supported sandbox escalation mechanism", relPath)
+			assert.NotContains(t, text, `sandbox_permissions: "require_escalated"`, relPath)
+			assert.NotContains(t, text, "dangerouslyDisableSandbox: true", relPath)
+		} else {
+			assert.Contains(t, text, "dangerouslyDisableSandbox: true", relPath)
+			assert.NotContains(t, text, `sandbox_permissions: "require_escalated"`, relPath)
 		}
 	}
 }


### PR DESCRIPTION
Sandboxes can deny access to loopback or Unix sockets even while the local roborev daemon is healthy. Previously that ambiguity could collapse into “daemon absent” and trigger cleanup, restart, or a competing auto-start. Fixes #1006.

Permission denial is now preserved as an indeterminate liveness result throughout discovery and lifecycle handling. On supported Unix platforms, TCP daemons also publish a private, best-effort Unix-socket fallback; TCP remains authoritative, while explicit Unix configuration, systemd activation, and Windows retain their existing single-transport behavior.

Status output and every shipped Codex and Claude workflow now explain the sandbox failure using each harness’s native escalation vocabulary, and explicitly prohibit starting or restarting a daemon merely because a sandboxed probe cannot reach it.

The main operational risk is dual-listener lifecycle consistency. The alternate endpoint is readiness-checked before publication, failures leave primary TCP service intact, and shutdown removes only sockets created by the daemon process.

<sup>generated by a clanker</sup>