### PR TITLE
fix(agent): pass OpenCode prompts as arguments

### DIFF
--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -99,14 +99,13 @@ func (a *OpenCodeAgent) Review(
 	repoPath, commitSHA, prompt string,
 	output io.Writer,
 ) (string, error) {
-	args := a.buildArgs()
+	args := append(a.buildArgs(), prompt)
 
 	runResult, runErr := runStreamingCLI(ctx, streamingCLISpec{
 		Name:    "opencode",
 		Command: a.Command,
 		Args:    args,
 		Dir:     repoPath,
-		Stdin:   strings.NewReader(prompt),
 		Output:  output,
 		// opencode prints sqlite-migration progress to stderr
 		// on every invocation, drowning the live log with

--- a/internal/agent/opencode_test.go
+++ b/internal/agent/opencode_test.go
@@ -55,16 +55,15 @@ func TestOpenCodeReviewModelFlag(t *testing.T) {
 	}
 }
 
-func TestOpenCodeReviewPipesPromptViaStdin(t *testing.T) {
+func TestOpenCodeReviewPassesPromptAsArgument(t *testing.T) {
 	t.Parallel()
 	skipIfWindows(t)
 
 	prompt := "Review this commit carefully"
 	_, args, stdin := runMockOpenCodeReview(t, "", prompt, nil)
 
-	assert.Equal(t, strings.TrimSpace(stdin), prompt)
-
-	assertNotContains(t, args, prompt)
+	assert.Contains(t, args, prompt)
+	assert.Empty(t, strings.TrimSpace(stdin))
 }
 
 func TestOpenCodeReviewParsesJSONStream(t *testing.T) {


### PR DESCRIPTION
## Summary

OpenCode's `run` command expects the review message as its positional argument. Passing the prompt only through stdin leaves the session without a message and exits unsuccessfully on current OpenCode releases.

This change passes the prompt as the positional `run` message and keeps stdin unused for the invocation.

## Tests

- `go test ./internal/agent`
- `go test -tags=integration ./internal/agent -run TestOpenCodeReviewPassesPromptAsArgument -count=1 -v`
- Verified the JSON stream path with a real OpenCode invocation using an explicit model.
