### PR TITLE
Document roborev 0.64.0 release

### DIFF
--- a/docs/advanced/postgres-sync.md
+++ b/docs/advanced/postgres-sync.md
@@ -87,7 +87,9 @@ unreadable, configuration validation warns about it and the reference expands to
 an empty value, causing the PostgreSQL connection to fail.
 
 File references and environment variables can be used together in the same URL.
-Restart the daemon after changing either form of sync configuration.
+Restart the daemon after editing `postgres_url`. Updating only the contents of a
+referenced password file does not require a restart; roborev reads it again on
+the next connection attempt.
 
 ## Changing Sync Servers
 

--- a/docs/agent-hook.md
+++ b/docs/agent-hook.md
@@ -62,6 +62,11 @@ outside a git repository it returns `{}` and stays out of the way. Reminders
 also depend on the roborev daemon reporting an open failed review, so a
 repository roborev does not track never produces a reminder.
 
+When a Stop hook emits a blocking reminder, the response also tells the agent to
+resume the task it was doing after addressing the review findings. This keeps a
+review repair from replacing work that paused at a specification, approval, or
+implementation checkpoint.
+
 If the main roborev daemon is unavailable, the failed-review check is skipped.
 Turn and commit counts still work through the local hook daemon, but they only
 prompt the agent once roborev reports at least one open failed review.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,20 +7,23 @@ All notable changes to roborev, grouped by minor release.
 
 ## Unreleased
 
+______________________________________________________________________
+
+## 0.64.0
+
+<small>2026-08-06</small>
+
 **New features**
 
-- First-class [Grok Build](https://x.ai/cli) agent support (`--agent grok`,
-    alias `grok-build`) as a Claude-peer CommandAgent. Non-agentic review uses
-    layered safety (`--sandbox read-only`, read-only `--tools`, explicit
-    `--disallowed-tools` including MCP meta, `--no-subagents`,
-    `--disable-web-search`). Agentic jobs use `--always-approve`. Classification
-    is fail-closed (no empty `--tools`, deny-list + one turn) and accepts only
-    validated `structuredOutput`. Cursor/`agent` identity is disambiguated from
-    Grok's installer alias; generated GitHub Actions pin `--agent` and
-    `--synthesis-agent`. Also: streaming-json TTY formatting, full skills parity
-    under `~/.grok/skills`, and `roborev agent-hook install --agent grok`.
-    Override the binary with `grok_cmd`. Authenticate with `grok login` or
-    `XAI_API_KEY`. See [Supported Agents](/agents/#grok-build).
+- `roborev ci review` can review GitLab merge requests in GitLab CI, resolve
+    merge request ranges automatically, and create or update MR notes. It also
+    supports self-managed GitLab hosts and explicit project, host, and MR
+    selection. See [GitLab Integration](/integrations/gitlab/).
+- [Grok Build](https://x.ai/cli) is now a first-class agent under `--agent grok`
+    (alias `grok-build`), with streamed output, session resume, structured
+    classification, agentic jobs, bundled skills, and Agent Hook support.
+    Reviews use layered read-only restrictions, while agentic work continues to
+    require the unsafe-agent opt-in. See [Grok Build](/agents/#grok-build).
 - ACP configuration now supports multiple named agents through `[acp.<name>]`
     subtables. Repository entries replace only the matching global agent, and
     commands, models, backups, CI jobs, and synthesis remain isolated by name.
@@ -28,6 +31,84 @@ All notable changes to roborev, grouped by minor release.
     subscription authentication. This is a breaking configuration change:
     migrate `[acp]` plus `name = "foo"` to `[acp.foo]`. See
     [Agent Client Protocol (ACP)](/advanced/acp/).
+- `roborev snooze` temporarily silences Agent Hook reminders for the current
+    repository, linked worktree, and branch without pausing review enqueueing or
+    processing. Bundled Claude Code, Codex, and Factory Droid skills expose the
+    same workflow. See [Snoozing Reminders](/agent-hook/#snoozing-reminders).
+- `roborev skills install --path <directory>` installs a selected bundled skill
+    variant into a custom final skills directory, supporting agents such as Pi
+    whose personal skill paths roborev does not auto-detect. See
+    [Agent Skills](/guides/agent-skills/).
+- PostgreSQL sync passwords can use `${file:/absolute/path}` references in
+    `postgres_url`, keeping credentials out of the TOML file and making them
+    available to daemons that do not inherit the operator's environment. See
+    [Credential Expansion](/advanced/postgres-sync/#credential-expansion).
+
+**Improvements**
+
+- Agent Hook Stop reminders now tell the coding agent to resume its interrupted
+    task after addressing roborev findings, preserving multi-turn work that had
+    paused at a specification, approval, or implementation checkpoint.
+- Repositories with no configured `review_guidelines` now fall back to a
+    repository-root `REVIEW.md`. Configured guidelines still take precedence,
+    and commit/range reviews read the fallback from the default branch to
+    prevent the reviewed change from rewriting its own policy. See
+    [Review Guidelines](/configuration/#review-guidelines).
+- `roborev check-agents` now honors configured agent command overrides, so its
+    smoke tests exercise the same wrapper or binary as actual jobs.
+- Concurrent post-commit hooks now coalesce identical automatic review requests
+    by repository, resolved Git ref, and review target. Explicit review commands
+    still enqueue fresh work. See
+    [Post-Commit Reviews](/automation/post-commit-reviews/).
+- CI synthesis summaries that explicitly report a passing review now produce a
+    passing verdict, while structured severity findings continue to take
+    precedence as failures.
+- Metadata job listings no longer hydrate completed-job prompts and review
+    outputs that callers do not use, substantially reducing daemon response size
+    and transient memory use. Active-job prompts remain available to the TUI.
+- Review prompts now discourage test recommendations that merely search source
+    text or mirror constants, and instead require observable behavior,
+    invariants, failure modes, or integration boundaries.
+
+**Bug fixes**
+
+- CLI output now renders commit ranges as two shortened refs separated by `..`
+    instead of truncating the range into a value that looks like one commit.
+- `roborev show --prompt <job_id>` can read the stored prompt while a job is
+    still queued or running.
+- The TUI displays `(detached @ <shortsha>)` for branchless detached-HEAD commit
+    reviews instead of leaving the Branch column blank.
+- Token backfill and cost displays now accept agentsview v0.39.0's
+    `cost.microdollars` format while remaining compatible with the older
+    `cost_usd` field.
+- Empty Antigravity review runs now fail and engage retry or backup-agent
+    handling instead of being recorded as completed placeholder reviews. See
+    [Gemini: Antigravity vs Legacy CLI](/agents/#gemini-antigravity-vs-legacy-cli).
+
+**Acknowledgements**
+
+- Thanks to [Nico Albers](https://github.com/nicoa) for GitLab merge request
+    support in `roborev ci review`.
+- Thanks to [Enzo Tironi](https://github.com/EnzoTironi) for first-class Grok
+    Build support.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for named
+    ACP agents and Goose, workspace-scoped snoozing, custom skill paths,
+    config-aware agent checks, post-commit deduplication, and slimmer job
+    listings.
+- Thanks to [TechnoPhobe01](https://github.com/Technophobe01) for file-backed
+    PostgreSQL password references.
+- Thanks to [Phillip Cloud](https://github.com/cpcloud) for Stop-hook task
+    continuation and stronger test-recommendation guidance.
+- Thanks to [Sam Odio](https://github.com/srosro) for the repository-root
+    `REVIEW.md` fallback.
+- Thanks to [Wes McKinney](https://github.com/wesm) for recognizing passing CI
+    synthesis summaries.
+- Thanks to [Nat Torkington](https://github.com/njt) for accurate commit-range
+    display.
+- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for queued-job prompt
+    access, detached-HEAD TUI labels, and agentsview cost compatibility.
+- Thanks to [Graham Taylor](https://github.com/gwtaylor) for failing empty
+    Antigravity reviews so retries and backup agents can run.
 
 ______________________________________________________________________
 
@@ -54,11 +135,6 @@ ______________________________________________________________________
 
 **Improvements**
 
-- `roborev skills install --path <directory>` installs bundled skills directly
-    into a custom final skills directory, defaulting to the Claude-compatible
-    variant and supporting explicit `--agent claude|codex|droid` selection. This
-    supports personal skill directories such as Pi's `~/.pi/agent/skills/`. See
-    [Agent Skills](/guides/agent-skills/).
 - The bundled `roborev-fix` skills now distinguish current operative invocations
     and direct Agent Hook instructions from literal skill syntax inside pasted
     findings, logs, transcripts, quotations, and examples, preventing historical

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -142,6 +142,10 @@ roborev log <job_id>             # View job log
 | `--prompt` | Show the prompt sent to the agent instead of the review output |
 | `--json` | Output as JSON for machine-readable workflows |
 
+When the argument is a numeric job ID, `--prompt` can display the stored prompt
+while the job is queued or running; review output does not exist until the job
+completes.
+
 `roborev show` displays review comments after the review output when comments
 exist, matching the layout in the TUI review detail view.
 
@@ -878,6 +882,9 @@ roborev check-agents --timeout 30   # Set timeout per agent (seconds)
 |------|-------------|
 | `--agent <name>` | Test only this agent |
 | `--timeout <secs>` | Timeout per agent (default: 60) |
+
+Health checks honor configured `*_cmd` overrides, so they test the same binary
+or wrapper that roborev uses for review and agentic jobs.
 
 ## Agent Skills
 

--- a/docs/integrations/tui.md
+++ b/docs/integrations/tui.md
@@ -193,6 +193,10 @@ The queue displays two separate status columns:
     the job itself errored. A job can finish successfully (Status = Done) with a
     Fail verdict if the reviewer flagged problems.
 
+For a commit review with no resolvable branch, the Branch column displays
+`(detached @ <shortsha>)` instead of an empty value. The label is display-only;
+branch filtering continues to group the review under `(none)`.
+
 The default-visible "Cost" column shows the model-pricing estimate from
 [agentsview](/commands/#token-usage) for jobs that have reported usage. The cell
 stays blank for unpriced models, for jobs whose usage has not been fetched yet,


### PR DESCRIPTION
roborev 0.64.0 spans new forge and agent integrations, a breaking ACP configuration migration, workflow refinements, and fixes that were only partially represented in the unreleased notes. Without a complete release entry, users could miss required migration work and operational changes around credentials, hooks, prompts, and usage accounting.

This makes the changelog a migration-aware record of the release and credits contributors from the merged PR authorship. It also moves custom skill-path installation out of the already-published 0.63.0 section, where its post-release placement made the history inaccurate.

The adjacent guide clarifications keep the less visible behavior discoverable after readers leave the changelog, particularly queued-job prompts, configured command checks, Stop-hook continuation, detached-HEAD labels, and file-backed password rotation.