### PR TITLE
Retry fresh session usage indexing

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -72,6 +72,8 @@ ______________________________________________________________________
 
 **Bug fixes**
 
+- Fresh review sessions briefly retry missing agentsview usage lookups, avoiding
+    permanently token-only jobs when indexing finishes just after the review.
 - CLI output now renders commit ranges as two shortened refs separated by `..`
     instead of truncating the range into a value that looks like one commit.
 - `roborev show --prompt <job_id>` can read the stored prompt while a job is

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -607,6 +607,11 @@ Older agentsview versions still record token counts; the cost column stays blank
 for unpriced models and for jobs whose usage has not yet been fetched. The tilde
 marks the value as a model-pricing estimate rather than a billed amount.
 
+Fresh agent sessions can finish before agentsview has indexed their final usage.
+roborev briefly retries a missing session lookup before storing the job-log
+token fallback, so normally indexed reviews receive their cost without a later
+backfill.
+
 If you run a central usage service, configure `[cost] endpoint` to fetch usage
 over HTTP instead of through the local `agentsview` CLI. See
 [Cost Usage Endpoint](/configuration/#cost-usage-endpoint).

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -1378,8 +1378,9 @@ func (wp *WorkerPool) captureTokenUsageForSession(
 				return tokens.FetchForSessionWithConfig(
 					ctx, sessionID,
 					tokens.FetchConfig{
-						Endpoint: cfg.Cost.Endpoint,
-						Timeout:  cfg.Cost.ResolvedTimeout(),
+						Endpoint:   cfg.Cost.Endpoint,
+						Timeout:    cfg.Cost.ResolvedTimeout(),
+						RequireCLI: true,
 					},
 				)
 			}
@@ -1387,11 +1388,12 @@ func (wp *WorkerPool) captureTokenUsageForSession(
 		fetched, tokenErr := wp.fetchFreshSessionUsage(
 			ctx, fetcher, capturedSession,
 		)
-		if tokenErr != nil {
+		switch {
+		case tokenErr == nil:
+			usage = backfill.MergeTokenUsage(tokens.ToJSON(usage), fetched)
+		case !errors.Is(tokenErr, tokens.ErrUsageProviderUnavailable):
 			log.Printf("[%s] Warning: fetch token usage for job %d: %v",
 				workerID, job.ID, tokenErr)
-		} else {
-			usage = backfill.MergeTokenUsage(tokens.ToJSON(usage), fetched)
 		}
 	}
 

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -27,7 +27,11 @@ import (
 	"go.kenn.io/roborev/internal/tokens"
 )
 
-const agentTimeoutErrorPrefix = "agent timeout after"
+const (
+	agentTimeoutErrorPrefix      = "agent timeout after"
+	tokenUsageIndexRetryWindow   = 3 * time.Second
+	tokenUsageIndexRetryInterval = 500 * time.Millisecond
+)
 
 // WorkerPool manages a pool of review workers
 type WorkerPool struct {
@@ -63,6 +67,10 @@ type WorkerPool struct {
 	// configured tokens.FetchForSessionWithConfig path; tests substitute a
 	// deterministic fetcher.
 	tokenUsageFetcher func(context.Context, string) (*tokens.Usage, error)
+	// tokenUsageIndexRetryWindow and tokenUsageIndexRetryInterval bound the
+	// fresh-session indexing retry. Tests shorten both values.
+	tokenUsageIndexRetryWindow   time.Duration
+	tokenUsageIndexRetryInterval time.Duration
 
 	// Output capture for tail command
 	outputBuffers *OutputBuffer
@@ -83,20 +91,22 @@ type WorkerPool struct {
 // NewWorkerPool creates a new worker pool
 func NewWorkerPool(db *storage.DB, cfgGetter ConfigGetter, numWorkers int, broadcaster Broadcaster, errorLog *ErrorLog, activityLog *ActivityLog) *WorkerPool {
 	return &WorkerPool{
-		db:             db,
-		cfgGetter:      cfgGetter,
-		broadcaster:    broadcaster,
-		errorLog:       errorLog,
-		activityLog:    activityLog,
-		numWorkers:     numWorkers,
-		stopCh:         make(chan struct{}),
-		readyCh:        make(chan struct{}),
-		runningJobs:    make(map[int64]context.CancelFunc),
-		pendingCancels: make(map[int64]bool),
-		agentCooldowns: make(map[string]time.Time),
-		outputBuffers:  NewOutputBuffer(512*1024, 4*1024*1024), // 512KB/job, 4MB total
-		classify:       agent.ClassifyLimit,
-		retryBackoff:   2 * time.Second,
+		db:                           db,
+		cfgGetter:                    cfgGetter,
+		broadcaster:                  broadcaster,
+		errorLog:                     errorLog,
+		activityLog:                  activityLog,
+		numWorkers:                   numWorkers,
+		stopCh:                       make(chan struct{}),
+		readyCh:                      make(chan struct{}),
+		runningJobs:                  make(map[int64]context.CancelFunc),
+		pendingCancels:               make(map[int64]bool),
+		agentCooldowns:               make(map[string]time.Time),
+		outputBuffers:                NewOutputBuffer(512*1024, 4*1024*1024), // 512KB/job, 4MB total
+		classify:                     agent.ClassifyLimit,
+		retryBackoff:                 2 * time.Second,
+		tokenUsageIndexRetryWindow:   tokenUsageIndexRetryWindow,
+		tokenUsageIndexRetryInterval: tokenUsageIndexRetryInterval,
 	}
 }
 
@@ -1374,7 +1384,9 @@ func (wp *WorkerPool) captureTokenUsageForSession(
 				)
 			}
 		}
-		fetched, tokenErr := fetcher(ctx, capturedSession)
+		fetched, tokenErr := wp.fetchFreshSessionUsage(
+			ctx, fetcher, capturedSession,
+		)
 		if tokenErr != nil {
 			log.Printf("[%s] Warning: fetch token usage for job %d: %v",
 				workerID, job.ID, tokenErr)
@@ -1405,6 +1417,38 @@ func (wp *WorkerPool) captureTokenUsageForSession(
 	if err != nil {
 		log.Printf("[%s] Warning: save token usage for job %d: %v",
 			workerID, job.ID, err)
+	}
+}
+
+func (wp *WorkerPool) fetchFreshSessionUsage(
+	ctx context.Context,
+	fetcher func(context.Context, string) (*tokens.Usage, error),
+	sessionID string,
+) (*tokens.Usage, error) {
+	retryCtx, cancel := context.WithTimeout(ctx, wp.tokenUsageIndexRetryWindow)
+	defer cancel()
+
+	for {
+		usage, err := fetcher(retryCtx, sessionID)
+		if err != nil {
+			if retryCtx.Err() != nil {
+				return nil, nil
+			}
+			return nil, err
+		}
+		if usage != nil {
+			return usage, nil
+		}
+
+		timer := time.NewTimer(wp.tokenUsageIndexRetryInterval)
+		select {
+		case <-retryCtx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return nil, nil
+		case <-timer.C:
+		}
 	}
 }
 

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -68,6 +68,8 @@ func newWorkerTestContext(t *testing.T, workers int) *workerTestContext {
 	b := NewBroadcaster()
 	pool := NewWorkerPool(db, NewStaticConfig(cfg), cfg.MaxWorkers, b, nil, nil)
 	pool.retryBackoff = 0 // keep retry-driven tests fast
+	pool.tokenUsageIndexRetryWindow = 20 * time.Millisecond
+	pool.tokenUsageIndexRetryInterval = time.Millisecond
 
 	return &workerTestContext{
 		DB:          db,
@@ -917,6 +919,78 @@ func TestCaptureTokenUsageForSessionUsesCodexJobLog(t *testing.T) {
 	assert.InDelta(t, 0.42, usage.CostUSD, 1e-9)
 	assert.Equal(t, "job_log_turn_completed", usage.UsageSource)
 	assert.Equal(t, "thread-123", usage.ThreadID)
+}
+
+func TestCaptureTokenUsageForSessionRetriesUntilFreshSessionIsIndexed(t *testing.T) {
+	t.Setenv("ROBOREV_DATA_DIR", t.TempDir())
+	tc := newWorkerTestContext(t, 1)
+	sha := testutil.GetHeadSHA(t, tc.TmpDir)
+	job := tc.createAndClaimJobWithAgent(t, sha, testWorkerID, "codex")
+	require.NoError(t, tc.DB.CompleteJob(job.ID, "codex", "prompt", "No issues found."))
+
+	var attempts atomic.Int32
+	tc.Pool.tokenUsageFetcher = func(context.Context, string) (*tokens.Usage, error) {
+		if attempts.Add(1) < 3 {
+			return nil, nil
+		}
+		return &tokens.Usage{
+			OutputTokens: 481,
+			CostUSD:      0.17,
+			HasCost:      true,
+		}, nil
+	}
+
+	tc.Pool.captureTokenUsageForSession(
+		context.Background(), testWorkerID, job, "fresh-session-123",
+	)
+
+	updated, err := tc.DB.GetJobByID(job.ID)
+	require.NoError(t, err)
+	usage := tokens.ParseJSON(updated.TokenUsage)
+	require.NotNil(t, usage)
+	assert.Equal(t, int32(3), attempts.Load())
+	assert.Equal(t, int64(481), usage.OutputTokens)
+	assert.True(t, usage.HasCost)
+	assert.InDelta(t, 0.17, usage.CostUSD, 1e-9)
+}
+
+func TestCaptureTokenUsageForSessionStopsRetryingAtContextDeadline(t *testing.T) {
+	t.Setenv("ROBOREV_DATA_DIR", t.TempDir())
+	tc := newWorkerTestContext(t, 1)
+	sha := testutil.GetHeadSHA(t, tc.TmpDir)
+	job := tc.createAndClaimJobWithAgent(t, sha, testWorkerID, "codex")
+	require.NoError(t, tc.DB.CompleteJob(job.ID, "codex", "prompt", "No issues found."))
+
+	logPath := JobLogPath(job.ID)
+	require.NoError(t, os.MkdirAll(filepath.Dir(logPath), 0o700))
+	require.NoError(t, os.WriteFile(logPath, []byte(
+		`{"type":"thread.started","thread_id":"fresh-session-456"}`+"\n"+
+			`{"type":"turn.completed","usage":{"input_tokens":1024,`+
+			`"output_tokens":64}}`+"\n",
+	), 0o600))
+
+	var attempts atomic.Int32
+	tc.Pool.tokenUsageFetcher = func(context.Context, string) (*tokens.Usage, error) {
+		attempts.Add(1)
+		return nil, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	tc.Pool.captureTokenUsageForSession(
+		ctx, testWorkerID, job, "fresh-session-456",
+	)
+
+	updated, err := tc.DB.GetJobByID(job.ID)
+	require.NoError(t, err)
+	usage := tokens.ParseJSON(updated.TokenUsage)
+	require.NotNil(t, usage)
+	assert.GreaterOrEqual(t, attempts.Load(), int32(2))
+	assert.Less(t, time.Since(started), 250*time.Millisecond)
+	assert.Equal(t, int64(1024), usage.InputTokens)
+	assert.Equal(t, int64(64), usage.OutputTokens)
+	assert.False(t, usage.HasCost)
 }
 
 func TestProcessJob_UsesStoredReviewPromptOverride(t *testing.T) {

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -954,6 +954,29 @@ func TestCaptureTokenUsageForSessionRetriesUntilFreshSessionIsIndexed(t *testing
 	assert.InDelta(t, 0.17, usage.CostUSD, 1e-9)
 }
 
+func TestCaptureTokenUsageForSessionDoesNotRetryUnavailableProvider(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH handling differs on Windows")
+	}
+
+	t.Setenv("ROBOREV_DATA_DIR", t.TempDir())
+	tc := newWorkerTestContext(t, 1)
+	sha := testutil.GetHeadSHA(t, tc.TmpDir)
+	job := tc.createAndClaimJobWithAgent(t, sha, testWorkerID, "codex")
+	require.NoError(t, tc.DB.CompleteJob(job.ID, "codex", "prompt", "No issues found."))
+
+	tc.Pool.tokenUsageIndexRetryWindow = 400 * time.Millisecond
+	tc.Pool.tokenUsageIndexRetryInterval = 200 * time.Millisecond
+	t.Setenv("PATH", t.TempDir())
+
+	started := time.Now()
+	tc.Pool.captureTokenUsageForSession(
+		context.Background(), testWorkerID, job, "fresh-session-789",
+	)
+
+	assert.Less(t, time.Since(started), 100*time.Millisecond)
+}
+
 func TestCaptureTokenUsageForSessionStopsRetryingAtContextDeadline(t *testing.T) {
 	t.Setenv("ROBOREV_DATA_DIR", t.TempDir())
 	tc := newWorkerTestContext(t, 1)

--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -18,6 +18,11 @@ import (
 	"go.kenn.io/roborev/internal/procutil"
 )
 
+// ErrUsageProviderUnavailable marks a required usage provider that cannot be
+// invoked. Callers can distinguish it from a missing session without treating
+// the optional provider as a user-visible failure.
+var ErrUsageProviderUnavailable = errors.New("usage provider unavailable")
+
 // Usage holds token consumption data for a single review job.
 // Stored as JSON in the review_jobs.token_usage column.
 // Fields align with agentsview's session-usage output.
@@ -199,7 +204,10 @@ func fetchForSessionCLI(
 	binPath, err := resolveAgentsview()
 	if err != nil {
 		if cfg.RequireCLI {
-			return nil, fmt.Errorf("agentsview lookup: %w", err)
+			return nil, fmt.Errorf(
+				"%w: agentsview lookup: %w",
+				ErrUsageProviderUnavailable, err,
+			)
 		}
 		return nil, nil
 	}

--- a/internal/tokens/tokens_test.go
+++ b/internal/tokens/tokens_test.go
@@ -578,6 +578,7 @@ func TestFetchForSessionWithConfigRequiresAgentsviewWhenRequested(t *testing.T) 
 
 	require.Error(t, err)
 	assert.Nil(t, usage)
+	require.ErrorIs(t, err, ErrUsageProviderUnavailable)
 	assert.Contains(t, err.Error(), "agentsview lookup")
 }
 


### PR DESCRIPTION
Agentsview can still be indexing a newly completed session when roborev performs its completion-time lookup. A single miss then becomes permanent token-only usage, leaving cost displays incomplete until an operator runs a backfill.

This gives fresh sessions a short, bounded retry window before retaining the existing job-log fallback. Only missing-session results are retried: provider unavailability and lookup errors return immediately, and indexed but genuinely unpriced sessions keep their current behavior. Cancellation and the overall deadline keep worker completion bounded. Normal reviews and panel synthesis share this path.