### PR TITLE
Add kata-style split-screen review view to the TUI

### DIFF
--- a/cmd/roborev/tui/action_test.go
+++ b/cmd/roborev/tui/action_test.go
@@ -492,6 +492,10 @@ func TestTUIClosedRollbackRestoresSelectionAfterLeavingQueue(t *testing.T) {
 	assertSelection(t, m, 2, 3)
 
 	m.currentView = viewReview
+	// viewReview requires a loaded review (normalizeSplitState repairs a
+	// dangling viewReview/nil-currentReview pair back to viewQueue in
+	// every layout); this test only cares about selection rollback.
+	m.currentReview = &storage.Review{JobID: 3, Job: &m.jobs[2]}
 
 	m, _ = updateModel(t, m, closedResultMsg{
 		jobID:            2,

--- a/cmd/roborev/tui/actions.go
+++ b/cmd/roborev/tui/actions.go
@@ -282,7 +282,10 @@ func (m model) submitComment(jobID int64, text string) tea.Cmd {
 			return commentResultMsg{jobID: jobID, err: fmt.Errorf("submit comment: %w", err)}
 		}
 
-		return commentResultMsg{jobID: jobID, err: nil}
+		return commentResultMsg{
+			jobID: jobID, err: nil,
+			responder: commenter, comment: strings.TrimSpace(text),
+		}
 	}
 }
 

--- a/cmd/roborev/tui/actions.go
+++ b/cmd/roborev/tui/actions.go
@@ -226,6 +226,7 @@ func (m model) rerunJob(snap rerunSnapshot) tea.Cmd {
 			oldError:      snap.oldError,
 			oldClosed:     snap.oldClosed,
 			oldVerdict:    snap.oldVerdict,
+			spawnsNewRun:  snap.spawnsNewRun,
 			err:           err,
 		}
 	}
@@ -241,6 +242,21 @@ type rerunSnapshot struct {
 	oldError      string
 	oldClosed     *bool
 	oldVerdict    *string
+	// spawnsNewRun is true when the daemon will answer this rerun by
+	// enqueueing a BRAND-NEW run with new job IDs instead of re-running
+	// this job in place -- i.e. this job is a panel synthesis parent
+	// (internal/daemon/server.go routes those to rerunPanelRun, which
+	// clones the members and the synthesis row under a fresh
+	// panel_run_uuid and leaves the original run intact as history).
+	//
+	// Captured HERE, at dispatch, rather than looked up when the result
+	// lands: both dispatchers already hold the job, whereas by the time
+	// rerunResultMsg arrives the job may have left m.jobs (a filter change
+	// or a refresh), and a failed lookup would silently pick the wrong
+	// branch in handleRerunResultMsg -- which is the one thing this flag
+	// exists to get right. See that handler and m.jobAttemptGen's contract
+	// clause 2 (tui.go).
+	spawnsNewRun bool
 }
 
 func (m model) submitComment(jobID int64, text string) tea.Cmd {

--- a/cmd/roborev/tui/control_handlers.go
+++ b/cmd/roborev/tui/control_handlers.go
@@ -76,6 +76,10 @@ func (m model) handleControlMutation(
 // --- Query response builders ---
 
 func (m model) buildStateResponse() controlResponse {
+	focus := ""
+	if m.layout == layoutSplit {
+		focus = m.focus.String()
+	}
 	return controlResponse{
 		OK: true,
 		Data: stateSnapshot{
@@ -89,6 +93,8 @@ func (m model) buildStateResponse() controlResponse {
 			JobCount:        len(m.jobs),
 			VisibleJobCount: len(m.getVisibleJobs()),
 			Stats:           m.jobStats,
+			Layout:          m.layout.String(),
+			Focus:           focus,
 		},
 	}
 }
@@ -337,9 +343,24 @@ func (m model) handleCtrlSelectJob(
 					),
 				}, nil
 			}
+			prevSelected := m.selectedJobID
 			m.selectedIdx = i
 			m.selectedJobID = params.JobID
-			return m, controlResponse{OK: true}, nil
+			// In split layout a selection change must go through the same
+			// detail-follow path as keyboard/mouse navigation. Mutating
+			// selectedIdx/selectedJobID alone left the detail pane showing
+			// the PREVIOUS job's live tail (and any splitDetailErr from it)
+			// until the next jobs refresh reconciled it, and left an
+			// in-flight pane-log fetch for the old job able to land:
+			// handlePaneLogOutputMsg's seq+jobID gates both still reference
+			// the old job on this path, so nothing rejected it -- including
+			// a successful response, which would clear an error belonging
+			// to the newly selected job. scheduleDetailFollow bumps
+			// paneLogSeq when the selection moved off the tailed job
+			// (invalidating exactly those responses), clears
+			// splitDetailErr, and arms the debounced fetch for the new job.
+			mm, cmd := m.followSelectionChange(prevSelected)
+			return mm, controlResponse{OK: true}, cmd
 		}
 	}
 	return m, controlResponse{
@@ -376,9 +397,15 @@ func (m model) handleCtrlSetView(
 		}, nil
 	}
 
-	m.currentView = v
 	var cmd tea.Cmd
-	if v == viewTasks {
+	if v == viewQueue {
+		// Same repair as the keyboard exits: the tasks flow may have moved
+		// the selection to a fix job no queue row resolves -- see
+		// exitTasksToQueue. A no-op when the selection still resolves
+		// (including when this call didn't come from the tasks view).
+		m, cmd = m.exitTasksToQueue()
+	} else {
+		m.currentView = v
 		cmd = m.startFetchFixJobs()
 	}
 	return m, controlResponse{OK: true}, cmd
@@ -439,7 +466,24 @@ func (m model) handleCtrlCloseReview(
 		newState: newState, seq: seq,
 	}
 	m.applyStatsDelta(newState)
+	// Mirrors handleCloseKey's split-list optimistic flip (R9): without
+	// this, the control-socket close route leaves the split detail pane's
+	// header showing the stale closed state until the user reselects, the
+	// same staleness R9 fixed for the key path. Keyed by the same seq as
+	// pendingClosed so handleClosedResultMsg's rollback-on-failure path
+	// rolls both back together; the rollback itself is effectively a
+	// no-op here in the sense that it just reverts to oldState, same as
+	// the key path.
+	if m.currentReview != nil && m.currentReview.JobID == params.JobID {
+		m.currentReview.Closed = newState
+	}
 
+	// The hideClosed branch below hides the job just closed and moves the
+	// selection to an adjacent row. That is a selection change like any
+	// other and must take the shared detail-follow transition, or the
+	// detail pane (and a fix panel still bound to the just-closed job)
+	// stays pointed at it while the list highlights something else.
+	prevSelected := m.selectedJobID
 	restoreSelection := false
 	if m.hideClosed && newState &&
 		m.selectedJobID == params.JobID {
@@ -461,10 +505,11 @@ func (m model) handleCtrlCloseReview(
 		}
 	}
 
-	return m, controlResponse{OK: true},
-		m.closeReviewInBackground(
-			params.JobID, newState, oldState, seq, restoreSelection,
-		)
+	closeCmd := m.closeReviewInBackground(
+		params.JobID, newState, oldState, seq, restoreSelection,
+	)
+	m, followCmd := m.followSelectionChange(prevSelected)
+	return m, controlResponse{OK: true}, tea.Batch(closeCmd, followCmd)
 }
 
 func (m model) handleCtrlCancelJob(
@@ -513,6 +558,10 @@ func (m model) handleCtrlCancelJob(
 	now := time.Now()
 	job.FinishedAt = &now
 
+	// Same as the close path above: canceling the selected job hides it
+	// when hideClosed is on, so the selection move below has to take the
+	// shared detail-follow transition.
+	prevSelected := m.selectedJobID
 	restoreSelection := false
 	if m.hideClosed && m.selectedJobID == params.JobID {
 		idx := m.findPrevVisibleJob(m.selectedIdx)
@@ -532,11 +581,12 @@ func (m model) handleCtrlCancelJob(
 		restoreSelection = true
 	}
 
-	return m, controlResponse{OK: true},
-		m.cancelJob(
-			params.JobID, oldStatus, oldFinishedAt,
-			restoreSelection,
-		)
+	cancelCmd := m.cancelJob(
+		params.JobID, oldStatus, oldFinishedAt,
+		restoreSelection,
+	)
+	m, followCmd := m.followSelectionChange(prevSelected)
+	return m, controlResponse{OK: true}, tea.Batch(cancelCmd, followCmd)
 }
 
 func (m model) handleCtrlRerunJob(
@@ -580,6 +630,19 @@ func (m model) handleCtrlRerunJob(
 		}, nil
 	}
 
+	// Same suppression as the keyboard path: a synthesis
+	// parent's row stays terminal while its rerun is in flight, so the
+	// status check above cannot stop a second request from spawning a
+	// second full panel run. An explicit error, rather than a silent
+	// success, so a scripted caller can tell the two apart.
+	if job.IsSynthesisJob() && m.panelRerunInFlight[job.ID] {
+		return m, controlResponse{
+			Error: fmt.Sprintf(
+				"panel rerun already in flight for job %d", job.ID,
+			),
+		}, nil
+	}
+
 	snap := rerunSnapshot{
 		jobID:         job.ID,
 		oldStatus:     job.Status,
@@ -588,17 +651,29 @@ func (m model) handleCtrlRerunJob(
 		oldError:      job.Error,
 		oldClosed:     job.Closed,
 		oldVerdict:    job.Verdict,
+		// Same as the keyboard path: a synthesis parent's rerun spawns a
+		// new panel run with new job IDs, not a new attempt of this job.
+		spawnsNewRun: job.IsSynthesisJob(),
 	}
-	job.Status = storage.JobStatusQueued
-	job.StartedAt = nil
-	job.FinishedAt = nil
-	job.Error = ""
-	// Clear review-derived fields so the rerun job is visible
-	// under hideClosed and doesn't expose stale verdict data.
-	// The daemon deletes the review row on rerun; this keeps
-	// the local optimistic state consistent until the next fetch.
-	job.Closed = nil
-	job.Verdict = nil
+	// Same gate as the keyboard path: this optimistic
+	// re-queue is only consistent with what the daemon will do when the
+	// daemon really re-runs THIS row. A synthesis parent's rerun enqueues a
+	// separate run and leaves this row -- and its review -- exactly as they
+	// are, so the mutation would be wrong from the instant it was made.
+	if !snap.spawnsNewRun {
+		job.Status = storage.JobStatusQueued
+		job.StartedAt = nil
+		job.FinishedAt = nil
+		job.Error = ""
+		// Clear review-derived fields so the rerun job is visible
+		// under hideClosed and doesn't expose stale verdict data.
+		// For an ordinary rerun the daemon deletes the review row, so this
+		// keeps the local optimistic state consistent until the next fetch.
+		job.Closed = nil
+		job.Verdict = nil
+	} else {
+		m.markPanelRerunInFlight(job.ID)
+	}
 
 	return m, controlResponse{OK: true}, m.rerunJob(snap)
 }

--- a/cmd/roborev/tui/control_types.go
+++ b/cmd/roborev/tui/control_types.go
@@ -54,6 +54,8 @@ type stateSnapshot struct {
 	JobCount        int              `json:"job_count"`
 	VisibleJobCount int              `json:"visible_job_count"`
 	Stats           storage.JobStats `json:"stats"`
+	Layout          string           `json:"layout"`
+	Focus           string           `json:"focus"`
 }
 
 // jobSnapshot is a lightweight job representation for the get-jobs query.

--- a/cmd/roborev/tui/fetch.go
+++ b/cmd/roborev/tui/fetch.go
@@ -507,7 +507,7 @@ func (m model) fetchBranchesForRepo(
 // unbackfilled: a detached single-commit review renders a
 // "(detached @ <sha>)" placeholder from its empty stored branch, and
 // persisting the branchNone sentinel would freeze the row at "(none)"
-// (#499). Backfill runs once per TUI session (branchBackfillDone), so the
+// Backfill runs once per TUI session (branchBackfillDone), so the
 // repeated lookup cost for skipped rows is bounded.
 func backfillBranchValue(job storage.ReviewJob, machineID string) (string, bool) {
 	// Mark task jobs (run, analyze, custom) or dirty jobs with no-branch sentinel
@@ -721,18 +721,153 @@ func (m model) loadJob(jobID int64) (*storage.ReviewJob, error) {
 	return nil, fmt.Errorf("job %d not found", jobID)
 }
 
-func (m model) fetchReview(jobID int64) tea.Cmd {
+// dispatchReviewFetch is the ONE entry point for an ordinary (non-follow)
+// review-content fetch: it bumps the shared ordering epoch and stamps the
+// new value onto the request. Every caller goes through it (or through
+// dispatchReviewFollow, its follow-tagged twin) so no dispatcher can be
+// added that skips the epoch -- see m.reviewFetchSeq's doc comment
+// (tui.go). The pointer receiver is what makes the bump stick; the value
+// snapshot the command closes over is taken after it.
+//
+// CALL IT ON ITS OWN LINE -- every one of the call sites is written
+//
+//	cmd := m.dispatchReviewFetch(job.ID)
+//	return m, cmd
+//
+// and NOT the tempting one-liner `return m, m.dispatchReviewFetch(job.ID)`.
+// In a return statement Go evaluates the function calls among the operands
+// first, but the order of a plain variable operand (m) relative to those
+// calls is unspecified -- so the one-liner may return the model as it was
+// BEFORE the bump, silently stamping a request with an epoch the model
+// never advanced to. Such a request can never be accepted (its stamp will
+// never equal m.reviewFetchSeq) and the fetch is simply lost. The same
+// applies to any other pointer-receiver mutation returned alongside m.
+func (m *model) dispatchReviewFetch(jobID int64) tea.Cmd {
+	m.reviewFetchSeq++
+	// Arm the pending-open intent (see pendingReviewOpenJobID's doc comment,
+	// tui.go) BEFORE the fetch closure captures m.currentView below, so a
+	// follow fetch that later races this one and lands first still knows
+	// where to switch to. Matches what fetchReview stamps onto the message
+	// as dispatchedFrom -- both read m.currentView at this same point.
+	m.pendingReviewOpenJobID = jobID
+	m.pendingReviewOpenOrigin = m.currentView
+	// This dispatch's own identity (see pendingReviewOpenSeq's
+	// doc comment, tui.go): m.reviewFetchSeq was just bumped above, so this
+	// is the exact value fetchReview will stamp onto the outgoing request.
+	m.pendingReviewOpenSeq = m.reviewFetchSeq
+	// A fresh arm gets its own single follow-failure retry (see
+	// pendingReviewOpenRetried's doc comment, tui.go). Reset here rather
+	// than at every clear site: "retried" is only ever read while an
+	// intent is armed.
+	m.pendingReviewOpenRetried = false
+	return m.fetchReview(jobID, m.reviewFetchSeq)
+}
+
+// dispatchReviewFollow is dispatchReviewFetch's follow-tagged twin: same
+// epoch, same stamp, but the response updates the split detail pane's
+// content without stealing focus or switching views, and its failures land
+// in m.splitDetailErr. See fetchReviewFollow.
+func (m *model) dispatchReviewFollow(jobID int64) tea.Cmd {
+	m.reviewFetchSeq++
+	return m.fetchReviewFollow(jobID, m.reviewFetchSeq)
+}
+
+// fetchReview dispatches the review fetch shared by every review-loading
+// path -- queue Enter, tasks Enter/P, stepReviewNav, pagination nav, the
+// queue 'F' fix-panel fetch, and (via fetchReviewFollow) the split-view
+// debounced follow. The resulting reviewMsg is stamped with the dispatch
+// origin, m.detailFollowGen, the fetch epoch fetchSeq, and this job's
+// attempt counter m.jobAttemptGen[jobID], all captured at command-CREATION
+// time (m is a value snapshot here, so these reflect state at dispatch, not
+// whatever it drifts to before the response lands).
+// Callers reach this through dispatchReviewFetch/dispatchReviewFollow,
+// which own the epoch bump.
+func (m model) fetchReview(jobID int64, fetchSeq uint64) tea.Cmd {
+	// dispatchedFrom: the view the user was actually on when the fetch was
+	// issued, regardless of where they navigate before it resolves (see
+	// reviewMsg.dispatchedFrom).
+	origin := m.currentView
+	// gen: originally stamped only by fetchReviewFollow for split-view
+	// follow fetches, so handleReviewMsg's follow path could reject a
+	// response whose m.detailFollowGen had moved on by the time it landed
+	// (a new selection via scheduleDetailFollow, or a rerun-success
+	// clear/bump of the same job via handleRerunResultMsg -- see that
+	// handler's doc comment for the full race). Stamping it here instead,
+	// on every fetchReview call, closes the same race for NON-follow
+	// fetches: a regular fetchReview already in flight when a rerun of the
+	// SAME selected job succeeds can land afterward with the jobID check
+	// alone still passing (a rerun reuses the job ID and doesn't move the
+	// selection), restoring the previous attempt's review -- after which
+	// splitReconcileDetail/handleDetailFollowTick see currentReview.JobID
+	// already matching and skip fetching the rerun's actual result.
+	// detailFollowGen is bumped by every abandonment path in BOTH layouts
+	// -- followSelectionChange's stacked branch, scheduleDetailFollow,
+	// handleJobsMsg's normalization epilogue, resetQueueForFilterChange
+	// (the authoritative bumper list lives on the field's doc comment,
+	// tui.go) -- so a fetch dispatched and landing without an intervening
+	// abandonment lands at an unchanged gen and is unaffected. The
+	// stacked-mode bump is load-bearing: it is what dooms an abandoned
+	// dispatch's response after Enter on X, navigate to Y, return to X.
+	// See handleReviewMsg for the rejection check, and detailFollowGen's
+	// doc comment (tui.go) for the contract any bumper must satisfy.
+	//
+	// Rerun invalidation is NOT gen's job -- the per-job attempt stamp
+	// below covers that, for any job.
+	gen := m.detailFollowGen
+	// attempt: this JOB's confirmed-rerun count at dispatch time. Stamped
+	// here, alongside gen and fetchSeq, because fetchReview is the single
+	// constructor of reviewMsg/reviewErrMsg -- clause 3 of jobAttemptGen's
+	// contract (tui.go). Reading a nil map is legal and yields 0, the
+	// correct "no rerun of this job observed yet" value, so no dispatcher
+	// has to care whether the map has been populated.
+	attempt := m.jobAttemptGen[jobID]
 	return func() tea.Msg {
 		review, err := m.loadReview(jobID)
 		if err != nil {
-			return errMsg(err)
+			// Typed, not the generic errMsg:
+			// jobID/gen/fetchSeq let handleReviewErrMsg resolve
+			// pendingReviewOpenJobID/the pending fix panel for THIS job on a
+			// genuine failure, the same way handleReviewFollowErrMsg already
+			// does for a follow's failure. fetchReviewFollow below re-tags
+			// this into reviewFollowErrMsg for its own wrapped call.
+			return reviewErrMsg{
+				jobID: jobID, err: err, gen: gen,
+				fetchSeq: fetchSeq, attempt: attempt,
+			}
 		}
 
 		responses := m.loadResponses(jobID, review)
 
 		branchName := reviewBranchName(review.Job)
 
-		return reviewMsg{review: review, responses: responses, jobID: jobID, branchName: branchName}
+		return reviewMsg{
+			review: review, responses: responses, jobID: jobID,
+			branchName: branchName, dispatchedFrom: origin, gen: gen,
+			fetchSeq: fetchSeq, attempt: attempt,
+		}
+	}
+}
+
+// fetchReviewFollow wraps fetchReview, tagging the resulting reviewMsg as a
+// split-view follow fetch so the handler updates the pane without stealing
+// focus or switching views. A fetch failure is re-tagged from fetchReview's
+// own reviewErrMsg (jobID/gen/fetchSeq already correct, captured by
+// fetchReview at the same command-creation point) into reviewFollowErrMsg,
+// so handleReviewFollowErrMsg can record it in m.splitDetailErr for the pane
+// to render instead of the plain review-open resolution
+// handleReviewErrMsg performs for an ordinary fetch's failure.
+func (m model) fetchReviewFollow(jobID int64, fetchSeq uint64) tea.Cmd {
+	inner := m.fetchReview(jobID, fetchSeq)
+	return func() tea.Msg {
+		msg := inner()
+		if rm, ok := msg.(reviewMsg); ok {
+			rm.follow = true
+			return rm
+		}
+		if em, ok := msg.(reviewErrMsg); ok {
+			return reviewFollowErrMsg(em)
+		}
+		return msg
 	}
 }
 
@@ -762,13 +897,37 @@ func reviewBranchName(job *storage.ReviewJob) string {
 	return detachedBranchLabel(*job)
 }
 
-func (m model) fetchReviewForPrompt(jobID int64) tea.Cmd {
+// dispatchPromptFetch is the single entry point for prompt fetches: it
+// advances the prompt path's own request identity and stamps it (plus the
+// dispatch-origin view) onto the outgoing request. Callers must invoke it
+// as a standalone statement, never inline in a return -- the same
+// evaluation-order pitfall documented on dispatchReviewFetch above.
+func (m *model) dispatchPromptFetch(jobID int64) tea.Cmd {
+	m.promptFetchSeq++
+	return m.fetchReviewForPrompt(jobID, m.promptFetchSeq)
+}
+
+// fetchReviewForPrompt loads a done job's review so the prompt view can
+// show the prompt it was built from. It writes the SAME currentReview
+// field as fetchReview, so it stamps the same per-job attempt counter at
+// dispatch (jobAttemptGen contract clause 3, tui.go) -- a rerun of the job
+// abandons this request exactly as it abandons a review fetch. It does not
+// join the shared fetch epoch (see handlePromptMsg for why); staleness is
+// tracked by the prompt path's own promptFetchSeq, stamped here along with
+// the dispatch-origin view. Reached only through dispatchPromptFetch,
+// which owns the seq bump.
+func (m model) fetchReviewForPrompt(jobID int64, promptSeq uint64) tea.Cmd {
+	attempt := m.jobAttemptGen[jobID]
+	origin := m.currentView
 	return func() tea.Msg {
 		review, err := m.loadReview(jobID)
 		if err != nil {
 			return errMsg(err)
 		}
-		return promptMsg{review: review, jobID: jobID}
+		return promptMsg{
+			review: review, jobID: jobID, attempt: attempt,
+			promptSeq: promptSeq, dispatchedFrom: origin,
+		}
 	}
 }
 
@@ -910,6 +1069,121 @@ func (m model) fetchJobLog(jobID int64) tea.Cmd {
 		}
 
 		return logOutputMsg{
+			lines:     lines,
+			hasMore:   hasMore,
+			newOffset: newOffset,
+			append:    isIncremental,
+			seq:       seq,
+			fmtr:      renderFmtr,
+		}
+	}
+}
+
+// fetchPaneLog is fetchJobLog's fetch/format logic cloned for the split
+// detail pane's live log tail: same /api/job/log incremental-fetch
+// protocol, but reading/writing the model's paneLog* fields and emitting
+// paneLogOutputMsg so the pane's stream never collides with the full-screen
+// log view's independent offset/formatter/seq state. Keep the two in sync
+// if the log-fetch protocol changes.
+func (m model) fetchPaneLog(jobID int64) tea.Cmd {
+	baseURL := m.endpoint.BaseURL()
+	width := m.paneLogWidth()
+	client := m.client
+	style := m.glamourStyle
+	offset := m.paneLogOffset
+	fmtr := m.paneLogFmtr
+	seq := m.paneLogSeq
+	return func() tea.Msg {
+		url := fmt.Sprintf(
+			"%s/api/job/log?job_id=%d&offset=%d",
+			baseURL, jobID, offset,
+		)
+		resp, err := client.Get(url)
+		if err != nil {
+			return paneLogOutputMsg{jobID: jobID, err: err, seq: seq}
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode == http.StatusNotFound {
+			return paneLogOutputMsg{jobID: jobID, err: errNoLog, seq: seq}
+		}
+		if resp.StatusCode != http.StatusOK {
+			return paneLogOutputMsg{
+				jobID: jobID,
+				err:   fmt.Errorf("fetch log: %s", resp.Status),
+				seq:   seq,
+			}
+		}
+
+		// Determine if job is still running from header
+		jobStatus := resp.Header.Get("X-Job-Status")
+		hasMore := jobStatus == "running"
+
+		// Parse new offset from response header
+		newOffset := offset
+		if v := resp.Header.Get("X-Log-Offset"); v != "" {
+			if parsed, perr := strconv.ParseInt(
+				v, 10, 64,
+			); perr == nil {
+				newOffset = parsed
+			}
+		}
+
+		// Server reset offset (log truncated/rotated) — force
+		// full replace even if we sent a nonzero offset.
+		isIncremental := offset > 0 && fmtr != nil
+		if newOffset < offset {
+			isIncremental = false
+		}
+
+		// No new data — return early with current state
+		if newOffset == offset && isIncremental {
+			return paneLogOutputMsg{
+				jobID:     jobID,
+				hasMore:   hasMore,
+				newOffset: newOffset,
+				append:    true,
+				seq:       seq,
+			}
+		}
+
+		// Render JSONL through streamFormatter. Use pre-computed
+		// glamour style to avoid terminal queries from goroutine.
+		var buf bytes.Buffer
+		var renderFmtr *streamfmt.Formatter
+		if isIncremental {
+			// Reuse persistent formatter — redirect its output
+			// to a fresh buffer for this batch only.
+			fmtr.SetWriter(&buf)
+			renderFmtr = fmtr
+		} else {
+			renderFmtr = streamfmt.NewWithWidth(
+				&buf, width, style,
+			)
+		}
+
+		if err := streamfmt.RenderLogWith(
+			resp.Body, renderFmtr, &buf,
+		); err != nil {
+			return paneLogOutputMsg{jobID: jobID, err: err, seq: seq}
+		}
+
+		// Split rendered output into lines
+		raw := buf.String()
+		var lines []logLine
+		if raw != "" {
+			for s := range strings.SplitSeq(raw, "\n") {
+				lines = append(lines, logLine{text: s})
+			}
+			// Remove trailing empty line from final newline
+			if len(lines) > 0 &&
+				lines[len(lines)-1].text == "" {
+				lines = lines[:len(lines)-1]
+			}
+		}
+
+		return paneLogOutputMsg{
+			jobID:     jobID,
 			lines:     lines,
 			hasMore:   hasMore,
 			newOffset: newOffset,

--- a/cmd/roborev/tui/fetch.go
+++ b/cmd/roborev/tui/fetch.go
@@ -705,18 +705,30 @@ func (m model) loadComments(
 	return decodeAPIBody(resp.Body, out)
 }
 
+// dispatchFailedCommentsFetch is the single entry point for the
+// synthesized-review comments fetch: it advances the side channel's own
+// request identity and stamps it onto the outgoing request, so a stale
+// response can never overwrite a newer fetch's result or a post-success
+// local append. Standalone-statement rule applies (see
+// dispatchReviewFetch's evaluation-order pitfall above).
+func (m *model) dispatchFailedCommentsFetch(jobID int64) tea.Cmd {
+	m.failedCommentsSeq++
+	return m.fetchFailedJobComments(jobID, m.failedCommentsSeq)
+}
+
 // fetchFailedJobComments loads persisted comments for a job whose review
-// is synthesized -- see failedCommentsMsg.
-func (m model) fetchFailedJobComments(jobID int64) tea.Cmd {
+// is synthesized -- see failedCommentsMsg. Reached only through
+// dispatchFailedCommentsFetch, which owns the seq bump.
+func (m model) fetchFailedJobComments(jobID int64, seq uint64) tea.Cmd {
 	return func() tea.Msg {
 		var result struct {
 			Responses []storage.Response `json:"responses"`
 		}
 		query := &daemonclient.ListCommentsQuery{JobID: &jobID}
 		if err := m.loadComments(query, &result); err != nil {
-			return failedCommentsMsg{jobID: jobID, err: err}
+			return failedCommentsMsg{jobID: jobID, err: err, seq: seq}
 		}
-		return failedCommentsMsg{jobID: jobID, responses: result.Responses}
+		return failedCommentsMsg{jobID: jobID, responses: result.Responses, seq: seq}
 	}
 }
 

--- a/cmd/roborev/tui/fetch.go
+++ b/cmd/roborev/tui/fetch.go
@@ -705,6 +705,21 @@ func (m model) loadComments(
 	return decodeAPIBody(resp.Body, out)
 }
 
+// fetchFailedJobComments loads persisted comments for a job whose review
+// is synthesized -- see failedCommentsMsg.
+func (m model) fetchFailedJobComments(jobID int64) tea.Cmd {
+	return func() tea.Msg {
+		var result struct {
+			Responses []storage.Response `json:"responses"`
+		}
+		query := &daemonclient.ListCommentsQuery{JobID: &jobID}
+		if err := m.loadComments(query, &result); err != nil {
+			return failedCommentsMsg{jobID: jobID, err: err}
+		}
+		return failedCommentsMsg{jobID: jobID, responses: result.Responses}
+	}
+}
+
 func (m model) loadJob(jobID int64) (*storage.ReviewJob, error) {
 	params := neturl.Values{}
 	params.Set("id", fmt.Sprintf("%d", jobID))

--- a/cmd/roborev/tui/filter.go
+++ b/cmd/roborev/tui/filter.go
@@ -259,11 +259,48 @@ func (m *model) resetQueueForFilterChange() {
 	m.hasMore = false
 	m.loadingMore = false
 	m.paginateNav = 0
+	prevSelected := m.selectedJobID
 	m.selectedIdx = -1
 	m.selectedJobID = 0
 	m.fetchSeq++
 	m.queueColGen++
 	m.loadingJobs = true
+	// Zeroing the selection is a selection change like any other, so it
+	// abandons a job-scoped intent bound to the job it just deselected --
+	// same rule as followSelectionChange and handleJobsMsg's normalization
+	// (the same rule stated on followSelectionChange, layout.go).
+	//
+	// The reactive path does NOT cover this one: it clears an intent only
+	// when a message for the old job arrives while selectedJobID differs.
+	// Here selectedJobID becomes 0, but the refetch this reset triggers can
+	// RE-SELECT the very job the intent is bound to (normalization picks
+	// the first visible row) before that message ever arrives -- at which
+	// point the intent looks perfectly current again and the next response
+	// for the job, typically reconcile's follow, opens the review or
+	// springs the fix panel open with the user's filter change as the only
+	// thing they actually asked for. Keyed on the deselected job so an
+	// intent for some other job is untouched; closeFixPanelIfJobChanged is
+	// self-guarding the same way (fixPromptJobID != selectedJobID, now 0).
+	if m.pendingReviewOpenJobID != 0 && m.pendingReviewOpenJobID == prevSelected {
+		m.disarmPendingReviewOpen()
+	}
+	m.closeFixPanelIfJobChanged()
+	// ABANDONMENT bumper (see detailFollowGen's contract, tui.go): the
+	// disarms above make abandoned intents unservable, but an armed-era
+	// ORDINARY dispatch for the deselected job would still be gen-fresh
+	// when the refetch re-selects that job, and openReviewView would
+	// switch views off a filter change the user made for other reasons --
+	// the same hole handleJobsMsg's normalization bump closes. The inline
+	// disarms this contract class requires are exactly the ones above.
+	if prevSelected != 0 {
+		m.detailFollowGen++
+		// Same abandonment event, same request-scoped state: doom an
+		// in-flight prompt response and release the reconcile suppression
+		// slot for the abandoned era -- left armed, the slot would
+		// suppress the replacement fetch if the refetch re-selects the
+		// same job. See abandonInFlightSelectionRequests (layout.go).
+		m.abandonInFlightSelectionRequests()
+	}
 }
 
 // isJobVisible checks if a job passes all active filters
@@ -296,7 +333,7 @@ func (m model) branchMatchesFilter(job storage.ReviewJob) bool {
 	branch := m.getBranchForJob(job)
 	// The detached placeholder is display-only; for filter identity those
 	// jobs group under (none), matching how the server-side branch list
-	// counts their empty stored branch (#499).
+	// counts their empty stored branch.
 	if branch == "" || isDetachedLabel(branch) {
 		branch = branchNone
 	}

--- a/cmd/roborev/tui/filter_queue_test.go
+++ b/cmd/roborev/tui/filter_queue_test.go
@@ -548,7 +548,9 @@ func TestTUIAutoRepoFilterKeepsTrackedCloneWithSharedIdentity(t *testing.T) {
 
 func TestTUIBKeyNoOpOutsideQueue(t *testing.T) {
 	m := newModel(localhostEndpoint, withExternalIODisabled())
+	job := makeJob(1)
 	m.currentView = viewReview
+	m.currentReview = &storage.Review{JobID: 1, Job: &job} // viewReview requires a loaded review (normalizeSplitState repairs otherwise)
 
 	m2, cmd := pressKey(m, 'b')
 

--- a/cmd/roborev/tui/handlers.go
+++ b/cmd/roborev/tui/handlers.go
@@ -626,9 +626,10 @@ func (m model) stepReviewNav(dir int) (tea.Model, tea.Cmd) {
 		cmd := m.dispatchReviewFetch(job.ID)
 		return m, tea.Batch(followCmd, cmd)
 	case storage.JobStatusFailed:
-		m.currentBranch = ""
-		m.currentResponses = nil
-		m.currentReview = synthesizeFailedReview(&job, m.currentReview)
+		// Shared synthesized acceptance: also loads persisted comments,
+		// which no review fetch can carry for a row-less review.
+		commentsCmd := m.acceptSynthesizedFailure(job.ID, synthesizeFailedReview(&job, m.currentReview))
+		return m, tea.Batch(followCmd, commentsCmd)
 	}
 	return m, followCmd
 }

--- a/cmd/roborev/tui/handlers.go
+++ b/cmd/roborev/tui/handlers.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"io"
 	"time"
 
@@ -35,11 +36,88 @@ func (m model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleColumnOptionsInput(msg)
 	}
 
+	// Review-scoped actions must not fire against a review the detail pane
+	// has already moved past (see guardStaleSplitDetailAction).
+	if mm, blocked := m.guardStaleSplitDetailAction(msg); blocked {
+		return mm, nil
+	}
+
 	// Global keys shared across queue/review/prompt/commitMsg/help views
-	return m.handleGlobalKey(msg)
+	prevSelected := m.selectedJobID
+	res, cmd := m.handleGlobalKey(msg)
+	if mm, ok := res.(model); ok && mm.currentView == viewQueue {
+		mm, followCmd := mm.followSelectionChange(prevSelected)
+		if followCmd != nil {
+			return mm, tea.Batch(cmd, followCmd)
+		}
+		return mm, cmd
+	}
+	return res, cmd
+}
+
+// guardStaleSplitDetailAction blocks the review-scoped action keys while
+// the split detail pane is showing a review that is NOT the selected job's.
+// Split's two panes advance independently: detail navigation (stepReviewNav's
+// arrow keys) moves selectedJobID immediately and only replaces
+// m.currentReview once the async fetch lands, so in that window every
+// review-scoped key -- 'a' (close), 'c' (comment), 'F' (fix), 'p' (prompt),
+// 'm' (commit message), 'y' (copy) -- would act on the PREVIOUS job's
+// review while the list already highlights the new one. 'F' is the worst of
+// them: it opens the inline fix panel over the newly selected job while
+// bound to the old job's ID, so submitting starts a fix for the wrong job.
+//
+// The predicate is m.selectedReviewLoaded() (helpers.go) -- the same one
+// tab (handleTabKey) and the detail-pane click (split_render.go) already
+// use to refuse handing review actions to the wrong job -- so all three
+// entry points agree by construction.
+//
+// Only the split DETAIL pane is gated: splitActive() excludes a
+// tasks-origin review (rendered full-screen even on a split-capable
+// terminal), whose displayed review legitimately has nothing to do with
+// the queue selection, and list focus (currentView == viewQueue) acts on
+// the selected JOB rather than on currentReview, so neither is affected.
+//
+// The three keys with side effects flash, because silently swallowing a
+// close/comment/fix reads as a broken keyboard; the three read-only ones
+// (prompt/commit message/copy) are silent, since a flash on every stray
+// keypress during the sub-second load window would be noise.
+func (m model) guardStaleSplitDetailAction(msg tea.KeyMsg) (model, bool) {
+	if !m.splitActive() || m.currentView != viewReview || m.selectedReviewLoaded() {
+		return m, false
+	}
+	switch msg.String() {
+	case "a", "c", "F":
+		m.setFlash("Review still loading", 2*time.Second, m.currentView)
+		return m, true
+	case "p", "m", "y":
+		return m, true
+	}
+	return m, false
+}
+
+// mouseNavWithFollow invokes nav (handleUpKey/handleDownKey) and routes any
+// resulting queue selection change through followSelectionChange, mirroring
+// handleKeyMsg's viewQueue wrapper. Mouse events never pass through
+// handleKeyMsg, so without this the non-split wheel paths would move the
+// selection while skipping the abandonment chokepoint, leaving pending
+// review/fix intents armed for a job the cursor already left.
+func (m model) mouseNavWithFollow(nav func() (tea.Model, tea.Cmd)) (tea.Model, tea.Cmd) {
+	prevSelected := m.selectedJobID
+	res, cmd := nav()
+	if mm, ok := res.(model); ok && mm.currentView == viewQueue {
+		mm, followCmd := mm.followSelectionChange(prevSelected)
+		if followCmd != nil {
+			return mm, tea.Batch(cmd, followCmd)
+		}
+		return mm, cmd
+	}
+	return res, cmd
 }
 
 func (m model) handleMouseMsg(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	if m.splitActive() {
+		return m.handleSplitMouse(msg)
+	}
 	mouse := msg.Mouse()
 	switch msg.(type) {
 	case tea.MouseWheelMsg:
@@ -57,7 +135,7 @@ func (m model) handleMouseMsg(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 				}
 				return m, nil
 			}
-			return m.handleUpKey()
+			return m.mouseNavWithFollow(m.handleUpKey)
 		case tea.MouseWheelDown:
 			if m.currentView == viewColumnOptions {
 				if m.colOptionsIdx < len(m.colOptionsList)-1 {
@@ -71,7 +149,7 @@ func (m model) handleMouseMsg(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 				}
 				return m, nil
 			}
-			return m.handleDownKey()
+			return m.mouseNavWithFollow(m.handleDownKey)
 		default:
 			return m, nil
 		}
@@ -81,7 +159,9 @@ func (m model) handleMouseMsg(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		}
 		switch m.currentView {
 		case viewQueue:
+			prevSelected := m.selectedJobID
 			m.handleQueueMouseClick(mouse.X, mouse.Y)
+			return m.followSelectionChange(prevSelected)
 		case viewTasks:
 			m.handleTasksMouseClick(mouse.Y)
 		case viewColumnOptions:
@@ -172,8 +252,40 @@ func (m model) handleGlobalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleTogglePauseKey()
 	case "tab":
 		return m.handleTabKey()
+	case "L":
+		return m.handleToggleLayoutKey()
 	}
 	return m, nil
+}
+
+// handleToggleLayoutKey toggles between split and stacked layout, locking
+// the user's preference so it survives subsequent resizes.
+func (m model) handleToggleLayoutKey() (tea.Model, tea.Cmd) {
+	if m.currentView != viewQueue && m.currentView != viewReview {
+		return m, nil
+	}
+	target := layoutSplit
+	if m.layout == layoutSplit {
+		target = layoutStacked
+	}
+	// applyLayout below is a direct transition that bypasses resolveLayout,
+	// so distraction-free's stacked override (see resolveLayout) must be
+	// enforced here too or L would re-engage the split composition while
+	// the title-plus-list-only contract is active.
+	if target == layoutSplit && m.distractionFree {
+		m.setFlash("Split layout is unavailable in distraction-free mode (press D to exit)",
+			3*time.Second, m.currentView)
+		return m, nil
+	}
+	if target == layoutSplit && pickLayout(m.width, m.height) != layoutSplit {
+		m.setFlash(fmt.Sprintf("Terminal too small for split view (needs %dx%d)",
+			splitMinWidth, splitMinHeight), 3*time.Second, m.currentView)
+		return m, nil
+	}
+	m.layoutLocked = true
+	m.preferredLayout = target
+	m.applyLayout(target)
+	return m.maybeBootstrapDetail()
 }
 
 // handleTogglePauseKey pauses or resumes daemon queue processing. Pause is a
@@ -195,6 +307,37 @@ func (m model) handleTogglePauseKey() (tea.Model, tea.Cmd) {
 }
 
 func (m model) handleQuitKey() (tea.Model, tea.Cmd) {
+	// A tasks-origin review renders full-screen even in split (splitActive()
+	// excludes it -- see its doc comment), so this split-pane-specific
+	// "back to the queue list" shortcut must not fire for it; falling
+	// through to the general viewReview branch below returns to
+	// reviewFromView (viewTasks) instead, via the same logic that handles
+	// every other full-screen review return.
+	if m.layout == layoutSplit && m.currentView == viewReview && m.reviewFromView != viewTasks {
+		if m.reviewFixPanelOpen {
+			m.closeFixPanel()
+			return m, nil
+		}
+		m.focus = focusList
+		m.currentView = viewQueue
+		// The review just left may now be hidden -- closing it with
+		// hideClosed enabled removes its row -- which would leave the
+		// selection pointing at a job with no highlighted row, so later
+		// actions would target a job the user cannot see. Normalize
+		// exactly as the stacked return path does, and refill the queue
+		// when hideClosed pruned it (the same refill the stacked path
+		// performs). The follow transition (followSelectionChange) is NOT
+		// called here: handleKeyMsg's wrapper performs it after this
+		// handler returns to viewQueue, against the prevSelected it
+		// captured before dispatch, so calling it here too would
+		// double-bump detailFollowGen and schedule a stale extra tick.
+		m.normalizeSelectionIfHidden()
+		if m.hideClosed && !m.loadingJobs {
+			m.loadingJobs = true
+			return m, m.fetchJobs()
+		}
+		return m, nil
+	}
 	if m.currentView == viewReview {
 		returnTo := m.reviewFromView
 		if returnTo == 0 {
@@ -214,8 +357,8 @@ func (m model) handleQuitKey() (tea.Model, tea.Cmd) {
 		m.paginateNav = 0
 		if m.promptFromQueue {
 			m.currentView = viewQueue
-			m.currentReview = nil
 			m.promptScroll = 0
+			m = m.preserveOrClearReviewOnQueueReturn()
 		} else {
 			m.currentView = viewReview
 			m.promptScroll = 0
@@ -332,16 +475,45 @@ func (m model) handleLeftKey() (tea.Model, tea.Cmd) {
 	return m.handlePrevKey()
 }
 
+// queueNavUp moves the queue cursor one row toward newer entries, flashing
+// the boundary when the move clamps in place. Shared by handleUpKey's
+// viewQueue arm and the split list pane's wheel-up (handleSplitMouse), so
+// keyboard and wheel navigation cannot drift apart.
+func (m model) queueNavUp() (model, tea.Cmd) {
+	prevID := m.selectedJobID
+	m = m.moveQueueSelection(-1)
+	// id unchanged after a clamped move ⇒ already at the top; re-flash the boundary hint.
+	if m.selectedJobID == prevID {
+		m.setFlash("No newer review", 2*time.Second, viewQueue)
+	}
+	return m, nil
+}
+
+// queueNavDown moves the queue cursor one row toward older entries,
+// prefetching near the end of loaded data and resuming pagination at the
+// bottom boundary. Shared by handleDownKey's viewQueue arm and the split
+// list pane's wheel-down (handleSplitMouse), so wheel users can pull older
+// pages exactly like keyboard users.
+func (m model) queueNavDown() (model, tea.Cmd) {
+	prevID := m.selectedJobID
+	m = m.moveQueueSelection(+1)
+	if m.selectedJobID != prevID {
+		if cmd := m.maybePrefetch(m.selectedIdx); cmd != nil {
+			return m, cmd
+		}
+	} else if m.canPaginate() {
+		m.loadingMore = true
+		return m, m.fetchMoreJobs()
+	} else if !m.hasMore || m.activeBranchFilter == branchNone {
+		m.setFlash("No older review", 2*time.Second, viewQueue)
+	}
+	return m, nil
+}
+
 func (m model) handleUpKey() (tea.Model, tea.Cmd) {
 	switch m.currentView {
 	case viewQueue:
-		prevID := m.selectedJobID
-		m = m.moveQueueSelection(-1)
-		// id unchanged after a clamped move ⇒ already at the top; re-flash the boundary hint.
-		if m.selectedJobID == prevID {
-			m.setFlash("No newer review", 2*time.Second, viewQueue)
-		}
-		return m, nil
+		return m.queueNavUp()
 	case viewReview:
 		if m.reviewScroll > 0 {
 			m.reviewScroll--
@@ -417,6 +589,19 @@ func (m *model) resolveAbsentSelection(
 // stepReviewNav walks the flattened rows for the queue-origin review view in
 // direction dir (-1 = newer, +1 = older) and opens the target review, or
 // flashes/paginates at the boundary. Never indexes m.jobs by a stale index.
+//
+// Takes the shared detail-follow transition (followSelectionChange) like
+// every other selection-moving site. It was long argued not to need one,
+// because eligibleReviewRow admits only done/failed jobs and both branches
+// below replace currentReview for the new job -- true for the CONTENT, and
+// false for splitDetailErr: renderDetailPane's done branch
+// renders that error whenever currentReview does not yet match the selected
+// job, which is exactly the state this function creates for the duration of
+// the dispatched fetch. So a reconcile follow that failed while job X was
+// displayed left "Failed to load review: ..." rendering under job Y's status
+// card the moment the user arrowed to it. Routing through the shared
+// transition clears it (and stops any tail, and disarms the intent) instead
+// of hand-clearing one field here.
 func (m model) stepReviewNav(dir int) (tea.Model, tea.Cmd) {
 	job, found, present := m.contentNavStep(dir, eligibleReviewRow)
 	if !present {
@@ -428,26 +613,44 @@ func (m model) stepReviewNav(dir int) (tea.Model, tea.Cmd) {
 	} else if !found {
 		return m, m.contentNavBoundary(viewReview, dir)
 	}
+	prevSelected := m.selectedJobID
 	m.closeFixPanel()
 	m = m.moveSelectionToJobID(job.ID)
 	m.reviewScroll = 0
+	// Before the dispatch: the gen bump must precede the fetch it stamps,
+	// and disarmPendingReviewOpen must precede the re-arm below.
+	var followCmd tea.Cmd
+	m, followCmd = m.followSelectionChange(prevSelected)
 	switch job.Status {
 	case storage.JobStatusDone:
-		return m, m.fetchReview(job.ID)
+		cmd := m.dispatchReviewFetch(job.ID)
+		return m, tea.Batch(followCmd, cmd)
 	case storage.JobStatusFailed:
 		m.currentBranch = ""
-		m.currentReview = &storage.Review{
-			Agent:  job.Agent,
-			Output: "Job failed:\n\n" + job.Error,
-			Job:    &job,
-		}
+		m.currentResponses = nil
+		m.currentReview = synthesizeFailedReview(&job, m.currentReview)
 	}
-	return m, nil
+	return m, followCmd
 }
 
 // stepPromptNav walks the flattened rows for the queue-origin prompt view in
 // direction dir (-1 = newer, +1 = older) and opens the target prompt, or
 // flashes/paginates at the boundary.
+//
+// Takes the shared detail-follow transition (followSelectionChange), same as
+// stepLogNav. An earlier audit marked this site safe, but for the narrower
+// question of whether a pending INTENT could be stranded here -- not for
+// whether the split detail PANE follows the selection. It does not follow on
+// its own: eligiblePromptRow admits RUNNING and QUEUED jobs, so prompt nav
+// can move the selection from one running job to another, and for those the
+// branch below writes only a synthetic prompt-only review. Nothing stops the
+// pane's live log tail for the job navigated away from (paneLogSeq is bumped
+// only by scheduleDetailFollow), nothing clears a splitDetailErr belonging to
+// it, and nothing starts the NEW job's tail until an unrelated jobs refresh
+// reconciles it -- so the previous job's buffered log or error kept rendering
+// beneath the new job's status. The Done branch's fetchReviewForPrompt has
+// the same gap: it writes currentReview through handlePromptMsg without
+// touching any pane-follow state.
 func (m model) stepPromptNav(dir int) (tea.Model, tea.Cmd) {
 	job, found, present := m.contentNavStep(dir, eligiblePromptRow)
 	if !present {
@@ -459,10 +662,18 @@ func (m model) stepPromptNav(dir int) (tea.Model, tea.Cmd) {
 	} else if !found {
 		return m, m.contentNavBoundary(viewKindPrompt, dir)
 	}
+	prevSelected := m.selectedJobID
 	m = m.moveSelectionToJobID(job.ID)
 	m.promptScroll = 0
+	var followCmd tea.Cmd
+	m, followCmd = m.followSelectionChange(prevSelected)
 	if job.Status == storage.JobStatusDone {
-		return m, m.fetchReviewForPrompt(job.ID)
+		// Batched, not returned in place of the prompt fetch: both must
+		// run. Dispatched as a standalone statement so the returned m
+		// carries the seq bump (dispatchReviewFetch's evaluation-order
+		// pitfall, fetch.go).
+		promptCmd := m.dispatchPromptFetch(job.ID)
+		return m, tea.Batch(followCmd, promptCmd)
 	}
 	if (job.Status == storage.JobStatusRunning || job.Status == storage.JobStatusQueued) && job.Prompt != "" {
 		m.currentReview = &storage.Review{
@@ -471,12 +682,25 @@ func (m model) stepPromptNav(dir int) (tea.Model, tea.Cmd) {
 			Job:    &job,
 		}
 	}
-	return m, nil
+	return m, followCmd
 }
 
 // stepLogNav walks the flattened rows for the queue-origin log view in direction
 // dir (-1 = newer, +1 = older) and opens the target log, or flashes/paginates
 // at the boundary.
+//
+// Its target view (viewLog) never touches currentReview -- the log view's
+// content lives entirely in separate fields (logLines, paneLog*) -- so
+// without an explicit follow here the split detail pane would keep
+// showing the job the user navigated away from until an unrelated jobs
+// refresh reconciled it (see cmd/roborev/tui's PR review finding on
+// handlers.go:27). followSelectionChange only gates on m.layout (not
+// splitActive()), so this still arms the debounced follow while the log view
+// is on screen in split layout; the resulting tick/fetch lands quietly in
+// the background and the pane is already caught up by the time the user
+// returns to the queue. In stacked layout (or tasks-origin log nav, which
+// never reaches this function -- see handleNextKey/handlePrevKey's
+// logFromView == viewTasks branch) followSelectionChange is a no-op.
 func (m model) stepLogNav(dir int) (tea.Model, tea.Cmd) {
 	job, found, present := m.contentNavStep(dir, eligibleLogRow)
 	if !present {
@@ -488,9 +712,13 @@ func (m model) stepLogNav(dir int) (tea.Model, tea.Cmd) {
 	} else if !found {
 		return m, m.contentNavBoundary(viewLog, dir)
 	}
+	prevSelected := m.selectedJobID
 	m = m.moveSelectionToJobID(job.ID)
 	m.logStreaming = false
-	return m.openLogView(job.ID, job.Status, m.logFromView)
+	var followCmd tea.Cmd
+	m, followCmd = m.followSelectionChange(prevSelected)
+	logModel, logCmd := m.openLogView(job.ID, job.Status, m.logFromView)
+	return logModel, tea.Batch(followCmd, logCmd)
 }
 
 func (m model) handleNextKey() (tea.Model, tea.Cmd) {
@@ -527,18 +755,7 @@ func (m model) nextFixLog() (tea.Model, tea.Cmd) {
 func (m model) handleDownKey() (tea.Model, tea.Cmd) {
 	switch m.currentView {
 	case viewQueue:
-		prevID := m.selectedJobID
-		m = m.moveQueueSelection(+1)
-		if m.selectedJobID != prevID {
-			if cmd := m.maybePrefetch(m.selectedIdx); cmd != nil {
-				return m, cmd
-			}
-		} else if m.canPaginate() {
-			m.loadingMore = true
-			return m, m.fetchMoreJobs()
-		} else if !m.hasMore || m.activeBranchFilter == branchNone {
-			m.setFlash("No older review", 2*time.Second, viewQueue)
-		}
+		return m.queueNavDown()
 	case viewReview:
 		m.reviewScroll++
 		if m.mdCache != nil && m.reviewScroll > m.mdCache.lastReviewMaxScroll {
@@ -675,6 +892,35 @@ func (m model) handleHelpKey() (tea.Model, tea.Cmd) {
 }
 
 func (m model) handleEscKey() (tea.Model, tea.Cmd) {
+	// See handleQuitKey's matching comment: a tasks-origin review must
+	// fall through to the general viewReview branch below (which returns
+	// to reviewFromView == viewTasks) instead of this split-pane-specific
+	// "back to the queue list" shortcut.
+	if m.layout == layoutSplit && m.currentView == viewReview && m.reviewFromView != viewTasks {
+		if m.reviewFixPanelOpen {
+			m.closeFixPanel()
+			return m, nil
+		}
+		m.focus = focusList
+		m.currentView = viewQueue
+		// The review just left may now be hidden -- closing it with
+		// hideClosed enabled removes its row -- which would leave the
+		// selection pointing at a job with no highlighted row, so later
+		// actions would target a job the user cannot see. Normalize
+		// exactly as the stacked return path does, and refill the queue
+		// when hideClosed pruned it (the same refill the stacked path
+		// performs). The follow transition (followSelectionChange) is NOT
+		// called here: handleKeyMsg's wrapper performs it after this
+		// handler returns to viewQueue, against the prevSelected it
+		// captured before dispatch, so calling it here too would
+		// double-bump detailFollowGen and schedule a stale extra tick.
+		m.normalizeSelectionIfHidden()
+		if m.hideClosed && !m.loadingJobs {
+			m.loadingJobs = true
+			return m, m.fetchJobs()
+		}
+		return m, nil
+	}
 	if m.currentView == viewQueue && len(m.filterStack) > 0 {
 		popped := m.popFilter()
 		if popped == filterTypeRepo || popped == filterTypeBranch {
@@ -712,8 +958,8 @@ func (m model) handleEscKey() (tea.Model, tea.Cmd) {
 		m.paginateNav = 0
 		if m.promptFromQueue {
 			m.currentView = viewQueue
-			m.currentReview = nil
 			m.promptScroll = 0
+			m = m.preserveOrClearReviewOnQueueReturn()
 		} else {
 			m.currentView = viewReview
 			m.promptScroll = 0

--- a/cmd/roborev/tui/handlers_modal.go
+++ b/cmd/roborev/tui/handlers_modal.go
@@ -351,6 +351,30 @@ func (m model) handleWorktreeConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// exitTasksToQueue returns to the queue view from the tasks flow,
+// repairing the selection when the flow moved it off the queue: opening a
+// task's review points selectedJobID at the FIX job (handleTasksKey's
+// Enter -- required so handleReviewMsg's jobID==selectedJobID acceptance
+// gate admits that fetch), and no queue row or panel member can resolve a
+// fix job's ID. Left in place, the queue renders no highlighted row and
+// the split detail pane says "No job selected" until a jobs refresh
+// normalizes it. selectedIdx is untouched by the tasks flow, so
+// normalizeSelectionIfHidden restores the row under it, and the shared
+// follow transition re-points the split pane. A selection that still
+// resolves (a queue job, or a side-fetched panel member -- which
+// normalizeSelectionIfHidden would wrongly clobber) is left alone.
+// Shared by every tasks-to-queue exit: handleTasksKey's esc/T,
+// handleToggleTasksKey, and the control socket's set-view.
+func (m model) exitTasksToQueue() (model, tea.Cmd) {
+	m.currentView = viewQueue
+	if _, ok := m.selectedJob(); ok {
+		return m, nil
+	}
+	prevSelected := m.selectedJobID
+	m.normalizeSelectionIfHidden()
+	return m.followSelectionChange(prevSelected)
+}
+
 // handleTasksKey handles key input in the tasks view.
 func (m model) handleTasksKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if isSubmitKey(msg) {
@@ -360,6 +384,22 @@ func (m model) handleTasksKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			switch {
 			case job.Status == storage.JobStatusRunning:
 				if job.Prompt != "" {
+					// Move the QUEUE selection to the fix job and take the
+					// shared transition, exactly like the completed-task
+					// Enter below and the 'P' case: left pointing at the
+					// previously selected queue job, split reconciliation
+					// keeps following THAT job on every refresh and its
+					// follow fetch would replace currentReview -- swapping
+					// the displayed prompt's backing review out from under
+					// the user. With the selection on the fix job (absent
+					// from m.jobs), reconcile resolves nothing and any
+					// stale response fails the jobID gate;
+					// exitTasksToQueue repairs the selection on the way
+					// back to the queue.
+					prevSelected := m.selectedJobID
+					m.selectedJobID = job.ID
+					var followCmd tea.Cmd
+					m, followCmd = m.followSelectionChange(prevSelected)
 					m.currentReview = &storage.Review{
 						Agent:  job.Agent,
 						Prompt: job.Prompt,
@@ -369,14 +409,22 @@ func (m model) handleTasksKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					m.currentView = viewKindPrompt
 					m.promptScroll = 0
 					m.promptFromQueue = false
-					return m, nil
+					return m, followCmd
 				}
 				// No prompt yet, go straight to log view
 				return m.openLogView(job.ID, job.Status, viewTasks)
 			case job.HasViewableOutput():
+				// Moves the QUEUE selection to a fix job, so it takes the
+				// shared detail-follow transition like every other
+				// selection change -- see the note on the 'P' case below,
+				// which has the identical shape.
+				prevSelected := m.selectedJobID
 				m.selectedJobID = job.ID
 				m.reviewFromView = viewTasks
-				return m, m.fetchReview(job.ID)
+				var followCmd tea.Cmd
+				m, followCmd = m.followSelectionChange(prevSelected)
+				cmd := m.dispatchReviewFetch(job.ID)
+				return m, tea.Batch(followCmd, cmd)
 			case job.Status == storage.JobStatusFailed:
 				return m.openLogView(job.ID, job.Status, viewTasks)
 			}
@@ -393,8 +441,7 @@ func (m model) handleTasksKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, tea.Quit
 	case "esc", "T":
-		m.currentView = viewQueue
-		return m, nil
+		return m.exitTasksToQueue()
 	case "o":
 		return m.handleColumnOptionsKey()
 	case "up", "k":
@@ -470,9 +517,25 @@ func (m model) handleTasksKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.setFlash("No parent review for this task", 2*time.Second, viewTasks)
 				return m, nil
 			}
+			// This moves the QUEUE selection from inside the Tasks
+			// view, which handleKeyMsg dispatches through its early
+			// modal switch -- BEFORE its followSelectionChange wrapper
+			// -- so this handler must apply the shared transition
+			// itself, or the split pane keeps tailing the job the
+			// selection moved off until the next poll/refresh heals it.
+			//
+			// Called BEFORE the dispatch, deliberately: the gen bump must
+			// precede the fetch it stamps (otherwise the request is born
+			// stale), and disarmPendingReviewOpen must run before
+			// dispatchReviewFetch re-arms the intent for the job opened
+			// here.
+			prevSelected := m.selectedJobID
 			m.selectedJobID = *job.ParentJobID
 			m.reviewFromView = viewTasks
-			return m, m.fetchReview(*job.ParentJobID)
+			var followCmd tea.Cmd
+			m, followCmd = m.followSelectionChange(prevSelected)
+			cmd := m.dispatchReviewFetch(*job.ParentJobID)
+			return m, tea.Batch(followCmd, cmd)
 		}
 		return m, nil
 	case "?":

--- a/cmd/roborev/tui/handlers_msg.go
+++ b/cmd/roborev/tui/handlers_msg.go
@@ -283,9 +283,12 @@ func (m model) handleJobsMsg(msg jobsMsg) (tea.Model, tea.Cmd) {
 					cmd := m.dispatchReviewFetch(job.ID)
 					return m, tea.Batch(navFollowCmd, cmd)
 				case storage.JobStatusFailed:
-					m.currentBranch = ""
-					m.currentResponses = nil
-					m.currentReview = synthesizeFailedReview(&job, m.currentReview)
+					// Shared synthesized acceptance: also loads persisted
+					// comments, which no review fetch can carry for a
+					// row-less review. Folded into navFollowCmd so the
+					// arm's fall-through bookkeeping below still runs.
+					commentsCmd := m.acceptSynthesizedFailure(job.ID, synthesizeFailedReview(&job, m.currentReview))
+					navFollowCmd = tea.Batch(navFollowCmd, commentsCmd)
 				}
 			}
 		case viewKindPrompt:
@@ -1961,6 +1964,27 @@ func (m model) handleRerunResultMsg(
 			3*time.Second, origin,
 		)
 	}
+	return m, nil
+}
+
+// handleFailedCommentsMsg applies persisted comments fetched for a
+// synthesized failed-job review (see failedCommentsMsg). Accepted only
+// while that job's synthetic review is still the loaded, selected content:
+// a persisted review's responses arrive with its own epoch-ordered fetch
+// and must not be stomped by this side channel, and a response for a job
+// the user has navigated away from is simply stale.
+func (m model) handleFailedCommentsMsg(msg failedCommentsMsg) (tea.Model, tea.Cmd) {
+	if m.currentReview == nil || m.currentReview.JobID != msg.jobID ||
+		m.currentReview.ID != 0 || m.selectedJobID != msg.jobID {
+		return m, nil
+	}
+	if msg.err != nil {
+		// Comments are additive context on a failure review; a failed
+		// load keeps the review itself fully usable, so no error surface
+		// beyond leaving the existing (possibly locally-appended) state.
+		return m, nil
+	}
+	m.currentResponses = msg.responses
 	return m, nil
 }
 

--- a/cmd/roborev/tui/handlers_msg.go
+++ b/cmd/roborev/tui/handlers_msg.go
@@ -1975,6 +1975,25 @@ func (m model) handleCommentResultMsg(
 			m.commentText = ""
 			m.commentJobID = 0
 		}
+		// A synthesized failed-job review has no persisted review row
+		// (ID == 0): the refresh fetch below would 404 against
+		// /api/review and the just-created comment would never appear.
+		// The daemon stored the comment keyed by the job, so append what
+		// was posted directly; a later real review fetch (e.g. after a
+		// rerun completes) supersedes this local copy with server state.
+		// No selection gate needed: unlike the fetch branches below, a
+		// local append advances no ordering epoch, so it cannot supersede
+		// anything.
+		if m.currentReview != nil && m.currentReview.JobID == msg.jobID &&
+			m.currentReview.ID == 0 {
+			m.currentResponses = append(m.currentResponses, storage.Response{
+				JobID:     &msg.jobID,
+				Responder: msg.responder,
+				Response:  msg.comment,
+				CreatedAt: time.Now(),
+			})
+			return m, nil
+		}
 		// splitActive() -- not the coarser m.layout == layoutSplit -- is
 		// the knob: it encodes "the split pane is actually rendering",
 		// including the tasks-origin exclusion. A tasks-origin review is

--- a/cmd/roborev/tui/handlers_msg.go
+++ b/cmd/roborev/tui/handlers_msg.go
@@ -86,6 +86,7 @@ func (m model) handleJobsMsg(msg jobsMsg) (tea.Model, tea.Cmd) {
 	}
 
 	// Selection management
+	normalizePrevSelected := m.selectedJobID
 	if m.selectedIsMember() {
 		// A panel member is selected. Members are side-fetched and absent
 		// from the parents-only m.jobs, so keep the id authoritative and
@@ -167,15 +168,90 @@ func (m model) handleJobsMsg(msg jobsMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	// The selection reassignments above (a selected job that vanished from
+	// the refreshed list, or became hidden by a filter) don't go through
+	// followSelectionChange -- splitReconcileDetail below is the authority
+	// for the detail pane's CONTENT on this path -- but the fix panel is
+	// keyed to a job rather than to content, so it needs the same treatment
+	// scheduleDetailFollow gives it on every other selection change.
+	// splitActive() rather than layout: a tasks-origin review renders
+	// full-screen with a selection that legitimately isn't the displayed
+	// job's, and stacked mode can show one job's review while the queue
+	// selection sits elsewhere.
+	if m.splitActive() {
+		m.closeFixPanelIfJobChanged()
+	} else if m.reviewFixPanelPending &&
+		m.selectedJobID != normalizePrevSelected &&
+		m.fixPromptJobID == normalizePrevSelected {
+		// Outside split only the PENDING half of the fix intent is
+		// selection-bound: F was pressed with the selection on the intent's
+		// job and no review on screen yet, so a normalization that moves the
+		// selection off it abandons the request exactly like the
+		// pending-open disarm below (same keying, same rule). An OPEN panel
+		// is different outside split -- it is bound to the review displayed
+		// full-screen, whose viewReview branch above re-syncs the selection
+		// to it -- so it is deliberately left alone here.
+		m.closeFixPanel()
+	}
+	// The pending-open intent gets the same treatment. Waiting for the
+	// reactive clear (a message for the old job arriving with a
+	// mismatched jobID) is not enough: when nothing is in flight for the
+	// old job, nothing arrives, the intent waits for the selection to
+	// come back, and the next response for that job -- typically
+	// reconcile's follow fetch after a later refresh reselects it --
+	// consumes it and opens the review unbidden.
+	//
+	// The abandonment rule, stated once: ANY selection change abandons an
+	// intent bound to the job it moves off, whoever causes it -- user
+	// navigation (followSelectionChange), a jobs refresh normalizing the
+	// selection (here), a rollback, or the control socket. Keyed on the
+	// intent's own job (normalizePrevSelected) so it cannot touch an
+	// intent armed for a job the selection never sat on, and not gated on
+	// layout -- an intent is a request to open a review, not a pane, and
+	// a stacked queue Enter arms it identically.
+	if m.pendingReviewOpenJobID != 0 &&
+		m.selectedJobID != normalizePrevSelected &&
+		m.pendingReviewOpenJobID == normalizePrevSelected {
+		m.disarmPendingReviewOpen()
+	}
+	// ABANDONMENT bumper (see detailFollowGen's contract, tui.go): the
+	// disarms above make an abandoned intent unservable, but an armed-era
+	// ORDINARY dispatch is dangerous even with no intent left -- if the
+	// user is still on its dispatch origin view when it lands gen-fresh,
+	// openReviewView switches views with no fresh request. A refresh
+	// normalization that moves the selection is the same abandonment
+	// event as user navigation, so it dooms in-flight dispatches the same
+	// way. A refresh that leaves the selection in place bumps nothing.
+	if m.selectedJobID != normalizePrevSelected {
+		m.detailFollowGen++
+		// Same abandonment event, same request-scoped state: doom an
+		// in-flight prompt response and release the reconcile suppression
+		// slot for the abandoned era. See
+		// abandonInFlightSelectionRequests (layout.go).
+		m.abandonInFlightSelectionRequests()
+	}
+
 	// Auto-paginate when hide-closed hides too many jobs
 	if m.currentView == viewQueue &&
 		m.hideClosed &&
 		m.canPaginate() &&
 		len(m.getVisibleJobs()) < m.queueVisibleRows() {
 		m.loadingMore = true
-		return m, m.fetchMoreJobs()
+		cmds := []tea.Cmd{m.fetchMoreJobs()}
+		var reconcileCmd tea.Cmd
+		m, reconcileCmd = m.splitReconcileDetail()
+		if reconcileCmd != nil {
+			cmds = append(cmds, reconcileCmd)
+		}
+		return m, tea.Batch(cmds...)
 	}
 
+	// Carries the review and prompt arms' detail-follow command out of the
+	// switch below: unlike the log arm, those arms' non-Done branches fall
+	// through to this function's shared tail (splitReconcileDetail and the
+	// SSE/panel refreshes), so the command has to be batched there rather
+	// than returned early.
+	var navFollowCmd tea.Cmd
 	// Auto-navigate after pagination triggered from review/prompt view
 	if msg.append && m.paginateNav != 0 && m.currentView == m.paginateNav {
 		nav := m.paginateNav
@@ -184,31 +260,60 @@ func (m model) handleJobsMsg(msg jobsMsg) (tea.Model, tea.Cmd) {
 		case viewReview:
 			nextIdx := m.stepVisibleJobIndex(1, eligibleReviewRow)
 			if nextIdx >= 0 {
+				// Same shape as stepReviewNav (handlers.go): the branches
+				// below replace currentReview for the new job, so the
+				// selection change must go through the shared transition
+				// (dropping the old job's splitDetailErr and pending
+				// intents). This jump changes the DISPLAYED review, so
+				// outside split a panel bound to the previous job -- open
+				// or pending -- must also close; followSelectionChange
+				// only closes the pending half there, hence the explicit
+				// close below.
+				prevSelected := m.selectedJobID
 				m.selectedIdx = nextIdx
 				m.updateSelectedJobID()
 				m.reviewScroll = 0
 				job := m.jobs[nextIdx]
+				m, navFollowCmd = m.followSelectionChange(prevSelected)
+				if m.layout != layoutSplit {
+					m.closeFixPanelIfJobChanged()
+				}
 				switch job.Status {
 				case storage.JobStatusDone:
-					return m, m.fetchReview(job.ID)
+					cmd := m.dispatchReviewFetch(job.ID)
+					return m, tea.Batch(navFollowCmd, cmd)
 				case storage.JobStatusFailed:
 					m.currentBranch = ""
-					m.currentReview = &storage.Review{
-						Agent:  job.Agent,
-						Output: "Job failed:\n\n" + job.Error,
-						Job:    &job,
-					}
+					m.currentResponses = nil
+					m.currentReview = synthesizeFailedReview(&job, m.currentReview)
 				}
 			}
 		case viewKindPrompt:
 			nextIdx := m.stepVisibleJobIndex(1, eligiblePromptRow)
 			if nextIdx >= 0 {
+				// Same shape as stepPromptNav (handlers.go): this arm
+				// resumes prompt-view content nav past the previously
+				// loaded page, and eligiblePromptRow admits running/queued
+				// jobs, so the selection change needs the shared follow
+				// transition (stop the old tail, drop splitDetailErr,
+				// start the new job's) -- this early return skips the
+				// splitReconcileDetail call at the bottom of the function.
+				prevSelected := m.selectedJobID
 				m.selectedIdx = nextIdx
 				m.updateSelectedJobID()
 				m.promptScroll = 0
 				job := m.jobs[nextIdx]
+				m, navFollowCmd = m.followSelectionChange(prevSelected)
+				// This jump changes the displayed content, so outside
+				// split a panel bound to the previous job -- open or
+				// pending -- must close; followSelectionChange only
+				// closes the pending half there.
+				if m.layout != layoutSplit {
+					m.closeFixPanelIfJobChanged()
+				}
 				if job.Status == storage.JobStatusDone {
-					return m, m.fetchReviewForPrompt(job.ID)
+					promptCmd := m.dispatchPromptFetch(job.ID)
+					return m, tea.Batch(navFollowCmd, promptCmd)
 				} else if (job.Status == storage.JobStatusRunning || job.Status == storage.JobStatusQueued) && job.Prompt != "" {
 					m.currentReview = &storage.Review{
 						Agent:  job.Agent,
@@ -220,12 +325,23 @@ func (m model) handleJobsMsg(msg jobsMsg) (tea.Model, tea.Cmd) {
 		case viewLog:
 			nextIdx := m.stepVisibleJobIndex(1, eligibleLogRow)
 			if nextIdx >= 0 {
+				// Same gap as stepLogNav (handlers.go): this auto-navigates
+				// selectedJobID after a pagination fetch resumes log-view
+				// content nav past the previously loaded page, but the log
+				// view never touches currentReview, so the split detail pane
+				// needs its own explicit follow here too -- this early
+				// return skips the splitReconcileDetail call at the bottom
+				// of this function entirely.
+				prevSelected := m.selectedJobID
 				m.selectedIdx = nextIdx
 				m.updateSelectedJobID()
 				job := m.jobs[nextIdx]
-				return m.openLogView(
+				var followCmd tea.Cmd
+				m, followCmd = m.followSelectionChange(prevSelected)
+				logModel, logCmd := m.openLogView(
 					job.ID, job.Status, m.logFromView,
 				)
+				return logModel, tea.Batch(followCmd, logCmd)
 			}
 		}
 	} else if !msg.append && !m.loadingMore {
@@ -233,8 +349,16 @@ func (m model) handleJobsMsg(msg jobsMsg) (tea.Model, tea.Cmd) {
 	}
 
 	cmds := []tea.Cmd{m.consumeSSEPendingRefresh()}
+	if navFollowCmd != nil {
+		cmds = append(cmds, navFollowCmd)
+	}
 	for _, uuid := range m.staleExpandedPanelRuns() {
 		cmds = append(cmds, m.fetchPanelMembers(uuid))
+	}
+	var reconcileCmd tea.Cmd
+	m, reconcileCmd = m.splitReconcileDetail()
+	if reconcileCmd != nil {
+		cmds = append(cmds, reconcileCmd)
 	}
 	return m, tea.Batch(cmds...)
 }
@@ -279,6 +403,17 @@ func (m model) handlePanelMembersMsg(msg panelMembersMsg) (tea.Model, tea.Cmd) {
 	}
 	m.panelMembers[msg.runUUID] = msg.members
 	m.queueColGen++
+	// Panel members are absent from the main jobs response, so THIS message
+	// is the only carrier of a selected member's status transition -- the
+	// jobs-refresh path that normally follows a transition with
+	// splitReconcileDetail never sees it. Reconcile here when the selection
+	// belongs to this run, or a member going queued->running/done leaves
+	// the detail pane stalled (no log tail, no review fetch) until an
+	// unrelated SSE event or the fallback poll. Safe for a selected
+	// synthesis PARENT too: reconcile is idempotent against m.jobs state.
+	if job, ok := m.selectedJob(); ok && job.PanelRunUUID == msg.runUUID {
+		return m.splitReconcileDetail()
+	}
 	return m, nil
 }
 
@@ -555,41 +690,737 @@ func (m model) handleFixJobsMsg(
 	return m, nil
 }
 
-// handleReviewMsg processes review fetch results.
-func (m model) handleReviewMsg(
-	msg reviewMsg,
-) (tea.Model, tea.Cmd) {
-	if msg.jobID != m.selectedJobID {
-		// Stale fetch -- clear pending fix panel if it was
-		// for this (now-discarded) review.
-		if m.reviewFixPanelPending &&
-			m.fixPromptJobID == msg.jobID {
-			m.reviewFixPanelPending = false
-			m.fixPromptJobID = 0
-		}
-		return m, nil
+// releaseReconcileFetch clears splitReconcileDetail's duplicate-dispatch
+// suppression slot when the response to the dispatch that set it arrives,
+// identified by that dispatch's own fetch epoch. Called
+// unconditionally at the top of both review-response handlers, BEFORE any
+// staleness check, because a response for a given dispatch arrives exactly
+// once: if the arrival of the outstanding dispatch's own response didn't
+// release the slot, nothing else would.
+//
+// Keyed on the epoch, NOT on jobID: an older response for the same job
+// (e.g. a selection-follow fetch dispatched before reconcile's) would
+// otherwise unlock the gate for a dispatch that is still in flight, the
+// next jobs refresh would dispatch again and supersede it, and with
+// fetches slower than the refresh interval nothing would ever land --
+// suppression exists for exactly that liveness property, so releasing it
+// on anything but the matching response defeats its only purpose. A real
+// epoch value is never 0 and reconcileFetchSeq is 0 exactly when nothing
+// is outstanding, so a 0-stamped message can never match. See
+// reconcileFetchSeq's doc comment (tui.go) for the stuck-forever
+// derivation this ordering satisfies.
+func (m *model) releaseReconcileFetch(fetchSeq uint64) {
+	if fetchSeq != 0 && m.reconcileFetchSeq == fetchSeq {
+		m.reconcileFetchJobID = 0
+		m.reconcileFetchSeq = 0
 	}
+}
+
+// acceptReview applies a review response that has been confirmed FRESHEST
+// (its fetchSeq still equals m.reviewFetchSeq) to the displayed content.
+// This is the single acceptance point for every dispatcher, follow or not,
+// so anything that must happen exactly when currentReview is replaced
+// lives here and cannot drift from the ordering logic.
+func (m *model) acceptReview(msg reviewMsg) {
 	m.consecutiveErrors = 0
 	m.currentReview = msg.review
 	m.currentResponses = msg.responses
 	m.currentBranch = msg.branchName
-	m.currentView = viewReview
 	m.reviewScroll = 0
-	if m.reviewFixPanelPending &&
-		m.fixPromptJobID == msg.review.JobID {
+	// The review is now ACCEPTED -- clear here, not at dispatch
+	// (splitReconcileDetail), so a fetch that instead FAILS
+	// (handleReviewFollowErrMsg) leaves the observation outstanding and a
+	// later reconcile pass retries. Scoped to the accepted job: an
+	// observation for a DIFFERENT job's loaded review must survive this
+	// acceptance. Within the same job the clear still wipes an
+	// observation made AFTER dispatch (the job going running again while
+	// this fetch was in flight); if that happened, this response may be
+	// stale relative to the job's CURRENT state, and a later jobs
+	// refresh's own FinishedAt/Output comparison is what would eventually
+	// catch that, same as for any other staleness. See
+	// paneReviewSeenNonTerminalJob's doc comment (tui.go).
+	if m.paneReviewSeenNonTerminalJob == msg.jobID {
+		m.paneReviewSeenNonTerminalJob = 0
+	}
+	// The inline fix panel is scoped to the job it was opened for
+	// (fixPromptJobID). The detail pane now shows a DIFFERENT job, so a
+	// panel left open (or pending) over it would submit a fix against the
+	// job the user is no longer looking at -- the same hazard
+	// scheduleDetailFollow closes for selection changes, closed here for
+	// the other half of the split's two-speed model: the CONTENT changing
+	// under a panel whose job didn't. Living on the acceptance path means
+	// it can never drift from the ordering rule that decides which
+	// content wins. The queue-'F' flow is unaffected: it sets
+	// fixPromptJobID to the job it fetches, so the arriving review is
+	// that same job and the panel is left alone (and opened just below).
+	if (m.reviewFixPanelOpen || m.reviewFixPanelPending) && m.fixPromptJobID != msg.jobID {
+		m.closeFixPanel()
+	}
+	// Consume a queue-initiated pending fix panel ('F' from the queue sets
+	// reviewFixPanelPending and dispatches a fetch for that job). Done on
+	// the shared acceptance path rather than only for non-follow
+	// responses, so whichever dispatch's response actually lands first for
+	// that job opens the panel -- a follow fetch overtaking the 'F' fetch
+	// no longer strands the pending flag.
+	//
+	// Opening the panel WITHOUT the view/focus switch produces a panel the
+	// keyboard cannot reach: handleKeyMsg routes to the panel only when
+	// currentView == viewReview, and normalizeSplitState pins focus =
+	// focusList while currentView is viewQueue -- so the pane would render
+	// a panel that LOOKS focused while every keystroke went to the queue
+	// ('f' opening the filter modal, 'a' closing the review, 'q' quitting,
+	// ... instead of typing the fix prompt). That was only reachable once
+	// a FOLLOW response could consume the pending flag (an ordinary
+	// response performs the switch itself just below), which is exactly
+	// what moving this consume onto the shared path enabled: split, list
+	// focus, 'F' on a job whose review isn't loaded, and a jobs refresh
+	// whose reconcile fetch overtakes the 'F' fetch.
+	//
+	// A guarded switch, not an unconditional one: the pending flag IS
+	// explicit user intent to open the panel, but that intent doesn't
+	// override the guard's actual purpose, which is about WHEN the intent
+	// is served -- a user who pressed 'F' and then opened the comment
+	// editor while the fetch was in flight is mid-typing in a view they
+	// chose afterward, and yanking them into the review view is precisely
+	// the surprise the guard exists to prevent (the transient-view case
+	// has its own named test).
+	//
+	// Guarded on the origin of the request that ARMED the flag
+	// (fixPromptOrigin), NOT on msg.dispatchedFrom: the accepting
+	// response need not be the 'F' fetch at all -- any later dispatcher's
+	// response can supersede it and consume the flag -- so the armed
+	// origin is the only value that describes the user's actual request
+	// no matter which dispatcher's response lands first.
+	// jobID-only matching is sound here (no fixPromptSeq check needed,
+	// unlike the two stale-rejection branches below): acceptReview only
+	// ever runs for a message whose fetchSeq equals the CURRENT
+	// m.reviewFetchSeq (handleReviewMsg's caller already established that
+	// by not taking the superseded branch), and fixPromptSeq can never
+	// exceed whatever was true of reviewFetchSeq at its own arm time -- so
+	// it is provably <= msg.fetchSeq here. See fixPromptSeq's doc comment,
+	// tui.go.
+	if m.reviewFixPanelPending && m.fixPromptJobID == msg.jobID {
+		origin := m.fixPromptOrigin
 		m.reviewFixPanelPending = false
 		m.reviewFixPanelOpen = true
 		m.reviewFixPanelFocused = true
+		m.fixPromptOrigin = 0
+		m.fixPromptFollowRetried = false
+		m.fixPromptSeq = 0
+		m.openReviewViewFrom(origin)
+	}
+	// The plain "open the review view" intent -- pendingReviewOpenJobID
+	// generalizes the pattern just above to every ordinary dispatch, not
+	// only the queue-'F' fix-panel one. Consumed on the shared acceptance
+	// path regardless of msg.follow, for the same reason: whichever
+	// dispatcher's response lands this job's content FIRST performs the
+	// transition. A follow response never switches views on its own (see
+	// the early return just below), so without this consume a follow that
+	// beat the superseded ordinary response would leave nothing to ever
+	// open the review. See pendingReviewOpenJobID's doc comment, tui.go.
+	// Redundant (harmless) with the fix-panel branch above when both are
+	// armed for the same job -- openReviewViewFrom is idempotent.
+	// jobID-only matching is sound here for the same reason as above
+	// (pendingReviewOpenSeq is provably <= msg.fetchSeq at this point).
+	if m.pendingReviewOpenJobID == msg.jobID {
+		origin := m.pendingReviewOpenOrigin
+		m.pendingReviewOpenJobID = 0
+		m.pendingReviewOpenOrigin = 0
+		m.pendingReviewOpenSeq = 0
+		m.openReviewViewFrom(origin)
+	}
+}
+
+// openReviewViewFrom performs the guarded switch into the review view for
+// a request that originated on view `origin`. Split out from openReviewView
+// so the pending fix-panel consume can pass the origin of the request that
+// ARMED it rather than of whatever response happens to serve it -- see
+// fixPromptOrigin's doc comment (tui.go).
+func (m *model) openReviewViewFrom(origin viewKind) {
+	if m.currentView == origin || m.currentView == viewReview {
+		m.currentView = viewReview
+		if m.layout == layoutSplit {
+			m.focus = focusDetail
+		}
+	}
+}
+
+// openReviewView performs the view switch an ORDINARY (non-follow) review
+// response carries: a view the user explicitly navigated to after the
+// fetch was dispatched -- e.g. Enter on a done job from the queue, then
+// quickly 'c' before the review lands -- must not be yanked into the
+// review view out from under the user. An allowlist of "queue-origin"
+// views (viewQueue/viewReview/viewTasks) is NOT sound here: viewQueue and
+// viewTasks are mutually reachable via 'T'/Esc while a fetch from EITHER
+// one is still in flight, so an allowlist would let a fetch dispatched
+// from the queue resolve into viewReview even after the user explicitly
+// switched to Tasks (and the mirror case, tasks -> queue). Instead,
+// compare against the fetch's true dispatch origin, carried on the message
+// itself (msg.dispatchedFrom, stamped by fetchReview from currentView at
+// command-creation time). m.reviewFromView is NOT that origin -- it is the
+// Esc RETURN target, and the two diverge exactly when the review view
+// dispatches its own fetch: arrow-key review nav runs with currentView ==
+// viewReview while reviewFromView still says viewQueue, so comparing
+// against it re-opened the review for a user who had already escaped back
+// to the queue. Only switch when the user is still on the exact origin
+// view, or already in viewReview.
+func (m *model) openReviewView(msg reviewMsg) {
+	m.openReviewViewFrom(msg.dispatchedFrom)
+}
+
+// reviewIntentRescuable reports whether a gen-stale rejection -- jobID
+// still equals m.selectedJobID, only detailFollowGen differs -- should be
+// treated as CURRENT instead of discarded: this message is still the
+// single freshest dispatch for the job (fetchSeq matches m.reviewFetchSeq,
+// so nothing newer has superseded it) AND a pending intent is genuinely
+// armed for it.
+//
+// Why the rescue exists: an incidental gen bump (maybeBootstrapDetail's
+// same-selection bootstrap on a layout toggle or resize) is not
+// abandonment, but its own debounced follow tick can be dropped (the
+// layout flips back before it fires) or can take a branch that dispatches
+// nothing -- leaving a bump with nothing behind it to ever serve a
+// still-armed intent. The response that WOULD have served it is this one;
+// discarding it would either silently drop an explicit open-review request
+// or leave the intent stranded for some much later, unrelated event to
+// "spring open" with whatever content loads then.
+//
+// The invariant that makes rescuing safe: any intent still armed when a
+// gen-mismatched response for its job arrives here is (a) still bound to
+// the currently-selected job (that is what put the message in the
+// gen-mismatch branch rather than the jobID-mismatch one), and (b) has had
+// no rerun of that job confirmed, THAT THIS TUI OBSERVED, since it was
+// armed -- enforced twice: handleRerunResultMsg disarms both intents
+// unconditionally on its own msg.jobID, and callers only reach this
+// function after the per-job attempt gate has already accepted the
+// message. "This TUI observed" is deliberate: a rerun triggered by the
+// CLI, another TUI instance, or the daemon produces no rerunResultMsg
+// here, so neither the disarm nor the attempt bump happens for it -- an
+// input boundary shared by every rerun-driven invalidation in this file.
+// Within that boundary, an intent still armed here has nothing this TUI
+// knows of that could have invalidated it, so serving it is correct.
+func (m model) reviewIntentRescuable(jobID int64, fetchSeq uint64) bool {
+	if fetchSeq != m.reviewFetchSeq {
+		return false
+	}
+	return (m.reviewFixPanelPending && m.fixPromptJobID == jobID) ||
+		m.pendingReviewOpenJobID == jobID
+}
+
+// handleReviewMsg processes review fetch results. Acceptance is gated on
+// ONE rule shared by every dispatcher: the response must still carry the
+// newest fetch epoch (msg.fetchSeq == m.reviewFetchSeq). See
+// m.reviewFetchSeq's doc comment (tui.go).
+func (m model) handleReviewMsg(
+	msg reviewMsg,
+) (tea.Model, tea.Cmd) {
+	m.releaseReconcileFetch(msg.fetchSeq)
+	// Three staleness reasons, three treatments. msg.jobID !=
+	// m.selectedJobID: the selection moved on since dispatch --
+	// unconditional abandonment, content and both pending intents are
+	// dropped below. msg.gen != m.detailFollowGen with the job unchanged:
+	// content is stale and rejected, but a gen bump alone does not mean
+	// the REQUEST was abandoned (an incidental same-job bootstrap bumps
+	// too) -- the one exception, reviewIntentRescuable, is documented on
+	// that function. msg.attempt != m.jobAttemptGen[msg.jobID]: a
+	// confirmed rerun superseded the ATTEMPT this response belongs to;
+	// its content must never resurrect over the rerun's own result, so
+	// this is unconditional, unrescuable, and needs no disarm here
+	// (handleRerunResultMsg disarmed inline, keyed on its own msg.jobID).
+	if msg.jobID != m.selectedJobID {
+		// The jobID mismatch alone proves abandonment:
+		// dispatchReviewFetch always sets the armed field and
+		// m.selectedJobID together, so a fresh re-arm of the SAME job can
+		// never leave the field pointing at a job the selection has since
+		// diverged from. The msg.fetchSeq >= <field>Seq conjunct is
+		// defense-in-depth for that unstated invariant across the
+		// dispatch call sites, not load-bearing.
+		if m.reviewFixPanelPending && m.fixPromptJobID == msg.jobID &&
+			msg.fetchSeq >= m.fixPromptSeq {
+			m.reviewFixPanelPending = false
+			m.fixPromptJobID = 0
+			m.fixPromptOrigin = 0
+			m.fixPromptFollowRetried = false
+			m.fixPromptSeq = 0
+		}
+		if m.pendingReviewOpenJobID == msg.jobID &&
+			msg.fetchSeq >= m.pendingReviewOpenSeq {
+			m.pendingReviewOpenJobID = 0
+			m.pendingReviewOpenOrigin = 0
+			m.pendingReviewOpenSeq = 0
+		}
+		return m, nil
+	}
+	if msg.attempt != m.jobAttemptGen[msg.jobID] {
+		// This response belongs to an ATTEMPT of this job that a
+		// confirmed rerun has since superseded. Dropped outright and
+		// unconditionally -- no rescue (that would serve content the user
+		// explicitly replaced) and nothing to disarm
+		// (handleRerunResultMsg disarmed both intents when it bumped, and
+		// any intent armed since carries the post-bump stamp). See
+		// m.jobAttemptGen's contract, clause 4 (tui.go), for why this
+		// sits after the jobID gate and before the gen gate.
+		return m, nil
+	}
+	if msg.gen != m.detailFollowGen {
+		// Ordinarily just stale, dropped (see the function-level comment
+		// above for why gen-mismatch-alone isn't abandonment). The one
+		// exception -- reviewIntentRescuable -- treats this response as
+		// CURRENT instead, falling through to the normal acceptance path
+		// below exactly as if gen had matched; see its doc comment for the
+		// full derivation.
+		if !m.reviewIntentRescuable(msg.jobID, msg.fetchSeq) {
+			return m, nil
+		}
+	}
+	if msg.fetchSeq != m.reviewFetchSeq {
+		// SUPERSEDED: a NEWER dispatch (from any call site, ordinary or
+		// follow) has since gone out or already landed, so this older
+		// response must not overwrite the fresher content -- the general
+		// form of "a just-submitted comment disappears when an older
+		// in-flight fetch lands after the comment refresh".
+		//
+		// reviewFixPanelPending is deliberately NOT cleared here (unlike
+		// the jobID/gen rejection above): the job and attempt are still
+		// current, only this particular request lost the race, and the
+		// newer response for the same job will consume the pending flag
+		// on the acceptance path.
+		//
+		// pendingReviewOpenJobID is left untouched for the same reason --
+		// see its doc comment (tui.go) -- EXCEPT when this fallback below
+		// actually performs the switch, in which case the intent it was
+		// tracking has now been served.
+		//
+		// The fallback fires ONLY while the matching intent is still ARMED
+		// (with the per-arm identity guard, so a stale message cannot serve
+		// a fresher re-arm). An unconditional content-present switch would
+		// REOPEN a review the user already left: a newer response consumes
+		// the intent and opens the view, the user presses esc back to the
+		// queue, and then this older response arrives -- content still
+		// loaded, jobID still matching -- and would yank them back in with
+		// no request outstanding. The armed intent is exactly the record of
+		// "an open is still owed"; once it is consumed, a late response owes
+		// nothing. The switch uses the INTENT's stored origin (the request
+		// that armed it), not this stale message's own dispatch origin.
+		//
+		// Content-present gating still matters within that: acceptReview's
+		// own consume normally serves the intent when a newer response
+		// lands, so what remains for this fallback is the race where the
+		// newer landing happened before this intent was armed, or content
+		// arrived while the intent's own dispatch was superseded -- either
+		// way it must never switch to an empty or foreign review.
+		if !msg.follow && m.currentReview != nil && m.currentReview.JobID == msg.jobID &&
+			m.pendingReviewOpenJobID == msg.jobID &&
+			msg.fetchSeq >= m.pendingReviewOpenSeq {
+			origin := m.pendingReviewOpenOrigin
+			m.pendingReviewOpenJobID = 0
+			m.pendingReviewOpenOrigin = 0
+			m.pendingReviewOpenSeq = 0
+			m.openReviewViewFrom(origin)
+		}
+		return m, nil
+	}
+	m.acceptReview(msg)
+	if msg.follow {
+		// A follow response updates the pane's content only -- no view
+		// switch, no focus steal.
+		return m, nil
+	}
+	m.openReviewView(msg)
+	return m, nil
+}
+
+// handleReviewFollowErrMsg processes a failed split-view follow fetch
+// (fetchReviewFollow). Four kinds of stale response are dropped silently
+// rather than recorded in m.splitDetailErr: a stale jobID (the selection
+// has since moved on), a stale attempt (a rerun of this job confirmed
+// since the fetch was dispatched -- never rescuable), a stale gen
+// (another selection change since dispatch) UNLESS reviewIntentRescuable
+// says nothing else is left to serve a still-armed intent, and a
+// superseded fetchSeq (a newer review fetch, from any dispatcher, has
+// since gone out or already landed). Anything else is recorded in
+// m.splitDetailErr so renderDetailPane can surface it instead of leaving
+// the "Loading review..." placeholder stuck forever.
+func (m model) handleReviewFollowErrMsg(msg reviewFollowErrMsg) (tea.Model, tea.Cmd) {
+	m.releaseReconcileFetch(msg.fetchSeq)
+	// jobID and gen are checked together, mirroring handleReviewMsg's
+	// success-path rejection exactly: a stale error from a fetch
+	// dispatched for a job the user has since navigated away from (jobID
+	// mismatch) or invalidated by a later selection change (gen mismatch)
+	// must not clobber splitDetailErr for whatever is currently selected.
+	if msg.jobID != m.selectedJobID {
+		// Mirrors handleReviewMsg's matching branch: clearing either
+		// pending intent requires the JOB to have genuinely moved on.
+		// The msg.fetchSeq >= <field>Seq conjunct is defense-in-depth,
+		// not load-bearing, same reasoning as there.
+		if m.reviewFixPanelPending && m.fixPromptJobID == msg.jobID &&
+			msg.fetchSeq >= m.fixPromptSeq {
+			m.reviewFixPanelPending = false
+			m.fixPromptJobID = 0
+			m.fixPromptOrigin = 0
+			m.fixPromptFollowRetried = false
+			m.fixPromptSeq = 0
+		}
+		if m.pendingReviewOpenJobID == msg.jobID &&
+			msg.fetchSeq >= m.pendingReviewOpenSeq {
+			m.pendingReviewOpenJobID = 0
+			m.pendingReviewOpenOrigin = 0
+			m.pendingReviewOpenSeq = 0
+		}
+		return m, nil
+	}
+	if msg.attempt != m.jobAttemptGen[msg.jobID] {
+		// Same attempt gate as handleReviewMsg: a FAILURE
+		// belonging to a superseded attempt must not reach splitDetailErr
+		// or resolve an intent, for the same reasons its success
+		// counterpart must not reach currentReview.
+		return m, nil
+	}
+	if msg.gen != m.detailFollowGen {
+		// Same rescue reasoning as handleReviewMsg: a gen-mismatch-only
+		// rejection (job unchanged) is ordinarily just dropped, UNLESS
+		// reviewIntentRescuable says nothing else is left to serve a
+		// still-armed intent -- in which case this FAILURE is treated as
+		// current instead of silently discarded,
+		// falling through to record it in splitDetailErr and resolve
+		// whichever intent is armed (retry, for the fix panel; clear +
+		// flash, for the plain open-review intent) exactly as the
+		// un-rescued "current failure" path below already does.
+		if !m.reviewIntentRescuable(msg.jobID, msg.fetchSeq) {
+			return m, nil
+		}
+	}
+	// Same ordering rule as the success path: a fetchSeq mismatch means a
+	// NEWER dispatch has since gone out or already landed, and this is an
+	// older, now-superseded error arriving late. Drop it without touching
+	// splitDetailErr, which the newer request/response already owns.
+	//
+	// reviewFixPanelPending is deliberately left untouched here too, for
+	// the same reason handleReviewMsg's mirror-image branch leaves it
+	// alone on a superseded SUCCESS: the job/attempt is still current,
+	// only this particular response lost the race, and the newer
+	// dispatch's own eventual response -- success or (per the retry
+	// below) failure -- is what resolves the pending flag.
+	if msg.fetchSeq != m.reviewFetchSeq {
+		return m, nil
+	}
+	m.splitDetailErr = msg.err
+	// Deliberately does NOT clear paneReviewSeenNonTerminal: a fresh
+	// attempt was genuinely observed and this fetch failed to pick it up,
+	// so the next reconcile pass must still retry (see that field's doc
+	// comment).
+
+	// A pending queue-'F' request armed against this same
+	// job normally gets served by acceptReview when SOME review response
+	// for the job lands -- but reviewFixPanelPending is deliberately left
+	// armed (just above, and in handleReviewMsg's fetchSeq-superseded
+	// branch) whenever a NEWER dispatch has superseded an older one, on
+	// the assumption that the newer dispatch will eventually resolve and
+	// consume it. A follow fetch FAILING is that newer dispatch resolving
+	// -- as an outcome acceptReview's success-only consume never sees. Left
+	// unhandled, an already-loaded (merely stale) review for this job makes
+	// splitReconcileDetail's Done-branch idempotency check skip re-fetching
+	// entirely, so nothing else would ever try again: the panel stays armed
+	// with nothing in flight to serve it, and the user's deliberate 'F' is
+	// silently swallowed.
+	//
+	// The user's 'F' was a deliberate action and the review is very likely
+	// still fetchable (this is far more often a transient hiccup than a
+	// permanent failure), so retry once -- automatically, since the user
+	// already asked for this by pressing 'F' and has no simpler way to ask
+	// again while the panel isn't even open yet -- before giving up.
+	// Bounded to exactly one retry so a persistently failing fetch can't
+	// loop forever; the second failure clears the pending flag with
+	// user-visible feedback instead of leaving it silently stranded.
+	if m.reviewFixPanelPending && m.fixPromptJobID == msg.jobID {
+		if !m.fixPromptFollowRetried {
+			m.fixPromptFollowRetried = true
+			cmd := m.dispatchReviewFollow(msg.jobID)
+			// Re-stamp the identity at the RETRY's own dispatch,
+			// mirroring the arm site (handlers_review.go). Otherwise
+			// fixPromptSeq keeps pointing at the original (now-dead)
+			// dispatch, and that dispatch's own long-in-flight, gen-stale
+			// response would pass the `msg.fetchSeq >= fixPromptSeq`
+			// guard and wrongly clear the retry still in flight.
+			m.fixPromptSeq = m.reviewFetchSeq
+			return m, cmd
+		}
+		m.reviewFixPanelPending = false
+		m.fixPromptJobID = 0
+		m.fixPromptOrigin = 0
+		m.fixPromptFollowRetried = false
+		m.fixPromptSeq = 0
+		m.setWarningFlash(
+			fmt.Sprintf("Could not load review to fix job #%d: %v", msg.jobID, msg.err),
+			3*time.Second, m.currentView,
+		)
+		// The 'F' fetch is an ordinary dispatch, so dispatchReviewFetch
+		// armed the plain open intent alongside this panel. The panel's
+		// terminal failure resolves BOTH: left armed, the block below
+		// would start its own retry chain against a review that just
+		// failed twice, and a late success would pop the review open
+		// after the user was already told the fix couldn't load.
+		if m.pendingReviewOpenJobID == msg.jobID {
+			m.pendingReviewOpenJobID = 0
+			m.pendingReviewOpenOrigin = 0
+			m.pendingReviewOpenSeq = 0
+		}
+	}
+	// The plain "open the review" intent needs the same handling as the
+	// fix panel above: a follow failure resolves the freshest dispatch for
+	// this job, and left unhandled nothing would EVER resolve the intent --
+	// reconcile cannot re-arm it on its own, because splitReconcileDetail
+	// dispatches through dispatchReviewFollow, the one dispatcher that
+	// deliberately never touches pendingReviewOpen* (a follow is not a
+	// view-opening request). A later successful follow would populate the
+	// pane but never switch the view, leaving the user's explicit
+	// navigation permanently swallowed.
+	//
+	// Clearing OUTRIGHT here is wrong, though: the intent's own ORIGINATING
+	// ordinary dispatch may still be in flight, and even when it later
+	// SUCCEEDS its response arrives fetchSeq-superseded -- and with no
+	// content loaded (precisely because this follow failed), the
+	// superseded branch cannot serve the open. The user's deliberate
+	// navigation would be swallowed despite its own request succeeding. So
+	// retry once, exactly like the fix panel above: a fresh follow whose
+	// success serves the intent via acceptReview's consume (which runs
+	// regardless of msg.follow). Bounded by pendingReviewOpenRetried
+	// (reset at each arm) so a persistently failing fetch can't loop; the
+	// second failure clears with user-visible feedback.
+	//
+	// jobID-only matching (no fetchSeq guard needed) for the same reason as
+	// acceptReview's consume: this code only runs for a message that is
+	// current (passed both the jobID/gen and fetchSeq staleness checks
+	// above), so pendingReviewOpenSeq is provably <= msg.fetchSeq here --
+	// see pendingReviewOpenSeq's doc comment, tui.go.
+	if m.pendingReviewOpenJobID == msg.jobID {
+		if !m.pendingReviewOpenRetried {
+			m.pendingReviewOpenRetried = true
+			cmd := m.dispatchReviewFollow(msg.jobID)
+			// Re-stamp the identity at the RETRY's own dispatch, mirroring
+			// the fix panel's re-stamp above: otherwise pendingReviewOpenSeq
+			// keeps pointing at the original (now-dead) dispatch, and that
+			// dispatch's own long-in-flight, gen-stale response would pass
+			// the `msg.fetchSeq >= pendingReviewOpenSeq` guard and wrongly
+			// clear the retry still in flight.
+			m.pendingReviewOpenSeq = m.reviewFetchSeq
+			return m, cmd
+		}
+		// Terminal: clear AND surface a warning flash targeted at
+		// pendingReviewOpenOrigin (the view the request was issued FROM,
+		// e.g. the tasks view for its 'P' key) -- not m.currentView,
+		// because the user may be elsewhere by now, and not splitDetailErr,
+		// because a tasks-origin request never renders the split pane. The
+		// origin view is the one feedback channel guaranteed visible if the
+		// user is still on (or returns to) the view where they made the
+		// request.
+		origin := m.pendingReviewOpenOrigin
+		m.pendingReviewOpenJobID = 0
+		m.pendingReviewOpenOrigin = 0
+		m.pendingReviewOpenSeq = 0
+		m.setWarningFlash(
+			fmt.Sprintf("Could not open review for job #%d: %v", msg.jobID, msg.err),
+			3*time.Second, origin,
+		)
 	}
 	return m, nil
 }
 
+// handleReviewErrMsg processes a failed ORDINARY (non-follow) review fetch
+// (fetchReview's reviewErrMsg). Unlike a gen-stale rejection (the request
+// may still be served by a later follow) or a fetchSeq-superseded response
+// (a newer dispatch is already in flight to serve it), a fetch that itself
+// FAILS is a first-party signal that THIS attempt cannot be served --
+// nothing is left in flight for it. Typed with jobID/gen/seq so the
+// staleness gates and the pending intents can be resolved; a generic,
+// jobID-less error could not be tied back to either intent, leaving both
+// silently armed indefinitely.
+//
+// Same staleness shape as handleReviewMsg/handleReviewFollowErrMsg
+// (jobID rejection, attempt gate, gen rejection with rescue, then
+// fetchSeq-superseded): a gen-mismatch-only rejection (job unchanged)
+// ordinarily clears nothing -- the failure belongs to an attempt the
+// model has moved past for CONTENT purposes (so m.err/reconnect-tracking
+// below must not see it), but the underlying request may still be served
+// by whatever caused the bump -- UNLESS reviewIntentRescuable says
+// nothing else is left to serve a still-armed intent.
+//
+// Deliberate asymmetry with handleReviewFollowErrMsg: that handler retries
+// once before giving up, this one does not -- there is no
+// separately-typed content to protect by retrying (an ordinary fetch's
+// only two possible outcomes for the caller are "opened" or "didn't"), and
+// a pending fix panel armed alongside pendingReviewOpenJobID (as
+// handleFixKey's queue-'F' path always arms both together) still gets
+// visible feedback for free, riding on the flash below.
+func (m model) handleReviewErrMsg(msg reviewErrMsg) (tea.Model, tea.Cmd) {
+	if msg.jobID != m.selectedJobID {
+		// Same defense-in-depth conjunct as handleReviewMsg's matching
+		// branch.
+		if m.reviewFixPanelPending && m.fixPromptJobID == msg.jobID &&
+			msg.fetchSeq >= m.fixPromptSeq {
+			m.closeFixPanel()
+		}
+		if m.pendingReviewOpenJobID == msg.jobID &&
+			msg.fetchSeq >= m.pendingReviewOpenSeq {
+			m.pendingReviewOpenJobID = 0
+			m.pendingReviewOpenOrigin = 0
+			m.pendingReviewOpenSeq = 0
+		}
+		return m, nil
+	}
+	if msg.attempt != m.jobAttemptGen[msg.jobID] {
+		// Same attempt gate as the other two handlers.
+		return m, nil
+	}
+	if msg.gen != m.detailFollowGen {
+		// Same rescue reasoning as handleReviewMsg/handleReviewFollowErrMsg.
+		if !m.reviewIntentRescuable(msg.jobID, msg.fetchSeq) {
+			return m, nil
+		}
+	}
+	if msg.fetchSeq != m.reviewFetchSeq {
+		// SUPERSEDED: a newer dispatch (from any call site, ordinary or
+		// follow) has since gone out or already landed for this job -- its
+		// own eventual response, success or failure, is what resolves
+		// either intent. Leave both armed.
+		return m, nil
+	}
+
+	// Current, un-superseded, genuine failure. Mirrors the generic
+	// errMsg handling (handleErrMsg) so the global error field and
+	// connection-error/reconnect detection still apply even though this
+	// failure is typed.
+	m.err = msg.err
+	reconnectCmd := m.handleConnectionError(msg.err)
+
+	// The pending fix panel ('F') is resolved the same way a selection
+	// change resolves it (closeFixPanel) -- this job's own dispatch is
+	// what would have opened it, and it just failed outright.
+	if m.reviewFixPanelPending && m.fixPromptJobID == msg.jobID {
+		m.closeFixPanel()
+	}
+	// No silent clear for the plain "open the review" intent, matching
+	// handleReviewFollowErrMsg's own resolve-on-failure treatment (see
+	// its doc comment): clear AND flash on pendingReviewOpenOrigin, the
+	// one feedback channel guaranteed visible regardless of where the
+	// user has navigated to since making the request.
+	if m.pendingReviewOpenJobID == msg.jobID {
+		origin := m.pendingReviewOpenOrigin
+		m.pendingReviewOpenJobID = 0
+		m.pendingReviewOpenOrigin = 0
+		m.pendingReviewOpenSeq = 0
+		m.setWarningFlash(
+			fmt.Sprintf("Could not open review for job #%d: %v", msg.jobID, msg.err),
+			3*time.Second, origin,
+		)
+	}
+	return m, reconnectCmd
+}
+
 // handlePromptMsg processes prompt fetch results.
+//
+// STALENESS IDENTITY, and why it is deliberately narrower than
+// handleReviewMsg's:
+//
+// This handler writes m.currentReview -- the same field the split detail
+// pane renders and the same field reconcile's idempotency check reads --
+// from a /api/review payload, so it is a review-content writer like
+// handleReviewMsg, and it is gated on four things:
+//
+//  0. promptSeq + dispatchedFrom: the prompt path's own request identity
+//     (promptFetchSeq, bumped at dispatch and by followSelectionChange's
+//     abandonment) and origin-view guard, so a slow response can neither
+//     be re-accepted after navigating away and back to the same job nor
+//     yank the user out of a transient view opened while it was in
+//     flight. See the inline comments on the gates below.
+//  1. jobID: the selection moved on since dispatch.
+//  2. attempt (the per-job counter): a confirmed rerun has
+//     superseded the attempt this response belongs to. This gate is
+//     exactly as necessary here as on the review path -- 'p' on a done job
+//     in stacked mode, a rerun of that job confirming while the fetch is in
+//     flight, and the response lands with the jobID gate still passing (a
+//     rerun reuses the job ID and doesn't move the selection): it
+//     overwrites the nil handleRerunResultMsg just wrote with the PREVIOUS
+//     attempt's review, and splitReconcileDetail/handleDetailFollowTick
+//     then see currentReview.JobID already matching and skip fetching the
+//     rerun's real result. Dropping is also COMPLETE here, unlike on the
+//     review path where an intent must be resolved: after a rerun the job
+//     is queued/running, and handlePromptKey renders a running job's prompt
+//     synchronously from job.Prompt with no fetch at all, so pressing 'p'
+//     again immediately shows the fresh attempt.
+//  3. NOT the shared fetch epoch (reviewFetchSeq), and NOT
+//     detailFollowGen. Both were considered and rejected on specifics, not
+//     on "structural" grounds:
+//     - The epoch cannot be joined in either direction. Stamping WITHOUT
+//     bumping means any review fetch dispatched after this one --
+//     splitReconcileDetail fires one on every jobs refresh -- silently
+//     discards the user's explicit 'p', with no pendingPromptOpen field
+//     to re-serve it (the review path only survives that because
+//     pendingReviewOpenJobID exists to be re-served). Stamping WITH
+//     bumping has the same swallow problem plus a new one: this handler
+//     populates currentReview but deliberately CLEARS its siblings
+//     (currentResponses/currentBranch, see below), so superseding an
+//     in-flight follow fetch would leave the pane holding a review with
+//     no comments, which reconcile's JobID-only idempotency check will
+//     not repair. Joining the epoch therefore requires giving the prompt
+//     view its own intent field first -- a real design change, not a
+//     stamp. Nothing is lost meanwhile: the only fetches that race this
+//     one are for the SAME job (the jobID gate rejects the rest) and
+//     carry the same /api/review payload, so their ordering is benign.
+//     - detailFollowGen would add nothing the jobID gate doesn't already
+//     cover (it bumps on a genuine selection change, which moves jobID
+//     too) and would wrongly discard this response after a mere layout
+//     toggle, which bumps gen with the selection unchanged.
 func (m model) handlePromptMsg(
 	msg promptMsg,
 ) (tea.Model, tea.Cmd) {
 	if msg.jobID != m.selectedJobID {
 		return m, nil
+	}
+	if msg.attempt != m.jobAttemptGen[msg.jobID] {
+		// A confirmed rerun superseded this attempt -- gate 2 in this
+		// function's doc comment, and jobAttemptGen's contract (tui.go).
+		return m, nil
+	}
+	if msg.promptSeq != m.promptFetchSeq {
+		// The prompt path's own request identity: superseded by a newer
+		// prompt dispatch, or abandoned by a selection change
+		// (followSelectionChange bumps the counter). The jobID gate alone
+		// cannot catch the abandoned case when the user navigates away and
+		// BACK to the same job before this lands -- accepting it would pop
+		// the prompt view open with no fresh keypress.
+		return m, nil
+	}
+	if m.currentView != msg.dispatchedFrom && m.currentView != viewKindPrompt {
+		// The user opened a different view (filter, tasks, help, ...)
+		// while this fetch was in flight -- same dispatch-origin guard as
+		// openReviewView. Dropped entirely rather than loaded without the
+		// view switch: this handler clears currentReview's siblings below,
+		// so a background content write would strand the split pane with a
+		// review and no comments. The prompt is cheap to refetch ('p'
+		// again); nothing needs re-serving.
+		return m, nil
+	}
+	// currentResponses/currentBranch are siblings of currentReview,
+	// normally kept in sync with it by whichever fetch populated them
+	// (the split pane's own follow fetch, most often). This handler only
+	// ever assigns currentReview -- if the review it's about to load is
+	// for a DIFFERENT job than whatever is currently loaded, the siblings
+	// belong to that other job and must be cleared here, or they persist
+	// stale alongside this job's review. Concretely: split, job X
+	// selected with X's review+comments loaded; 'p' opens the prompt;
+	// stepPromptNav (<-/->) walks to job Y's prompt, which calls
+	// fetchReviewForPrompt(Y) -- landing here with msg.review.JobID == Y
+	// while currentResponses is still X's. Esc then goes through
+	// preserveOrClearReviewOnQueueReturn, whose guard only checks
+	// currentReview.JobID (now Y) against selectedJobID (now Y) and
+	// retains it -- rendering Y's review with X's comments underneath.
+	// Nothing else corrects this: reconcile's idempotency checks only
+	// examine currentReview itself, never its siblings (see
+	// preserveOrClearReviewOnQueueReturn's doc comment).
+	if m.currentReview == nil || m.currentReview.JobID != msg.jobID {
+		m.currentResponses = nil
+		m.currentBranch = ""
 	}
 	m.consecutiveErrors = 0
 	m.currentReview = msg.review
@@ -685,6 +1516,153 @@ func (m model) handleLogOutputMsg(
 	return m, nil
 }
 
+// paneLogMaxLines caps the split detail pane's buffered live log lines,
+// trimming from the front once exceeded.
+const paneLogMaxLines = 500
+
+// handlePaneLogOutputMsg processes live log output for the split detail
+// pane's running-job tail. Mirrors handleLogOutputMsg but drives
+// the pane's own paneLog* fields, independent of the full-screen log view.
+func (m model) handlePaneLogOutputMsg(msg paneLogOutputMsg) (tea.Model, tea.Cmd) {
+	// Drop stale responses from a previous tail session (selection moved
+	// to a different job, or startPaneLog re-armed the same job). seq
+	// alone is scheduleDetailFollow's chosen invalidation point (bumped on
+	// every keyboard/mouse selection change), but other selection-mutation
+	// paths -- e.g. the control socket's select-job command, handleJobsMsg
+	// reassigning the selection when the tailed job vanishes from a
+	// refresh, closedResultMsg's restoreSelection rollback, and various
+	// transient-view-return paths -- mutate m.selectedJobID directly
+	// without going through scheduleDetailFollow at all, so they never
+	// bump paneLogSeq either. msg.jobID == m.paneLogJobID alone isn't
+	// enough to catch those: paneLogJobID is only ever updated when a NEW
+	// tail actually starts (startPaneLog), so it's just as stale as
+	// selectedJobID would be if we didn't also check it here -- a late
+	// response satisfies both the seq and paneLogJobID checks (neither
+	// was invalidated) while m.selectedJobID has already moved on.
+	// Requiring msg.jobID == m.selectedJobID too closes every such path at
+	// the message level, regardless of how the selection changed
+	// underneath it: an in-flight fetch for a job that's no longer both
+	// the tail's own bookkeeping AND the current selection can never land.
+	//
+	// The seq/paneLogJobID check and the selectedJobID check are
+	// deliberately split into two separate ifs (not one combined
+	// condition) because they need DIFFERENT consequences on rejection:
+	// a response that's ALSO stale by seq/paneLogJobID is rejected
+	// outright, untouched -- it doesn't correspond to a live tail at
+	// all, so there's nothing to invalidate (contrast
+	// handlePaneLogTickMsg's second guard: a stale-seq tick must not
+	// kill a LIVE tail). But a
+	// response that DOES match the tail's own bookkeeping (seq and
+	// paneLogJobID both current) yet disagrees with m.selectedJobID means
+	// the selection moved to a DIFFERENT job while this tail was still
+	// genuinely live -- returning here without touching paneLogStreaming
+	// would leave it claiming an active tail with no poll chain behind
+	// it (nothing re-arms paneLogTickMsg once this response is dropped).
+	// splitReconcileDetail's Running-branch restart guard and
+	// startPaneLog's already-tailing no-op guard would then both believe
+	// the tail is still live if the selection later returns to this SAME
+	// job via a path that also bypasses scheduleDetailFollow, so the
+	// live log would never get restarted -- frozen on stale output
+	// permanently.
+	if msg.seq != m.paneLogSeq || msg.jobID != m.paneLogJobID {
+		return m, nil
+	}
+	if msg.jobID != m.selectedJobID {
+		m.paneLogSeq++
+		m.paneLogStreaming = false
+		return m, nil
+	}
+	if msg.err != nil {
+		if errors.Is(msg.err, errNoLog) {
+			// Job just started; the daemon hasn't written any log
+			// output yet. Keep polling rather than giving up.
+			seq := msg.seq
+			return m, tea.Tick(2*time.Second, func(time.Time) tea.Msg {
+				return paneLogTickMsg{seq: seq}
+			})
+		}
+		m.paneLogStreaming = false
+		m.splitDetailErr = msg.err
+		return m, nil
+	}
+	// A successful fetch that passed the seq+jobID gates proves the pane is
+	// healthy, so any splitDetailErr still set is stale -- it belongs to an
+	// earlier tail or an earlier job. Clearing here (not just on the
+	// hasMore==false completion path below) keeps renderDetailPane's
+	// unconditional running-branch error from covering a live tail.
+	m.splitDetailErr = nil
+	if msg.fmtr != nil {
+		m.paneLogFmtr = msg.fmtr
+	}
+	if msg.append {
+		if len(msg.lines) > 0 {
+			m.paneLogLines = append(m.paneLogLines, msg.lines...)
+		}
+	} else {
+		// Non-incremental fetch: either the initial full fetch or a
+		// server-side offset reset (log truncated/rotated). Replace
+		// rather than append so stale pre-reset lines don't linger
+		// mixed in with the replacement log.
+		m.paneLogLines = msg.lines
+	}
+	if over := len(m.paneLogLines) - paneLogMaxLines; over > 0 {
+		m.paneLogLines = m.paneLogLines[over:]
+	}
+	m.paneLogOffset = msg.newOffset
+	m.paneLogStreaming = msg.hasMore
+	if msg.hasMore {
+		seq := msg.seq
+		return m, tea.Tick(2*time.Second, func(time.Time) tea.Msg {
+			return paneLogTickMsg{seq: seq}
+		})
+	}
+	// Job finished streaming -- swap the pane over to the review. The
+	// reviewMsg staleness gate (msg.jobID != m.selectedJobID) protects
+	// against the cursor having moved on in the meantime. splitDetailErr
+	// was already cleared above (this fetch succeeded), so no stale error
+	// can show through for this job while the fresh fetch is in flight.
+	// A one-shot dispatch triggered by the log stream ending, not
+	// splitReconcileDetail's every-refresh dispatch, so it needs no
+	// duplicate-dispatch suppression (it never touches
+	// reconcileFetchJobID) -- but it is ordered like every other review
+	// fetch: dispatchReviewFollow bumps the shared epoch and stamps it.
+	cmd := m.dispatchReviewFollow(m.paneLogJobID)
+	return m, cmd
+}
+
+// handlePaneLogTickMsg processes a poll tick for the split detail pane's
+// live log tail. Stale seq, a layout change, or the selection
+// having moved off the tailed job all silently stop the tail.
+//
+// Unlike handlePaneLogOutputMsg's seq+jobID+selectedJobID gate, this
+// doesn't need a separate m.selectedJobID check added: `m.selectedJob()`
+// below resolves the CURRENT selection fresh (not a cached field the way
+// paneLogJobID is), so `job.ID != m.paneLogJobID` already means "the
+// tailed job and the current selection disagree" -- it can't go stale the
+// way msg.jobID == m.paneLogJobID alone could.
+func (m model) handlePaneLogTickMsg(msg paneLogTickMsg) (tea.Model, tea.Cmd) {
+	if msg.seq != m.paneLogSeq || m.layout != layoutSplit || !m.paneLogStreaming {
+		return m, nil
+	}
+	job, ok := m.selectedJob()
+	if !ok || job.ID != m.paneLogJobID || job.Status != storage.JobStatusRunning {
+		// The tailed job stopped running (or the selection moved off it)
+		// out from under this tick. Stop claiming an active tail here --
+		// leaving paneLogStreaming true with no poll chain behind it would
+		// make both splitReconcileDetail's running-branch restart guard and
+		// startPaneLog's already-tailing no-op guard believe the tail is
+		// still alive, so a rerun that reuses this job ID and returns to
+		// running would never get its tail restarted. Bumping paneLogSeq
+		// also rejects any fetch response still in flight for the tail we
+		// just abandoned. paneLogLines/paneLogOffset are left alone: the
+		// last-known output stays visible until a restart replaces it.
+		m.paneLogSeq++
+		m.paneLogStreaming = false
+		return m, nil
+	}
+	return m, m.fetchPaneLog(m.paneLogJobID)
+}
+
 // handleCommitMsgMsg processes commit message fetch results.
 func (m model) handleCommitMsgMsg(
 	msg commitMsgMsg,
@@ -704,6 +1682,11 @@ func (m model) handleCommitMsgMsg(
 
 // handleClosedResultMsg processes the result of a closed toggle API call.
 func (m model) handleClosedResultMsg(msg closedResultMsg) (tea.Model, tea.Cmd) {
+	// A failed close is rolled back by restoring the selection the
+	// optimistic path moved away from -- a selection change like any
+	// other, so it takes the shared detail-follow transition below.
+	var followCmd tea.Cmd
+	prevSelected := m.selectedJobID
 	isCurrentRequest := false
 	if msg.jobID > 0 {
 		if pending, ok := m.pendingClosed[msg.jobID]; ok && pending.seq == msg.seq {
@@ -727,9 +1710,22 @@ func (m model) handleClosedResultMsg(msg closedResultMsg) (tea.Model, tea.Cmd) {
 				delete(m.pendingClosed, msg.jobID)
 				if msg.restoreSelection {
 					m.selectJobByID(msg.jobID)
+					m, followCmd = m.followSelectionChange(prevSelected)
 				}
 				// Reverse the optimistic stats delta
 				m.applyStatsDelta(msg.oldState)
+				// Mirror handleCloseKey's split-list optimistic flip: this
+				// job-keyed path (msg.reviewView is false here) is the one
+				// closeReviewInBackground uses for a close toggled from the
+				// split list, which also flips currentReview.Closed
+				// optimistically when it's loaded for this job. Roll that
+				// back here too -- gated on the SAME isCurrentRequest/seq
+				// check as the job rollback above, so job and review can't
+				// roll back independently (one seq, one pass, both or
+				// neither).
+				if m.currentReview != nil && m.currentReview.JobID == msg.jobID {
+					m.currentReview.Closed = msg.oldState
+				}
 			} else if msg.reviewID > 0 {
 				delete(m.pendingReviewClosed, msg.reviewID)
 			}
@@ -745,7 +1741,7 @@ func (m model) handleClosedResultMsg(msg closedResultMsg) (tea.Model, tea.Cmd) {
 			delete(m.pendingReviewClosed, msg.reviewID)
 		}
 	}
-	return m, nil
+	return m, followCmd
 }
 
 // handleClosedToggleMsg processes closed state toggle messages.
@@ -762,15 +1758,20 @@ func (m model) handleClosedToggleMsg(
 func (m model) handleCancelResultMsg(
 	msg cancelResultMsg,
 ) (tea.Model, tea.Cmd) {
+	var followCmd tea.Cmd
 	if msg.err != nil {
+		prevSelected := m.selectedJobID
 		m.setJobStatus(msg.jobID, msg.oldState)
 		m.setJobFinishedAt(msg.jobID, msg.oldFinishedAt)
+		// Restoring the selection the optimistic cancel moved away from is
+		// a selection change like any other -- same shared transition.
 		if msg.restoreSelection {
 			m.selectJobByID(msg.jobID)
+			m, followCmd = m.followSelectionChange(prevSelected)
 		}
 		m.err = msg.err
 	}
-	return m, nil
+	return m, followCmd
 }
 
 // handlePauseResultMsg reconciles the queue-pause badge with the daemon. On
@@ -796,16 +1797,169 @@ func (m model) handlePauseResultMsg(msg pauseResultMsg) (tea.Model, tea.Cmd) {
 func (m model) handleRerunResultMsg(
 	msg rerunResultMsg,
 ) (tea.Model, tea.Cmd) {
+	// Release the in-flight slot FIRST, before every early return below, so
+	// a rerun that fails, or one whose result is otherwise dropped, can
+	// never leave the job permanently blocked. See panelRerunInFlight's doc
+	// comment (tui.go) for the no-leak argument this is half of.
+	delete(m.panelRerunInFlight, msg.jobID)
 	if msg.err != nil {
-		m.setJobStatus(msg.jobID, msg.oldState)
-		m.setJobStartedAt(msg.jobID, msg.oldStartedAt)
-		m.setJobFinishedAt(msg.jobID, msg.oldFinishedAt)
-		m.setJobError(msg.jobID, msg.oldError)
-		m.mutateJob(msg.jobID, func(job *storage.ReviewJob) {
-			job.Closed = msg.oldClosed
-			job.Verdict = msg.oldVerdict
-		})
+		// Restore the optimistic mutation -- but only if there WAS one.
+		// For a panel synthesis parent the dispatchers skip
+		// the mutation entirely, so there is nothing to undo, and doing it
+		// anyway is not the same-value no-op it looks like: the snapshot
+		// was taken before the request went out, and anything that touched
+		// this row in the meantime -- a close/unclose toggle, or a jobs
+		// refresh landing fresh server state -- would be overwritten with
+		// pre-rerun values. Only the error is surfaced for that case.
+		if !msg.spawnsNewRun {
+			m.setJobStatus(msg.jobID, msg.oldState)
+			m.setJobStartedAt(msg.jobID, msg.oldStartedAt)
+			m.setJobFinishedAt(msg.jobID, msg.oldFinishedAt)
+			m.setJobError(msg.jobID, msg.oldError)
+			m.mutateJob(msg.jobID, func(job *storage.ReviewJob) {
+				job.Closed = msg.oldClosed
+				job.Verdict = msg.oldVerdict
+			})
+		}
 		m.err = msg.err
+		return m, nil
+	}
+	// PANEL SYNTHESIS EXCEPTION. Everything below this point
+	// rests on "a rerun reuses the same job ID", which is false for a panel
+	// synthesis parent: internal/daemon/server.go routes those to
+	// rerunPanelRun, which clones the members and the synthesis row into a
+	// BRAND-NEW run under a fresh panel_run_uuid with new job IDs and
+	// leaves the original run -- including this job's row and its review --
+	// intact as history. 'r' reaches this case: handleRerunKey blocks only
+	// PanelRoleMember, and the control socket blocks nothing.
+	//
+	// So for this job, a confirmed rerun is NOT abandonment, and running
+	// the block below would be wrong three ways: it clears a review that is
+	// still current (forcing a refetch and closing an open fix panel), it
+	// bumps jobAttemptGen and so drops a still-correct in-flight fetch
+	// (which then only heals on the next reconcile pass), and it cancels
+	// the user's pending open/fix intent with a "Job #N is rerunning"
+	// flash that is simply untrue of the job they asked about.
+	//
+	// This is stated as a CODE exception rather than a documented one
+	// precisely because jobAttemptGen's clause 4 ("nothing needs to be
+	// disarmed on the rejection path") is derived from clause 2 ("a bump is
+	// always abandonment"): leaving clause 2 with an unwritten exception
+	// would leave clause 4 resting on a premise that does not hold. The
+	// predicate is evaluated at DISPATCH, where the job is provably in
+	// hand, and carried on the message -- see rerunSnapshot.spawnsNewRun
+	// (actions.go) for why a lookup here would not be reliable.
+	//
+	// The new run's own jobs are ordinary rows with their own IDs; nothing
+	// here needs to know about them, and the next jobs refresh brings them
+	// in like any other newly enqueued work.
+	//
+	// Nor was this job's ROW optimistically mutated: both dispatchers skip
+	// the re-queue write for a synthesis parent, since the
+	// same fact that makes the attempt survive -- the daemon re-runs
+	// nothing here -- makes that write wrong from the instant it is made.
+	// So there is nothing to undo, and a flash is what confirms the action
+	// instead: without the row visibly changing, an accepted rerun would
+	// otherwise be completely silent until the new run's rows arrive on the
+	// next refresh.
+	if msg.spawnsNewRun {
+		m.setFlash(
+			fmt.Sprintf("Panel rerun queued for job #%d -- a new run will appear shortly", msg.jobID),
+			3*time.Second, m.currentView,
+		)
+		return m, nil
+	}
+	// Rerun confirmed: a rerun reuses the same job ID, so once the job
+	// finishes again `currentReview.JobID == job.ID` would keep matching
+	// even though currentReview still holds the PREVIOUS attempt's review
+	// -- splitReconcileDetail and handleDetailFollowTick both treat that
+	// match as "already loaded, nothing to fetch" and would leave the
+	// stale review displayed indefinitely. Clear it here, at the point the
+	// rerun is confirmed accepted (not on the earlier optimistic dispatch,
+	// so a failed rerun request -- the msg.err branch above -- leaves the
+	// old review in place). Guarded on JobID match so this can't disrupt a
+	// loaded review for a DIFFERENT job (including stacked mode, where
+	// currentReview is normally nil for the queue view anyway).
+	if m.currentReview != nil && m.currentReview.JobID == msg.jobID {
+		m.currentReview = nil
+		m.currentResponses = nil
+		m.reviewScroll = 0
+		m.splitDetailErr = nil
+		// The inline fix panel is scoped to whatever review is displayed
+		// (fixPromptJobID is stamped from the loaded review's job when the
+		// panel opens), so a review invalidated here can leave a stale
+		// panel behind: once normalizeSplitState repairs the view back to
+		// the queue and the user opens a DIFFERENT review, the old panel
+		// would render over it, and submitting would target the reran job
+		// instead of the one on screen. closeFixPanel resets
+		// reviewFixPanelOpen/Focused/Pending and fixPromptJobID together.
+		m.closeFixPanel()
+	}
+	// Invalidate every in-flight review fetch for THIS job, whether or not
+	// it is the selected one. The counter is keyed by job, so bumping it
+	// here says nothing about an in-flight fetch for any OTHER job -- which
+	// is what lets this be unconditional (a jobAttemptGen bumper; see that
+	// field's contract, tui.go, clauses 1 and 2).
+	//
+	// What this covers: a follow fetch in flight for the selected job while
+	// currentReview is still nil (the debounced follow hasn't resolved yet)
+	// and a rerun of that job confirms; and equally a regular (non-follow)
+	// fetch dispatched before the rerun (queue Enter, stepReviewNav, tasks
+	// 'P', ...). Left un-invalidated, either response later lands looking
+	// perfectly current, populates currentReview with the OLD attempt's
+	// content, and blocks the rerun's real result from ever being fetched
+	// -- splitReconcileDetail/handleDetailFollowTick see currentReview.JobID
+	// already matching and skip refetching.
+	//
+	// The per-job counter (not the global detailFollowGen) is what
+	// invalidates these: it has no cross-job cost, so it needs no
+	// selection gate and covers every job in both layouts. A global bump
+	// here would invalidate legitimate in-flight fetches for whatever
+	// unrelated job is currently selected, and a selection-gated bump
+	// would miss reruns of unselected jobs entirely.
+	if m.jobAttemptGen == nil {
+		m.jobAttemptGen = make(map[int64]uint64)
+	}
+	m.jobAttemptGen[msg.jobID]++
+	// Same reasoning as scheduleDetailFollow's matching clear
+	// (belt-and-suspenders, not strictly load-bearing now that both
+	// handlers release the slot on any response for the job -- see
+	// reconcileFetchJobID's doc comment, tui.go): clear the suppression
+	// slot immediately, rather than waiting for its doomed in-flight
+	// response to arrive and self-resolve, so a fresh dispatch once the
+	// rerun completes isn't unnecessarily delayed. Keyed on the SLOT's own
+	// job, not on the selection: the slot tracks one specific job's
+	// outstanding reconcile fetch, so clearing it for an unrelated job's
+	// rerun would only cost a duplicate dispatch.
+	if m.reconcileFetchJobID == msg.jobID {
+		m.reconcileFetchJobID = 0
+		m.reconcileFetchSeq = 0
+	}
+	// Disarm BOTH pending intents for THIS job, keyed on msg.jobID alone
+	// and never on the selection. A confirmed rerun of job X abandons any
+	// intent armed for X regardless of what is selected right now: the
+	// user asked for a fresh attempt, so whatever content an in-flight
+	// 'F'/'P'/Enter dispatch for X was waiting to serve belongs to the
+	// superseded attempt. A selection-gated disarm would skip exactly the
+	// reruns that target an unselected job (the control socket can target
+	// any job by ID; TUI 'r' can race the selection moving), leaving the
+	// intent armed and rescuable -- a later incidental gen bump would
+	// then get the previous attempt's review served for a job that is
+	// currently re-running. Per-job disarms have no cross-job cost: both
+	// fields are keyed on jobID, so clearing them for X cannot affect an
+	// intent armed for any other job.
+	if m.reviewFixPanelPending && m.fixPromptJobID == msg.jobID {
+		m.closeFixPanel()
+	}
+	if m.pendingReviewOpenJobID == msg.jobID {
+		origin := m.pendingReviewOpenOrigin
+		m.pendingReviewOpenJobID = 0
+		m.pendingReviewOpenOrigin = 0
+		m.pendingReviewOpenSeq = 0
+		m.setWarningFlash(
+			fmt.Sprintf("Job #%d is rerunning -- open request canceled", msg.jobID),
+			3*time.Second, origin,
+		)
 	}
 	return m, nil
 }
@@ -821,10 +1975,71 @@ func (m model) handleCommentResultMsg(
 			m.commentText = ""
 			m.commentJobID = 0
 		}
-		if m.currentView == viewReview &&
+		// splitActive() -- not the coarser m.layout == layoutSplit -- is
+		// the knob: it encodes "the split pane is actually rendering",
+		// including the tasks-origin exclusion. A tasks-origin review is
+		// rendered full-screen even on a split-capable terminal, and the
+		// follow path's failures land only in m.splitDetailErr, which
+		// only the split pane renders -- routed down the follow path, a
+		// failed comment refresh on a tasks-origin review would be
+		// completely silent. splitActive() routes it to the else branch,
+		// whose plain fetchReview failures surface through the ordinary
+		// full-screen error mechanism. For every non-tasks-origin case
+		// splitActive() reduces to m.layout == layoutSplit here, so only
+		// the tasks-origin review behaves differently.
+		if m.splitActive() {
+			// A one-shot dispatch triggered by this single
+			// commentResultMsg, not splitReconcileDetail's every-refresh
+			// dispatch, so it needs no duplicate-dispatch suppression --
+			// but it is ordered like every other review fetch
+			// (dispatchReviewFollow bumps the shared epoch and stamps
+			// it), which is what stops an OLDER fetch dispatched before
+			// the comment from landing after it and wiping the fresh
+			// comment back out of currentResponses. Gated on msg.jobID ==
+			// m.selectedJobID: the comment refresh is the only one of
+			// fetchReviewFollow's split-pane dispatchers not already tied
+			// to the selection, and a dispatch for a no-longer-selected
+			// job would advance the epoch and supersede a legitimate
+			// fetch for the job that IS selected. splitActive()
+			// already constrains currentView to viewQueue/viewReview
+			// (list or detail focus, queue-origin only), so this branch
+			// needs no separate currentView check of its own.
+			if m.currentReview != nil && m.currentReview.JobID == msg.jobID &&
+				msg.jobID == m.selectedJobID {
+				cmd := m.dispatchReviewFollow(msg.jobID)
+				return m, cmd
+			}
+		} else if m.currentView == viewReview &&
 			m.currentReview != nil &&
 			m.currentReview.JobID == msg.jobID {
-			return m, m.fetchReview(msg.jobID)
+			// Stacked mode, OR a tasks-origin review rendered full-screen
+			// even while layout == layoutSplit (see above):
+			// a plain non-follow fetch (ordered by the same epoch as
+			// every other review fetch, but not follow-TAGGED), whose
+			// failures surface through the ordinary full-screen error
+			// mechanism rather than m.splitDetailErr (which only the
+			// split detail pane renders, and which neither of these two
+			// cases displays).
+			//
+			// Gated on msg.jobID == m.selectedJobID as well as on the
+			// review being the DISPLAYED one. The selection gate has a
+			// real cost -- an unrelated reselect (e.g. the control
+			// socket's select-job, which in stacked mode moves
+			// selectedJobID without touching currentReview) means the
+			// displayed review's comments don't refresh -- but an
+			// ungated dispatch would be worse than useless: every review
+			// fetch advances the shared ordering epoch, so a dispatch
+			// whose response the jobID gate is guaranteed to drop still
+			// supersedes a concurrent, legitimate fetch for the job that
+			// IS selected (stacked, comment on X, right-arrow to Y
+			// before the POST resolves: X's refresh at epoch N+1 dooms
+			// Y's fetch at N, and both are dropped, with no reconcile in
+			// stacked to heal it). Since the dispatch could never be
+			// accepted in this state, gating it loses nothing.
+			if msg.jobID == m.selectedJobID {
+				cmd := m.dispatchReviewFetch(msg.jobID)
+				return m, cmd
+			}
 		}
 	}
 	return m, nil
@@ -980,6 +2195,32 @@ func (m model) handleReconnectMsg(msg reconnectMsg) (tea.Model, tea.Cmd) {
 }
 
 // handleWindowSizeMsg processes terminal resize events.
+// maybeResizeRefill dispatches a jobs refetch when the (resized) terminal
+// can show more rows than are loaded and more data is available. In split
+// layout the list pane's row budget (splitGeometry) differs from
+// queueVisibleRows' full-screen chrome reservation, so use the pane's own
+// capacity there or a resize into a tall split pane can leave rows unfilled
+// even though more data is available (hasMore). Shared by
+// handleWindowSizeMsg's two resize arms (the pane-tail restart and the
+// plain fall-through) so the tail-restart early return can't skip the
+// refill. Mutates loadingJobs when it dispatches.
+func (m *model) maybeResizeRefill() tea.Cmd {
+	if m.loadingMore || m.loadingJobs ||
+		len(m.jobs) == 0 || !m.hasMore ||
+		m.activeBranchFilter == branchNone {
+		return nil
+	}
+	visibleRows := m.queueVisibleRows()
+	if m.layout == layoutSplit {
+		visibleRows = m.queuePaneRowCapacity()
+	}
+	if visibleRows+queuePrefetchBuffer > len(m.jobs) {
+		m.loadingJobs = true
+		return m.fetchJobs()
+	}
+	return nil
+}
+
 func (m model) handleWindowSizeMsg(
 	msg tea.WindowSizeMsg,
 ) (tea.Model, tea.Cmd) {
@@ -987,15 +2228,58 @@ func (m model) handleWindowSizeMsg(
 	m.height = msg.Height
 	m.heightDetected = true
 
-	// If terminal can show more jobs than we have, re-fetch to fill
-	if !m.loadingMore && !m.loadingJobs &&
-		len(m.jobs) > 0 && m.hasMore &&
-		m.activeBranchFilter != branchNone {
-		newVisibleRows := m.queueVisibleRows() + queuePrefetchBuffer
-		if newVisibleRows > len(m.jobs) {
-			m.loadingJobs = true
-			return m, m.fetchJobs()
+	var followCmd tea.Cmd
+	if next := m.resolveLayout(); next != m.layout {
+		m.applyLayout(next)
+		m, followCmd = m.maybeBootstrapDetail()
+	}
+
+	// Width change while tailing a running job's live log in the split
+	// detail pane requires restarting the tail at the new pane width --
+	// otherwise the persistent paneLogFmtr keeps wrapping at the stale
+	// width for the rest of the session. Gated on splitActive() (layout
+	// split AND currentView queue/review) rather than bare
+	// layout==layoutSplit: a transient view (e.g. viewLog) can be open on
+	// top of split, and stealing the early return here would skip that
+	// view's own resize re-render below, leaving IT at the stale width
+	// instead. When the pane isn't the visible thing (transient view
+	// open), don't fetch now -- just invalidate the tail (bump seq, stop
+	// streaming) so it doesn't keep polling at the stale width in the
+	// background; startPaneLog restarts it cleanly on the next follow
+	// tick once the pane is visible again.
+	if m.paneLogStreaming {
+		if m.splitActive() {
+			if job, ok := m.selectedJob(); ok &&
+				job.ID == m.paneLogJobID &&
+				job.Status == storage.JobStatusRunning {
+				m.paneLogSeq++
+				m.paneLogOffset = 0
+				m.paneLogLines = nil
+				m.paneLogFmtr = streamfmt.NewWithWidth(
+					io.Discard, m.paneLogWidth(), m.glamourStyle,
+				)
+				// The same resize that re-widths the tail can also have
+				// grown the list pane past the loaded rows -- batch the
+				// refill check rather than skipping it, or the list stays
+				// underfilled until the next SSE event or fallback poll.
+				refillCmd := m.maybeResizeRefill()
+				return m, tea.Batch(followCmd, m.fetchPaneLog(job.ID), refillCmd)
+			}
+		} else if m.layout == layoutSplit {
+			// A transient view is covering the pane, so restarting the
+			// tail now would poll invisibly at the wrong width. Invalidate
+			// it and mark it paused; the Update tail resumes (via
+			// splitReconcileDetail) as soon as the split panes are visible
+			// again, rather than waiting for the next jobs refresh.
+			m.paneLogSeq++
+			m.paneLogStreaming = false
+			m.paneLogPaused = true
 		}
+	}
+
+	// If terminal can show more jobs than we have, re-fetch to fill.
+	if cmd := m.maybeResizeRefill(); cmd != nil {
+		return m, tea.Batch(followCmd, cmd)
 	}
 
 	// Width change in log view requires full re-render
@@ -1007,10 +2291,10 @@ func (m model) handleWindowSizeMsg(
 		)
 		m.logFetchSeq++
 		m.logLoading = true
-		return m, m.fetchJobLog(m.logJobID)
+		return m, tea.Batch(followCmd, m.fetchJobLog(m.logJobID))
 	}
 
-	return m, nil
+	return m, followCmd
 }
 
 // handleTickMsg processes periodic tick events for adaptive polling.

--- a/cmd/roborev/tui/handlers_msg.go
+++ b/cmd/roborev/tui/handlers_msg.go
@@ -1974,6 +1974,14 @@ func (m model) handleRerunResultMsg(
 // and must not be stomped by this side channel, and a response for a job
 // the user has navigated away from is simply stale.
 func (m model) handleFailedCommentsMsg(msg failedCommentsMsg) (tea.Model, tea.Cmd) {
+	if msg.seq != m.failedCommentsSeq {
+		// A newer comments fetch has since gone out: synthesized reviews
+		// all share ID 0, so without this identity an OLDER dispatch's
+		// response (navigate away and back re-dispatches, and the
+		// post-success refetch always re-dispatches) could land last and
+		// overwrite the newer result or a just-appended comment.
+		return m, nil
+	}
 	if m.currentReview == nil || m.currentReview.JobID != msg.jobID ||
 		m.currentReview.ID != 0 || m.selectedJobID != msg.jobID {
 		return m, nil
@@ -2016,7 +2024,12 @@ func (m model) handleCommentResultMsg(
 				Response:  msg.comment,
 				CreatedAt: time.Now(),
 			})
-			return m, nil
+			// Reconcile the optimistic append with server truth, and --
+			// via the seq bump -- doom any pre-post comments fetch still
+			// in flight, whose response would otherwise land WITHOUT the
+			// just-submitted comment and wipe the append.
+			cmd := m.dispatchFailedCommentsFetch(msg.jobID)
+			return m, cmd
 		}
 		// splitActive() -- not the coarser m.layout == layoutSplit -- is
 		// the knob: it encodes "the split pane is actually rendering",

--- a/cmd/roborev/tui/handlers_queue.go
+++ b/cmd/roborev/tui/handlers_queue.go
@@ -84,12 +84,34 @@ func (m model) handleDistractionFreeKey() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.distractionFree = !m.distractionFree
-	return m, nil
+	// Distraction-free forces stacked layout (see resolveLayout). Apply
+	// the transition through the same machinery a resize uses so
+	// view/focus mapping and the pane-log teardown stay consistent, and
+	// bootstrap the detail pane when toggling OFF re-engages split.
+	var followCmd tea.Cmd
+	if next := m.resolveLayout(); next != m.layout {
+		m.applyLayout(next)
+		m, followCmd = m.maybeBootstrapDetail()
+	}
+	return m, followCmd
 }
 
 func (m model) handleEnterKey() (tea.Model, tea.Cmd) {
+	if m.currentView != viewQueue {
+		return m, nil
+	}
+	// In split layout the detail pane already follows the queue cursor, so by
+	// the time Enter is pressed the review is already displayed -- Enter used
+	// to move focus into the detail pane (same as tab), which read as
+	// "nothing happened" since the pane content doesn't change. Make it a
+	// no-op in split (list focus) regardless of the selected job's status;
+	// tab remains the way to focus the detail pane. Stacked layout is
+	// unaffected.
+	if m.layout == layoutSplit {
+		return m, nil
+	}
 	job, ok := m.selectedJob()
-	if m.currentView != viewQueue || !ok {
+	if !ok {
 		return m, nil
 	}
 	if mm, handled := m.panelInProgressFlash(*job); handled {
@@ -98,15 +120,12 @@ func (m model) handleEnterKey() (tea.Model, tea.Cmd) {
 	switch job.Status {
 	case storage.JobStatusDone:
 		m.reviewFromView = viewQueue
-		return m, m.enterReviewCmd(*job)
+		cmd := m.enterReviewCmd(*job)
+		return m, cmd
 	case storage.JobStatusFailed:
 		m.currentBranch = ""
-		jobCopy := *job
-		m.currentReview = &storage.Review{
-			Agent:  job.Agent,
-			Output: "Job failed:\n\n" + job.Error,
-			Job:    &jobCopy,
-		}
+		m.currentResponses = nil
+		m.currentReview = synthesizeFailedReview(job, m.currentReview)
 		m.reviewFromView = viewQueue
 		m.currentView = viewReview
 		m.reviewScroll = 0
@@ -156,11 +175,15 @@ func (m model) flashNoReviewYet(job storage.ReviewJob) model {
 // shows fresh per-member verdicts rather than a PanelSummary fallback or a
 // status captured while a member was still running; a member's own review does
 // not trigger a member fetch.
-func (m model) enterReviewCmd(job storage.ReviewJob) tea.Cmd {
+// Pointer receiver: dispatchReviewFetch bumps the shared fetch epoch on
+// the model, and that bump has to survive back to the caller (see
+// m.reviewFetchSeq's doc comment, tui.go).
+func (m *model) enterReviewCmd(job storage.ReviewJob) tea.Cmd {
+	cmd := m.dispatchReviewFetch(job.ID)
 	if job.IsSynthesisJob() && m.panelMembersNeedFetch(job.PanelRunUUID) {
-		return tea.Batch(m.fetchReview(job.ID), m.fetchPanelMembers(job.PanelRunUUID))
+		return tea.Batch(cmd, m.fetchPanelMembers(job.PanelRunUUID))
 	}
-	return m.fetchReview(job.ID)
+	return cmd
 }
 
 // panelMembersNeedFetch reports whether a synthesis run's members should be

--- a/cmd/roborev/tui/handlers_queue.go
+++ b/cmd/roborev/tui/handlers_queue.go
@@ -123,13 +123,13 @@ func (m model) handleEnterKey() (tea.Model, tea.Cmd) {
 		cmd := m.enterReviewCmd(*job)
 		return m, cmd
 	case storage.JobStatusFailed:
-		m.currentBranch = ""
-		m.currentResponses = nil
-		m.currentReview = synthesizeFailedReview(job, m.currentReview)
+		// Routed through the shared synthesized acceptance so the job's
+		// persisted comments load too -- no review fetch can ever carry
+		// them for a review with no persisted row.
+		cmd := m.acceptSynthesizedFailure(job.ID, synthesizeFailedReview(job, m.currentReview))
 		m.reviewFromView = viewQueue
 		m.currentView = viewReview
-		m.reviewScroll = 0
-		return m, nil
+		return m, cmd
 	}
 	return m.flashNoReviewYet(*job), nil
 }

--- a/cmd/roborev/tui/handlers_review.go
+++ b/cmd/roborev/tui/handlers_review.go
@@ -110,8 +110,16 @@ func (m model) handleCloseKey() (tea.Model, tea.Cmd) {
 				if idx >= 0 {
 					m.selectedIdx = idx
 					m.updateSelectedJobID()
-					restoreSelection = true
+				} else {
+					// Closing the LAST visible job: clear the selection like
+					// the cancel twin below, or the list shows "No jobs"
+					// while the detail pane stays actionable for the hidden
+					// review. The rollback restores by msg.jobID
+					// (selectJobByID), so it works from a cleared selection.
+					m.selectedIdx = -1
+					m.selectedJobID = 0
 				}
+				restoreSelection = true
 			}
 			return m, m.closeReviewInBackground(job.ID, newState, oldState, seq, restoreSelection)
 		}

--- a/cmd/roborev/tui/handlers_review.go
+++ b/cmd/roborev/tui/handlers_review.go
@@ -15,7 +15,8 @@ func (m model) handlePromptKey() (tea.Model, tea.Cmd) {
 	if job, ok := m.selectedJob(); m.currentView == viewQueue && ok {
 		if job.Status == storage.JobStatusDone {
 			m.promptFromQueue = true
-			return m, m.fetchReviewForPrompt(job.ID)
+			cmd := m.dispatchPromptFetch(job.ID)
+			return m, cmd
 		} else if (job.Status == storage.JobStatusRunning || job.Status == storage.JobStatusQueued) && job.Prompt != "" {
 			jobCopy := *job
 			m.currentReview = &storage.Review{
@@ -36,8 +37,8 @@ func (m model) handlePromptKey() (tea.Model, tea.Cmd) {
 	} else if m.currentView == viewKindPrompt {
 		if m.promptFromQueue {
 			m.currentView = viewQueue
-			m.currentReview = nil
 			m.promptScroll = 0
+			m = m.preserveOrClearReviewOnQueueReturn()
 		} else {
 			m.currentView = viewReview
 			m.promptScroll = 0
@@ -81,6 +82,23 @@ func (m model) handleCloseKey() (tea.Model, tea.Cmd) {
 			*job.Closed = newState
 			m.pendingClosed[job.ID] = pendingState{newState: newState, seq: seq}
 			m.applyStatsDelta(newState)
+			// Closing from the split list mutates the QUEUE row's job.Closed
+			// above, but with list focus currentView stays viewQueue, so the
+			// currentView==viewReview branch above (which flips
+			// currentReview.Closed) never runs. Left alone, the detail
+			// pane's header would keep showing the OLD closed state
+			// indefinitely: splitReconcileDetail's Done-branch idempotency
+			// check matches on JobID (and on
+			// paneReviewSeenNonTerminal/FinishedAt) -- none of which this
+			// close toggle changes, so reconciliation has no reason to
+			// refetch and correct it. Flip it optimistically here too, keyed
+			// by the SAME seq as the job's pendingClosed entry (no separate
+			// pendingClosed-style map for the review side) so
+			// handleClosedResultMsg's single rollback-on-failure path, gated
+			// on that one seq, can't roll back one half without the other.
+			if m.layout == layoutSplit && m.currentReview != nil && m.currentReview.JobID == job.ID {
+				m.currentReview.Closed = newState
+			}
 			if m.hideClosed && newState {
 				idx := m.findPrevVisibleJob(m.selectedIdx)
 				if idx < 0 {
@@ -152,6 +170,19 @@ func (m model) handleRerunKey() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if job.Status == storage.JobStatusDone || job.Status == storage.JobStatusFailed || job.Status == storage.JobStatusCanceled {
+		// A synthesis parent's row stays terminal while its rerun is in
+		// flight (see below), so the status check above cannot suppress
+		// a second press the way it does for an ordinary job. Without
+		// this, a fast double-'r' spawns two full panel runs: the daemon
+		// accepts both, since the status IT checks is this same
+		// unchanged row. See panelRerunInFlight (tui.go).
+		if job.IsSynthesisJob() && m.panelRerunInFlight[job.ID] {
+			m.setFlash(
+				fmt.Sprintf("Panel rerun already in progress for job #%d", job.ID),
+				3*time.Second, m.currentView,
+			)
+			return m, nil
+		}
 		snap := rerunSnapshot{
 			jobID:         job.ID,
 			oldStatus:     job.Status,
@@ -160,13 +191,33 @@ func (m model) handleRerunKey() (tea.Model, tea.Cmd) {
 			oldError:      job.Error,
 			oldClosed:     job.Closed,
 			oldVerdict:    job.Verdict,
+			// 'r' is allowed on a panel SYNTHESIS parent (only members
+			// are blocked above), and the daemon answers that with a
+			// whole new panel run rather than a new attempt of this job
+			// -- record it now, while the job is in hand.
+			spawnsNewRun: job.IsSynthesisJob(),
 		}
-		job.Status = storage.JobStatusQueued
-		job.StartedAt = nil
-		job.FinishedAt = nil
-		job.Error = ""
-		job.Closed = nil
-		job.Verdict = nil
+		// The optimistic re-queue is correct ONLY when the daemon really
+		// will re-run THIS row. For a synthesis parent it will not
+		// (rerunPanelRun enqueues a separate run and leaves this row and
+		// its review untouched), so writing it here would be wrong the
+		// moment it is written, not merely wrong if the request fails --
+		// and not only cosmetically: a fake queued status makes
+		// panelInProgressFlash (handlers_queue.go) refuse to open the
+		// parent's still-current review on Enter, flashing "Panel still
+		// synthesizing" with counts from the run that already finished.
+		// Clearing Closed would also flip the row's visibility under
+		// hideClosed. See handleRerunResultMsg's spawnsNewRun branch.
+		if !snap.spawnsNewRun {
+			job.Status = storage.JobStatusQueued
+			job.StartedAt = nil
+			job.FinishedAt = nil
+			job.Error = ""
+			job.Closed = nil
+			job.Verdict = nil
+		} else {
+			m.markPanelRerunInFlight(job.ID)
+		}
 		return m, m.rerunJob(snap)
 	}
 	return m, nil
@@ -312,9 +363,20 @@ func (m model) handleFixKey() (tea.Model, tea.Cmd) {
 	m.fixPromptJobID = job.ID
 	m.fixPromptText = ""
 	m.reviewFixPanelPending = true
+	m.fixPromptFollowRetried = false
+	// The origin of this fix REQUEST, for the consume-time view-switch
+	// decision -- recorded rather than assumed, since the response that
+	// eventually serves it may come from an entirely different dispatcher
+	// (see fixPromptOrigin's doc comment, tui.go).
+	m.fixPromptOrigin = m.currentView
 	m.reviewFromView = viewQueue
 	m.selectedJobID = job.ID
-	return m, m.fetchReview(job.ID)
+	cmd := m.dispatchReviewFetch(job.ID)
+	// This request's own identity (see fixPromptSeq's doc
+	// comment, tui.go): read AFTER dispatchReviewFetch, which is what just
+	// bumped m.reviewFetchSeq to the value stamped on this dispatch.
+	m.fixPromptSeq = m.reviewFetchSeq
+	return m, cmd
 }
 
 // handleReviewFixPanelKey handles key input when the inline fix panel is focused.
@@ -327,6 +389,17 @@ func (m model) handleReviewFixPanelKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.reviewFixPanelFocused = false
 		m.fixPromptText = ""
 		m.fixPromptJobID = 0
+		// Complete the reset to match fixPromptSeq's doc claim (tui.go):
+		// "reset alongside fixPromptJobID wherever that is." These three
+		// sites only ever run on an already-OPEN panel (reviewFixPanelPending
+		// is false by the time reviewFixPanelOpen is true, so fixPromptSeq/
+		// Origin/FollowRetried are already inert leftovers from the arm
+		// cycle here) -- harmless today, but zeroing them keeps every
+		// fixPromptJobID-clearing site in this file uniform instead of
+		// leaving a partial-reset shape for a future change to trip on.
+		m.fixPromptOrigin = 0
+		m.fixPromptSeq = 0
+		m.fixPromptFollowRetried = false
 		return m, nil
 	case "tab":
 		m.reviewFixPanelFocused = false
@@ -337,6 +410,9 @@ func (m model) handleReviewFixPanelKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.reviewFixPanelFocused = false
 			m.fixPromptText = ""
 			m.fixPromptJobID = 0
+			m.fixPromptOrigin = 0
+			m.fixPromptSeq = 0
+			m.fixPromptFollowRetried = false
 			m.setFlash(m.tasksDisabledMessage(), 3*time.Second, viewReview)
 			return m, nil
 		}
@@ -346,6 +422,9 @@ func (m model) handleReviewFixPanelKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.reviewFixPanelFocused = false
 		m.fixPromptText = ""
 		m.fixPromptJobID = 0
+		m.fixPromptOrigin = 0
+		m.fixPromptSeq = 0
+		m.fixPromptFollowRetried = false
 		m.currentView = viewTasks
 		return m, m.triggerFix(jobID, prompt, "")
 	case "backspace":
@@ -367,7 +446,30 @@ func (m model) handleReviewFixPanelKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 // handleTabKey shifts focus to the fix panel when it is open in review view.
+// In split layout, tab from the list pane (with a review loaded) moves
+// focus to the detail pane instead.
 func (m model) handleTabKey() (tea.Model, tea.Cmd) {
+	if m.layout == layoutSplit && m.currentView == viewQueue {
+		if !m.selectedReviewLoaded() {
+			// Either nothing is loaded, or the loaded review belongs to a
+			// job other than the one currently highlighted (e.g. the
+			// cursor moved to a running/queued job before the follow-fetch
+			// for it landed) -- entering detail focus would hand review
+			// actions (close/comment/fix) to the wrong job.
+			return m, nil
+		}
+		// This transition (unlike handleReviewMsg's guarded switch) doesn't
+		// go through a fresh fetchReview dispatch -- m.currentReview here
+		// was already loaded by the split's background follow-fetch
+		// (fetchReviewFollow, which never touches reviewFromView). Stamp
+		// it explicitly so splitActive()'s tasks-origin exclusion can't
+		// misfire on a stale value left over from a previously-viewed
+		// tasks-origin review.
+		m.reviewFromView = viewQueue
+		m.focus = focusDetail
+		m.currentView = viewReview
+		return m, nil
+	}
 	if m.currentView == viewReview && m.reviewFixPanelOpen && !m.reviewFixPanelFocused {
 		m.reviewFixPanelFocused = true
 	}
@@ -381,8 +483,7 @@ func (m model) handleToggleTasksKey() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if m.currentView == viewTasks {
-		m.currentView = viewQueue
-		return m, nil
+		return m.exitTasksToQueue()
 	}
 	if m.currentView == viewQueue {
 		m.currentView = viewTasks
@@ -393,10 +494,41 @@ func (m model) handleToggleTasksKey() (tea.Model, tea.Cmd) {
 
 // closeFixPanel resets all inline fix panel state. Call this when
 // leaving review view or navigating to a different review.
+// closeFixPanelIfJobChanged drops an open or pending inline fix panel that
+// is bound to a job other than the currently selected one. The panel is
+// keyed to fixPromptJobID, so it does not follow the pane's content the way
+// currentReview does -- left alone over a different job, submitting would
+// start a fix for the job the user is no longer looking at. Shared by
+// scheduleDetailFollow (the selection-change transition) and handleJobsMsg
+// (whose vanished/hidden-selection reassignment doesn't go through it,
+// since splitReconcileDetail is the content authority on that path).
+// A panel still on the selected job -- including a same-job no-op "move" --
+// is left alone.
+// markPanelRerunInFlight records that a panel rerun has been dispatched for
+// jobID, so a second dispatch for the same job is suppressed until its
+// result lands. See panelRerunInFlight's doc comment (tui.go) -- including
+// why writing through a value receiver's shared map is the intended
+// behaviour here, and the argument that every entry is removed again.
+func (m *model) markPanelRerunInFlight(jobID int64) {
+	if m.panelRerunInFlight == nil {
+		m.panelRerunInFlight = make(map[int64]bool)
+	}
+	m.panelRerunInFlight[jobID] = true
+}
+
+func (m *model) closeFixPanelIfJobChanged() {
+	if (m.reviewFixPanelOpen || m.reviewFixPanelPending) && m.fixPromptJobID != m.selectedJobID {
+		m.closeFixPanel()
+	}
+}
+
 func (m *model) closeFixPanel() {
 	m.reviewFixPanelOpen = false
 	m.reviewFixPanelFocused = false
 	m.reviewFixPanelPending = false
 	m.fixPromptText = ""
 	m.fixPromptJobID = 0
+	m.fixPromptOrigin = 0
+	m.fixPromptFollowRetried = false
+	m.fixPromptSeq = 0
 }

--- a/cmd/roborev/tui/helpers.go
+++ b/cmd/roborev/tui/helpers.go
@@ -105,6 +105,71 @@ func (m *model) selectedJob() (*storage.ReviewJob, bool) {
 	return nil, false
 }
 
+// selectedReviewLoaded reports whether m.currentReview is populated AND
+// belongs to the currently selected job's CURRENT attempt. Split layout's
+// list and detail panes advance independently: selecting a different (e.g.
+// running or queued) job updates selectedJobID immediately, while the detail
+// pane's review only catches up once the debounced follow-fetch lands (or
+// never, if the newly selected job has no review at all). Entry points that
+// hand review-scoped actions (close/comment/fix/scroll) to m.currentReview --
+// entering detail focus via tab or a detail-pane click -- must use this
+// instead of a bare `m.currentReview != nil` check, or those actions can
+// land on the stale review's job instead of the one now highlighted.
+//
+// A JobID match alone can still name a PREVIOUS attempt's review: job IDs
+// are reused across reruns, and an external rerun (another client) arrives
+// as a plain jobs-refresh status change with no local handleRerunResultMsg
+// to clear the loaded review. Mirror splitReconcileDetail's attempt-freshness
+// signals: an observed queued/running window since the review was loaded
+// (paneReviewSeenNonTerminal) means a fresh attempt exists that has not been
+// accepted yet; a job currently in a non-terminal state definitionally
+// outdates the loaded review (renderDetailPane shows a status card for it,
+// not the review, so acting on the review would target invisible content);
+// and for a done job the completion-timestamp comparison catches a rerun
+// whose whole queued/running window fell between two jobs refreshes. A
+// failed job needs no extra check here: splitReconcileDetail rebuilds its
+// synthesized review synchronously on the same jobs refresh that observes
+// the failure.
+func (m *model) selectedReviewLoaded() bool {
+	if m.currentReview == nil {
+		return false
+	}
+	job, ok := m.selectedJob()
+	if !ok {
+		// An anchored review's job can be absent from m.jobs entirely:
+		// hide-closed prunes a just-closed job from the refresh while
+		// handleJobsMsg deliberately preserves the review-anchored
+		// selection. There is no row to check freshness against, and the
+		// loaded review is the only truth the TUI holds for the job the
+		// user is reading -- treat it as loaded so the pane keeps
+		// rendering it and review actions (unclose, comment) still work.
+		// JobID != 0 excludes synthetic prompt-only reviews, which set
+		// only the embedded Job.
+		return m.currentReview.JobID != 0 && m.currentReview.JobID == m.selectedJobID
+	}
+	if m.currentReview.JobID != job.ID {
+		return false
+	}
+	if m.paneReviewSeenNonTerminalJob == job.ID {
+		return false
+	}
+	switch job.Status {
+	case storage.JobStatusDone:
+		return !reviewJobCompletionChanged(m.currentReview, job)
+	case storage.JobStatusFailed:
+		// Failed needs the completion-identity check too: a rerun whose
+		// whole queued/running window fell between refreshes and then
+		// FAILED leaves a loaded earlier attempt (its done review, or an
+		// identically-worded earlier failure) matching on JobID with the
+		// observation signal never set. The failure synthesis embeds the
+		// row's FinishedAt at build time, so the comparison works for
+		// synthesized reviews exactly as for fetched ones.
+		return !reviewJobCompletionChanged(m.currentReview, job)
+	default:
+		return false
+	}
+}
+
 // selectedIsMember reports whether selectedJobID names a side-fetched panel
 // member (present in panelMembers, absent from m.jobs). Used to keep a member
 // selected across a parents-only refresh, since the member is not in m.jobs.

--- a/cmd/roborev/tui/layout.go
+++ b/cmd/roborev/tui/layout.go
@@ -422,9 +422,10 @@ func (m model) handleDetailFollowTick(msg detailFollowTickMsg) (tea.Model, tea.C
 	case storage.JobStatusFailed:
 		// Synchronous rebuild routed through the shared ordered acceptance
 		// (epoch bump + acceptReview) so a pre-rerun in-flight response
-		// cannot overwrite it -- see acceptSynthesizedFailure.
-		m.acceptSynthesizedFailure(job.ID, synthesizeFailedReview(job, m.currentReview))
-		return m, nil
+		// cannot overwrite it -- see acceptSynthesizedFailure. The
+		// returned cmd loads the job's persisted comments.
+		cmd := m.acceptSynthesizedFailure(job.ID, synthesizeFailedReview(job, m.currentReview))
+		return m, cmd
 	case storage.JobStatusRunning:
 		return m.startPaneLog(*job)
 	}
@@ -479,9 +480,16 @@ func synthesizeFailedReview(job *storage.ReviewJob, prev *storage.Review) *stora
 // superseded same-job response arriving later finds content already
 // present and at most serves its own open intent via handleReviewMsg's
 // fallback switch; it can no longer replace content.
-func (m *model) acceptSynthesizedFailure(jobID int64, fresh *storage.Review) {
+//
+// The returned cmd loads the job's persisted comments: acceptance clears
+// currentResponses, and no review fetch can ever repopulate them for a
+// synthesized review (the /api/review request 404s), so without this a
+// navigation round-trip or a fresh TUI would show the failure with its
+// comments permanently missing. Callers must run the cmd.
+func (m *model) acceptSynthesizedFailure(jobID int64, fresh *storage.Review) tea.Cmd {
 	m.reviewFetchSeq++
 	m.acceptReview(reviewMsg{review: fresh, jobID: jobID, fetchSeq: m.reviewFetchSeq})
+	return m.fetchFailedJobComments(jobID)
 }
 
 // reviewJobCompletionChanged reports whether job has completed AGAIN since
@@ -840,9 +848,10 @@ func (m model) splitReconcileDetail() (model, tea.Cmd) {
 		// (epoch bump + acceptReview): sibling clears, scroll reset, the
 		// scoped observation clear and the pending-intent consumes all run
 		// there, and the epoch bump dooms any pre-rerun in-flight response
-		// for this job -- see acceptSynthesizedFailure.
-		m.acceptSynthesizedFailure(job.ID, fresh)
-		return m, nil
+		// for this job -- see acceptSynthesizedFailure. The returned cmd
+		// loads the job's persisted comments.
+		cmd := m.acceptSynthesizedFailure(job.ID, fresh)
+		return m, cmd
 	case storage.JobStatusRunning:
 		if m.paneLogJobID != job.ID || !m.paneLogStreaming {
 			// Restarting the tail invalidates any earlier error; clear it

--- a/cmd/roborev/tui/layout.go
+++ b/cmd/roborev/tui/layout.go
@@ -489,7 +489,7 @@ func synthesizeFailedReview(job *storage.ReviewJob, prev *storage.Review) *stora
 func (m *model) acceptSynthesizedFailure(jobID int64, fresh *storage.Review) tea.Cmd {
 	m.reviewFetchSeq++
 	m.acceptReview(reviewMsg{review: fresh, jobID: jobID, fetchSeq: m.reviewFetchSeq})
-	return m.fetchFailedJobComments(jobID)
+	return m.dispatchFailedCommentsFetch(jobID)
 }
 
 // reviewJobCompletionChanged reports whether job has completed AGAIN since

--- a/cmd/roborev/tui/layout.go
+++ b/cmd/roborev/tui/layout.go
@@ -1,0 +1,942 @@
+package tui
+
+import (
+	"io"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/streamfmt"
+)
+
+type layoutMode int
+
+const (
+	layoutStacked layoutMode = iota
+	layoutSplit
+)
+
+func (l layoutMode) String() string {
+	if l == layoutSplit {
+		return "split"
+	}
+	return "stacked"
+}
+
+type focusPane int
+
+const (
+	focusList focusPane = iota
+	focusDetail
+)
+
+func (f focusPane) String() string {
+	if f == focusDetail {
+		return "detail"
+	}
+	return "list"
+}
+
+// Split layout breakpoints and pane sizing. Detail-first allocation: the
+// review pane reserves splitDetailReservedWidth cells; the list takes the
+// remainder clamped to [splitListMinWidth, splitListMaxWidth].
+const (
+	splitMinWidth            = 140
+	splitMinHeight           = 36
+	splitDetailReservedWidth = 100
+	splitListMinWidth        = 50
+	splitListMaxWidth        = 90
+)
+
+// detailFollowDebounce coalesces held-down queue navigation into a single
+// detail fetch (kata uses the same value).
+const detailFollowDebounce = 75 * time.Millisecond
+
+// splitGeom is the single source of truth for split-layout pane math.
+// Outer sizes include the 1-cell border on each side; inner sizes are the
+// content area inside the border.
+type splitGeom struct {
+	listOuterW, detailOuterW, bodyH                    int
+	listInnerW, listInnerH, detailInnerW, detailInnerH int
+}
+
+// splitGeometry computes pane rectangles for the given terminal size.
+// Bands: title(1) + body(bodyH) + info(1) + footer(footerLines).
+func splitGeometry(width, height, footerLines int) splitGeom {
+	listW := min(max(width-splitDetailReservedWidth, splitListMinWidth), splitListMaxWidth)
+	detailW := width - listW
+	bodyH := max(height-2-footerLines, 5)
+	return splitGeom{
+		listOuterW:   listW,
+		detailOuterW: detailW,
+		bodyH:        bodyH,
+		listInnerW:   listW - 2,
+		listInnerH:   bodyH - 2,
+		detailInnerW: detailW - 2,
+		detailInnerH: bodyH - 2,
+	}
+}
+
+func pickLayout(width, height int) layoutMode {
+	if width >= splitMinWidth && height >= splitMinHeight {
+		return layoutSplit
+	}
+	return layoutStacked
+}
+
+// resolveLayout picks the layout for the current terminal size, honoring a
+// manual L-toggle lock: a locked stacked preference always wins; a locked
+// split preference engages whenever the terminal fits and degrades
+// gracefully when it doesn't. Distraction-free mode overrides everything:
+// its contract is title plus job list ONLY (docs/integrations/tui.md), and
+// the split composition's detail pane, borders, info line and footer all
+// violate it -- so while it is active the layout is stacked regardless of
+// terminal size or lock, and every consumer keyed on m.layout (rendering,
+// mouse routing, tab, reconcile) follows automatically.
+func (m model) resolveLayout() layoutMode {
+	if m.distractionFree {
+		return layoutStacked
+	}
+	fits := pickLayout(m.width, m.height)
+	if m.layoutLocked && m.preferredLayout == layoutStacked {
+		return layoutStacked
+	}
+	return fits
+}
+
+// splitActive reports whether the split composition should render: split
+// layout is on and the current view is one of the two split-rooted views.
+// Transient views (prompt, comment, help, log, ...) remain full-screen. A
+// tasks-origin review (reviewFromView == viewTasks) is ALSO excluded even
+// though currentView == viewReview: fix tasks live in m.fixJobs, not
+// m.jobs, so the split's list pane (which only ever shows m.jobs rows) and
+// renderDetailPane's m.selectedJob() lookup (m.jobs/panelMembers-only)
+// have nothing to resolve selectedJobID against -- it would render "No job
+// selected" instead of the loaded review. A tasks-origin review renders
+// full-screen via the ordinary review renderer instead, same as any other
+// transient view.
+func (m model) splitActive() bool {
+	if m.currentView == viewReview && m.reviewFromView == viewTasks {
+		return false
+	}
+	return m.layout == layoutSplit &&
+		(m.currentView == viewQueue || m.currentView == viewReview)
+}
+
+// applyLayout transitions the layout, mapping view<->focus in both
+// directions so selection and the open review survive the flip. When a
+// transient view (help, log, comment editor, ...) is open, only m.layout is
+// updated -- focus/currentView/currentReview are left untouched so the
+// transient view's in-progress state (e.g. a comment being typed) survives
+// a resize. normalizeSplitState reconciles focus once such a view exits.
+func (m *model) applyLayout(target layoutMode) {
+	if m.layout == target {
+		return
+	}
+	m.layout = target
+	if target != layoutSplit && m.paneLogStreaming {
+		// Leaving split kills the pane log's poll chain: the pending
+		// paneLogTickMsg is dropped by handlePaneLogTickMsg's layout gate
+		// and nothing re-arms it. Invalidate the tail explicitly (the same
+		// idiom handleWindowSizeMsg uses when the pane stops being the
+		// visible thing) so the model stops claiming an active tail --
+		// otherwise toggling back to split with the same running job still
+		// selected finds startPaneLog's "already tailing this job" early
+		// return and splitReconcileDetail's `!paneLogStreaming` guard both
+		// satisfied, and the pane sits on frozen stale lines until the job
+		// completes. Bumping the seq also rejects any response still in
+		// flight from the tail we just abandoned. Done before the
+		// transient-view early return below: the poll chain dies whether
+		// or not a transient view happens to be open over the split.
+		m.paneLogSeq++
+		m.paneLogStreaming = false
+	}
+	if m.currentView != viewQueue && m.currentView != viewReview {
+		return
+	}
+	if target == layoutSplit {
+		if m.currentView == viewReview && m.currentReview != nil {
+			m.focus = focusDetail
+		} else {
+			m.focus = focusList
+			if m.currentView == viewReview {
+				m.currentView = viewQueue
+			}
+		}
+		return
+	}
+	// Leaving split: detail focus keeps the full-screen review open --
+	// but only when the loaded review is the selected job's CURRENT
+	// attempt (selectedReviewLoaded). A bare non-nil check would carry a
+	// stale attempt's review (external rerun observed, refetch not yet
+	// landed) into stacked full-screen, where splitReconcileDetail no
+	// longer runs to replace it and the stacked review actions
+	// (close/comment/fix) would target the obsolete attempt indefinitely.
+	// A tasks-origin review is preserved unconditionally: its fix job
+	// never resolves in m.jobs, so selectedReviewLoaded is false for it by
+	// construction, yet the review on screen is exactly what the user is
+	// reading and stacked continues to render it the same way.
+	if m.focus == focusDetail && m.currentReview != nil &&
+		(m.reviewFromView == viewTasks || m.selectedReviewLoaded()) {
+		m.currentView = viewReview
+	} else {
+		m.currentView = viewQueue
+		m.currentReview = nil
+		m.reviewScroll = 0
+		// The displayed review was just discarded, and an OPEN panel is
+		// bound to whatever review is displayed (fixPromptJobID stamped
+		// when it opened). Left open, the next review to render in stacked
+		// -- e.g. Enter on a failed job, whose synchronous synthesis
+		// assigns currentReview directly without acceptReview's wrong-job
+		// panel close -- would show the panel still bound to the previous
+		// job, and submitting would start a fix for a job no longer on
+		// screen. A PENDING intent is left alone: it is bound to the
+		// SELECTION, which this branch does not move, and its response is
+		// consumed through acceptReview, which re-binds correctly.
+		if m.reviewFixPanelOpen {
+			m.closeFixPanel()
+		}
+	}
+}
+
+// followSelectionChange is the shared chokepoint every selection mutation
+// runs through. It does two distinct things, and only one of them is a
+// split-layout concern:
+//
+//  1. ABANDONMENT (any layout): a genuine selection change abandons the
+//     old job's pending intents -- the pending-open request and a fix
+//     panel bound to it (outside split, only a PENDING panel: an open one
+//     is bound to the review displayed full-screen, not to the queue
+//     selection -- see the inline comment below) -- and invalidates that
+//     job's in-flight dispatch by bumping detailFollowGen. The abandonment rule is "the selection
+//     leaving a job abandons its pending requests, whoever moves it";
+//     layout is irrelevant to it. Gated on split layout, stacked mode
+//     would let a user press Enter or F on job X, navigate to Y, return
+//     to X before the response arrived, and have the abandoned response
+//     accepted -- unexpectedly opening X's review or fix panel with no
+//     fresh keypress. The gen bump rejects that response, and the
+//     disarms make it un-rescuable.
+//  2. DETAIL FOLLOW (split only): scheduleDetailFollow arms the debounced
+//     fetch for the new selection, stops the old job's pane log tail and
+//     clears splitDetailErr. Stacked has no pane, so none of that
+//     applies; only the abandonment above runs.
+//
+// Paths that mutate the selection outside keyboard/mouse navigation route
+// through here too: the control socket's close-review and cancel-job
+// handlers move the selection when hideClosed hides the job they just
+// acted on, and the optimistic-operation rollbacks
+// (handleClosedResultMsg/handleCancelResultMsg) restore it when the
+// server rejects the operation. Left to decide for themselves, each would
+// leave the detail pane loaded for the old job until some later jobs
+// refresh happened to reconcile it.
+//
+// Callers pass the selection as it was BEFORE their mutation and must batch
+// the returned cmd with their own. Any code that mutates the selection must
+// come through here (or, for handleJobsMsg's normalization and the filter
+// reset, perform the same abandonment inline); calling
+// scheduleDetailFollow directly is reserved for same-selection callers
+// (maybeBootstrapDetail), which have nothing to abandon.
+func (m model) followSelectionChange(prevSelected int64) (model, tea.Cmd) {
+	if m.selectedJobID == prevSelected {
+		return m, nil
+	}
+	// The guard above is what proves the selection GENUINELY changed --
+	// the precondition both disarms require (a same-job bootstrap must
+	// NOT reach these). See disarmPendingReviewOpen's doc.
+	m.disarmPendingReviewOpen()
+	m.abandonInFlightSelectionRequests()
+	if m.layout != layoutSplit {
+		// Outside split only the PENDING half of the fix intent is
+		// selection-bound (the same asymmetry as handleJobsMsg's
+		// normalization epilogue): F was pressed with the selection on the
+		// intent's job and no review on screen yet, so the selection moving
+		// off it abandons the request. An OPEN panel is different outside
+		// split -- it is bound to the review displayed full-screen, and the
+		// selection can move under it without the display changing (a
+		// control-socket close of a hidden job, a rollback), so closing it
+		// here would dump an in-progress fix prompt for a review the user
+		// is still looking at. Displayed-review changes close open panels
+		// at their own sites (review nav, the wrong-job acceptance guard).
+		if m.reviewFixPanelPending && !m.reviewFixPanelOpen &&
+			m.fixPromptJobID != m.selectedJobID {
+			m.closeFixPanel()
+		}
+		// A detailFollowGen bumper -- classified ABANDONMENT, disarms
+		// performed inline above per the field's contract (tui.go). The
+		// bump dooms the abandoned dispatch's response at the gen gate;
+		// with the intents disarmed it is also un-rescuable
+		// (reviewIntentRescuable requires an armed intent). No tick is
+		// scheduled: there is no pane to follow in stacked, and
+		// handleDetailFollowTick would drop it anyway.
+		m.detailFollowGen++
+		return m, nil
+	}
+	m.closeFixPanelIfJobChanged()
+	return m.scheduleDetailFollow()
+}
+
+// abandonInFlightSelectionRequests dooms the request-scoped state a genuine
+// selection change leaves behind, shared by every abandonment site --
+// followSelectionChange, handleJobsMsg's normalization epilogue, and
+// resetQueueForFilterChange. Like disarmPendingReviewOpen it has no
+// self-guard: callers must only invoke it when the selection GENUINELY
+// changed.
+//
+//   - promptFetchSeq: an in-flight 'p' response must not be accepted if a
+//     later refetch re-selects the abandoned job before it lands -- every
+//     handlePromptMsg gate (jobID, attempt, origin) passes again in that
+//     state, and only the bumped identity rejects it. See promptFetchSeq's
+//     doc comment (tui.go).
+//   - reconcileFetchJobID/Seq: the suppression slot was armed for the era
+//     being abandoned; its response will be gen-rejected on arrival, so
+//     left set it only SUPPRESSES the re-selected job's replacement fetch
+//     until another jobs refresh, stalling the pane at "Loading review...".
+//     Same belt-and-suspenders clear scheduleDetailFollow performs.
+//
+// detailFollowGen bumps stay at the call sites: followSelectionChange's
+// split branch delegates its bump to scheduleDetailFollow, so folding gen
+// in here would double-count responsibility for it.
+func (m *model) abandonInFlightSelectionRequests() {
+	m.promptFetchSeq++
+	m.reconcileFetchJobID = 0
+	m.reconcileFetchSeq = 0
+}
+
+// disarmPendingReviewOpen clears the pending-open intent
+// (pendingReviewOpenJobID/Origin/Seq, tui.go). Unlike closeFixPanelIfJobChanged,
+// this has no per-call job comparison to make it self-guarding -- it doesn't
+// compare against anything, it just clears -- so callers must only invoke it
+// at a point where the selection is ALREADY KNOWN to have genuinely changed.
+//
+// This deliberately does NOT live in scheduleDetailFollow:
+// scheduleDetailFollow cannot tell a real selection change from a same-job
+// bootstrap (maybeBootstrapDetail calls it on a plain layout toggle, where
+// the selection is unchanged and any armed intent is still valid --
+// clearing it there would silently discard the user's explicit Enter). It
+// lives in the code that can tell: followSelectionChange, behind its
+// `selectedJobID != prevSelected` guard, which every selection-changing
+// path routes through (the handleKeyMsg wrapper, the step*Nav helpers, the
+// pagination arms, tasks Enter/'P', handleSplitMouse, the control-socket
+// handlers and the rollback restores), plus the inline sites that perform
+// the same abandonment without scheduling a follow (handleJobsMsg's
+// normalization and resetQueueForFilterChange).
+func (m *model) disarmPendingReviewOpen() {
+	m.pendingReviewOpenJobID = 0
+	m.pendingReviewOpenOrigin = 0
+	m.pendingReviewOpenSeq = 0
+}
+
+// scheduleDetailFollow arms the debounced detail fetch after a queue cursor
+// move in split layout. The generation counter cancels earlier ticks.
+func (m model) scheduleDetailFollow() (model, tea.Cmd) {
+	// A detailFollowGen bumper -- see that field's doc comment (tui.go)
+	// for the contract every bumper must satisfy. This one is incidental
+	// refresh, not abandonment, so it must not (and does not) disarm
+	// either pending intent.
+	m.detailFollowGen++
+	gen := m.detailFollowGen
+	m.reviewScroll = 0
+	m.splitDetailErr = nil
+	// The selection moved to a different job -- invalidate any in-flight
+	// pane log fetch/poll for the job we just navigated away from by
+	// bumping paneLogSeq, so a response for it (including a late-arriving
+	// error) fails handlePaneLogOutputMsg/handlePaneLogTickMsg's seq gate
+	// instead of landing after the fact and getting misattributed (via
+	// splitDetailErr) to the newly selected job. paneLogSeq alone gates
+	// those handlers, not jobID, so this is the one place that must catch
+	// every selection change.
+	if m.paneLogStreaming && m.paneLogJobID != m.selectedJobID {
+		m.paneLogSeq++
+		m.paneLogStreaming = false
+	}
+	// NEITHER pending intent (pendingReviewOpen*, the fix panel) is
+	// touched here. Both disarms live in followSelectionChange, behind
+	// its selection-actually-changed guard, because this function cannot
+	// tell a real selection change from a same-job bootstrap: it is
+	// called both by followSelectionChange (abandonment already performed
+	// by the time it gets here) and by maybeBootstrapDetail on a plain
+	// layout toggle, where the selection is UNCHANGED and any armed
+	// intent belongs to a request that is still valid -- the rescue path,
+	// reviewIntentRescuable, exists to serve exactly that surviving
+	// intent past this function's own gen bump. A future direct caller
+	// with a genuine selection change belongs in followSelectionChange,
+	// not here.
+	// The gen bump above already dooms any in-flight reconcile-dispatched
+	// response for the PREVIOUS selection -- it'll fail handleReviewMsg's
+	// gen check, and both handlers release the suppression slot on any
+	// response for the job before checking anything, so this isn't
+	// load-bearing for correctness. Kept as belt-and-suspenders: it clears
+	// the slot for the OLD job IMMEDIATELY, synchronously, rather than
+	// waiting for that doomed response to actually arrive over the network
+	// -- narrowing the window where a genuine need to re-dispatch for that
+	// same job, were the user to return to it before the stale response
+	// lands, would otherwise still be (correctly, if unnecessarily)
+	// suppressed. Same idiom as paneLogStreaming above.
+	m.reconcileFetchJobID = 0
+	m.reconcileFetchSeq = 0
+	return m, tea.Tick(detailFollowDebounce, func(time.Time) tea.Msg {
+		return detailFollowTickMsg{gen: gen}
+	})
+}
+
+// handleDetailFollowTick resolves a follow tick: fetch the review for a
+// done job, synthesize the error review for a failed job, start the pane
+// log for a running job. Stale generations are dropped.
+//
+// The Done branch's idempotency check is selectedReviewLoaded, not a bare
+// JobID match: renderDetailPane gates the review body on the same
+// predicate, so a stale-but-matching review (the selected job was rerun
+// and completed while the selection was elsewhere, then re-selected)
+// renders as "Loading review..." -- skipping the fetch here would leave
+// that placeholder stalled with nothing in flight until the next fallback
+// poll. The shared predicate makes "shows loading" imply "a fetch is
+// coming". The Failed branch still doesn't stop an active tail, unlike
+// splitReconcileDetail's twin: this only runs on a fresh selection change,
+// and reconcile self-heals that narrower imprecision within one refresh.
+func (m model) handleDetailFollowTick(msg detailFollowTickMsg) (tea.Model, tea.Cmd) {
+	if msg.gen != m.detailFollowGen || m.layout != layoutSplit {
+		return m, nil
+	}
+	job, ok := m.selectedJob()
+	if !ok {
+		return m, nil
+	}
+	switch job.Status {
+	case storage.JobStatusDone:
+		if m.selectedReviewLoaded() {
+			return m, nil
+		}
+		// Clear any earlier splitDetailErr before issuing the follow fetch
+		// so a stale error from a previous job/attempt can't briefly show
+		// through for this one while the fresh fetch is in flight.
+		m.splitDetailErr = nil
+		// Fires once per selection-change debounce, not
+		// splitReconcileDetail's every-refresh dispatch, so it needs no
+		// duplicate-dispatch suppression (it never touches
+		// reconcileFetchJobID) -- but it is ordered like every other
+		// review fetch: dispatchReviewFollow bumps the shared epoch and
+		// stamps it (see reviewFetchSeq's doc comment, tui.go).
+		cmd := m.dispatchReviewFollow(job.ID)
+		return m, cmd
+	case storage.JobStatusFailed:
+		// Synchronous rebuild routed through the shared ordered acceptance
+		// (epoch bump + acceptReview) so a pre-rerun in-flight response
+		// cannot overwrite it -- see acceptSynthesizedFailure.
+		m.acceptSynthesizedFailure(job.ID, synthesizeFailedReview(job, m.currentReview))
+		return m, nil
+	case storage.JobStatusRunning:
+		return m.startPaneLog(*job)
+	}
+	return m, nil
+}
+
+// synthesizeFailedReview builds the synthetic review shown for a failed job
+// in the split detail pane, shared by handleDetailFollowTick (selection
+// change) and splitReconcileDetail (jobs refresh) so both render identically
+// through renderReviewPaneBody's scrollable pane-body path rather than
+// renderDetailPane's card+wrapped-error fallback.
+//
+// prev is the review currently displayed (m.currentReview, may be nil).
+// When it belongs to this same job and carries a prompt, the prompt is
+// preserved on the synthesized review: the prompt view over a queued/
+// running job renders a synthetic review built from the row's Prompt
+// (handlePromptKey/stepPromptNav), and the daemon strips terminal jobs'
+// prompts from job listings (stripJobPrompts) -- so once the job fails,
+// that displayed review is the LAST copy of the prompt the TUI will ever
+// hold, and replacing it wholesale would blank an open prompt view
+// unrecoverably. The same-job match accepts prev.Job.ID as well as
+// prev.JobID because those synthetic prompt reviews set only the embedded
+// Job, not the JobID field.
+func synthesizeFailedReview(job *storage.ReviewJob, prev *storage.Review) *storage.Review {
+	jobCopy := *job
+	fresh := &storage.Review{
+		JobID:  job.ID,
+		Agent:  job.Agent,
+		Prompt: job.Prompt,
+		Output: "Job failed:\n\n" + job.Error,
+		Job:    &jobCopy,
+	}
+	if fresh.Prompt == "" && prev != nil && prev.Prompt != "" &&
+		(prev.JobID == job.ID || (prev.Job != nil && prev.Job.ID == job.ID)) {
+		fresh.Prompt = prev.Prompt
+	}
+	return fresh
+}
+
+// acceptSynthesizedFailure joins the synchronous failed-job rebuild into
+// the same ordered acceptance mechanism as fetched reviews. Bumping the
+// shared fetch epoch first makes every older in-flight response land
+// fetchSeq-superseded -- without it, a pre-rerun reviewMsg dispatched for
+// this job (an EXTERNAL rerun bumps no jobAttemptGen and moves no
+// selection, so the attempt/gen/jobID gates all still pass) could arrive
+// after this rebuild and overwrite the synthesized failure with the
+// previous attempt's review until a later refresh corrected it. Routing
+// the content through acceptReview keeps every acceptance side effect --
+// sibling clears, scroll reset, the scoped paneReviewSeenNonTerminalJob
+// clear, wrong-job panel close, and the pending-intent consumes with
+// their guarded view switches -- identical to a fetched landing. A
+// superseded same-job response arriving later finds content already
+// present and at most serves its own open intent via handleReviewMsg's
+// fallback switch; it can no longer replace content.
+func (m *model) acceptSynthesizedFailure(jobID int64, fresh *storage.Review) {
+	m.reviewFetchSeq++
+	m.acceptReview(reviewMsg{review: fresh, jobID: jobID, fetchSeq: m.reviewFetchSeq})
+}
+
+// reviewJobCompletionChanged reports whether job has completed AGAIN since
+// review was loaded -- true means review is STALE and should be refetched.
+// review.Job is the ReviewJob snapshot embedded in the review at fetch
+// time; job is the freshly-polled job from m.jobs (or, for a panel member,
+// from m.panelMembers -- see selectedJob). Job IDs are reused across
+// reruns, so a JobID match alone (splitReconcileDetail's Done/Failed
+// idempotency checks) can't tell a review from a previous attempt apart
+// from the current one. job.FinishedAt is stamped fresh by the daemon on
+// every completion (including a rerun's) and already tracked in memory --
+// no new persisted state needed.
+//
+// The comparison is intentionally forward-only -- job.FinishedAt strictly
+// AFTER review.Job.FinishedAt -- not a plain inequality. m.panelMembers is
+// refreshed only while a member is queued/running and left FROZEN once all
+// members go terminal (staleExpandedPanelRuns), so selectedJob can hand
+// back a snapshot OLDER than the one already embedded in the loaded review
+// (e.g. currentReview was fetched at a completion the frozen snapshot
+// predates -- an external rerun of a member, review opened via stacked
+// Enter, then L into split). A plain inequality would treat that as
+// "changed" too and refetch on EVERY reconcile pass forever, each landing
+// resetting reviewScroll to 0 -- an unscrollable pane, not just a wasted
+// fetch. A nil FinishedAt on either side (the loaded review's job snapshot
+// is missing it, or the polled job hasn't recorded one yet) is treated
+// conservatively as "changed" so an ambiguous case triggers a refetch
+// rather than risking a stuck stale display; this is unaffected by the
+// forward-only change since neither side can be "after" a nil.
+//
+// finished_at is stored and compared at whole-second resolution (RFC3339),
+// so a rerun that completes within the same wall-clock second as the
+// attempt it replaced is a false negative here (no refetch triggered) --
+// not a practical concern for real review jobs, which run for seconds to
+// minutes, but worth noting since a plain-equality read of this comment
+// would otherwise assume exact timestamps.
+func reviewJobCompletionChanged(review *storage.Review, job *storage.ReviewJob) bool {
+	if review.Job == nil || review.Job.FinishedAt == nil || job.FinishedAt == nil {
+		return true
+	}
+	return job.FinishedAt.After(*review.Job.FinishedAt)
+}
+
+// maybeBootstrapDetail populates the detail pane when split engages
+// (launch, resize past the breakpoint, or L) without a cursor nudge. If the
+// current selection's review is already loaded AND current
+// (selectedReviewLoaded -- the same predicate renderDetailPane gates the
+// review body on), there's nothing to fetch; scheduling anyway would
+// needlessly reset reviewScroll. A stale-but-JobID-matching review (the
+// selected job was rerun and completed since it was loaded) schedules the
+// follow instead: renderDetailPane shows "Loading review..." for it, and
+// without the fetch that placeholder would stall until the next fallback
+// poll.
+//
+// Deliberately does NOT call disarmPendingReviewOpen before
+// scheduleDetailFollow: this function's whole point is a
+// layout toggle or resize where the SELECTION HAS NOT CHANGED -- if an
+// ordinary fetch is in flight for the still-selected job (e.g. stacked,
+// Enter on a done job, then L before the response lands), that request's
+// own "open the review" intent is still exactly what the user wants
+// served once a response lands, and must survive this call.
+func (m model) maybeBootstrapDetail() (model, tea.Cmd) {
+	if m.layout != layoutSplit {
+		return m, nil
+	}
+	// A tasks-origin review renders full-screen even while split is engaged
+	// (splitActive excludes it): the fix job's ID doesn't resolve in
+	// m.jobs/panelMembers, so the currentReview early-return below would be
+	// skipped and scheduleDetailFollow would zero reviewScroll -- yanking
+	// the scroll position of the review the user is READING, to bootstrap a
+	// pane that isn't even rendered. Skip; splitReconcileDetail populates
+	// the pane on the next jobs refresh once the tasks-origin review closes.
+	if m.currentView == viewReview && m.reviewFromView == viewTasks {
+		return m, nil
+	}
+	// Split re-binds the fix panel to the SELECTION (the pane follows it),
+	// so a panel carried across the layout transition while bound to some
+	// other job -- legal in stacked, where an open panel tracks the
+	// full-screen review and the selection can move under it -- must not
+	// survive the engage: focused over the split pane it would submit a
+	// fix for a job the pane doesn't show. Self-guarding on the job
+	// mismatch, so a panel or pending intent for the still-selected job
+	// survives, per the no-disarm rule above.
+	m.closeFixPanelIfJobChanged()
+	if m.selectedReviewLoaded() {
+		return m, nil
+	}
+	return m.scheduleDetailFollow()
+}
+
+// preserveOrClearReviewOnQueueReturn decides what to do with currentReview
+// when a queue-origin transient view (the prompt view, opened via
+// handlePromptKey's queue branch) exits back to viewQueue. Nil-ing
+// currentReview unconditionally on such an exit blanks the split detail
+// pane to "Loading review..." until the next periodic jobs refresh (up to
+// ~15s) even though nothing about the review changed -- the prompt view
+// doesn't mutate it. When split is active and currentReview still
+// belongs to the selected job (the one the prompt was opened for, and
+// which stepPromptNav keeps selectedJobID in sync with if the user
+// navigated within the prompt view), retain it instead: the pane just
+// keeps showing what it already had.
+//
+// This is safe for currentReview ITSELF: splitReconcileDetail re-validates
+// and refreshes it on every subsequent jobs refresh exactly the same way
+// regardless of how the pane arrived at its current content. It does NOT,
+// on its own, say anything about currentReview's SIBLINGS
+// (currentResponses, currentBranch) -- reconcile only inspects
+// currentReview.JobID/Output/embedded-Job, never the siblings, so this
+// function retaining a still-matching review does nothing to guarantee
+// those siblings belong to the SAME job. That guarantee has to come from
+// whoever populates currentReview: handlePromptMsg, the other producer on
+// this path (stepPromptNav -> fetchReviewForPrompt), clears
+// currentResponses/currentBranch itself when the incoming review's job
+// differs from whatever was loaded before -- see its doc comment. Without
+// that, navigating the prompt view to a DIFFERENT job's prompt (which
+// updates currentReview but not the split pane's siblings) and then
+// exiting here would retain the new job's review displayed alongside the
+// PREVIOUS job's stale comments/branch.
+//
+// Stacked layout (no persistent pane to retain it for) and split with no
+// matching review both keep the prior nil-and-reload behavior.
+func (m model) preserveOrClearReviewOnQueueReturn() model {
+	if m.layout == layoutSplit && m.currentReview != nil && m.currentReview.JobID == m.selectedJobID {
+		return m
+	}
+	m.currentReview = nil
+	return m
+}
+
+// paneLogWidth returns the split detail pane's inner content width. Both
+// startPaneLog (the initial formatter) and fetchPaneLog (the formatter
+// rebuilt on a non-incremental fetch) must size the streamfmt.Formatter to
+// this -- not m.width -- or log text wraps for the full terminal and then
+// gets hard-truncated to the pane. Shared here so the two callers can't
+// drift apart.
+func (m model) paneLogWidth() int {
+	footerRows := m.splitFooterRows()
+	g := splitGeometry(m.width, m.height, len(reflowHelpRows(footerRows, m.width)))
+	return g.detailInnerW
+}
+
+// startPaneLog begins tailing a running job's log in the detail pane
+// Resets the pane's log state and kicks off the first fetch;
+// a no-op if the pane is already tailing this same job.
+func (m model) startPaneLog(job storage.ReviewJob) (tea.Model, tea.Cmd) {
+	if m.paneLogJobID == job.ID && m.paneLogStreaming {
+		return m, nil // already tailing this job
+	}
+	m.paneLogJobID = job.ID
+	m.paneLogLines = nil
+	m.paneLogOffset = 0
+	m.paneLogSeq++
+	m.paneLogStreaming = true
+	m.paneLogPaused = false
+	// A fresh tail makes any prior detail-pane error stale by definition:
+	// whatever failed belonged to the previous tail (or to a previous job
+	// entirely, when the selection changed through a path that doesn't go
+	// via scheduleDetailFollow -- e.g. the control socket's select-job).
+	// renderDetailPane's running branch renders splitDetailErr
+	// unconditionally, so leaving it set would show a dead error over this
+	// job's live tail indefinitely. This is the single chokepoint: every
+	// new tail starts here.
+	m.splitDetailErr = nil
+	m.paneLogFmtr = streamfmt.NewWithWidth(io.Discard, m.paneLogWidth(), m.glamourStyle)
+	return m, m.fetchPaneLog(job.ID)
+}
+
+// splitReconcileDetail refreshes the detail pane after a jobs update: if
+// the highlighted job finished while its log was tailing (or while showing
+// a stale review), fetch its review; if the highlighted job is running but
+// the pane isn't (or is no longer) tailing it -- e.g. a resize while a
+// transient view was open invalidated the tail rather than restarting it --
+// restart the tail. Called from handleJobsMsg after a successful jobs
+// refresh (SSE push or the periodic poll), so a stalled running-job pane
+// recovers automatically within one refresh cycle without needing a new
+// selection change to re-trigger it.
+//
+// Attempt identity for the Done/Failed idempotency checks below: job IDs
+// are reused across reruns, so "same JobID" alone doesn't prove the loaded
+// review reflects THIS attempt rather than a previous one -- both branches
+// need a signal for "has a NEW attempt completed since this review was
+// loaded." Two field-based signals were considered and rejected as the
+// SOLE signal (each still composes in as a fallback, see below):
+//   - job.FinishedAt (reviewJobCompletionChanged): stamped fresh by the
+//     daemon on every completion, but stored/compared at whole-second
+//     (RFC3339) resolution -- a rerun completing within the same
+//     wall-clock second as the attempt it replaced compares equal, so the
+//     stale review would survive.
+//   - Rendered error text (Failed branch): a rerun that fails with the
+//     SAME message but different execution metadata (resolved model,
+//     agent, ...) produces identical Output, so the stale synthetic
+//     review (including its embedded Job snapshot/title metadata) would
+//     survive too.
+//
+// Neither timestamp precision nor rendered text is a genuine per-attempt
+// identity. storage.ReviewJob has no field that is (RetryCount resets on
+// some paths and isn't bumped by every rerun path; storage.Review.ID is
+// per-review-ROW, changing on a rerun, but only observable AFTER a fetch
+// already landed -- useful to confirm a fetch was fresh, not to decide
+// whether to fetch). So instead of inventing a timestamp/ID-based identity,
+// m.paneReviewSeenNonTerminal tracks a state-machine fact that's immune to
+// both precision problems: a rerun MUST pass through queued/running before
+// it can complete again, and this function observes the selected job on
+// every jobs refresh -- so "was the selected job seen queued/running since
+// the currently-loaded review was fetched" proves a fresh attempt occurred,
+// independent of what its timestamp or output happen to be. Set below
+// whenever the selected job is queued/running while currentReview is
+// already loaded for it; consulted (as an unconditional "stale" signal) and
+// cleared when a Done/Failed observation rebuilds the review.
+//
+// This alone has one gap, by design: if the job's ENTIRE queued+running
+// window is missed between two jobs refreshes (e.g. the daemon claims and
+// finishes an external rerun faster than both the SSE push and the ~15s
+// poll happen to land), paneReviewSeenNonTerminal never gets set for that
+// attempt, and the fallback signal (FinishedAt.After / Output comparison)
+// takes over -- which is precision-limited as described above, so a
+// same-second, same-text rerun that's ALSO missed entirely in-flight is the
+// residual, deliberately-accepted edge case. In practice a real review job
+// runs for seconds to minutes, and the daemon SSE-broadcasts both the
+// running and the completed transition, so this compound miss requires
+// both the SSE connection to be down/backed-off AND the poll to land
+// exactly outside the run window -- narrow enough not to warrant more
+// persisted state for it.
+func (m model) splitReconcileDetail() (model, tea.Cmd) {
+	if m.layout != layoutSplit {
+		return m, nil
+	}
+	job, ok := m.selectedJob()
+	if !ok {
+		return m, nil
+	}
+	if job.Status == storage.JobStatusQueued || job.Status == storage.JobStatusRunning {
+		if m.currentReview != nil && m.currentReview.JobID == job.ID {
+			m.paneReviewSeenNonTerminalJob = job.ID
+		}
+		// A fix panel bound to a job observed back in queued/running is
+		// bound to an attempt being replaced: submitting would start a fix
+		// against the review the rerun is about to overwrite. Worse, a
+		// FOCUSED panel keeps capturing every keystroke (handleKeyMsg's
+		// panel capture runs before any staleness guard) even though
+		// renderDetailPane now shows a status card instead of the panel.
+		// Close it -- the same decision handleRerunResultMsg makes when the
+		// rerun was initiated locally; this is the external-rerun twin,
+		// observed via the jobs refresh rather than a local confirmation.
+		if (m.reviewFixPanelOpen || m.reviewFixPanelPending) && m.fixPromptJobID == job.ID {
+			m.closeFixPanel()
+		}
+	}
+	switch job.Status {
+	case storage.JobStatusDone:
+		// job.FinishedAt is stamped fresh by the daemon on every completion
+		// (including a rerun's); reviewJobCompletionChanged compares it
+		// against the FinishedAt captured on the loaded review's embedded
+		// Job as a supplementary signal alongside paneReviewSeenNonTerminal
+		// -- see this function's doc comment for why neither is used alone.
+		if m.currentReview != nil && m.currentReview.JobID == job.ID &&
+			m.paneReviewSeenNonTerminalJob != job.ID && !reviewJobCompletionChanged(m.currentReview, job) {
+			// Retaining the loaded review is right for its CONTENT, but
+			// Closed changes independently of completion (another TUI or
+			// the CLI can toggle it, arriving here as refreshed m.jobs
+			// state with no new FinishedAt). Left unsynced, the pane's
+			// [CLOSED] badge goes stale and the next local toggle submits
+			// the already-current state -- appearing to do nothing. Sync
+			// it in place; no refetch needed for a boolean the jobs
+			// refresh already delivered.
+			if job.Closed != nil && m.currentReview.Closed != *job.Closed {
+				m.currentReview.Closed = *job.Closed
+			}
+			return m, nil
+		}
+		// paneReviewSeenNonTerminal is deliberately NOT cleared here: this
+		// only DISPATCHES the fetch, it doesn't yet know whether the
+		// review will actually be replaced. Clearing at dispatch time
+		// would lose the "a fresh attempt was observed" fact if this
+		// fetch fails (handleReviewFollowErrMsg records splitDetailErr but
+		// leaves currentReview and the flag alone) -- the flag stays true
+		// so the NEXT reconcile pass retries instead of being stuck behind
+		// a fallback signal that's blind to same-second/same-text reruns.
+		// The reset lives where the review is actually ACCEPTED: the
+		// follow-landing branch in handleReviewMsg.
+		//
+		// A follow fetch for this job may already be in flight -- not
+		// necessarily for THIS exact completion; it could have been
+		// dispatched for an EARLIER completion of the same job that's
+		// still unresolved, and the guard below suppresses this dispatch
+		// either way (the earlier one's eventual response, whenever it
+		// lands, is ordered by the shared fetch epoch like everything
+		// else). This branch can be re-entered on every jobs refresh (SSE
+		// push or the ~15s poll) while paneReviewSeenNonTerminal stays
+		// true awaiting acceptance, unlike this function's other
+		// branches/callers, which only fire once per discrete event.
+		//
+		// Correctness no longer depends on this guard -- the epoch alone
+		// guarantees no older response can overwrite newer content. Its
+		// remaining value is LIVENESS (plus not piling up duplicate
+		// in-flight requests against a slow daemon): without it, a fetch
+		// slower than the jobs-refresh interval would be superseded by
+		// its own successor before it could ever land, and the pane would
+		// never converge. Scoped to THIS job specifically (not a bare
+		// bool) so a stale entry left over for a DIFFERENT job can never
+		// block dispatching here. See reconcileFetchJobID's doc comment
+		// (tui.go) for why no reachable sequence leaves it stuck set for
+		// this job with nothing able to clear it.
+		if m.reconcileFetchJobID == job.ID {
+			return m, nil
+		}
+		// Clear any earlier splitDetailErr before issuing the follow
+		// fetch so a stale error from a previous job/attempt can't
+		// briefly show through for this one while the fresh fetch is
+		// in flight.
+		m.splitDetailErr = nil
+		m.reconcileFetchJobID = job.ID
+		cmd := m.dispatchReviewFollow(job.ID)
+		// Captured AFTER the dispatch, which is what advanced the epoch:
+		// this is the value stamped on the outgoing request, and the only
+		// value whose arrival may release the slot (see
+		// reconcileFetchSeq's doc comment, tui.go).
+		m.reconcileFetchSeq = m.reviewFetchSeq
+		return m, cmd
+	case storage.JobStatusFailed:
+		// A failed job is never streaming, period -- stop any active tail
+		// for it BEFORE the idempotency check below, unconditionally. Round
+		// 1 only stopped the tail on the rebuild path (after the
+		// idempotency check passed), which left a live tail running
+		// whenever the check below decided the review already looked
+		// current: left claiming an active tail with no live job behind
+		// it, the poll chain would die on its next tick
+		// (handlePaneLogTickMsg's second guard) or, worse, keep polling a
+		// job that's no longer running. Bumping paneLogSeq also rejects any
+		// fetch response still in flight for the tail we just stopped.
+		if m.paneLogJobID == job.ID && m.paneLogStreaming {
+			m.paneLogSeq++
+			m.paneLogStreaming = false
+		}
+		// The idempotency check composes THREE signals: same job ID with no
+		// observed queued/running window since load
+		// (paneReviewSeenNonTerminalJob), an unchanged completion identity
+		// (reviewJobCompletionChanged on the embedded snapshot's
+		// FinishedAt, mirroring the Done branch -- this is what catches a
+		// missed-window rerun whose failure text happens to match), AND
+		// the same rendered error text. Only all three together mean the
+		// displayed review already IS today's failure; anything else gets
+		// replaced. See this function's doc comment for why no single
+		// signal suffices.
+		fresh := synthesizeFailedReview(job, m.currentReview)
+		if m.currentReview != nil && m.currentReview.JobID == job.ID &&
+			m.paneReviewSeenNonTerminalJob != job.ID &&
+			!reviewJobCompletionChanged(m.currentReview, job) &&
+			m.currentReview.Output == fresh.Output {
+			return m, nil
+		}
+		// Mirrors the Done branch above: clear any stale error before
+		// swapping in the synthesized review so it can't briefly show
+		// through for this job.
+		m.splitDetailErr = nil
+		// Synchronous rebuild routed through the shared ordered acceptance
+		// (epoch bump + acceptReview): sibling clears, scroll reset, the
+		// scoped observation clear and the pending-intent consumes all run
+		// there, and the epoch bump dooms any pre-rerun in-flight response
+		// for this job -- see acceptSynthesizedFailure.
+		m.acceptSynthesizedFailure(job.ID, fresh)
+		return m, nil
+	case storage.JobStatusRunning:
+		if m.paneLogJobID != job.ID || !m.paneLogStreaming {
+			// Restarting the tail invalidates any earlier error; clear it
+			// here as well as in startPaneLog so this reconcile pass is
+			// self-contained (startPaneLog can no-op if it is already
+			// tailing this job, which the guard above rules out).
+			m.splitDetailErr = nil
+			mm, cmd := m.startPaneLog(*job)
+			return mm.(model), cmd
+		}
+	}
+	return m, nil
+}
+
+// normalizeSplitState reconciles view/focus state after any Update()
+// handler runs -- the single chokepoint (tui.go's Update, right before
+// returning) every path funnels through before the next render.
+//
+// Three invariants are repaired here:
+//
+//  1. currentView == viewReview implies currentReview != nil, in BOTH
+//     layouts. Most paths that set currentView = viewReview pair it with
+//     currentReview in the same assignment (handleReviewMsg, the
+//     synthesized failed-job review, ...), but several "return to the
+//     review" paths (handlePromptKey's viewKindPrompt branch, handleEscKey/
+//     handleQuitKey's prompt/help/commitMsg returns) instead assume
+//     currentReview is still whatever it was when the transient view was
+//     entered. That assumption breaks if an async event nils currentReview
+//     while the transient view (or viewReview itself) is on screen -- e.g.
+//     a rerun success confirmed for the open review's job (see
+//     handleRerunResultMsg's stale-review clear). Left unrepaired, stacked
+//     layout has no self-healing path: viewContent's nil guard silently
+//     falls back to rendering the queue while currentView stays viewReview,
+//     so arrow/page keys keep manipulating the invisible reviewScroll
+//     instead of the queue until the user presses esc. Fixing it here,
+//     regardless of layout, means every one of those return paths is
+//     covered by a single check instead of needing its own guard.
+//  2. In split layout only, focus == focusDetail iff currentView ==
+//     viewReview -- so a transient view (help, log, ...) exiting into a
+//     layout that changed underneath it while it was open still lands with
+//     consistent focus.
+//  3. reviewFixPanelFocused implies currentView == viewReview, in BOTH
+//     layouts. handleKeyMsg routes keys to the panel only there, and
+//     renderReviewFixPanelPaneLines renders the focused (active input)
+//     variant off the flag alone -- so a focused panel surviving a view
+//     move away from viewReview LOOKS like it is capturing input while
+//     every keystroke actually lands on the current view's keymap ('q'
+//     quits, 'a' closes the review, 'f' opens the filter modal). Two
+//     paths could previously strand that state: acceptReview's pending-'F'
+//     consume when the guarded view switch declines (a transient view was
+//     open at acceptance), and a same-row list-pane click in split (whose
+//     followSelectionChange no-ops on the unchanged selection, so
+//     closeFixPanelIfJobChanged never runs). Repairing it here covers
+//     every such path at once; the panel stays OPEN (the typed prompt is
+//     preserved), it just requires an explicit tab to re-focus once the
+//     user is back on the review.
+//
+// For view/focus, transient views themselves are left untouched; invariants
+// 1-2 only act when currentView is viewQueue or viewReview (after invariant
+// 1's repair may have turned a stale viewReview into viewQueue). Invariant 3
+// acts regardless of the current view: a focused panel is inconsistent the
+// moment currentView is anything but viewReview.
+func (m model) normalizeSplitState() model {
+	if m.currentView == viewReview && m.currentReview == nil {
+		m.currentView = viewQueue
+		m.reviewScroll = 0
+	}
+	// Invariant 1's prompt-view twin: viewContent renders the prompt only
+	// while currentReview is non-nil and silently falls back to the queue
+	// otherwise -- so an async clear while the prompt view is open (e.g. a
+	// control-socket rerun of the prompted job confirming, whose
+	// handleRerunResultMsg nils currentReview regardless of view) would
+	// leave the queue on screen while keys still route as prompt input
+	// (invisible promptScroll, prompt-flavored esc). Return to the queue
+	// directly: the prompt's usual viewReview return target is equally
+	// unbacked with currentReview nil and invariant 1 would send it there
+	// anyway.
+	if m.currentView == viewKindPrompt && m.currentReview == nil {
+		m.currentView = viewQueue
+		m.promptScroll = 0
+	}
+
+	if m.reviewFixPanelFocused && m.currentView != viewReview {
+		m.reviewFixPanelFocused = false
+	}
+
+	if m.layout != layoutSplit {
+		return m
+	}
+	switch m.currentView {
+	case viewQueue:
+		m.focus = focusList
+	case viewReview:
+		m.focus = focusDetail
+	}
+	return m
+}

--- a/cmd/roborev/tui/layout_test.go
+++ b/cmd/roborev/tui/layout_test.go
@@ -1,0 +1,78 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPickLayout(t *testing.T) {
+	tests := []struct {
+		name string
+		w, h int
+		want layoutMode
+	}{
+		{"exactly at breakpoint", 140, 36, layoutSplit},
+		{"one column short", 139, 36, layoutStacked},
+		{"one row short", 140, 35, layoutStacked},
+		{"very wide", 300, 80, layoutSplit},
+		{"default init size", 80, 24, layoutStacked},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, pickLayout(tt.w, tt.h))
+		})
+	}
+}
+
+func TestSplitGeometry(t *testing.T) {
+	assert := assert.New(t)
+
+	// At 140 wide: list = clamp(140-100, 50, 90) = 50, detail = 90.
+	g := splitGeometry(140, 36, 2)
+	assert.Equal(50, g.listOuterW)
+	assert.Equal(90, g.detailOuterW)
+	assert.Equal(140, g.listOuterW+g.detailOuterW)
+	// bodyH = height - title(1) - info(1) - footerLines
+	assert.Equal(32, g.bodyH)
+	assert.Equal(48, g.listInnerW)
+	assert.Equal(30, g.listInnerH)
+	assert.Equal(88, g.detailInnerW)
+	assert.Equal(30, g.detailInnerH)
+
+	// Very wide: list caps at 90, detail absorbs the rest.
+	g = splitGeometry(300, 50, 1)
+	assert.Equal(90, g.listOuterW)
+	assert.Equal(210, g.detailOuterW)
+
+	// Wide-but-tight: list floor 50 holds even if detail dips below 100.
+	// (Cannot happen above the 140 breakpoint, but geometry must not panic.)
+	g = splitGeometry(120, 40, 1)
+	assert.Equal(50, g.listOuterW)
+	assert.Equal(70, g.detailOuterW)
+}
+
+func TestResolveLayoutLocking(t *testing.T) {
+	assert := assert.New(t)
+	m := initTestModel(withDimensions(150, 40))
+
+	// Unlocked: follows the breakpoint.
+	assert.Equal(layoutSplit, m.resolveLayout())
+	m.width, m.height = 100, 30
+	assert.Equal(layoutStacked, m.resolveLayout())
+
+	// Locked to stacked: never splits.
+	m.width, m.height = 200, 50
+	m.layoutLocked = true
+	m.preferredLayout = layoutStacked
+	assert.Equal(layoutStacked, m.resolveLayout())
+
+	// Locked to split: engages only when it fits, degrades when not,
+	// re-engages when the terminal grows again.
+	m.preferredLayout = layoutSplit
+	assert.Equal(layoutSplit, m.resolveLayout())
+	m.width = 100
+	assert.Equal(layoutStacked, m.resolveLayout())
+	m.width = 200
+	assert.Equal(layoutSplit, m.resolveLayout())
+}

--- a/cmd/roborev/tui/nav.go
+++ b/cmd/roborev/tui/nav.go
@@ -43,6 +43,17 @@ func (m model) moveQueueSelection(delta int) model {
 }
 
 // eligibleReviewRow reports whether a job can be opened in the review view.
+//
+// This predicate is a content filter only, NOT a pane-follow guarantee:
+// its consumers (stepReviewNav in handlers.go, handleJobsMsg's pagination
+// viewReview arm in handlers_msg.go) take the shared selection transition
+// (followSelectionChange) like every other selection-moving site, so
+// widening this predicate cannot strand pane state.
+//
+// What remains is a product decision, not a correctness constraint: the
+// review view has nothing to show for a job that has not produced a review
+// yet, so running and queued jobs stay out of its nav.
+// TestEligibleReviewRowExcludesLiveJobs (split_test.go) pins that decision.
 func eligibleReviewRow(j storage.ReviewJob) bool {
 	return j.Status == storage.JobStatusDone || j.Status == storage.JobStatusFailed
 }

--- a/cmd/roborev/tui/nav.go
+++ b/cmd/roborev/tui/nav.go
@@ -234,6 +234,14 @@ func (m *model) normalizeSelectionIfHidden() {
 		if idx >= 0 {
 			m.selectedIdx = idx
 			m.updateSelectedJobID()
+		} else {
+			// No visible job anywhere (e.g. the last one was just closed
+			// with hide-closed on): clear rather than leave the selection
+			// on a hidden job -- the list shows "No jobs" while the detail
+			// pane would stay actionable for the invisible review. Matches
+			// the out-of-bounds branch above.
+			m.selectedIdx = -1
+			m.selectedJobID = 0
 		}
 	} else if m.selectedJobID != m.jobs[m.selectedIdx].ID {
 		// Resync stale selectedJobID (e.g., a job was removed from

--- a/cmd/roborev/tui/queue_test.go
+++ b/cmd/roborev/tui/queue_test.go
@@ -3481,6 +3481,8 @@ func TestContentNavSelectionGoneFlashesStable(t *testing.T) {
 	m := seededPanelModel(t)
 	m.selectedJobID, m.selectedIdx = 11, -1 // member, but R is NOT expanded → 11 not in rows
 	m.currentView = viewReview
+	member := m.panelMembers["R"][0] // job 11
+	m.currentReview = &storage.Review{JobID: member.ID, Job: &member}
 	before := m.currentReview
 	m, _ = pressKey(m, 'k')
 	assert.Equal(t, int64(11), m.selectedJobID, "selection unchanged when gone from rows")
@@ -3577,6 +3579,8 @@ func TestContentNavHiddenMemberFlashesStable(t *testing.T) {
 	m := seededPanelModel(t)                // members 11,12 in panelMembers, not m.jobs
 	m.selectedJobID, m.selectedIdx = 11, -1 // member, but R is NOT expanded → 11 absent from rows
 	m.currentView = viewReview
+	member := m.panelMembers["R"][0] // job 11
+	m.currentReview = &storage.Review{JobID: member.ID, Job: &member}
 	before := m.currentReview
 
 	assert.True(m.selectedIsMember(), "selection is a side-fetched member")

--- a/cmd/roborev/tui/render_log.go
+++ b/cmd/roborev/tui/render_log.go
@@ -281,6 +281,7 @@ func helpLines(tasksEnabled, noQuit bool) []string {
 				{"p", "View prompt"},
 				{"l", "View agent log"},
 				{"m", "View commit message"},
+				{"tab", "Focus detail pane (split)"},
 			},
 		},
 		{
@@ -317,6 +318,7 @@ func helpLines(tasksEnabled, noQuit bool) []string {
 				{"m", "View commit message"},
 				{"F", "Trigger fix (opens inline panel)"},
 				{"esc/q", "Back to queue"},
+				{"esc", "Back to list (split)"},
 			},
 		},
 		{
@@ -359,6 +361,7 @@ func helpLines(tasksEnabled, noQuit bool) []string {
 			keys: func() []struct{ key, desc string } {
 				keys := []struct{ key, desc string }{
 					{"?", "Toggle this help"},
+					{"L", "Toggle split layout"},
 				}
 				if !noQuit {
 					keys = append(keys, struct{ key, desc string }{

--- a/cmd/roborev/tui/render_queue.go
+++ b/cmd/roborev/tui/render_queue.go
@@ -574,313 +574,20 @@ func (m model) renderQueueView() string {
 		visCols := m.visibleColumns()
 
 		// Compute per-column max content widths, using cache when data hasn't changed.
-		allHeaders := [colCount]string{"", "JobID", "Ref", "Branch", "Repo", "Agent", "Queued", "Elapsed", "Status", "P/F", "Closed", "Session", "Req Model", "Req Provider", "Cost"}
-		var contentWidth map[int]int
-		if m.queueColCache.gen == m.queueColGen {
-			contentWidth = m.queueColCache.contentWidths
-		} else {
-			contentWidth = make(map[int]int, len(visCols))
-			for _, c := range visCols {
-				contentWidth[c] = lipgloss.Width(allHeaders[c])
-			}
-			for i := range rows {
-				fullRow := m.queueFullRowCells(rows[i], hasAnyPanel, treeColor)
-				for _, c := range visCols {
-					contentWidth[c] = max(contentWidth[c], lipgloss.Width(fullRow[c]))
-				}
-			}
-			m.queueColCache.gen = m.queueColGen
-			m.queueColCache.contentWidths = contentWidth
+		contentWidth := m.queueContentWidths(rows, visCols, hasAnyPanel, treeColor)
+
+		tableLines := m.renderQueueTable(rows, m.width, visibleRows, visCols, contentWidth)
+		for _, line := range tableLines {
+			b.WriteString(line)
+			b.WriteString("\x1b[K\n")
 		}
-
-		// Compute column widths: fixed columns get their natural size,
-		// flexible columns (Ref, Branch, Repo) absorb excess space.
-		bordersOn := m.colBordersOn
-		borderColor := adaptiveColor("248", "242")
-
-		// Spacing per column: non-first, non-sel columns get 1 char of spacing
-		// (either PaddingRight or border ▕ + PaddingLeft = 2 chars)
-		spacing := func(tableCol int, logCol int) int {
-			if logCol == colSel || tableCol == 0 {
-				return 0
-			}
-			if bordersOn {
-				return 2 // ▕ + PaddingLeft(1)
-			}
-			return 1 // PaddingRight(1)
-		}
-
-		// Fixed-width columns: exact sizes (content + padding, not counting inter-column spacing)
-		fixedWidth := map[int]int{
-			colSel:               2,
-			colJobID:             max(contentWidth[colJobID], 5),
-			colStatus:            max(contentWidth[colStatus], 6), // "Status" header = 6, auto-sizes to content
-			colQueued:            12,
-			colElapsed:           8,
-			colPF:                3,                                                    // "P/F" header = 3
-			colHandled:           max(contentWidth[colHandled], 6),                     // "Closed" header = 6
-			colAgent:             min(max(contentWidth[colAgent], 5), 12),              // "Agent" header = 5, cap at 12
-			colSessionID:         min(max(contentWidth[colSessionID], 7), 12),          // "Session" header = 7, cap at 12
-			colRequestedModel:    min(max(contentWidth[colRequestedModel], 9), 24),     // "Req Model" header = 9
-			colRequestedProvider: min(max(contentWidth[colRequestedProvider], 12), 24), // "Req Provider" header = 12
-			colCost:              max(contentWidth[colCost], 4),                        // "Cost" header = 4
-		}
-
-		// Flexible columns absorb excess space
-		flexCols := []int{colRef, colBranch, colRepo}
-
-		// Compute total fixed consumption
-		totalFixed := 0
-		for ti, c := range visCols {
-			sp := spacing(ti, c)
-			if fw, ok := fixedWidth[c]; ok {
-				totalFixed += fw + sp
-			} else {
-				totalFixed += sp // spacing is always consumed
-			}
-		}
-
-		remaining := m.width - totalFixed
-		// Distribute remaining space among flex columns.
-		// colWidths stores content-only width; StyleFunc adds spacing via
-		// s.Width(w + spacing(col, logicalCol)) so the total column width
-		// on screen = content width + inter-column spacing.
-		colWidths := make(map[int]int, len(visCols))
-		maps.Copy(colWidths, fixedWidth)
-
-		// Build visible-only flex list once.
-		var visFlex []int
-		for _, c := range flexCols {
-			if !m.hiddenColumns[c] {
-				visFlex = append(visFlex, c)
-			}
-		}
-
-		if len(visFlex) > 0 && remaining > 0 {
-			// Two-phase distribution: first guarantee each flex
-			// column at least min(contentWidth, equalShare), then
-			// distribute surplus proportionally to remaining
-			// content headroom. This prevents a single wide column
-			// from starving narrower ones.
-			equalShare := remaining / len(visFlex)
-
-			// Phase 1: allocate floors.
-			distributed := 0
-			for _, c := range visFlex {
-				floor := min(contentWidth[c], equalShare)
-				colWidths[c] = max(floor, 1)
-				distributed += colWidths[c]
-			}
-
-			// Drain overshoot from max(...,1) inflation when
-			// remaining < len(visFlex).
-			if distributed > remaining {
-				drainFlexOverflow(visFlex, colWidths, distributed-remaining)
-				distributed = remaining
-			}
-
-			// Compute headroom from actual allocated widths.
-			totalHeadroom := 0
-			headroom := make(map[int]int, len(visFlex))
-			for _, c := range visFlex {
-				h := contentWidth[c] - colWidths[c]
-				if h > 0 {
-					headroom[c] = h
-					totalHeadroom += h
-				}
-			}
-
-			// Phase 2: distribute surplus proportionally to
-			// content headroom (columns already at content width
-			// have zero headroom and get nothing extra).
-			surplus := remaining - distributed
-			if surplus > 0 && totalHeadroom > 0 {
-				phase2 := 0
-				for i, c := range visFlex {
-					var extra int
-					if i == len(visFlex)-1 {
-						extra = surplus - phase2
-					} else {
-						extra = surplus * headroom[c] / totalHeadroom
-					}
-					colWidths[c] += extra
-					phase2 += extra
-				}
-			} else if surplus > 0 {
-				// All columns at content width — distribute
-				// remaining space equally.
-				for i, c := range visFlex {
-					extra := surplus / (len(visFlex) - i)
-					colWidths[c] += extra
-					surplus -= extra
-				}
-			}
-		} else if len(visFlex) > 0 {
-			// No remaining space: give flex columns 1 char each to
-			// avoid overflow at very narrow terminal widths.
-			for _, c := range visFlex {
-				colWidths[c] = 1
-			}
-		}
-
-		// Build visible rows for the window
-		windowRows := rows[start:end]
-		tableRows := make([][]string, 0, end-start)
-		for i := range windowRows {
-			sel := "  "
-			if start+i == visibleSelectedIdx {
-				sel = "> "
-			}
-			fullRow := m.queueFullRowCells(windowRows[i], hasAnyPanel, treeColor)
-			fullRow[colSel] = sel
-
-			row := make([]string, len(visCols))
-			for vi, c := range visCols {
-				row[vi] = fullRow[c]
-			}
-			tableRows = append(tableRows, row)
-		}
-
-		// Compute the selected row index within the visible window
-		selectedWindowIdx := visibleSelectedIdx - start
-
-		// Find the last visible table column index (for padding logic)
-		lastVisCol := len(visCols) - 1
-
-		// Group banding: a panel parent and its members share one zebra band so
-		// the nesting reads as a group. Only computed (and applied) when the page
-		// has panels, so a panel-free page keeps its original un-banded bytes.
-		var bands []bool
-		if hasAnyPanel {
-			bands = groupBanding(rows)
-		}
-
-		t := table.New().
-			BorderTop(false).
-			BorderBottom(false).
-			BorderLeft(false).
-			BorderRight(false).
-			BorderColumn(false).
-			BorderRow(false).
-			BorderHeader(!compact).
-			Border(lipgloss.Border{
-				Top:    "─",
-				Bottom: "─",
-				Middle: "─",
-			}).
-			Width(m.width).
-			Wrap(false).
-			StyleFunc(func(row, col int) lipgloss.Style {
-				s := lipgloss.NewStyle()
-
-				// Map table col index to logical column
-				logicalCol := colSel
-				if col >= 0 && col < len(visCols) {
-					logicalCol = visCols[col]
-				}
-
-				// Inter-column spacing: non-sel, non-first columns get border or padding
-				if logicalCol != colSel && col > 0 {
-					if bordersOn {
-						s = s.Border(lipgloss.Border{Left: "▕"}, false, false, false, true).
-							BorderForeground(borderColor).PaddingLeft(1)
-					} else if col < lastVisCol {
-						s = s.PaddingRight(1)
-					}
-				}
-
-				// Set explicit width for all columns (includes spacing)
-				w := colWidths[logicalCol]
-				if w > 0 {
-					s = s.Width(w + spacing(col, logicalCol))
-				}
-
-				// Right-align elapsed column
-				if logicalCol == colElapsed {
-					s = s.Align(lipgloss.Right)
-				}
-
-				// Header row styling
-				if row == table.HeaderRow {
-					return s.Foreground(adaptiveColor("242", "246"))
-				}
-
-				// Selection highlighting — uniform background, no per-cell coloring
-				if row == selectedWindowIdx {
-					bg := adaptiveColor("153", "24")
-					s = s.Background(bg)
-					if bordersOn {
-						s = s.BorderBackground(bg)
-					}
-					return s
-				}
-
-				// Group banding for non-selected rows: every other panel group
-				// gets a subtle background so a parent and its members read as
-				// one block. Foreground per-cell coloring is applied on top.
-				if absIdx := start + row; bands != nil && absIdx < len(bands) && bands[absIdx] {
-					bg := adaptiveColor("254", "236") // subtle zebra band
-					s = s.Background(bg)
-					if bordersOn {
-						s = s.BorderBackground(bg)
-					}
-				}
-
-				// Per-cell coloring for non-selected rows
-				if row >= 0 && row < len(windowRows) {
-					job := windowRows[row].job
-					switch logicalCol {
-					case colStatus:
-						if c := statusColor(job.Status); c != nil {
-							s = s.Foreground(c)
-						}
-					case colPF:
-						if c := verdictColor(job.Verdict); c != nil {
-							s = s.Foreground(c)
-						}
-					case colHandled:
-						if job.Closed != nil {
-							if *job.Closed {
-								s = s.Foreground(closedStyle.GetForeground())
-							} else {
-								s = s.Foreground(queuedStyle.GetForeground())
-							}
-						}
-					}
-				}
-				return s
-			})
-
-		// Always set headers — lipgloss table drops the last data row
-		// when Headers() is not called.
-		headers := make([]string, len(visCols))
-		if !compact {
-			for vi, c := range visCols {
-				headers[vi] = allHeaders[c]
-			}
-		}
-		t = t.Headers(headers...)
-		t = t.Rows(tableRows...)
-
-		tableStr := t.Render()
-
-		// In compact mode, strip the empty header line we added as a
-		// workaround (it renders as a row of spaces).
-		if compact {
-			if idx := strings.Index(tableStr, "\n"); idx >= 0 {
-				tableStr = tableStr[idx+1:]
-			}
-		}
-		b.WriteString(tableStr)
-		b.WriteString("\x1b[K\n")
 
 		// Pad with clear-to-end-of-line sequences to prevent ghost text
-		tableLines := strings.Count(tableStr, "\n") + 1
 		headerLines := 0
 		if !compact {
 			headerLines = 2 // header + separator
 		}
-		jobLinesWritten := tableLines - headerLines
+		jobLinesWritten := len(tableLines) - headerLines
 		for jobLinesWritten < visibleRows {
 			b.WriteString("\x1b[K\n")
 			jobLinesWritten++
@@ -930,6 +637,341 @@ func (m model) renderQueueView() string {
 	output += "\x1b[J" // Clear to end of screen to prevent artifacts
 
 	return output
+}
+
+// queueContentWidths computes each visible column's max content width across
+// rows, using m.queueColCache (keyed on m.queueColGen) to skip recomputation
+// when nothing has changed since the last render. Callers should always pass
+// the full m.visibleColumns() set as visCols (never a pane-narrowed subset)
+// so the cached map stays a superset that any pane-specific column subset
+// can safely index into.
+func (m model) queueContentWidths(rows []queueRow, visCols []int, hasAnyPanel, treeColor bool) map[int]int {
+	allHeaders := [colCount]string{"", "JobID", "Ref", "Branch", "Repo", "Agent", "Queued", "Elapsed", "Status", "P/F", "Closed", "Session", "Req Model", "Req Provider", "Cost"}
+	var contentWidth map[int]int
+	if m.queueColCache.gen == m.queueColGen {
+		contentWidth = m.queueColCache.contentWidths
+	} else {
+		contentWidth = make(map[int]int, len(visCols))
+		for _, c := range visCols {
+			contentWidth[c] = lipgloss.Width(allHeaders[c])
+		}
+		for i := range rows {
+			fullRow := m.queueFullRowCells(rows[i], hasAnyPanel, treeColor)
+			for _, c := range visCols {
+				contentWidth[c] = max(contentWidth[c], lipgloss.Width(fullRow[c]))
+			}
+		}
+		m.queueColCache.gen = m.queueColGen
+		m.queueColCache.contentWidths = contentWidth
+	}
+	return contentWidth
+}
+
+// renderQueueTable renders the queue table (header row, separator when
+// borders are enabled, and the windowed data rows) sized to width, and
+// returns the rendered lines with no "\x1b[K" escapes — callers append their
+// own clear-to-end-of-line sequences as they write each line out. Windowing
+// is computed internally via queueWindowStart/visibleSelectedRowIndex,
+// exactly as the inline code in renderQueueView did before extraction.
+func (m model) renderQueueTable(rows []queueRow, width, visibleRows int, visCols []int, contentWidth map[int]int) []string {
+	compact := m.queueCompact()
+	hasAnyPanel := anyPanelRow(rows)
+	treeColor := queueColorEnabled()
+	allHeaders := [colCount]string{"", "JobID", "Ref", "Branch", "Repo", "Agent", "Queued", "Elapsed", "Status", "P/F", "Closed", "Session", "Req Model", "Req Provider", "Cost"}
+
+	visibleSelectedIdx := visibleSelectedRowIndex(rows, m.selectedJobID)
+	start, end := queueWindowStart(len(rows), visibleSelectedIdx, visibleRows)
+
+	// Compute column widths: fixed columns get their natural size,
+	// flexible columns (Ref, Branch, Repo) absorb excess space.
+	bordersOn := m.colBordersOn
+	borderColor := adaptiveColor("248", "242")
+
+	// Spacing per column: non-first, non-sel columns get 1 char of spacing
+	// (either PaddingRight or border ▕ + PaddingLeft = 2 chars)
+	spacing := func(tableCol int, logCol int) int {
+		if logCol == colSel || tableCol == 0 {
+			return 0
+		}
+		if bordersOn {
+			return 2 // ▕ + PaddingLeft(1)
+		}
+		return 1 // PaddingRight(1)
+	}
+
+	// Fixed-width columns: exact sizes (content + padding, not counting inter-column spacing)
+	fixedWidth := map[int]int{
+		colSel:               2,
+		colJobID:             max(contentWidth[colJobID], 5),
+		colStatus:            max(contentWidth[colStatus], 6), // "Status" header = 6, auto-sizes to content
+		colQueued:            12,
+		colElapsed:           8,
+		colPF:                3,                                                    // "P/F" header = 3
+		colHandled:           max(contentWidth[colHandled], 6),                     // "Closed" header = 6
+		colAgent:             min(max(contentWidth[colAgent], 5), 12),              // "Agent" header = 5, cap at 12
+		colSessionID:         min(max(contentWidth[colSessionID], 7), 12),          // "Session" header = 7, cap at 12
+		colRequestedModel:    min(max(contentWidth[colRequestedModel], 9), 24),     // "Req Model" header = 9
+		colRequestedProvider: min(max(contentWidth[colRequestedProvider], 12), 24), // "Req Provider" header = 12
+		colCost:              max(contentWidth[colCost], 4),                        // "Cost" header = 4
+	}
+
+	// Flexible columns absorb excess space
+	flexCols := []int{colRef, colBranch, colRepo}
+
+	// Compute total fixed consumption
+	totalFixed := 0
+	for ti, c := range visCols {
+		sp := spacing(ti, c)
+		if fw, ok := fixedWidth[c]; ok {
+			totalFixed += fw + sp
+		} else {
+			totalFixed += sp // spacing is always consumed
+		}
+	}
+
+	remaining := width - totalFixed
+	// Distribute remaining space among flex columns.
+	// colWidths stores content-only width; StyleFunc adds spacing via
+	// s.Width(w + spacing(col, logicalCol)) so the total column width
+	// on screen = content width + inter-column spacing.
+	colWidths := make(map[int]int, len(visCols))
+	maps.Copy(colWidths, fixedWidth)
+
+	// Build visible-only flex list once. A flex column only absorbs excess
+	// space when it's both user-visible (not in hiddenColumns) and actually
+	// present in visCols — callers such as renderQueuePaneBody may pass a
+	// pane-narrowed visCols that drops colBranch/colRepo while they remain
+	// user-visible; without the visCols membership check, remaining width
+	// would be split across those phantom (unrendered) columns and starve
+	// the ones actually on screen.
+	inVisCols := make(map[int]bool, len(visCols))
+	for _, c := range visCols {
+		inVisCols[c] = true
+	}
+	var visFlex []int
+	for _, c := range flexCols {
+		if !m.hiddenColumns[c] && inVisCols[c] {
+			visFlex = append(visFlex, c)
+		}
+	}
+
+	if len(visFlex) > 0 && remaining > 0 {
+		// Two-phase distribution: first guarantee each flex
+		// column at least min(contentWidth, equalShare), then
+		// distribute surplus proportionally to remaining
+		// content headroom. This prevents a single wide column
+		// from starving narrower ones.
+		equalShare := remaining / len(visFlex)
+
+		// Phase 1: allocate floors.
+		distributed := 0
+		for _, c := range visFlex {
+			floor := min(contentWidth[c], equalShare)
+			colWidths[c] = max(floor, 1)
+			distributed += colWidths[c]
+		}
+
+		// Drain overshoot from max(...,1) inflation when
+		// remaining < len(visFlex).
+		if distributed > remaining {
+			drainFlexOverflow(visFlex, colWidths, distributed-remaining)
+			distributed = remaining
+		}
+
+		// Compute headroom from actual allocated widths.
+		totalHeadroom := 0
+		headroom := make(map[int]int, len(visFlex))
+		for _, c := range visFlex {
+			h := contentWidth[c] - colWidths[c]
+			if h > 0 {
+				headroom[c] = h
+				totalHeadroom += h
+			}
+		}
+
+		// Phase 2: distribute surplus proportionally to
+		// content headroom (columns already at content width
+		// have zero headroom and get nothing extra).
+		surplus := remaining - distributed
+		if surplus > 0 && totalHeadroom > 0 {
+			phase2 := 0
+			for i, c := range visFlex {
+				var extra int
+				if i == len(visFlex)-1 {
+					extra = surplus - phase2
+				} else {
+					extra = surplus * headroom[c] / totalHeadroom
+				}
+				colWidths[c] += extra
+				phase2 += extra
+			}
+		} else if surplus > 0 {
+			// All columns at content width — distribute
+			// remaining space equally.
+			for i, c := range visFlex {
+				extra := surplus / (len(visFlex) - i)
+				colWidths[c] += extra
+				surplus -= extra
+			}
+		}
+	} else if len(visFlex) > 0 {
+		// No remaining space: give flex columns 1 char each to
+		// avoid overflow at very narrow terminal widths.
+		for _, c := range visFlex {
+			colWidths[c] = 1
+		}
+	}
+
+	// Build visible rows for the window
+	windowRows := rows[start:end]
+	tableRows := make([][]string, 0, end-start)
+	for i := range windowRows {
+		sel := "  "
+		if start+i == visibleSelectedIdx {
+			sel = "> "
+		}
+		fullRow := m.queueFullRowCells(windowRows[i], hasAnyPanel, treeColor)
+		fullRow[colSel] = sel
+
+		row := make([]string, len(visCols))
+		for vi, c := range visCols {
+			row[vi] = fullRow[c]
+		}
+		tableRows = append(tableRows, row)
+	}
+
+	// Compute the selected row index within the visible window
+	selectedWindowIdx := visibleSelectedIdx - start
+
+	// Find the last visible table column index (for padding logic)
+	lastVisCol := len(visCols) - 1
+
+	// Group banding: a panel parent and its members share one zebra band so
+	// the nesting reads as a group. Only computed (and applied) when the page
+	// has panels, so a panel-free page keeps its original un-banded bytes.
+	var bands []bool
+	if hasAnyPanel {
+		bands = groupBanding(rows)
+	}
+
+	t := table.New().
+		BorderTop(false).
+		BorderBottom(false).
+		BorderLeft(false).
+		BorderRight(false).
+		BorderColumn(false).
+		BorderRow(false).
+		BorderHeader(!compact).
+		Border(lipgloss.Border{
+			Top:    "─",
+			Bottom: "─",
+			Middle: "─",
+		}).
+		Width(width).
+		Wrap(false).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			s := lipgloss.NewStyle()
+
+			// Map table col index to logical column
+			logicalCol := colSel
+			if col >= 0 && col < len(visCols) {
+				logicalCol = visCols[col]
+			}
+
+			// Inter-column spacing: non-sel, non-first columns get border or padding
+			if logicalCol != colSel && col > 0 {
+				if bordersOn {
+					s = s.Border(lipgloss.Border{Left: "▕"}, false, false, false, true).
+						BorderForeground(borderColor).PaddingLeft(1)
+				} else if col < lastVisCol {
+					s = s.PaddingRight(1)
+				}
+			}
+
+			// Set explicit width for all columns (includes spacing)
+			w := colWidths[logicalCol]
+			if w > 0 {
+				s = s.Width(w + spacing(col, logicalCol))
+			}
+
+			// Right-align elapsed column
+			if logicalCol == colElapsed {
+				s = s.Align(lipgloss.Right)
+			}
+
+			// Header row styling
+			if row == table.HeaderRow {
+				return s.Foreground(adaptiveColor("242", "246"))
+			}
+
+			// Selection highlighting — uniform background, no per-cell coloring
+			if row == selectedWindowIdx {
+				bg := adaptiveColor("153", "24")
+				s = s.Background(bg)
+				if bordersOn {
+					s = s.BorderBackground(bg)
+				}
+				return s
+			}
+
+			// Group banding for non-selected rows: every other panel group
+			// gets a subtle background so a parent and its members read as
+			// one block. Foreground per-cell coloring is applied on top.
+			if absIdx := start + row; bands != nil && absIdx < len(bands) && bands[absIdx] {
+				bg := adaptiveColor("254", "236") // subtle zebra band
+				s = s.Background(bg)
+				if bordersOn {
+					s = s.BorderBackground(bg)
+				}
+			}
+
+			// Per-cell coloring for non-selected rows
+			if row >= 0 && row < len(windowRows) {
+				job := windowRows[row].job
+				switch logicalCol {
+				case colStatus:
+					if c := statusColor(job.Status); c != nil {
+						s = s.Foreground(c)
+					}
+				case colPF:
+					if c := verdictColor(job.Verdict); c != nil {
+						s = s.Foreground(c)
+					}
+				case colHandled:
+					if job.Closed != nil {
+						if *job.Closed {
+							s = s.Foreground(closedStyle.GetForeground())
+						} else {
+							s = s.Foreground(queuedStyle.GetForeground())
+						}
+					}
+				}
+			}
+			return s
+		})
+
+	// Always set headers — lipgloss table drops the last data row
+	// when Headers() is not called.
+	headers := make([]string, len(visCols))
+	if !compact {
+		for vi, c := range visCols {
+			headers[vi] = allHeaders[c]
+		}
+	}
+	t = t.Headers(headers...)
+	t = t.Rows(tableRows...)
+
+	tableStr := t.Render()
+
+	// In compact mode, strip the empty header line we added as a
+	// workaround (it renders as a row of spaces).
+	if compact {
+		if idx := strings.Index(tableStr, "\n"); idx >= 0 {
+			tableStr = tableStr[idx+1:]
+		}
+	}
+
+	return strings.Split(tableStr, "\n")
 }
 
 // jobCells returns plain text cell values for a job row.

--- a/cmd/roborev/tui/render_review.go
+++ b/cmd/roborev/tui/render_review.go
@@ -36,6 +36,32 @@ func panelReviewHeader(job storage.ReviewJob, members []storage.ReviewJob) strin
 	return fmt.Sprintf("%d reviewers: %s", s.MembersTotal, panelOutcomeSplit(s))
 }
 
+// reviewContentString builds the markdown-source content for a review:
+// panel header (synthesis parent only) + review output + comment responses.
+// Shared by the full-screen review view and the split detail pane.
+func (m model) reviewContentString(review *storage.Review) string {
+	var content strings.Builder
+	if review.Job != nil && review.Job.IsSynthesisJob() {
+		if header := panelReviewHeader(*review.Job, m.panelMembers[review.Job.PanelRunUUID]); header != "" {
+			content.WriteString(sanitizeForDisplay(header))
+			content.WriteString("\n\n")
+		}
+	}
+	content.WriteString(review.Output)
+
+	// Append responses if any
+	if len(m.currentResponses) > 0 {
+		content.WriteString("\n\n--- Comments ---\n")
+		for _, r := range m.currentResponses {
+			timestamp := r.CreatedAt.Format("Jan 02 15:04")
+			fmt.Fprintf(&content, "\n[%s] %s:\n", timestamp, r.Responder)
+			content.WriteString(r.Response)
+			content.WriteString("\n")
+		}
+	}
+	return content.String()
+}
+
 func (m model) renderReviewView() string {
 	var b strings.Builder
 
@@ -121,32 +147,11 @@ func (m model) renderReviewView() string {
 		b.WriteString("\x1b[K\n") // Clear to end of line
 	}
 
-	// Build content: panel header (synthesis parent only) + review output + responses
-	var content strings.Builder
-	if review.Job != nil && review.Job.IsSynthesisJob() {
-		if header := panelReviewHeader(*review.Job, m.panelMembers[review.Job.PanelRunUUID]); header != "" {
-			content.WriteString(sanitizeForDisplay(header))
-			content.WriteString("\n\n")
-		}
-	}
-	content.WriteString(review.Output)
-
-	// Append responses if any
-	if len(m.currentResponses) > 0 {
-		content.WriteString("\n\n--- Comments ---\n")
-		for _, r := range m.currentResponses {
-			timestamp := r.CreatedAt.Format("Jan 02 15:04")
-			fmt.Fprintf(&content, "\n[%s] %s:\n", timestamp, r.Responder)
-			content.WriteString(r.Response)
-			content.WriteString("\n")
-		}
-	}
-
 	// Render markdown content with glamour (cached), falling back to plain text wrapping.
 	// wrapWidth caps at 100 for readability; maxWidth uses actual terminal width for truncation.
 	maxWidth := max(20, m.width-4)
 	wrapWidth := min(maxWidth, 100)
-	contentStr := content.String()
+	contentStr := m.reviewContentString(review)
 	var lines []string
 	if m.mdCache != nil {
 		lines = m.mdCache.getReviewLines(contentStr, wrapWidth, maxWidth, review.ID)
@@ -232,7 +237,12 @@ func (m model) renderReviewView() string {
 
 			// Input content — show tail so cursor always visible
 			inputDisplay := m.fixPromptText
-			maxInputLen := innerWidth - 3 // " > " (3) + "_" (1) = 4 overhead, but Width handles right padding
+			// lipgloss v2's Width is border-box: content wider than
+			// innerWidth-2 wraps the box to 4+ lines, overflowing the
+			// 5-line panelReserve and pushing the frame past the terminal
+			// height. " > " (3) + "_" (1) = 4 overhead, so the input
+			// itself may use innerWidth-6.
+			maxInputLen := innerWidth - 6
 			if runewidth.StringWidth(inputDisplay) > maxInputLen {
 				runes := []rune(inputDisplay)
 				for runewidth.StringWidth(string(runes)) > maxInputLen {
@@ -260,8 +270,9 @@ func (m model) renderReviewView() string {
 			if inputDisplay == "" {
 				inputDisplay = "(blank = default)"
 			}
-			if runewidth.StringWidth(inputDisplay) > innerWidth-2 {
-				inputDisplay = runewidth.Truncate(inputDisplay, innerWidth-2, "")
+			// Border-box again: " " (1) + display must fit in innerWidth-2.
+			if runewidth.StringWidth(inputDisplay) > innerWidth-3 {
+				inputDisplay = runewidth.Truncate(inputDisplay, innerWidth-3, "")
 			}
 			content := " " + inputDisplay
 			boxStyle := lipgloss.NewStyle().

--- a/cmd/roborev/tui/review_fetch_test.go
+++ b/cmd/roborev/tui/review_fetch_test.go
@@ -16,24 +16,37 @@ func TestTUIFetchReviewNotFound(t *testing.T) {
 	_, m := mockServerModel(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	})
-	cmd := m.fetchReview(999)
+	cmd := m.fetchReview(999, 1)
 	msg := cmd()
 
-	errMsg, ok := msg.(errMsg)
-	assert.True(t, ok)
-	assert.Equal(t, "no review found", errMsg.Error())
+	// fetchReview's failure is the typed reviewErrMsg, not the generic
+	// errMsg -- see reviewErrMsg's doc comment (types.go).
+	rem, ok := msg.(reviewErrMsg)
+	require.True(t, ok)
+	assert.Equal(t, int64(999), rem.jobID)
+	assert.Equal(t, "no review found", rem.err.Error())
+	// This and TestTUIFetchReviewServerError are the ONLY tests exercising
+	// fetchReview's REAL failure path (mockServerModel, not a hand-built
+	// message) -- if fetchReview ever stamped fetchSeq: 0 instead of the
+	// fetchSeq it was called with, every handler gated on
+	// msg.fetchSeq == m.reviewFetchSeq would silently treat every ordinary
+	// failure as stale/superseded and swallow it, with no other test
+	// catching the regression.
+	assert.Equal(t, uint64(1), rem.fetchSeq)
 }
 
 func TestTUIFetchReviewServerError(t *testing.T) {
 	_, m := mockServerModel(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
-	cmd := m.fetchReview(1)
+	cmd := m.fetchReview(1, 1)
 	msg := cmd()
 
-	errMsg, ok := msg.(errMsg)
-	assert.True(t, ok)
-	assert.Equal(t, "fetch review: 500 Internal Server Error", errMsg.Error())
+	rem, ok := msg.(reviewErrMsg)
+	require.True(t, ok)
+	assert.Equal(t, int64(1), rem.jobID)
+	assert.Equal(t, "fetch review: 500 Internal Server Error", rem.err.Error())
+	assert.Equal(t, uint64(1), rem.fetchSeq)
 }
 
 func TestTUIFetchReviewFallbackSHAResponses(t *testing.T) {
@@ -83,7 +96,7 @@ func TestTUIFetchReviewFallbackSHAResponses(t *testing.T) {
 
 		w.WriteHeader(http.StatusNotFound)
 	})
-	cmd := m.fetchReview(42)
+	cmd := m.fetchReview(42, 1)
 	msg := cmd()
 
 	reviewMsg, ok := msg.(reviewMsg)
@@ -142,7 +155,7 @@ func TestTUIFetchReviewNoFallbackForRangeReview(t *testing.T) {
 
 		w.WriteHeader(http.StatusNotFound)
 	})
-	cmd := m.fetchReview(42)
+	cmd := m.fetchReview(42, 1)
 	msg := cmd()
 
 	_, ok := msg.(reviewMsg)
@@ -197,7 +210,7 @@ func TestTUIFetchReviewNoFallbackForDirtyReviewWithCommitID(t *testing.T) {
 
 		w.WriteHeader(http.StatusNotFound)
 	})
-	cmd := m.fetchReview(42)
+	cmd := m.fetchReview(42, 1)
 	msg := cmd()
 
 	reviewMsg, ok := msg.(reviewMsg)

--- a/cmd/roborev/tui/review_fix_panel_test.go
+++ b/cmd/roborev/tui/review_fix_panel_test.go
@@ -28,8 +28,10 @@ func TestReviewFixPanelOpenFromReview(t *testing.T) {
 }
 
 func TestReviewFixPanelTabTogglesReviewFocus(t *testing.T) {
+	job := makeJob(1)
 	m := initTestModel(
 		withCurrentView(viewReview),
+		withReview(&storage.Review{JobID: 1, Job: &job}),
 		withFixPanel(true, true),
 	)
 
@@ -43,8 +45,10 @@ func TestReviewFixPanelTabTogglesReviewFocus(t *testing.T) {
 }
 
 func TestReviewFixPanelTextInput(t *testing.T) {
+	job := makeJob(1)
 	m := initTestModel(
 		withCurrentView(viewReview),
+		withReview(&storage.Review{JobID: 1, Job: &job}),
 		withFixPanel(true, true),
 	)
 
@@ -66,8 +70,10 @@ func TestReviewFixPanelTextNotCapturedWhenUnfocused(t *testing.T) {
 }
 
 func TestReviewFixPanelEscWhenFocusedClosesPanel(t *testing.T) {
+	job := makeJob(1)
 	m := initTestModel(
 		withCurrentView(viewReview),
+		withReview(&storage.Review{JobID: 1, Job: &job}),
 		withFixPanel(true, true),
 		withFixPrompt(0, "some text"),
 	)
@@ -240,7 +246,12 @@ func TestFixPanelPendingNotConsumedByWrongReview(t *testing.T) {
 	})
 
 	assert.False(t, got.reviewFixPanelOpen)
-	assert.True(t, got.reviewFixPanelPending)
+	// The pending panel is bound to job 5, and the pane has just accepted
+	// job 10's review: acceptReview closes a panel (open OR pending) whose
+	// job is not the one now displayed, so the pending flag is dropped
+	// with it rather than left armed for a job the user is no longer on.
+	assert.False(t, got.reviewFixPanelPending)
+	assert.Zero(t, got.fixPromptJobID)
 }
 
 func TestFixPanelPendingClearedOnStaleFetch(t *testing.T) {

--- a/cmd/roborev/tui/review_navigation_test.go
+++ b/cmd/roborev/tui/review_navigation_test.go
@@ -41,7 +41,7 @@ func TestTUIReviewNavigation(t *testing.T) {
 			wantIdx:       3,
 			wantJobID:     4,
 			wantScroll:    0,
-			wantCmd:       false, // Failed job = inline, no fetch
+			wantCmd:       true, // Failed job = inline synthesis + persisted-comments fetch
 		},
 		{
 			name: "K Prev skips queued/running",
@@ -59,7 +59,7 @@ func TestTUIReviewNavigation(t *testing.T) {
 			wantIdx:       3,
 			wantJobID:     4,
 			wantScroll:    0,
-			wantCmd:       false,
+			wantCmd:       true, // inline synthesis + persisted-comments fetch
 		},
 		{
 			name: "Left Arrow acts like J (Prev)",
@@ -128,7 +128,7 @@ func TestTUIReviewNavigation(t *testing.T) {
 			key:                  'j',
 			wantIdx:              1,
 			wantJobID:            2,
-			wantCmd:              false,
+			wantCmd:              true, // inline synthesis + persisted-comments fetch
 			checkFailedJobInline: true,
 		},
 	}

--- a/cmd/roborev/tui/review_views_test.go
+++ b/cmd/roborev/tui/review_views_test.go
@@ -132,6 +132,10 @@ func TestTUICommitMsgViewNavigationWithQ(t *testing.T) {
 	m.currentView = viewCommitMsg
 	m.commitMsgFromView = viewReview
 	m.commitMsgContent = "test message"
+	// The commitMsg->viewReview return relies on currentReview still being
+	// loaded (normalizeSplitState repairs a dangling viewReview/nil-review
+	// pair back to viewQueue in every layout).
+	m.currentReview = makeReview(1, &storage.ReviewJob{ID: 1})
 
 	// Press 'q' to go back
 	m2, _ := pressKey(m, 'q')

--- a/cmd/roborev/tui/split_detail_pane.go
+++ b/cmd/roborev/tui/split_detail_pane.go
@@ -1,0 +1,321 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	xansi "github.com/charmbracelet/x/ansi"
+	"github.com/mattn/go-runewidth"
+
+	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/tokens"
+)
+
+// reviewFixPanelPaneReserve is the number of pane rows the inline fix panel
+// occupies when open (label + top border + input line + bottom border +
+// help line), mirroring render_review.go's panelReserve so scroll math
+// (renderReviewPaneBody / reviewPaneScrollInfo) never drifts from what's
+// actually rendered.
+const reviewFixPanelPaneReserve = 5
+
+// reviewPaneHeaderLines returns the compact header lines rendered above the
+// markdown body in the split detail pane: title, an optional verdict/closed/
+// tokens line, and a trailing blank separator. renderReviewPaneBody and
+// reviewPaneScrollInfo both call this so their header-height accounting can
+// never drift apart.
+func (m model) reviewPaneHeaderLines(innerW int) []string {
+	review := m.currentReview
+	if review == nil || review.Job == nil {
+		return nil
+	}
+	var out []string
+	title := fmt.Sprintf("Review #%d %s (%s)", review.Job.ID,
+		m.getDisplayName(review.Job.RepoPath, review.Job.RepoName),
+		formatAgentLabel(review.Agent, review.Job.Model))
+	out = append(out, xansi.Truncate(titleStyle.Render(title), innerW, ""))
+
+	var verdictParts []string
+	if review.Job.Verdict != nil && *review.Job.Verdict != "" && !review.Job.IsFixJob() {
+		if *review.Job.Verdict == "P" {
+			verdictParts = append(verdictParts, passStyle.Render("Verdict: Pass"))
+		} else {
+			verdictParts = append(verdictParts, failStyle.Render("Verdict: Fail"))
+		}
+	}
+	if review.Closed {
+		verdictParts = append(verdictParts, closedStyle.Render("[CLOSED]"))
+	}
+	if tu := tokens.ParseJSON(review.Job.TokenUsage); tu != nil {
+		verdictParts = append(verdictParts, statusStyle.Render("["+tu.FormatSummary()+"]"))
+	}
+	if len(verdictParts) > 0 {
+		out = append(out, xansi.Truncate(strings.Join(verdictParts, " "), innerW, ""))
+	}
+	out = append(out, "")
+	return out
+}
+
+// reviewPaneBodyLines returns the markdown-rendered body lines for the
+// current review, windowed to wrapWidth/maxWidth derived from innerW.
+// Shared by renderReviewPaneBody and reviewPaneScrollInfo so both compute
+// the exact same line set.
+func (m model) reviewPaneBodyLines(innerW int) []string {
+	review := m.currentReview
+	maxWidth := max(20, innerW)
+	wrapWidth := min(maxWidth, 100)
+	if m.mdCache != nil {
+		return m.mdCache.getReviewLines(m.reviewContentString(review), wrapWidth, maxWidth, review.ID)
+	}
+	return sanitizeLines(wrapText(m.reviewContentString(review), wrapWidth))
+}
+
+// renderReviewPaneBody renders the current review body-only for the split
+// detail pane: exactly innerH clean lines. When m.reviewFixPanelOpen, the
+// inline fix panel (adapted from render_review.go's full-screen block) is
+// reserved out of the body budget and appended after it, so the pane never
+// silently swallows keystrokes without showing where they're going -- see
+// handleKeyMsg's reviewFixPanelFocused capture at the top of the key
+// dispatch chain.
+func (m model) renderReviewPaneBody(innerW, innerH int) []string {
+	panelReserve := 0
+	if m.reviewFixPanelOpen {
+		panelReserve = reviewFixPanelPaneReserve
+	}
+	bodyH := max(innerH-panelReserve, 1)
+
+	out := append([]string{}, m.reviewPaneHeaderLines(innerW)...)
+
+	// Markdown body, windowed by m.reviewScroll.
+	lines := m.reviewPaneBodyLines(innerW)
+	visible := max(bodyH-len(out), 1)
+	maxScroll := max(len(lines)-visible, 0)
+	if m.mdCache != nil {
+		m.mdCache.lastReviewMaxScroll = maxScroll
+	}
+	start := max(min(m.reviewScroll, maxScroll), 0)
+	for i := start; i < min(start+visible, len(lines)); i++ {
+		out = append(out, xansi.Truncate(lines[i], innerW, ""))
+	}
+	for len(out) < bodyH {
+		out = append(out, "")
+	}
+	out = out[:bodyH]
+
+	if m.reviewFixPanelOpen {
+		out = append(out, m.renderReviewFixPanelPaneLines(innerW)...)
+	}
+	for len(out) < innerH {
+		out = append(out, "")
+	}
+	return out[:innerH]
+}
+
+// renderReviewFixPanelPaneLines renders the inline fix panel adapted for
+// the split detail pane at innerW, producing exactly
+// reviewFixPanelPaneReserve lines. Mirrors render_review.go's full-screen
+// fix panel block (focused: label + bordered input + help; unfocused:
+// dimmed label + gray box + hint) so the two stay visually consistent; kept
+// separate rather than shared because the two write to different targets
+// (a line slice here vs. a strings.Builder with "\x1b[K" trailers there).
+func (m model) renderReviewFixPanelPaneLines(innerW int) []string {
+	boxW := max(innerW-2, 10) // box inner width; total visual width = boxW+2 (borders)
+	trunc := func(s string) string { return xansi.Truncate(s, innerW, "") }
+
+	var out []string
+	if m.reviewFixPanelFocused {
+		label := "Fix: enter instructions (or leave blank for default)"
+		if runewidth.StringWidth(label) > innerW {
+			label = runewidth.Truncate(label, innerW, "")
+		}
+		out = append(out, label)
+
+		inputDisplay := m.fixPromptText
+		// lipgloss v2's Width is border-box: content wider than boxW-2
+		// wraps the box past its 3-line budget, and the 5-line pane cap
+		// then silently drops the help line. " > " (3) + "_" (1) = 4
+		// overhead, so the input itself may use boxW-6.
+		maxInputLen := boxW - 6
+		if runewidth.StringWidth(inputDisplay) > maxInputLen {
+			runes := []rune(inputDisplay)
+			for runewidth.StringWidth(string(runes)) > maxInputLen {
+				runes = runes[1:]
+			}
+			inputDisplay = string(runes)
+		}
+		content := fmt.Sprintf(" > %s_", inputDisplay)
+		boxStyle := lipgloss.NewStyle().
+			Border(lipgloss.NormalBorder()).
+			BorderForeground(adaptiveColor("125", "205")). // magenta/pink (active)
+			Width(boxW)
+		for line := range strings.SplitSeq(strings.TrimRight(boxStyle.Render(content), "\n"), "\n") {
+			out = append(out, trunc(line))
+		}
+		out = append(out, trunc(helpStyle.Render("tab: scroll review | enter: submit | esc: cancel")))
+	} else {
+		out = append(out, trunc(statusStyle.Render("Fix (Tab to focus)")))
+
+		inputDisplay := m.fixPromptText
+		if inputDisplay == "" {
+			inputDisplay = "(blank = default)"
+		}
+		// Border-box again: " " (1) + display must fit in boxW-2.
+		if runewidth.StringWidth(inputDisplay) > boxW-3 {
+			inputDisplay = runewidth.Truncate(inputDisplay, boxW-3, "")
+		}
+		content := " " + inputDisplay
+		boxStyle := lipgloss.NewStyle().
+			Border(lipgloss.NormalBorder()).
+			BorderForeground(adaptiveColor("242", "246")). // gray (inactive)
+			Foreground(adaptiveColor("242", "246")).
+			Width(boxW)
+		for line := range strings.SplitSeq(strings.TrimRight(boxStyle.Render(content), "\n"), "\n") {
+			out = append(out, trunc(statusStyle.Render(line)))
+		}
+		out = append(out, trunc(helpStyle.Render("F: fix | tab: focus fix panel")))
+	}
+
+	for len(out) < reviewFixPanelPaneReserve {
+		out = append(out, "")
+	}
+	return out[:reviewFixPanelPaneReserve]
+}
+
+// reviewPaneScrollInfo reports the visible body window for the info line.
+func (m model) reviewPaneScrollInfo(innerW, innerH int) (start, end, total int) {
+	review := m.currentReview
+	if review == nil {
+		return 0, 0, 0
+	}
+	headerLines := len(m.reviewPaneHeaderLines(innerW))
+	panelReserve := 0
+	if m.reviewFixPanelOpen {
+		panelReserve = reviewFixPanelPaneReserve
+	}
+	lines := m.reviewPaneBodyLines(innerW)
+	visible := max(innerH-headerLines-panelReserve, 1)
+	total = len(lines)
+	start = max(min(m.reviewScroll, max(total-visible, 0)), 0)
+	end = min(start+visible, total)
+	return start, end, total
+}
+
+// renderDetailPane picks the detail pane content for the highlighted job:
+// done -> review (or loading placeholder until the follow fetch lands),
+// failed -> error text, running -> status card (+ live log),
+// queued/canceled -> status card.
+func (m model) renderDetailPane(innerW, innerH int) []string {
+	pad := func(lines []string) []string {
+		for len(lines) < innerH {
+			lines = append(lines, "")
+		}
+		return lines[:innerH]
+	}
+	job, ok := m.selectedJob()
+	if !ok {
+		// selectedReviewLoaded's anchored fallback: hide-closed can prune
+		// a just-closed job's row from the refresh while its review is
+		// still the anchored, displayed content -- render it from the
+		// loaded review rather than vanishing into "No job selected".
+		if m.selectedReviewLoaded() {
+			return m.renderReviewPaneBody(innerW, innerH)
+		}
+		return pad([]string{statusStyle.Render("No job selected")})
+	}
+	switch job.Status {
+	case storage.JobStatusDone:
+		// selectedReviewLoaded, not a bare JobID match: job IDs are reused
+		// across reruns, so a matching ID can still name a PREVIOUS
+		// attempt's review while reconcile refetches the current one.
+		// Rendering it would display obsolete output -- indefinitely, if
+		// the refetch fails, since the review body would also mask the
+		// splitDetailErr card below -- and would show content whose
+		// actions the staleness guards refuse (tab silently dead). Falling
+		// through shows the loading/error state until the fresh review is
+		// accepted, exactly like a not-yet-loaded review.
+		if m.selectedReviewLoaded() {
+			return m.renderReviewPaneBody(innerW, innerH)
+		}
+		if m.splitDetailErr != nil {
+			card := m.renderJobStatusCard(*job, innerW)
+			card = append(card, "",
+				errorStyle.Render(xansi.Truncate("Failed to load review: "+m.splitDetailErr.Error(), innerW, "")),
+				statusStyle.Render("(re-select the row to retry)"))
+			return pad(card)
+		}
+		return pad(append(m.renderJobStatusCard(*job, innerW),
+			"", statusStyle.Render("Loading review...")))
+	case storage.JobStatusFailed:
+		// Same attempt-freshness gate as the Done branch above. A stale
+		// synthesized review is a one-refresh transient here (reconcile
+		// rebuilds synchronously), and the fallback below renders the same
+		// job.Error text, so the gate costs nothing and keeps the
+		// display's condition identical to the action guards'.
+		if m.selectedReviewLoaded() {
+			return m.renderReviewPaneBody(innerW, innerH)
+		}
+		card := m.renderJobStatusCard(*job, innerW)
+		card = append(card, "")
+		// job.Error is untrusted agent/process output rendered directly
+		// (unlike the done-job path above, which routes through the
+		// synthesized review and its glamour/sanitizeEscapes pipeline once
+		// the follow-fetch lands) -- sanitize it here per the repo's
+		// sanitizeForDisplay convention for multi-line untrusted content,
+		// so it can't inject terminal escapes (cursor moves, OSC clipboard
+		// writes, \r/\b overwrites) while this direct render is showing.
+		for _, l := range wrapText("Job failed:\n\n"+sanitizeForDisplay(job.Error), max(innerW-2, 20)) {
+			card = append(card, xansi.Truncate(failStyle.Render(l), innerW, ""))
+		}
+		return pad(card)
+	case storage.JobStatusRunning:
+		card := m.renderJobStatusCard(*job, innerW)
+		if m.splitDetailErr != nil {
+			card = append(card, "",
+				errorStyle.Render(xansi.Truncate("Failed to load log: "+m.splitDetailErr.Error(), innerW, "")))
+			return pad(card)
+		}
+		divider := xansi.Truncate(statusStyle.Render(strings.Repeat("─", max(innerW/3, 8))+" live log"), innerW, "")
+		card = append(card, "", divider)
+		return pad(m.appendPaneLogTail(card, innerW, innerH))
+	default:
+		return pad(m.renderJobStatusCard(*job, innerW))
+	}
+}
+
+// appendPaneLogTail appends the tail of the live log buffer to
+// lines, filling the space remaining below the status card/divider (one row
+// held back as a bottom margin), each entry truncated to innerW.
+func (m model) appendPaneLogTail(lines []string, innerW, innerH int) []string {
+	avail := innerH - len(lines) - 1
+	if avail <= 0 {
+		return lines
+	}
+	total := len(m.paneLogLines)
+	start := max(total-avail, 0)
+	for i := start; i < total; i++ {
+		lines = append(lines, xansi.Truncate(m.paneLogLines[i].text, innerW, ""))
+	}
+	return lines
+}
+
+// renderJobStatusCard renders job metadata for non-review pane states.
+func (m model) renderJobStatusCard(job storage.ReviewJob, innerW int) []string {
+	trunc := func(s string) string { return xansi.Truncate(s, innerW, "") }
+	title := fmt.Sprintf("Job #%d · %s", job.ID, job.Status)
+	card := []string{trunc(titleStyle.Render(title)), ""}
+	add := func(label, val string) {
+		if val != "" {
+			card = append(card, trunc(statusStyle.Render(label+": ")+val))
+		}
+	}
+	add("Repo", m.getDisplayName(job.RepoPath, job.RepoName))
+	add("Ref", shortJobRef(job))
+	add("Branch", m.getBranchForJob(job))
+	add("Agent", formatAgentLabel(job.Agent, job.Model))
+	if job.StartedAt != nil {
+		add("Elapsed", m.jobElapsedCell(job))
+	} else if !job.EnqueuedAt.IsZero() {
+		add("Queued", job.EnqueuedAt.Local().Format("Jan 02 15:04"))
+	}
+	return card
+}

--- a/cmd/roborev/tui/split_fetch_order_test.go
+++ b/cmd/roborev/tui/split_fetch_order_test.go
@@ -1,0 +1,1696 @@
+package tui
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/storage"
+)
+
+// orderingServerModel builds a split-layout model wired to a mock daemon
+// that serves job 2's review plus whatever *responses currently holds, so a
+// test can change the server's answer BETWEEN executing two already-issued
+// fetch commands -- the only faithful way to reproduce an out-of-order
+// landing (the older request genuinely carries the older content).
+func orderingServerModel(t *testing.T, responses *[]storage.Response) model {
+	t.Helper()
+	_, m := mockServerModel(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/review":
+			// No GitRef/commit on the embedded job, so loadResponses makes
+			// no legacy SHA/commit lookup and the comment list below is the
+			// whole answer.
+			_ = json.NewEncoder(w).Encode(storage.Review{
+				ID: 10, JobID: 2, Agent: "codex", Output: "## Findings\n\n1. first finding\n",
+				Job: &storage.ReviewJob{ID: 2, Status: storage.JobStatusDone},
+			})
+		case "/api/comments":
+			_ = json.NewEncoder(w).Encode(map[string]any{"responses": *responses})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	m.width, m.height = 150, 40
+	m.layout = layoutSplit
+	m.tasksEnabled = true // 'F' is one of the ordinary (non-follow) dispatchers
+	m.currentView = viewQueue
+	m.jobs = testQueueJobs()
+	m.selectedIdx, m.selectedJobID = 1, 2 // job 2: done
+	m.currentReview = &storage.Review{
+		ID: 10, JobID: 2, Agent: "codex", Output: "## Findings\n\n1. first finding\n",
+		Job: &storage.ReviewJob{ID: 2, Status: storage.JobStatusDone},
+	}
+	m.currentResponses = *responses
+	return m
+}
+
+func applyReviewMsg(t *testing.T, m model, msg tea.Msg) model {
+	t.Helper()
+	rm, ok := msg.(reviewMsg)
+	require.True(t, ok, "expected a reviewMsg, got %T", msg)
+	res, _ := m.handleReviewMsg(rm)
+	return res.(model)
+}
+
+// TestOlderOrdinaryFetchMustNotOverwriteNewerCommentRefresh: if ordering
+// covered only the split-pane FOLLOW dispatchers, an ORDINARY
+// fetchReview (here the queue 'F' fix-panel fetch; equally queue Enter,
+// tasks Enter/'P', stepReviewNav or the pagination auto-nav) that was
+// already in flight when a comment landed could resolve AFTER the comment
+// refresh and overwrite currentResponses with pre-comment content -- the
+// user's just-submitted comment vanishing indefinitely.
+func TestOlderOrdinaryFetchMustNotOverwriteNewerCommentRefresh(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	responses := []storage.Response{{ID: 1, Responder: "user", Response: "old comment"}}
+	m := orderingServerModel(t, &responses)
+
+	// 'F' from the split list dispatches an ORDINARY review fetch. It
+	// resolves against the server as it is NOW (pre-comment) but is
+	// delivered later, below.
+	res, fixCmd := m.handleFixKey()
+	m = res.(model)
+	require.NotNil(fixCmd, "'F' must dispatch a review fetch")
+	olderMsg := fixCmd()
+
+	// The user's comment is accepted by the daemon; the split comment
+	// refresh dispatches a follow fetch, which sees the new comment.
+	responses = append(responses, storage.Response{ID: 2, Responder: "user", Response: "the user's new comment"})
+	res, refreshCmd := m.handleCommentResultMsg(commentResultMsg{jobID: 2})
+	m = res.(model)
+	require.NotNil(refreshCmd, "the comment refresh must dispatch")
+	newerMsg := refreshCmd()
+
+	// The comment refresh lands first and is accepted.
+	m = applyReviewMsg(t, m, newerMsg)
+	require.Len(m.currentResponses, 2, "the comment refresh must land the new comment")
+
+	// The older ordinary fetch finally resolves.
+	got := applyReviewMsg(t, m, olderMsg)
+	assert.Len(got.currentResponses, 2,
+		"an ordinary fetch dispatched BEFORE the comment refresh must not overwrite it -- the user's comment must not disappear")
+}
+
+// TestOlderFollowResponseMustNotOverwriteNewerOrdinaryFetch is the mirror
+// direction: the newest dispatch must win regardless of WHICH dispatcher
+// issued either response. Before one shared epoch, an ordinary fetch did
+// not advance the ordering at all, so a follow response dispatched before
+// it still compared equal to the current sequence and was accepted on top
+// of the fresher ordinary content.
+func TestOlderFollowResponseMustNotOverwriteNewerOrdinaryFetch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	responses := []storage.Response{{ID: 1, Responder: "user", Response: "old comment"}}
+	m := orderingServerModel(t, &responses)
+
+	// A FOLLOW fetch goes out first and resolves against the old content.
+	res, refreshCmd := m.handleCommentResultMsg(commentResultMsg{jobID: 2})
+	m = res.(model)
+	require.NotNil(refreshCmd)
+	olderFollowMsg := refreshCmd()
+
+	// An ORDINARY fetch is dispatched afterward and sees fresher content.
+	responses = append(responses, storage.Response{ID: 2, Responder: "user", Response: "newer comment"})
+	res, fixCmd := m.handleFixKey()
+	m = res.(model)
+	require.NotNil(fixCmd)
+	newerOrdinaryMsg := fixCmd()
+
+	m = applyReviewMsg(t, m, newerOrdinaryMsg)
+	require.Len(m.currentResponses, 2, "the newer ordinary fetch must be accepted")
+
+	got := applyReviewMsg(t, m, olderFollowMsg)
+	assert.Len(got.currentResponses, 2,
+		"a follow response dispatched BEFORE the ordinary fetch must not overwrite it")
+}
+
+// TestQueueFixKeyFlowOpensPanelWhenReviewLands is the guard rail for the
+// acceptance-path fix-panel close: the legitimate queue-'F' flow, where
+// the panel is pending for exactly the job whose review is arriving, must
+// still open the panel.
+func TestQueueFixKeyFlowOpensPanelWhenReviewLands(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	responses := []storage.Response{}
+	m := orderingServerModel(t, &responses)
+	m.currentReview = nil // nothing loaded yet -- 'F' from the queue list
+
+	res, fixCmd := m.handleFixKey()
+	m = res.(model)
+	require.NotNil(fixCmd)
+	require.True(m.reviewFixPanelPending, "'F' from the queue arms the pending panel")
+	require.Equal(int64(2), m.fixPromptJobID)
+
+	got := applyReviewMsg(t, m, fixCmd())
+	assert.True(got.reviewFixPanelOpen, "the review for the panel's own job must open it")
+	assert.False(got.reviewFixPanelPending)
+	assert.Equal(int64(2), got.fixPromptJobID)
+}
+
+// TestAcceptedReviewForDifferentJobClosesFixPanel covers the second half of
+// the stale-action finding: the fix panel is bound to fixPromptJobID, and
+// the split's two panes advance independently, so a review ACCEPTED for a
+// different job leaves an open (or pending) panel floating over content it
+// has nothing to do with -- submitting would start a fix for the job the
+// user is no longer looking at.
+func TestAcceptedReviewForDifferentJobClosesFixPanel(t *testing.T) {
+	arriving := &storage.Review{
+		ID: 40, JobID: 3, Agent: "codex", Output: "job 3 review",
+		Job: &storage.ReviewJob{ID: 3},
+	}
+	cases := []struct {
+		name    string
+		arm     func(*model)
+		follow  bool
+		checkOn func(*assert.Assertions, model)
+	}{
+		{
+			name: "open panel",
+			arm: func(m *model) {
+				m.reviewFixPanelOpen = true
+				m.reviewFixPanelFocused = true
+				m.fixPromptJobID = 2
+				m.fixPromptText = "please fix"
+			},
+			follow: true,
+			checkOn: func(a *assert.Assertions, got model) {
+				a.False(got.reviewFixPanelOpen, "an open panel bound to job 2 must close when job 3's review is accepted")
+				a.False(got.reviewFixPanelFocused)
+				a.Zero(got.fixPromptJobID)
+				a.Empty(got.fixPromptText)
+			},
+		},
+		{
+			name: "pending panel",
+			arm: func(m *model) {
+				m.reviewFixPanelPending = true
+				m.fixPromptJobID = 2
+			},
+			follow: false,
+			checkOn: func(a *assert.Assertions, got model) {
+				a.False(got.reviewFixPanelPending, "a pending panel bound to job 2 must not survive job 3's review")
+				a.False(got.reviewFixPanelOpen)
+				a.Zero(got.fixPromptJobID)
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			m := splitModel(withSelection(0, 3)) // job 3 selected
+			tc.arm(&m)
+			res, _ := m.handleReviewMsg(reviewMsg{
+				review: arriving, jobID: 3, follow: tc.follow,
+				gen: m.detailFollowGen, dispatchedFrom: viewQueue,
+			})
+			got := res.(model)
+			require.NotNil(t, got.currentReview)
+			require.Equal(t, int64(3), got.currentReview.JobID, "the review must be accepted")
+			tc.checkOn(assert, got)
+		})
+	}
+}
+
+// TestSplitDetailReviewActionsBlockedWhileReviewStale covers the loading
+// window opened by detail-pane navigation: stepReviewNav moves
+// selectedJobID immediately and only replaces currentReview once the async
+// fetch lands, so every review-scoped key in between would act on the
+// PREVIOUS job -- closing, commenting on, fixing, prompting, fetching a
+// commit message for, or copying the wrong review.
+func TestSplitDetailReviewActionsBlockedWhileReviewStale(t *testing.T) {
+	require := require.New(t)
+
+	// Three done jobs so detail nav has somewhere to go that requires an
+	// async fetch (a failed job is synthesized locally, with no window).
+	verdictP := "P"
+	jobs := []storage.ReviewJob{
+		{
+			ID: 3, GitRef: "cccc333", Branch: "main", RepoName: "repoA", Agent: "codex",
+			Status: storage.JobStatusDone, Verdict: &verdictP,
+		},
+		{
+			ID: 2, GitRef: "bbbb222", Branch: "feat/x", RepoName: "repoA", Agent: "codex",
+			Status: storage.JobStatusDone, Verdict: &verdictP,
+		},
+		{
+			ID: 1, GitRef: "aaaa111", Branch: "main", RepoName: "repoB", Agent: "codex",
+			Status: storage.JobStatusDone, Verdict: &verdictP,
+		},
+	}
+	closed := false
+	loaded := &storage.Review{
+		ID: 10, JobID: 2, Agent: "codex", Output: "job 2 review",
+		Prompt: "job 2 prompt", Closed: closed,
+		Job: &storage.ReviewJob{ID: 2, GitRef: "bbbb222", Status: storage.JobStatusDone},
+	}
+
+	base := splitModel(withTestJobs(jobs...), withSelection(1, 2))
+	base.tasksEnabled = true // so 'F' would really open the panel if unguarded
+	base.currentView = viewReview
+	base.focus = focusDetail
+	base.currentReview = loaded
+
+	// Detail nav to the newer job dispatches its fetch and leaves job 2's
+	// review displayed until it lands: the stale-action window.
+	res, navCmd := base.stepReviewNav(-1)
+	stale := res.(model)
+	require.NotNil(navCmd, "detail nav must dispatch a fetch for the newly selected job")
+	require.Equal(int64(3), stale.selectedJobID, "the selection moved ahead of the loaded review")
+	require.NotNil(stale.currentReview)
+	require.Equal(int64(2), stale.currentReview.JobID, "the previous job's review is still what's loaded")
+
+	cases := []struct {
+		key   rune
+		check func(*assert.Assertions, model, tea.Cmd)
+	}{
+		{'a', func(a *assert.Assertions, got model, cmd tea.Cmd) {
+			a.Nil(cmd, "'a' must not fire a close against the old job")
+			a.Empty(got.pendingClosed)
+			a.False(got.currentReview.Closed)
+		}},
+		{'c', func(a *assert.Assertions, got model, cmd tea.Cmd) {
+			a.NotEqual(viewKindComment, got.currentView, "'c' must not open the comment editor for the old job")
+			a.Zero(got.commentJobID)
+		}},
+		{'F', func(a *assert.Assertions, got model, cmd tea.Cmd) {
+			a.False(got.reviewFixPanelOpen, "'F' must not open a fix panel bound to the old job")
+			a.Zero(got.fixPromptJobID)
+		}},
+		{'p', func(a *assert.Assertions, got model, cmd tea.Cmd) {
+			a.NotEqual(viewKindPrompt, got.currentView, "'p' must not open the old job's prompt")
+		}},
+		{'m', func(a *assert.Assertions, got model, cmd tea.Cmd) {
+			a.Nil(cmd, "'m' must not fetch the old job's commit message")
+			a.Zero(got.commitMsgJobID)
+		}},
+		{'y', func(a *assert.Assertions, got model, cmd tea.Cmd) {
+			a.Nil(cmd, "'y' must not copy the old job's review")
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.key), func(t *testing.T) {
+			assert := assert.New(t)
+			m := stale
+			reviewCopy := *loaded // fresh copy: 'a' mutates the review in place
+			m.currentReview = &reviewCopy
+			res, cmd := m.handleKeyMsg(keyPressMsg(tc.key))
+			tc.check(assert, res.(model), cmd)
+		})
+	}
+}
+
+// TestCtrlCloseReviewHideClosedFollowsSelection covers the control-socket
+// half of "selection changes that skip the detail follow": with hideClosed
+// on, closing the selected job hides it and
+// the handler advances the selection itself, bypassing the shared
+// detail-follow transition -- leaving the detail pane, and a fix panel
+// still bound to the just-closed job, pointed at a job the list no longer
+// highlights.
+func TestCtrlCloseReviewHideClosedFollowsSelection(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	newModelForClose := func(layout layoutMode) model {
+		jobs := testQueueJobs()
+		closed := false
+		jobs[1].Closed = &closed // job 2: done, selected
+		m := splitModel(withTestJobs(jobs...), withSelection(1, 2))
+		m.layout = layout
+		m.hideClosed = true
+		m.reviewFixPanelOpen = true
+		m.reviewFixPanelFocused = true
+		m.fixPromptJobID = 2
+		return m
+	}
+	params, err := json.Marshal(map[string]any{"job_id": 2, "closed": true})
+	require.NoError(err)
+
+	m := newModelForClose(layoutSplit)
+	beforeGen := m.detailFollowGen
+	got, resp, cmd := m.handleCtrlCloseReview(params)
+	require.True(resp.OK, "expected OK, got %s", resp.Error)
+	require.NotEqual(int64(2), got.selectedJobID, "closing the selected job with hideClosed on moves the selection")
+	assert.Greater(got.detailFollowGen, beforeGen, "the selection change must schedule a detail follow")
+	assert.NotNil(cmd, "the follow cmd must be batched with the close cmd, not dropped")
+	assert.False(got.reviewFixPanelOpen, "the fix panel bound to the closed job must not survive the selection change")
+
+	stacked := newModelForClose(layoutStacked)
+	gotStacked, respStacked, _ := stacked.handleCtrlCloseReview(params)
+	require.True(respStacked.OK)
+	// Abandonment is layout-independent: the selection leaving job 2
+	// abandons its intents in stacked too (the gen bump invalidates any
+	// in-flight dispatch for it) -- only the detail-follow scheduling is
+	// split-specific. The OPEN panel is the exception outside split: it is
+	// bound to the review displayed full-screen, not the queue selection,
+	// so the selection moving under it must not dump an in-progress fix
+	// prompt (displayed-review changes close it at their own sites).
+	assert.Greater(gotStacked.detailFollowGen, stacked.detailFollowGen,
+		"a genuine selection change is an abandonment in any layout")
+	assert.True(gotStacked.reviewFixPanelOpen,
+		"an open panel outside split is review-bound; the selection moving must not close it")
+}
+
+// TestClosedResultRollbackFollowsSelection covers the other half: when the
+// server rejects an optimistic close, the rollback restores the selection
+// via selectJobByID -- another selection mutation that skipped the shared
+// transition.
+func TestClosedResultRollbackFollowsSelection(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	newModelForRollback := func(layout layoutMode) model {
+		m := splitModel(withSelection(0, 3)) // the optimistic close moved the selection to job 3
+		m.layout = layout
+		m.pendingClosed = map[int64]pendingState{2: {newState: true, seq: 7}}
+		return m
+	}
+	msg := closedResultMsg{
+		jobID: 2, seq: 7, oldState: false, restoreSelection: true,
+		err: errors.New("daemon rejected the close"),
+	}
+
+	m := newModelForRollback(layoutSplit)
+	beforeGen := m.detailFollowGen
+	res, cmd := m.handleClosedResultMsg(msg)
+	got := res.(model)
+	require.Equal(int64(2), got.selectedJobID, "the rollback restores the selection to job 2")
+	assert.Greater(got.detailFollowGen, beforeGen, "the restored selection must schedule a detail follow")
+	assert.NotNil(cmd, "the follow cmd must be returned, not dropped")
+
+	stacked := newModelForRollback(layoutStacked)
+	resStacked, cmdStacked := stacked.handleClosedResultMsg(msg)
+	gotStacked := resStacked.(model)
+	require.Equal(int64(2), gotStacked.selectedJobID)
+	// The restored selection is a genuine selection change and therefore
+	// an abandonment in any layout (gen bump, intents disarmed); only the
+	// follow tick is split-specific, so no cmd is scheduled in stacked.
+	assert.Greater(gotStacked.detailFollowGen, stacked.detailFollowGen,
+		"a genuine selection change is an abandonment in any layout")
+	assert.Nil(cmdStacked, "no follow tick is scheduled in stacked")
+}
+
+// TestCancelResultRollbackFollowsSelection is the cancel-side twin of the
+// close rollback above.
+func TestCancelResultRollbackFollowsSelection(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	m := splitModel(withSelection(0, 3))
+	beforeGen := m.detailFollowGen
+	res, cmd := m.handleCancelResultMsg(cancelResultMsg{
+		jobID: 2, oldState: storage.JobStatusRunning, restoreSelection: true,
+		err: errors.New("cancel failed"),
+	})
+	got := res.(model)
+	require.Equal(int64(2), got.selectedJobID)
+	assert.Greater(got.detailFollowGen, beforeGen, "the restored selection must schedule a detail follow")
+	assert.NotNil(cmd)
+}
+
+// TestEveryReviewFetchDispatcherStampsTheSharedEpoch is the completeness
+// check behind the ordering guarantee: EVERY path that can emit a reviewMsg
+// -- follow and ordinary alike -- must go through dispatchReviewFetch /
+// dispatchReviewFollow, so it advances the one shared epoch and stamps the
+// new value on its request. A dispatcher that forgot to would be
+// permanently unorderable (and, worse, permanently unacceptable, since its
+// stamp could never match). It doubles as the "every dispatcher can still
+// dispatch" regression net for the suppression guard.
+func TestEveryReviewFetchDispatcherStampsTheSharedEpoch(t *testing.T) {
+	t1 := time.Now().Truncate(time.Second)
+	doneJob := func(id int64) storage.ReviewJob {
+		return storage.ReviewJob{
+			ID: id, GitRef: "aaaa111", RepoName: "repoA", Agent: "codex",
+			Status: storage.JobStatusDone, FinishedAt: &t1,
+		}
+	}
+
+	cases := []struct {
+		name     string
+		dispatch func() (model, tea.Model, tea.Cmd)
+	}{
+		{"queue Enter (stacked)", func() (model, tea.Model, tea.Cmd) {
+			m := initTestModel(withCurrentView(viewQueue), withDimensions(150, 40),
+				withTestJobs(doneJob(2), doneJob(1)), withSelection(0, 2))
+			m.layout = layoutStacked
+			res, cmd := m.handleEnterKey()
+			return m, res, cmd
+		}},
+		{"tasks Enter", func() (model, tea.Model, tea.Cmd) {
+			m := initTestModel(withCurrentView(viewTasks), withDimensions(150, 40))
+			m.fixJobs = []storage.ReviewJob{{ID: 101, Status: storage.JobStatusDone}}
+			res, cmd := pressSpecial(m, tea.KeyEnter)
+			return m, res, cmd
+		}},
+		{"tasks P (parent review)", func() (model, tea.Model, tea.Cmd) {
+			parentID := int64(77)
+			m := initTestModel(withCurrentView(viewTasks), withDimensions(150, 40))
+			m.fixJobs = []storage.ReviewJob{{ID: 101, Status: storage.JobStatusDone, ParentJobID: &parentID}}
+			res, cmd := pressKey(m, 'P')
+			return m, res, cmd
+		}},
+		{"stepReviewNav", func() (model, tea.Model, tea.Cmd) {
+			m := initTestModel(withCurrentView(viewReview), withDimensions(150, 40),
+				withTestJobs(doneJob(3), doneJob(2)), withSelection(1, 2))
+			m.currentReview = &storage.Review{ID: 10, JobID: 2, Job: &storage.ReviewJob{ID: 2}}
+			res, cmd := m.stepReviewNav(-1)
+			return m, res, cmd
+		}},
+		{"pagination auto-nav", func() (model, tea.Model, tea.Cmd) {
+			m := initTestModel(withCurrentView(viewReview), withDimensions(150, 40),
+				withTestJobs(doneJob(2), doneJob(1)), withSelection(0, 2))
+			m.paginateNav = viewReview
+			res, cmd := m.handleJobsMsg(jobsMsg{
+				jobs: []storage.ReviewJob{doneJob(2), doneJob(1)}, append: true,
+			})
+			return m, res, cmd
+		}},
+		{"queue F (fix panel fetch)", func() (model, tea.Model, tea.Cmd) {
+			m := splitModel(withSelection(1, 2))
+			m.tasksEnabled = true
+			res, cmd := m.handleFixKey()
+			return m, res, cmd
+		}},
+		{"comment refresh (stacked)", func() (model, tea.Model, tea.Cmd) {
+			m := initTestModel(withCurrentView(viewReview), withDimensions(150, 40),
+				withTestJobs(doneJob(2)), withSelection(0, 2))
+			m.layout = layoutStacked
+			m.currentReview = &storage.Review{ID: 10, JobID: 2, Job: &storage.ReviewJob{ID: 2}}
+			res, cmd := m.handleCommentResultMsg(commentResultMsg{jobID: 2})
+			return m, res, cmd
+		}},
+		{"comment refresh (split follow)", func() (model, tea.Model, tea.Cmd) {
+			m := splitModel(withSelection(1, 2), withReview(splitTestReview()))
+			res, cmd := m.handleCommentResultMsg(commentResultMsg{jobID: 2})
+			return m, res, cmd
+		}},
+		{"detail follow tick", func() (model, tea.Model, tea.Cmd) {
+			m := splitModel(withSelection(1, 2))
+			m.currentReview = nil
+			res, cmd := m.handleDetailFollowTick(detailFollowTickMsg{gen: m.detailFollowGen})
+			return m, res, cmd
+		}},
+		{"jobs-refresh reconcile", func() (model, tea.Model, tea.Cmd) {
+			m := splitModel(withSelection(1, 2))
+			m.currentReview = nil
+			res, cmd := m.splitReconcileDetail()
+			return m, res, cmd
+		}},
+		{"pane-log completion handoff", func() (model, tea.Model, tea.Cmd) {
+			m := splitModel(withSelection(1, 2))
+			m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 2, 5, true
+			res, cmd := m.handlePaneLogOutputMsg(paneLogOutputMsg{jobID: 2, seq: 5, hasMore: false})
+			return m, res, cmd
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			before, res, cmd := tc.dispatch()
+			after := res.(model)
+			require.NotNil(t, cmd, "this dispatcher must still be able to dispatch")
+			assert.Equal(t, before.reviewFetchSeq+1, after.reviewFetchSeq,
+				"every review-content fetch must advance the one shared ordering epoch")
+		})
+	}
+}
+
+// TestReconcileSuppressionReleasedByItsOwnResponse pins the suppression
+// contract: splitReconcileDetail holds a slot
+// released by the response to ITS OWN dispatch, identified by that
+// dispatch's fetch epoch -- released before any staleness check, so a
+// response rejected for display still frees it, and never released by a
+// foreign response, which is what would break convergence.
+func TestReconcileSuppressionReleasedByItsOwnResponse(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	t1 := time.Now().Truncate(time.Second)
+
+	m := splitModel(withSelection(1, 2))
+	m.currentReview = nil
+	m, cmd := m.splitReconcileDetail()
+	require.NotNil(cmd, "reconcile dispatches for the selected done job")
+	require.Equal(int64(2), m.reconcileFetchJobID, "the dispatch is tracked for suppression")
+
+	_, cmd2 := m.splitReconcileDetail()
+	assert.Nil(cmd2, "a second reconcile pass must not pile another request on top of the outstanding one")
+
+	// A FOREIGN response for the same job must NOT release the slot: the
+	// dispatch it belongs to is
+	// still in flight, and freeing the gate lets the next refresh
+	// supersede it.
+	dispatchSeq := m.reviewFetchSeq
+	m.reviewFetchSeq++ // something newer went out in the meantime
+	foreign := &storage.Review{ID: 12, JobID: 2, Agent: "codex", Output: "foreign", Job: &storage.ReviewJob{ID: 2, FinishedAt: &t1}}
+	resForeign, _ := m.handleReviewMsg(reviewMsg{
+		review: foreign, jobID: 2, follow: true, gen: m.detailFollowGen,
+		fetchSeq: m.reviewFetchSeq,
+	})
+	assert.Equal(int64(2), resForeign.(model).reconcileFetchJobID,
+		"a different dispatch's response must leave the outstanding slot held")
+
+	// Its OWN response releases the slot even when REJECTED for display
+	// (here: superseded by the newer dispatch above).
+	stale := &storage.Review{ID: 11, JobID: 2, Agent: "codex", Output: "stale", Job: &storage.ReviewJob{ID: 2, FinishedAt: &t1}}
+	res, _ := m.handleReviewMsg(reviewMsg{
+		review: stale, jobID: 2, follow: true, gen: m.detailFollowGen,
+		fetchSeq: dispatchSeq,
+	})
+	got := res.(model)
+	assert.Zero(got.reconcileFetchJobID, "its own response releases the slot even when dropped as stale")
+
+	// And a failure response releases it too.
+	m2 := splitModel(withSelection(1, 2))
+	m2.currentReview = nil
+	m2, cmd3 := m2.splitReconcileDetail()
+	require.NotNil(cmd3)
+	resErr, _ := m2.handleReviewFollowErrMsg(reviewFollowErrMsg{
+		jobID: 2, gen: m2.detailFollowGen, fetchSeq: m2.reviewFetchSeq, err: errors.New("boom"),
+	})
+	assert.Zero(resErr.(model).reconcileFetchJobID, "a failed fetch releases the slot so the next pass can retry")
+}
+
+// TestJobsRefreshSelectionReassignmentClosesStaleFixPanel is the last
+// selection-mutating path from the audit: handleJobsMsg reassigns the
+// selection when the selected job vanishes from the refreshed list.
+// splitReconcileDetail (called on the same pass) is the authority for the
+// pane's CONTENT there, but the fix panel is keyed to a job, so it needs
+// the same close the shared selection transition applies.
+func TestJobsRefreshSelectionReassignmentClosesStaleFixPanel(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	m := splitModel(withSelection(1, 2)) // job 2 selected, panel open for it
+	m.reviewFixPanelOpen = true
+	m.reviewFixPanelFocused = true
+	m.fixPromptJobID = 2
+	m.fixPromptText = "please fix"
+
+	// Job 2 vanishes from the refreshed list.
+	res, _ := m.handleJobsMsg(jobsMsg{jobs: []storage.ReviewJob{
+		{ID: 3, GitRef: "cccc333", RepoName: "repoA", Agent: "codex", Status: storage.JobStatusRunning},
+	}})
+	got := res.(model)
+	require.NotEqual(int64(2), got.selectedJobID, "the vanished selection must be reassigned")
+	assert.False(got.reviewFixPanelOpen, "a fix panel bound to the vanished job must not survive")
+	assert.Zero(got.fixPromptJobID)
+}
+
+// TestStackedCommentRefreshForUnselectedJobDoesNotDestroyConcurrentFetch
+// covers a hazard universal epoch stamping introduced in the
+// stacked/tasks-origin comment-refresh branch, which deliberately
+// dispatches for the DISPLAYED review rather than the selected job.
+// Once its dispatch advanced the shared epoch,
+// dispatching for a job that is no longer selected -- a request that
+// handleReviewMsg's own jobID gate would drop on arrival anyway -- began
+// superseding the concurrent, legitimate fetch for the job that IS
+// selected. Stacked mode has no splitReconcileDetail to heal it, so that
+// review is silently skipped entirely.
+func TestStackedCommentRefreshForUnselectedJobDoesNotDestroyConcurrentFetch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	_, m := mockServerModel(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/review":
+			id, _ := strconv.ParseInt(r.URL.Query().Get("job_id"), 10, 64)
+			_ = json.NewEncoder(w).Encode(storage.Review{
+				ID: id * 10, JobID: id, Agent: "codex",
+				Output: fmt.Sprintf("job %d review", id),
+				Job:    &storage.ReviewJob{ID: id, Status: storage.JobStatusDone},
+			})
+		case "/api/comments":
+			_ = json.NewEncoder(w).Encode(map[string]any{"responses": []storage.Response{}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	m.width, m.height = 150, 40
+	m.layout = layoutStacked
+	m.currentView = viewReview
+	m.reviewFromView = viewQueue
+	m.jobs = []storage.ReviewJob{
+		{ID: 2, GitRef: "bbbb222", RepoName: "repoA", Agent: "codex", Status: storage.JobStatusDone},
+		{ID: 6, GitRef: "ffff666", RepoName: "repoA", Agent: "codex", Status: storage.JobStatusDone},
+	}
+	m.selectedIdx, m.selectedJobID = 0, 2
+	m.currentReview = &storage.Review{
+		ID: 20, JobID: 2, Agent: "codex", Output: "job 2 review",
+		Job: &storage.ReviewJob{ID: 2, Status: storage.JobStatusDone},
+	}
+
+	// The user comments on job X (2), then arrow-navigates to job Y (6)
+	// before the comment POST resolves. Y's fetch is now in flight.
+	res, navCmd := m.stepReviewNav(1)
+	m = res.(model)
+	require.NotNil(navCmd, "arrowing to job 6 dispatches its review fetch")
+	require.Equal(int64(6), m.selectedJobID)
+	yMsg := navCmd()
+
+	// The comment result for X arrives afterwards.
+	res2, refreshCmd := m.handleCommentResultMsg(commentResultMsg{jobID: 2})
+	m = res2.(model)
+	assert.Nil(refreshCmd,
+		"a refresh for a job that is no longer selected could never be accepted -- dispatching it only supersedes the fetch that can be")
+
+	// Y's response finally lands. It must still be accepted.
+	got := applyReviewMsg(t, m, yMsg)
+	require.NotNil(got.currentReview)
+	assert.Equal(int64(6), got.currentReview.JobID,
+		"the review the user navigated to must not be silently skipped")
+}
+
+// TestFollowResponseOpeningPendingFixPanelMakesItReachable covers the
+// second regression from moving the pending-fix-panel consume onto the
+// shared acceptance path: a FOLLOW response opened the panel (open AND
+// focused) without the view/focus switch an ordinary response performs,
+// leaving currentView == viewQueue -- so handleKeyMsg never routed to the
+// panel and the user's fix prompt was interpreted as queue keys ('f'
+// opening the filter modal, and so on) over a panel that looked focused.
+func TestFollowResponseOpeningPendingFixPanelMakesItReachable(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	m := splitModel(withSelection(1, 2)) // split, LIST focus
+	m.tasksEnabled = true
+	m.currentReview = nil // job 2's review isn't loaded yet
+
+	// 'F' arms the pending panel and dispatches its own ordinary fetch.
+	res, fixCmd := m.handleFixKey()
+	m = res.(model)
+	require.NotNil(fixCmd)
+	require.True(m.reviewFixPanelPending)
+	require.Equal(viewQueue, m.currentView)
+
+	// A jobs refresh lands first: reconcile dispatches a FOLLOW fetch for
+	// the same job, which overtakes the 'F' fetch.
+	m, reconcileCmd := m.splitReconcileDetail()
+	require.NotNil(reconcileCmd, "reconcile dispatches a follow fetch for the unloaded selected job")
+
+	res2, _ := m.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2, follow: true, gen: m.detailFollowGen,
+		dispatchedFrom: viewQueue, fetchSeq: m.reviewFetchSeq,
+	})
+	got := res2.(model)
+	require.True(got.reviewFixPanelOpen, "the follow response consumes the pending panel")
+	require.True(got.reviewFixPanelFocused)
+	assert.Equal(viewReview, got.currentView, "an opened panel must be reachable by the keyboard")
+	assert.Equal(focusDetail, got.focus)
+
+	// The decisive check: a keystroke must reach the panel, not the queue.
+	res3, _ := got.handleKeyMsg(keyPressMsg('f'))
+	typed := res3.(model)
+	assert.Equal("f", typed.fixPromptText, "typing must go into the fix prompt")
+	assert.Equal(viewReview, typed.currentView, "'f' must not open the filter modal")
+}
+
+// TestPendingFixPanelStillWaitsWhenUserMovedToATransientView is the
+// guard rail for the switch added above: the pending flag is user intent
+// to open the panel, but not a licence to yank a user out of a view they
+// deliberately opened while the fetch was in flight (the comment editor,
+// mid-typing). openReviewView's guard is what keeps those two apart.
+func TestPendingFixPanelStillWaitsWhenUserMovedToATransientView(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	m := splitModel(withSelection(1, 2))
+	m.tasksEnabled = true
+	res, fixCmd := m.handleFixKey()
+	m = res.(model)
+	require.NotNil(fixCmd)
+
+	// The user opens the comment editor before the fetch resolves.
+	res, _ = m.handleCommentOpenKey()
+	m = res.(model)
+	require.Equal(viewKindComment, m.currentView)
+	m.commentText = "in progress comment"
+
+	res2, _ := m.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2, gen: m.detailFollowGen,
+		dispatchedFrom: viewQueue, fetchSeq: m.reviewFetchSeq,
+	})
+	got := res2.(model)
+	assert.Equal(viewKindComment, got.currentView, "must not be yanked out of the comment editor")
+	assert.Equal("in progress comment", got.commentText)
+	assert.True(got.reviewFixPanelOpen, "the panel is still consumed, ready for the return to the review")
+}
+
+// TestReconcileConvergesWhenAnOlderResponseForTheSameJobLands: releasing
+// the reconcile suppression slot on jobID alone would let an OLDER
+// response for that job unlock the gate for a dispatch still in flight.
+// The next jobs refresh would then dispatch again and supersede the
+// outstanding request, and with fetches slower than the refresh interval
+// every response would be superseded before it landed -- the detail pane
+// never converging. Suppression's only remaining job is
+// exactly this liveness property, so it must be released by the matching
+// response and nothing else.
+func TestReconcileConvergesWhenAnOlderResponseForTheSameJobLands(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	m := splitModel(withSelection(1, 2)) // job 2: done, selected
+	m.currentReview = nil                // the pane is still loading
+
+	// A selection-follow fetch for job 2 goes out first and stays in
+	// flight (the "older" response below).
+	res, tickCmd := m.handleDetailFollowTick(detailFollowTickMsg{gen: m.detailFollowGen})
+	m = res.(model)
+	require.NotNil(tickCmd, "the selection-follow fetch must dispatch")
+	olderSeq := m.reviewFetchSeq
+
+	// A jobs refresh comes in: reconcile dispatches its own fetch and
+	// records it as outstanding.
+	m, reconcileCmd := m.splitReconcileDetail()
+	require.NotNil(reconcileCmd, "reconcile dispatches for the unloaded selected job")
+	reconcileSeq := m.reviewFetchSeq
+	require.NotEqual(olderSeq, reconcileSeq)
+
+	// The OLDER selection-follow response lands. It is correctly dropped
+	// for display (superseded), and must NOT release the slot held by the
+	// still-outstanding reconcile fetch.
+	res2, _ := m.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2, follow: true,
+		gen: m.detailFollowGen, fetchSeq: olderSeq,
+	})
+	m = res2.(model)
+	require.Nil(m.currentReview, "the older response is superseded, so it must not land")
+
+	// The next jobs refresh must not dispatch on top of the outstanding
+	// request -- that is what would supersede it and restart the cycle.
+	m, cmd2 := m.splitReconcileDetail()
+	assert.Nil(cmd2, "the outstanding reconcile fetch must still suppress a duplicate dispatch")
+
+	// So the reconcile response is still the newest when it lands, and the
+	// pane converges.
+	res3, _ := m.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2, follow: true,
+		gen: m.detailFollowGen, fetchSeq: reconcileSeq,
+	})
+	got := res3.(model)
+	require.NotNil(got.currentReview, "the detail pane must converge -- this is the non-convergence repro")
+	assert.Equal(int64(2), got.currentReview.JobID)
+	assert.Zero(got.reconcileFetchJobID, "its own response releases the slot")
+}
+
+// TestPendingFixPanelUsesArmedOriginNotTheAcceptingResponsesOrigin: the
+// pending-panel consume must not decide its view switch from the
+// ACCEPTING response's dispatchedFrom. Any dispatcher's response can
+// supersede the 'F' fetch and consume the flag -- a reconcile follow
+// fetch dispatched while the comment editor is open carries
+// dispatchedFrom == viewKindComment, matching the user's current view and
+// interrupting the comment they are typing. The decision belongs to the
+// origin of the request that ARMED the flag.
+func TestPendingFixPanelUsesArmedOriginNotTheAcceptingResponsesOrigin(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	m := splitModel(withSelection(1, 2)) // split, LIST focus (viewQueue)
+	m.tasksEnabled = true
+	m.currentReview = nil
+
+	// 'F' arms the pending panel from the queue.
+	res, fixCmd := m.handleFixKey()
+	m = res.(model)
+	require.NotNil(fixCmd)
+	require.True(m.reviewFixPanelPending)
+
+	// The user opens the comment editor while that fetch is in flight.
+	res, _ = m.handleCommentOpenKey()
+	m = res.(model)
+	require.Equal(viewKindComment, m.currentView)
+	m.commentText = "half-written comment"
+
+	// A reconcile follow fetch dispatched from THIS view supersedes the
+	// 'F' fetch and is the response that consumes the pending flag.
+	m, reconcileCmd := m.splitReconcileDetail()
+	require.NotNil(reconcileCmd)
+	res2, _ := m.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2, follow: true,
+		gen: m.detailFollowGen, dispatchedFrom: viewKindComment,
+		fetchSeq: m.reviewFetchSeq,
+	})
+	got := res2.(model)
+
+	require.True(got.reviewFixPanelOpen, "the pending panel is still consumed")
+	assert.Equal(viewKindComment, got.currentView,
+		"the user's in-progress comment must not be interrupted by a response that merely happens to have been dispatched from this view")
+	assert.Equal("half-written comment", got.commentText)
+
+	// End state, once the user leaves the editor: the panel waits, open
+	// but not yet focused-and-reachable, and the ordinary way back into
+	// the detail pane (tab, which requires the review to be loaded --
+	// it is, this response loaded it) hands the keyboard to it.
+	got.currentView = viewQueue // Esc out of the comment editor
+	res3, _ := got.handleTabKey()
+	tabbed := res3.(model)
+	require.Equal(viewReview, tabbed.currentView)
+	require.Equal(focusDetail, tabbed.focus)
+	res4, _ := tabbed.handleKeyMsg(keyPressMsg('f'))
+	typed := res4.(model)
+	assert.Equal("f", typed.fixPromptText, "the waiting panel takes the keyboard once the user enters the detail pane")
+}
+
+// TestTasksParentReviewOpensDespiteReconcileFollowRace: pressing 'P' on a fix task's
+// parent review, with layout split, dispatches an ORDINARY fetch
+// (dispatchReviewFetch) whose eventual response is what's supposed to switch
+// into the review view. splitReconcileDetail gates only on
+// m.layout == layoutSplit -- not on whether the split pane is actually the
+// thing being rendered -- so it keeps running while the user sits on
+// viewTasks. On the very next jobs refresh it observes the SAME job
+// (selectedJobID already points at the parent, set by 'P' itself) with no
+// matching currentReview loaded, and dispatches its OWN follow fetch for it,
+// superseding the ordinary fetch's epoch. A follow response never switches
+// views by itself (that's the definition of "follow"). If the now-superseded
+// ordinary response -- dispatched first, so the realistic landing order --
+// arrives BEFORE the follow's response lands the content, the explicit 'P'
+// request must still result in the review opening once that follow response
+// does land, or the user's action silently does nothing.
+func TestTasksParentReviewOpensDespiteReconcileFollowRace(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	parentID := int64(2) // Done job in testQueueJobs()
+	m := initTestModel(withCurrentView(viewTasks), withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...), withSelection(1, 2))
+	m.layout = layoutSplit
+	m.fixJobs = []storage.ReviewJob{
+		{ID: 101, Status: storage.JobStatusDone, ParentJobID: &parentID},
+	}
+	m.fixSelectedIdx = 0
+
+	// 'P': dispatches the ordinary fetch (origin viewTasks) and points
+	// selectedJobID at the parent job. Doesn't switch views itself -- the
+	// response is what's supposed to do that.
+	got, cmd := pressKey(m, 'P')
+	require.NotNil(cmd)
+	require.Equal(viewTasks, got.currentView)
+	require.Equal(parentID, got.selectedJobID)
+	ordinarySeq := got.reviewFetchSeq
+	ordinaryGen := got.detailFollowGen
+
+	// A jobs refresh (SSE push or the periodic poll) lands next, BEFORE the
+	// ordinary fetch's response arrives. splitReconcileDetail runs
+	// regardless of currentView, sees the parent job (Done) selected with no
+	// matching currentReview loaded, and dispatches its own follow fetch.
+	res2, reconcileCmd := got.handleJobsMsg(jobsMsg{jobs: testQueueJobs(), stats: storage.JobStats{}})
+	got2 := res2.(model)
+	require.NotNil(reconcileCmd, "reconcile must dispatch a follow fetch for the parent job")
+	require.Greater(got2.reviewFetchSeq, ordinarySeq, "the follow dispatch must have advanced the shared epoch")
+	followSeq := got2.reviewFetchSeq
+
+	// The now-superseded ordinary response arrives first (it was dispatched
+	// first).
+	res3, _ := got2.handleReviewMsg(reviewMsg{
+		review:         &storage.Review{ID: 50, JobID: parentID, Agent: "codex", Job: &storage.ReviewJob{ID: parentID, Status: storage.JobStatusDone}},
+		jobID:          parentID,
+		fetchSeq:       ordinarySeq,
+		gen:            ordinaryGen,
+		follow:         false,
+		dispatchedFrom: viewTasks,
+	})
+	got3 := res3.(model)
+	require.Equal(viewTasks, got3.currentView,
+		"content for the parent job isn't loaded yet, so this stale response can't open the review on its own")
+
+	// The reconcile follow's response lands next, carrying the content.
+	res4, _ := got3.handleReviewMsg(reviewMsg{
+		review:         &storage.Review{ID: 51, JobID: parentID, Agent: "codex", Job: &storage.ReviewJob{ID: parentID, Status: storage.JobStatusDone}},
+		jobID:          parentID,
+		fetchSeq:       followSeq,
+		gen:            got2.detailFollowGen,
+		follow:         true,
+		dispatchedFrom: viewQueue, // irrelevant: a follow response never switches views using its own origin
+	})
+	got4 := res4.(model)
+
+	assert.Equal(viewReview, got4.currentView, "the user's explicit 'P' request must still open the parent review")
+	require.NotNil(got4.currentReview)
+	assert.Equal(parentID, got4.currentReview.JobID)
+}
+
+// TestTasksParentReviewOpensInStackedDespiteJobsRefresh confirms the race
+// TestTasksParentReviewOpensDespiteReconcileFollowRace exercises cannot arise
+// in stacked layout: splitReconcileDetail's own gate (m.layout != layoutSplit)
+// makes it a no-op there, so a jobs refresh landing between 'P' and its
+// response never dispatches a competing follow, and the ordinary response
+// opens the review exactly as before.
+func TestTasksParentReviewOpensInStackedDespiteJobsRefresh(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	parentID := int64(2)
+	m := initTestModel(withCurrentView(viewTasks), withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...), withSelection(1, 2))
+	m.layout = layoutStacked
+	m.fixJobs = []storage.ReviewJob{
+		{ID: 101, Status: storage.JobStatusDone, ParentJobID: &parentID},
+	}
+	m.fixSelectedIdx = 0
+
+	got, cmd := pressKey(m, 'P')
+	require.NotNil(cmd)
+	ordinarySeq := got.reviewFetchSeq
+	ordinaryGen := got.detailFollowGen
+
+	res2, reconcileCmd := got.handleJobsMsg(jobsMsg{jobs: testQueueJobs(), stats: storage.JobStats{}})
+	got2 := res2.(model)
+	assert.Nil(reconcileCmd, "splitReconcileDetail must no-op outside split layout")
+	assert.Equal(ordinarySeq, got2.reviewFetchSeq, "no competing dispatch in stacked layout")
+
+	res3, _ := got2.handleReviewMsg(reviewMsg{
+		review:         &storage.Review{ID: 50, JobID: parentID, Agent: "codex", Job: &storage.ReviewJob{ID: parentID, Status: storage.JobStatusDone}},
+		jobID:          parentID,
+		fetchSeq:       ordinarySeq,
+		gen:            ordinaryGen,
+		follow:         false,
+		dispatchedFrom: viewTasks,
+	})
+	got3 := res3.(model)
+	assert.Equal(viewReview, got3.currentView, "the ordinary response opens the review directly, unaffected by reconcile")
+}
+
+// TestFollowFailureResolvesSupersededPendingReviewOpen: the reconcile
+// follow that supersedes tasks 'P”s ordinary fetch
+// (TestTasksParentReviewOpensDespiteReconcileFollowRace's setup) can also
+// simply FAIL. Nothing else would ever resolve pendingReviewOpenJobID on
+// that outcome -- "reconcile will save us" does not hold, since reconcile
+// dispatches follows, which never re-arm the intent. This pins the
+// terminal-outcome treatment: one bounded retry first (the intent's own
+// originating ordinary dispatch may still be in flight and even its
+// SUCCESS arrives fetchSeq-superseded, unable to serve the open -- see
+// pendingReviewOpenRetried's doc comment), then the second failure
+// resolves (clears) the intent, the same shape reviewFixPanelPending gets.
+func TestFollowFailureResolvesSupersededPendingReviewOpen(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	parentID := int64(2)
+	m := initTestModel(withCurrentView(viewTasks), withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...), withSelection(1, 2))
+	m.layout = layoutSplit
+	m.fixJobs = []storage.ReviewJob{
+		{ID: 101, Status: storage.JobStatusDone, ParentJobID: &parentID},
+	}
+	m.fixSelectedIdx = 0
+
+	got, cmd := pressKey(m, 'P')
+	require.NotNil(cmd)
+	require.Equal(parentID, got.pendingReviewOpenJobID, "sanity: 'P' arms the pending-open intent")
+
+	res, reconcileCmd := got.handleJobsMsg(jobsMsg{jobs: testQueueJobs(), stats: storage.JobStats{}})
+	got2 := res.(model)
+	require.NotNil(reconcileCmd, "reconcile must dispatch a competing follow")
+	followSeq := got2.reviewFetchSeq
+
+	// The reconcile follow FAILS: retried once, intent survives.
+	res2, retryCmd := got2.handleReviewFollowErrMsg(reviewFollowErrMsg{
+		jobID: parentID, err: errors.New("boom"),
+		gen: got2.detailFollowGen, fetchSeq: followSeq,
+	})
+	got3 := res2.(model)
+	require.NotNil(retryCmd, "first failure with an armed open intent must retry")
+	require.Equal(parentID, got3.pendingReviewOpenJobID)
+
+	// The retry FAILS too: terminal, the intent is resolved.
+	res3, _ := got3.handleReviewFollowErrMsg(reviewFollowErrMsg{
+		jobID: parentID, err: errors.New("boom"),
+		gen: got3.detailFollowGen, fetchSeq: got3.reviewFetchSeq,
+	})
+	got4 := res3.(model)
+
+	assert.Equal(int64(0), got4.pendingReviewOpenJobID,
+		"the retry's failure must resolve (clear) the pending-open intent, not leave it stranded with nothing in flight")
+}
+
+// TestOrdinaryFetchStillOpensReviewAfterLayoutToggleBeforeResponseLands:
+// stacked queue, Enter on a done job, immediately L before the response
+// lands. The response then lands gen-stale (L's bootstrap bumped
+// detailFollowGen with the selection unchanged) while its fetchSeq is
+// still the single freshest dispatch (nothing has re-armed) -- so
+// reviewIntentRescuable rescues it: rather than being silently discarded
+// (the bootstrap's own follow can be dropped with nothing else ever
+// serving the intent -- see that function's doc comment), the response is
+// treated as current and opens the review directly. A later, harmless
+// follow response for the same job (as the bootstrap's own debounced tick
+// would eventually produce, had it not been rescued already) is asserted
+// not to do anything further -- the intent was already consumed.
+func TestOrdinaryFetchStillOpensReviewAfterLayoutToggleBeforeResponseLands(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	m := initTestModel(withCurrentView(viewQueue), withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...), withSelection(1, 2))
+	m.layout = layoutStacked
+
+	// Enter on job 2 (done): dispatches the ordinary fetch (A), arms the
+	// pending-open intent.
+	res, cmd := m.handleEnterKey()
+	got := res.(model)
+	require.NotNil(cmd)
+	require.Equal(int64(2), got.pendingReviewOpenJobID)
+	seqA := got.reviewFetchSeq
+	genA := got.detailFollowGen
+
+	// L, immediately, before A's response lands: toggles into split.
+	// maybeBootstrapDetail's own scheduleDetailFollow call bumps
+	// detailFollowGen (selection unchanged); nothing has dispatched a NEWER
+	// review fetch yet, so A's fetchSeq is still current.
+	res2, _ := got.handleToggleLayoutKey()
+	toggled := res2.(model)
+	require.Equal(layoutSplit, toggled.layout)
+	require.Greater(toggled.detailFollowGen, genA, "sanity: the bootstrap must have bumped gen")
+	require.Equal(int64(2), toggled.pendingReviewOpenJobID,
+		"the layout toggle alone must not clear a still-valid intent for the unchanged selection")
+
+	// A's response lands: gen-stale, but still fetchSeq-current with the
+	// intent still armed -- rescued.
+	res3, _ := toggled.handleReviewMsg(reviewMsg{
+		review: &storage.Review{ID: 80, JobID: 2, Agent: "codex", Job: &storage.ReviewJob{ID: 2, Status: storage.JobStatusDone}},
+		jobID:  2, fetchSeq: seqA, gen: genA, follow: false, dispatchedFrom: viewQueue,
+	})
+	afterA := res3.(model)
+	assert.Equal(viewReview, afterA.currentView,
+		"the user's explicit Enter must open the review even though its own response landed gen-stale")
+	assert.Equal(int64(0), afterA.pendingReviewOpenJobID, "the rescued response must consume the intent")
+
+	// A later, unrelated follow response for the same job (e.g. the
+	// bootstrap's own debounced tick, had it not been overtaken by the
+	// rescue above) must land harmlessly -- nothing left to consume, no
+	// further view-switch surprise.
+	res4, _ := afterA.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2, fetchSeq: afterA.reviewFetchSeq,
+		gen: afterA.detailFollowGen, follow: true, dispatchedFrom: viewQueue,
+	})
+	final := res4.(model)
+	assert.Equal(viewReview, final.currentView, "still open, unaffected by the later follow")
+}
+
+// TestGenuineSelectionChangeDisarmsPendingReviewOpen confirms that
+// disarmPendingReviewOpen, called from followSelectionChange only after
+// its own prevSelected/selectedJobID comparison proves the selection
+// GENUINELY changed, still fires for a real move -- distinguishing it from maybeBootstrapDetail's same-job
+// bootstrap call, which deliberately does not.
+func TestGenuineSelectionChangeDisarmsPendingReviewOpen(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	m := splitModel(withSelection(1, 2)) // split layout, job 2 selected
+	cmd := m.dispatchReviewFetch(2)
+	require.NotNil(cmd)
+	require.Equal(int64(2), m.pendingReviewOpenJobID)
+
+	prevSelected := m.selectedJobID
+	m = m.moveSelectionToJobID(3) // a genuine move to a different job
+	require.NotEqual(prevSelected, m.selectedJobID)
+
+	got, followCmd := m.followSelectionChange(prevSelected)
+	require.NotNil(followCmd, "a real selection change must still schedule the debounced follow")
+
+	assert.Equal(int64(0), got.pendingReviewOpenJobID,
+		"a genuine selection change must disarm the pending-open intent for the job left behind")
+}
+
+// TestStaleOrdinaryResponseDoesNotClobberFreshlyArmedPendingOpen: keying
+// pendingReviewOpenJobID's stale-rejection clear off jobID alone is
+// unsound. An ordinary fetch (A) arms the intent for job 2; the
+// user navigates away and back to job 2 (gen bumps, without anything
+// touching pendingReviewOpenJobID in between); a FRESH ordinary fetch (B)
+// for the SAME job re-arms the intent at a NEWER identity
+// (pendingReviewOpenSeq). A's now-doubly-stale response finally arrives,
+// carrying the OLD gen and fetchSeq -- it must not clear B's still-live
+// intent, and B's own eventual response must still be able to open the
+// review.
+func TestStaleOrdinaryResponseDoesNotClobberFreshlyArmedPendingOpen(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	m := initTestModel(withCurrentView(viewTasks), withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...), withSelection(1, 2))
+	m.layout = layoutSplit
+	m.selectedJobID = 2 // job 2: done
+
+	// Dispatch A: arms the pending-open intent for job 2.
+	cmdA := m.dispatchReviewFetch(2)
+	require.NotNil(cmdA)
+	seqA := m.reviewFetchSeq
+	genA := m.detailFollowGen
+
+	// The user navigates away and back to job 2 -- the precise mechanism
+	// (a real selection change, or a same-job rerun confirmation) doesn't
+	// matter to this guard, only that gen has moved on since A.
+	m.detailFollowGen++
+
+	// A fresh dispatch for the SAME job re-arms the intent.
+	cmdB := m.dispatchReviewFetch(2)
+	require.NotNil(cmdB)
+	seqB := m.reviewFetchSeq
+	require.Greater(seqB, seqA)
+	require.Equal(int64(2), m.pendingReviewOpenJobID, "sanity: the fresh dispatch is armed")
+
+	// A's now-doubly-stale response finally arrives: old gen AND old
+	// fetchSeq, same job (still selected).
+	res, _ := m.handleReviewMsg(reviewMsg{
+		review:         &storage.Review{ID: 50, JobID: 2, Agent: "codex", Job: &storage.ReviewJob{ID: 2, Status: storage.JobStatusDone}},
+		jobID:          2,
+		fetchSeq:       seqA,
+		gen:            genA,
+		follow:         false,
+		dispatchedFrom: viewTasks,
+	})
+	got := res.(model)
+
+	assert.Equal(int64(2), got.pendingReviewOpenJobID,
+		"A's stale response must not clear B's freshly armed intent")
+	assert.Equal(seqB, got.pendingReviewOpenSeq)
+
+	// B's own eventual response (here, a follow that overtook it) lands and
+	// must still be able to open the review.
+	res2, _ := got.handleReviewMsg(reviewMsg{
+		review:         &storage.Review{ID: 51, JobID: 2, Agent: "codex", Job: &storage.ReviewJob{ID: 2, Status: storage.JobStatusDone}},
+		jobID:          2,
+		fetchSeq:       seqB,
+		gen:            got.detailFollowGen,
+		follow:         true,
+		dispatchedFrom: viewQueue,
+	})
+	got2 := res2.(model)
+	assert.Equal(viewReview, got2.currentView, "B's intent must still open the review")
+}
+
+// TestOldFollowFailureDoesNotClobberFreshlyArmedFixPanel: the same
+// jobID-only-keying hazard as the test above, but for the fix panel's
+// early-rejection clear. An old follow fetch is in
+// flight for job 2; the user navigates away and back (gen bumps); the user
+// presses 'F' on job 2, arming a FRESH pending fix-panel request (a new
+// ordinary dispatch, re-arming fixPromptSeq); the OLD follow's failure
+// finally arrives, carrying the OLD gen -- it must not clear the fresh 'F'
+// request, and that fresh request must still open the panel once its own
+// review lands.
+func TestOldFollowFailureDoesNotClobberFreshlyArmedFixPanel(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	m := splitModel(withSelection(1, 2)) // job 2: done, viewQueue
+	m.tasksEnabled = true
+
+	// An old follow fetch is dispatched for job 2 (e.g. by reconcile).
+	oldFollowCmd := m.dispatchReviewFollow(2)
+	require.NotNil(oldFollowCmd)
+	oldFollowSeq := m.reviewFetchSeq
+	oldGen := m.detailFollowGen
+
+	// The user navigates away and back to job 2 -- gen bumps.
+	m.detailFollowGen++
+
+	// The user presses 'F': arms a fresh pending fix-panel request.
+	res, fixCmd := m.handleFixKey()
+	m = res.(model)
+	require.NotNil(fixCmd)
+	require.True(m.reviewFixPanelPending)
+	require.Equal(int64(2), m.fixPromptJobID)
+	freshFixSeq := m.fixPromptSeq
+	require.Greater(freshFixSeq, oldFollowSeq)
+
+	// The OLD follow finally fails, carrying the OLD gen.
+	res2, _ := m.handleReviewFollowErrMsg(reviewFollowErrMsg{
+		jobID: 2, err: errors.New("boom"), gen: oldGen, fetchSeq: oldFollowSeq,
+	})
+	got := res2.(model)
+
+	require.True(got.reviewFixPanelPending,
+		"the fresh 'F' request must survive the old follow's failure")
+	assert.Equal(int64(2), got.fixPromptJobID)
+	assert.Equal(freshFixSeq, got.fixPromptSeq)
+
+	// The fresh request's own review response lands and still opens the
+	// panel.
+	res3, _ := got.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2, fetchSeq: got.reviewFetchSeq,
+		gen: got.detailFollowGen, follow: false, dispatchedFrom: viewQueue,
+	})
+	got2 := res3.(model)
+	assert.True(got2.reviewFixPanelOpen, "the fresh request must still open the panel")
+}
+
+// TestOriginalDispatchGenStaleResponseDoesNotCancelInFlightFixPanelRetry:
+// the retry inside handleReviewFollowErrMsg dispatches a NEW follow
+// request (C) and must re-stamp fixPromptSeq to C's own identity --
+// left pointing at the ORIGINAL (now-dead) dispatch A, A's late response
+// would cancel C. Reproduced with ordinary
+// keystrokes: stacked, 'F' on a done job (dispatch A, panel pending,
+// currentReview nil) -> 'L' toggles into split, bumping detailFollowGen
+// with the selection unchanged (closeFixPanelIfJobChanged no-ops, the panel
+// stays pending) -> the resulting follow tick's fetch (B) for the same job
+// FAILS -> the retry dispatches C -> A's long-in-flight response
+// finally lands, gen-stale. It must not cancel C's still-in-flight retry,
+// and C's own success must still open the panel.
+func TestOriginalDispatchGenStaleResponseDoesNotCancelInFlightFixPanelRetry(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	m := initTestModel(withCurrentView(viewQueue), withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...), withSelection(1, 2)) // job 2: done
+	m.layout = layoutStacked
+	m.tasksEnabled = true
+
+	// 'F': dispatch A, arms the pending fix-panel request.
+	res, cmdA := m.handleFixKey()
+	m = res.(model)
+	require.NotNil(cmdA)
+	require.True(m.reviewFixPanelPending)
+	seqA := m.fixPromptSeq
+	genA := m.detailFollowGen
+
+	// 'L': toggles into split layout. currentReview is still nil (A hasn't
+	// landed), so maybeBootstrapDetail schedules a follow -- bumping
+	// detailFollowGen with the selection unchanged, so
+	// closeFixPanelIfJobChanged no-ops and the panel stays pending.
+	res2, _ := m.handleToggleLayoutKey()
+	m = res2.(model)
+	require.Equal(layoutSplit, m.layout)
+	require.Greater(m.detailFollowGen, genA)
+	require.True(m.reviewFixPanelPending, "sanity: L must not itself close the pending panel")
+
+	// The follow tick fires, dispatching B for the same job.
+	res3, followTickCmd := m.handleDetailFollowTick(detailFollowTickMsg{gen: m.detailFollowGen})
+	m = res3.(model)
+	require.NotNil(followTickCmd, "B must be dispatched")
+	seqB := m.reviewFetchSeq
+
+	// B fails: the bounded retry dispatches C.
+	res4, retryCmd := m.handleReviewFollowErrMsg(reviewFollowErrMsg{
+		jobID: 2, err: errors.New("boom"), gen: m.detailFollowGen, fetchSeq: seqB,
+	})
+	m = res4.(model)
+	require.NotNil(retryCmd, "the #478 retry (C) must be dispatched")
+	require.True(m.fixPromptFollowRetried)
+	seqC := m.fixPromptSeq
+	require.Greater(seqC, seqA, "the retry must re-stamp the identity to its own dispatch")
+
+	// A's long-in-flight response finally lands, carrying the OLD gen.
+	res5, _ := m.handleReviewMsg(reviewMsg{
+		review: &storage.Review{ID: 60, JobID: 2, Agent: "codex", Job: &storage.ReviewJob{ID: 2, Status: storage.JobStatusDone}},
+		jobID:  2, fetchSeq: seqA, gen: genA, follow: false, dispatchedFrom: viewQueue,
+	})
+	m = res5.(model)
+
+	assert.True(m.reviewFixPanelPending, "A's gen-stale response must not cancel the in-flight retry (C)")
+	assert.Equal(int64(2), m.fixPromptJobID)
+	assert.Equal(seqC, m.fixPromptSeq)
+
+	// C's own success lands and opens the panel.
+	res6, _ := m.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2, fetchSeq: m.reviewFetchSeq, gen: m.detailFollowGen,
+		follow: true, dispatchedFrom: viewQueue,
+	})
+	m = res6.(model)
+	assert.True(m.reviewFixPanelOpen, "the retry's success must open the panel")
+}
+
+// TestFollowFailureAfterTasksParentReviewShowsVisibleFlashNotSilence
+// reproduces the reviewer's blocker 2: resolving pendingReviewOpenJobID on
+// follow failure with a bare clear made the ORIGINALLY-reported tasks-'P'
+// bug silent again -- worse, permanently, since (unlike the fix panel)
+// dispatchReviewFollow never re-arms this intent, so reconcile can never
+// recover it. The exact 'P' repro through a follow failure must leave the
+// user with VISIBLE feedback in the view they made the request from
+// (viewTasks), never silence.
+func TestFollowFailureAfterTasksParentReviewShowsVisibleFlashNotSilence(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	parentID := int64(2)
+	m := initTestModel(withCurrentView(viewTasks), withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...), withSelection(1, 2))
+	m.layout = layoutSplit
+	m.fixJobs = []storage.ReviewJob{
+		{ID: 101, Status: storage.JobStatusDone, ParentJobID: &parentID},
+	}
+	m.fixSelectedIdx = 0
+
+	got, cmd := pressKey(m, 'P')
+	require.NotNil(cmd)
+	require.Equal(parentID, got.pendingReviewOpenJobID)
+
+	res, reconcileCmd := got.handleJobsMsg(jobsMsg{jobs: testQueueJobs(), stats: storage.JobStats{}})
+	got2 := res.(model)
+	require.NotNil(reconcileCmd)
+	followSeq := got2.reviewFetchSeq
+
+	// The reconcile follow FAILS, and its bounded retry fails too.
+	res2, retryCmd := got2.handleReviewFollowErrMsg(reviewFollowErrMsg{
+		jobID: parentID, err: errors.New("boom"), gen: got2.detailFollowGen, fetchSeq: followSeq,
+	})
+	require.NotNil(retryCmd)
+	res2, _ = res2.(model).handleReviewFollowErrMsg(reviewFollowErrMsg{
+		jobID: parentID, err: errors.New("boom"),
+		gen: res2.(model).detailFollowGen, fetchSeq: res2.(model).reviewFetchSeq,
+	})
+	got3 := res2.(model)
+
+	assert.Equal(int64(0), got3.pendingReviewOpenJobID,
+		"the intent must be resolved (cleared), not left silently stranded forever")
+	assert.Equal(viewTasks, got3.currentView, "still on Tasks -- the review never opened")
+	flash := got3.renderFlash(viewTasks)
+	assert.NotEmpty(flash,
+		"the user must get VISIBLE feedback in the view they made the request from, not silence")
+	assert.Contains(flash, "boom")
+}
+
+// TestReviewErrMsgResolvesPendingOpenWithVisibleFlashNotSilence: an
+// ordinary fetch's own outright failure is a first-party abandonment
+// signal, distinct from a success that merely arrived gen-stale, and
+// needs its own typed message (reviewErrMsg, mirroring
+// reviewFollowErrMsg). handleReviewErrMsg resolves pendingReviewOpenJobID on
+// this outcome -- clears it AND shows a visible flash on the request's
+// origin view -- so a later, unrelated bootstrap follow for the
+// still-selected job does not switch views (there is nothing left for it
+// to serve).
+func TestReviewErrMsgResolvesPendingOpenWithVisibleFlashNotSilence(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	m := initTestModel(withCurrentView(viewQueue), withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...), withSelection(1, 2))
+	m.layout = layoutStacked
+
+	// Queue Enter on job 2 (done): dispatches the ordinary fetch, arms the
+	// pending-open intent.
+	res, cmd := m.handleEnterKey()
+	got := res.(model)
+	require.NotNil(cmd)
+	require.Equal(int64(2), got.pendingReviewOpenJobID)
+	seq := got.reviewFetchSeq
+	gen := got.detailFollowGen
+
+	// The fetch fails outright: the typed reviewErrMsg lands.
+	res2, _ := got.handleReviewErrMsg(reviewErrMsg{
+		jobID: 2, err: errors.New("boom"), gen: gen, fetchSeq: seq,
+	})
+	failed := res2.(model)
+
+	assert.Equal(int64(0), failed.pendingReviewOpenJobID,
+		"the failure must resolve (clear) the pending-open intent, not leave it silently armed")
+	flash := failed.renderFlash(viewQueue)
+	assert.NotEmpty(flash, "the user must get visible feedback on the origin view")
+	assert.Contains(flash, "boom")
+
+	// Much later, unrelated to job 2, the user toggles into split layout.
+	res3, _ := failed.handleToggleLayoutKey()
+	toggled := res3.(model)
+	require.Equal(layoutSplit, toggled.layout)
+
+	// The bootstrap follow this triggers lands, carrying job 2's content.
+	res4, _ := toggled.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2, fetchSeq: toggled.reviewFetchSeq,
+		gen: toggled.detailFollowGen, follow: true, dispatchedFrom: viewQueue,
+	})
+	final := res4.(model)
+
+	assert.Equal(viewQueue, final.currentView,
+		"the intent was already resolved by the failure -- the bootstrap follow must not switch views")
+}
+
+// TestFixPanelDoesNotSpringOpenAfterRerunConfirmsWhilePaneLoading:
+// split, 'F' on job 2 with the pane still loading (currentReview nil), a
+// rerun of job 2 confirms, then 'F”s own ordinary fetch response finally
+// lands. handleRerunResultMsg's disarm must not be gated on
+// currentReview != nil (false in exactly this case), and the gen-based
+// early-reject deliberately does not clear the intent reactively, since
+// the job never moved. The panel must not spring open, switch view, or
+// steal focus for content that belongs to the pre-rerun attempt.
+//
+// MECHANISM NOTE: the stale response is rejected at the per-job attempt
+// stamp (a confirmed rerun does not bump detailFollowGen), so the rescue
+// path is never consulted here. The rescue path itself remains covered by
+// TestThreeKeystrokeRescueRepro and
+// TestFixPanelPendingRescuedOnGenMismatchWhenStillFreshest, which reach
+// it through a bootstrap bump rather than a rerun.
+func TestFixPanelDoesNotSpringOpenAfterRerunConfirmsWhilePaneLoading(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	m := splitModel(withSelection(1, 2)) // split, job 2 selected, viewQueue
+	m.tasksEnabled = true
+
+	// 'F' on job 2: arms the pending fix panel, dispatches ordinary fetch A.
+	res, cmdA := m.handleFixKey()
+	m = res.(model)
+	require.NotNil(cmdA)
+	require.True(m.reviewFixPanelPending)
+	require.Nil(m.currentReview, "sanity: the pane is still loading")
+	seqA := m.reviewFetchSeq
+	genA := m.detailFollowGen
+
+	// A rerun of job 2 confirms while the pane is still loading.
+	res2, _ := m.handleRerunResultMsg(rerunResultMsg{jobID: 2})
+	m = res2.(model)
+	require.Positive(m.jobAttemptGen[2],
+		"sanity: the rerun's per-job attempt bump must have happened (roborev #521 replaced the old detailFollowGen bump)")
+	require.False(m.reviewFixPanelPending, "the rerun must resolve the pending fix panel itself")
+	require.Equal(int64(0), m.fixPromptJobID)
+
+	// A's response finally lands, now gen-stale.
+	res3, _ := m.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2, fetchSeq: seqA, gen: genA,
+		follow: false, dispatchedFrom: viewQueue,
+	})
+	got := res3.(model)
+
+	assert.False(got.reviewFixPanelOpen, "the panel must not spring open for the pre-rerun attempt")
+	assert.False(got.reviewFixPanelFocused)
+	assert.Equal(viewQueue, got.currentView, "must not switch view")
+	assert.Equal(focusList, got.focus, "must not steal focus")
+}
+
+// TestTasksNotYankedOutAfterRerunConfirmsParentWhilePending: tasks 'P'
+// on a fix job's parent, a rerun of the parent confirms while the pane is
+// still loading, then 'P”s own response finally lands stale. The user
+// must not be yanked out of the Tasks list.
+//
+// Same mechanism note as the test above: the response is rejected by the
+// per-job attempt stamp rather than as gen-stale, so this does not
+// traverse reviewIntentRescuable; the property is unchanged.
+func TestTasksNotYankedOutAfterRerunConfirmsParentWhilePending(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	parentID := int64(2)
+	m := initTestModel(withCurrentView(viewTasks), withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...), withSelection(1, 2))
+	m.layout = layoutSplit
+	m.fixJobs = []storage.ReviewJob{
+		{ID: 101, Status: storage.JobStatusDone, ParentJobID: &parentID},
+	}
+	m.fixSelectedIdx = 0
+
+	got, cmd := pressKey(m, 'P')
+	require.NotNil(cmd)
+	require.Equal(parentID, got.pendingReviewOpenJobID)
+	seq := got.reviewFetchSeq
+	gen := got.detailFollowGen
+
+	// A rerun of the parent job confirms while the pane is still loading.
+	res2, _ := got.handleRerunResultMsg(rerunResultMsg{jobID: parentID})
+	got2 := res2.(model)
+	require.Positive(got2.jobAttemptGen[parentID],
+		"sanity: the rerun's per-job attempt bump must have happened")
+	require.Equal(int64(0), got2.pendingReviewOpenJobID,
+		"the rerun must disarm the pending-open intent itself")
+
+	// 'P''s response finally lands, now gen-stale.
+	res3, _ := got2.handleReviewMsg(reviewMsg{
+		review: &storage.Review{ID: 90, JobID: parentID, Agent: "codex", Job: &storage.ReviewJob{ID: parentID, Status: storage.JobStatusDone}},
+		jobID:  parentID, fetchSeq: seq, gen: gen, follow: false, dispatchedFrom: viewTasks,
+	})
+	final := res3.(model)
+
+	assert.Equal(viewTasks, final.currentView,
+		"the user must not be yanked out of Tasks by a stale response for a job that just reran")
+}
+
+// TestThreeKeystrokeRescueRepro is the end-to-end rescue repro: stacked,
+// job 2 Done, currentReview nil -> Enter -> L within the debounce
+// (bootstrap bumps gen, schedules a tick) -> L again before the tick
+// fires (maybeBootstrapDetail early-returns since layout flipped back to
+// stacked, so nothing NEW is scheduled) -> the outstanding tick fires and
+// is DROPPED (its gen still matches, but m.layout is no longer split) ->
+// A's SUCCESSFUL response finally lands, gen-stale, with nothing else
+// ever having been dispatched for this job. Without the rescue, that
+// response would be silently discarded and both the intent AND its
+// content lost, permanently unrecoverable since nothing is left in
+// flight. With it, the review opens directly
+// from A's own response, and no intent survives to later "spring open"
+// via an unrelated action -- verified by toggling layout again afterward
+// and confirming nothing unexpected happens.
+func TestThreeKeystrokeRescueRepro(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	m := initTestModel(withCurrentView(viewQueue), withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...), withSelection(1, 2))
+	m.layout = layoutStacked
+
+	// Enter on job 2 (done): dispatches the ordinary fetch (A), arms the
+	// pending-open intent.
+	res, cmd := m.handleEnterKey()
+	got := res.(model)
+	require.NotNil(cmd)
+	require.Equal(int64(2), got.pendingReviewOpenJobID)
+	seqA := got.reviewFetchSeq
+	genA := got.detailFollowGen
+
+	// L, within the debounce: toggles into split, bumps gen, schedules a
+	// tick.
+	res2, _ := got.handleToggleLayoutKey()
+	toggled1 := res2.(model)
+	require.Equal(layoutSplit, toggled1.layout)
+	require.Greater(toggled1.detailFollowGen, genA)
+
+	// L again, before the tick fires: toggles back to stacked.
+	// maybeBootstrapDetail early-returns (layout != layoutSplit), so no
+	// NEW tick is scheduled -- but the FIRST tick is still outstanding.
+	res3, _ := toggled1.handleToggleLayoutKey()
+	toggled2 := res3.(model)
+	require.Equal(layoutStacked, toggled2.layout)
+	require.Equal(toggled1.detailFollowGen, toggled2.detailFollowGen,
+		"sanity: the second L must not schedule another bump")
+
+	// The outstanding tick (from the first L) fires now: its gen still
+	// matches, but layout is no longer split, so it is dropped -- nothing
+	// gets dispatched.
+	res4, tickCmd := toggled2.handleDetailFollowTick(detailFollowTickMsg{gen: toggled2.detailFollowGen})
+	dropped := res4.(model)
+	require.Nil(tickCmd, "sanity: the dropped tick must not dispatch anything")
+	require.Equal(int64(2), dropped.pendingReviewOpenJobID, "sanity: still armed, nothing has resolved it yet")
+	require.Equal(seqA, dropped.reviewFetchSeq, "sanity: nothing new has been dispatched")
+
+	// A's successful response finally lands, gen-stale, with nothing else
+	// ever having been dispatched for this job.
+	res5, _ := dropped.handleReviewMsg(reviewMsg{
+		review: &storage.Review{ID: 81, JobID: 2, Agent: "codex", Job: &storage.ReviewJob{ID: 2, Status: storage.JobStatusDone}},
+		jobID:  2, fetchSeq: seqA, gen: genA, follow: false, dispatchedFrom: viewQueue,
+	})
+	final := res5.(model)
+
+	assert.Equal(viewReview, final.currentView, "the explicit Enter must still open the review")
+	assert.Equal(int64(0), final.pendingReviewOpenJobID, "no intent must be left armed")
+
+	// The delayed-L half: pressing L again later must not produce a
+	// surprise view switch, because nothing is stranded to spring open.
+	res6, _ := final.handleToggleLayoutKey()
+	afterLater := res6.(model)
+	assert.Equal(viewReview, afterLater.currentView, "still the same review, no surprise switch")
+	assert.Equal(int64(2), afterLater.currentReview.JobID)
+}
+
+// TestRerunConfirmedWhileNotSelectedDoesNotWronglyServePendingOpen
+// reproduces roborev ITEM 1: the previous round's fix hoisted
+// handleRerunResultMsg's two disarm blocks so they key on msg.jobID alone
+// -- but they used to be NESTED inside the SAME `m.selectedJobID ==
+// msg.jobID` gate as the gen bump, so a rerun confirmed for a job that is
+// NOT currently selected bumped nothing (correctly, per the gate's own
+// cross-job-cost reasoning) AND disarmed nothing (a real bug: the two
+// fields are already keyed on jobID, so gating their disarm on the
+// SELECTION was never justified the way gating the gen bump is).
+//
+// Exact probe: Enter on job 2 (arms the pending-open intent) -> R
+// (rerun dispatched, not yet confirmed) -> arrow to job 3 -- a REAL
+// selection change, but in STACKED layout, where followSelectionChange's
+// own layout gate means NOTHING proactively disarms (the same structural
+// fact several Table 2 rows lean on) -- so the intent for job 2 survives,
+// still armed, with the selection now on job 3 -> the rerun of job 2
+// confirms while job 2 is NOT selected -> arrow back to job 2 -> L, L
+// within the debounce (bumps gen once, then drops the resulting tick,
+// exactly like TestThreeKeystrokeRescueRepro) -> the PRE-RERUN response
+// for job 2 finally lands, gen-stale but still fetchSeq-fresh. Before this
+// fix, reviewIntentRescuable found the (wrongly still-armed) intent and
+// served it: the PREVIOUS attempt's review opened for a job that is
+// CURRENTLY RE-RUNNING. The two existing rerun regression tests
+// (TestFixPanelDoesNotSpringOpenAfterRerunConfirmsWhilePaneLoading,
+// TestTasksNotYankedOutAfterRerunConfirmsParentWhilePending) both have the
+// reran job SELECTED throughout, which is exactly why neither one catches
+// this.
+// NOTE: since the abandonment chokepoint became layout-independent
+// (followSelectionChange disarms in stacked too), the arrow-away step below
+// disarms the intent BEFORE the rerun ever confirms -- the scenario is now
+// protected twice over. The first half of this test therefore constructs
+// the armed-for-a-non-selected-job state directly (no navigation path can
+// produce it anymore) to keep the rerun disarm's contract property pinned
+// as defense-in-depth; the second half keeps the original end-to-end
+// keystroke sequence to prove the final outcome.
+func TestRerunConfirmedWhileNotSelectedDoesNotWronglyServePendingOpen(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// Contract property (jobAttemptGen clause 2b): a confirmed rerun
+	// disarms the intents for ITS job, keyed on the rerun's jobID, never
+	// on the selection. Constructed directly: every navigation path now
+	// disarms on the selection change itself, so this state cannot arise
+	// from real input -- the unconditional rerun disarm is the backstop
+	// for any future path that slips past the chokepoint.
+	direct := initTestModel(withCurrentView(viewQueue), withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...), withSelection(0, 3))
+	direct.layout = layoutStacked
+	direct.pendingReviewOpenJobID = 2
+	direct.pendingReviewOpenOrigin = viewQueue
+	direct.pendingReviewOpenSeq = 1
+	res, _ := direct.handleRerunResultMsg(rerunResultMsg{jobID: 2})
+	reran := res.(model)
+	assert.Equal(int64(0), reran.pendingReviewOpenJobID,
+		"a confirmed rerun must disarm the intent for ITS job regardless of what is currently selected")
+
+	// End to end, from real keystrokes: Enter on job 2 arms; arrowing away
+	// now abandons immediately (the Finding-1 fix); the rerun, the return
+	// to job 2 and the L,L toggle change nothing about that; the pre-rerun
+	// response lands multiply stale (gen from the abandonment, attempt
+	// from the rerun) with no intent to rescue, and is dropped.
+	m := initTestModel(withCurrentView(viewQueue), withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...), withSelection(1, 2))
+	m.layout = layoutStacked
+
+	res2, cmd := m.handleEnterKey()
+	got := res2.(model)
+	require.NotNil(cmd)
+	require.Equal(int64(2), got.pendingReviewOpenJobID)
+	seqA := got.reviewFetchSeq
+	genA := got.detailFollowGen
+
+	moved, _ := pressSpecial(got, tea.KeyUp)
+	require.Equal(int64(3), moved.selectedJobID, "sanity: selection actually moved")
+	assert.Equal(int64(0), moved.pendingReviewOpenJobID,
+		"the selection change abandons the intent immediately, in stacked too")
+
+	res3, _ := moved.handleRerunResultMsg(rerunResultMsg{jobID: 2})
+	reran2 := res3.(model)
+
+	back, _ := pressSpecial(reran2, tea.KeyDown)
+	require.Equal(int64(2), back.selectedJobID)
+
+	res5, _ := back.handleToggleLayoutKey()
+	toggled1 := res5.(model)
+	res6, _ := toggled1.handleToggleLayoutKey()
+	toggled2 := res6.(model)
+	res7, tickCmd := toggled2.handleDetailFollowTick(detailFollowTickMsg{gen: toggled2.detailFollowGen})
+	dropped := res7.(model)
+	require.Nil(tickCmd, "sanity: the dropped tick must not dispatch anything")
+
+	res8, _ := dropped.handleReviewMsg(reviewMsg{
+		review: &storage.Review{ID: 82, JobID: 2, Agent: "codex", Job: &storage.ReviewJob{ID: 2, Status: storage.JobStatusDone}},
+		jobID:  2, fetchSeq: seqA, gen: genA, follow: false, dispatchedFrom: viewQueue,
+	})
+	final := res8.(model)
+
+	assert.Equal(viewQueue, final.currentView,
+		"the pre-rerun response must not be wrongly served for a job that is currently re-running")
+}

--- a/cmd/roborev/tui/split_queue_pane.go
+++ b/cmd/roborev/tui/split_queue_pane.go
@@ -1,0 +1,72 @@
+package tui
+
+// queuePaneColumns returns the visible queue columns that fit paneW,
+// dropping from the end of the user's configured column order (rightmost-
+// configured drops first). colSel, colJobID, and colRef always survive.
+// Estimation: fixed columns use their minimum fixed widths; flex columns
+// (ref/branch/repo) count a floor of min(content, 12); +1 spacing per
+// non-first column. This mirrors renderQueueTable's sizing closely enough
+// to decide fit; renderQueueTable does the exact layout afterward.
+func (m model) queuePaneColumns(paneW int, contentWidth map[int]int) []int {
+	core := map[int]bool{colSel: true, colJobID: true, colRef: true}
+	estimate := func(c int) int {
+		w := contentWidth[c]
+		switch c {
+		case colSel:
+			return 2
+		case colRef, colBranch, colRepo:
+			return min(max(w, 4), 12)
+		default:
+			return w
+		}
+	}
+	fits := func(cols []int) bool {
+		total := 0
+		for i, c := range cols {
+			total += estimate(c)
+			if i > 0 && c != colSel {
+				total++
+			}
+		}
+		return total <= paneW
+	}
+
+	cols := m.visibleColumns()
+	// Drop candidates in reverse configured order until it fits.
+	for i := len(m.columnOrder) - 1; i >= 0 && !fits(cols); i-- {
+		drop := m.columnOrder[i]
+		if core[drop] {
+			continue
+		}
+		next := cols[:0:0]
+		for _, c := range cols {
+			if c != drop {
+				next = append(next, c)
+			}
+		}
+		cols = next
+	}
+	return cols
+}
+
+// renderQueuePaneBody renders the queue table body-only for the split list
+// pane: exactly innerH clean lines (no escape codes), header + windowed
+// rows, padded with blanks.
+func (m model) renderQueuePaneBody(innerW, innerH int) []string {
+	rows := m.visibleQueueRows()
+	lines := make([]string, 0, innerH)
+	if len(rows) == 0 {
+		lines = append(lines, statusStyle.Render("No jobs"))
+	} else {
+		hasAnyPanel := anyPanelRow(rows)
+		treeColor := queueColorEnabled()
+		cw := m.queueContentWidths(rows, m.visibleColumns(), hasAnyPanel, treeColor)
+		cols := m.queuePaneColumns(innerW, cw)
+		// Table header+separator occupy the top of the pane; the rest is rows.
+		lines = append(lines, m.renderQueueTable(rows, innerW, max(innerH-2, 1), cols, cw)...)
+	}
+	for len(lines) < innerH {
+		lines = append(lines, "")
+	}
+	return lines[:innerH]
+}

--- a/cmd/roborev/tui/split_render.go
+++ b/cmd/roborev/tui/split_render.go
@@ -1,0 +1,245 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+// splitPaneStyle wraps pane content in a border: accent when focused,
+// gray otherwise. lipgloss v2 sizes Width/Height border-box.
+func splitPaneStyle(focused bool, outerW, outerH int) lipgloss.Style {
+	border := adaptiveColor("242", "246")
+	if focused {
+		border = adaptiveColor("125", "205")
+	}
+	return lipgloss.NewStyle().
+		Border(lipgloss.NormalBorder()).
+		BorderForeground(border).
+		Width(outerW).
+		Height(outerH)
+}
+
+// splitFooterRows returns the help table for the focused pane.
+func (m model) splitFooterRows() [][]helpItem {
+	if m.focus == focusDetail {
+		rows := [][]helpItem{
+			{{"p", "prompt"}, {"c", "comment"}, {"m", "commit"}, {"a", "close"}, {"y", "copy"}},
+			{{"↑/↓", "scroll"}, {"←/→", "prev/next"}, {"L", "layout"}, {"esc", "back to list"}, {"?", "commands"}},
+		}
+		if m.tasksWorkflowEnabled() {
+			rows[0] = append(rows[0], helpItem{"F", "fix"})
+		}
+		return rows
+	}
+	rows := filterHelpItem(m.queueHelpRows(), "↵")
+	last := len(rows) - 1
+	rows[last] = append(rows[last], helpItem{"L", "layout"}, helpItem{"tab", "focus detail"})
+	return rows
+}
+
+// filterHelpItem returns a copy of rows with any entry whose key matches key
+// removed. Enter is a no-op with the queue focused in split layout (the
+// detail pane already follows the cursor), so the split footer omits the
+// "↵ review" hint that queueHelpRows carries for the stacked layout.
+func filterHelpItem(rows [][]helpItem, key string) [][]helpItem {
+	out := make([][]helpItem, len(rows))
+	for i, row := range rows {
+		filtered := make([]helpItem, 0, len(row))
+		for _, item := range row {
+			if item.key == key {
+				continue
+			}
+			filtered = append(filtered, item)
+		}
+		out[i] = filtered
+	}
+	return out
+}
+
+// renderSplit composes the split screen: full-width title, two bordered
+// panes, full-width info line and help footer.
+func (m model) renderSplit() string {
+	footerRows := m.splitFooterRows()
+	footerLines := len(reflowHelpRows(footerRows, m.width))
+	g := splitGeometry(m.width, m.height, footerLines)
+
+	title := m.renderQueueTitle()
+
+	listPane := splitPaneStyle(m.focus == focusList, g.listOuterW, g.bodyH).
+		Render(strings.Join(m.renderQueuePaneBody(g.listInnerW, g.listInnerH), "\n"))
+	detailPane := splitPaneStyle(m.focus == focusDetail, g.detailOuterW, g.bodyH).
+		Render(strings.Join(m.renderDetailPane(g.detailInnerW, g.detailInnerH), "\n"))
+	body := lipgloss.JoinHorizontal(lipgloss.Top, listPane, detailPane)
+
+	info := m.splitInfoLine(g)
+	footer := renderHelpTable(footerRows, m.width)
+
+	return title + "\x1b[K\n" + body + "\n" + info + "\x1b[K\n" + footer + "\x1b[K\x1b[J"
+}
+
+// splitInfoLine shows the flash (if any) or the focused pane's position.
+func (m model) splitInfoLine(g splitGeom) string {
+	if flash := m.renderFlash(m.currentView); flash != "" {
+		return flash
+	}
+	if m.focus == focusDetail && m.currentReview != nil {
+		// Exactly the condition renderDetailPane renders the review body
+		// under: anything looser describes content that is not on screen
+		// (a status card for a queued/running job, or the loading/error
+		// card while a stale attempt's review is being refetched).
+		if m.selectedReviewLoaded() {
+			start, end, total := m.reviewPaneScrollInfo(g.detailInnerW, g.detailInnerH)
+			if total > end-start {
+				return statusStyle.Render(fmt.Sprintf("[%d-%d of %d lines]", start+1, end, total))
+			}
+		}
+		return ""
+	}
+	rows := m.visibleQueueRows()
+	idx := visibleSelectedRowIndex(rows, m.selectedJobID)
+	if idx >= 0 {
+		return statusStyle.Render(fmt.Sprintf("%d/%d jobs", idx+1, len(rows)))
+	}
+	return ""
+}
+
+// handleSplitMouse handles mouse events while the split layout is active:
+// click focuses/selects by x-coordinate (list side selects a row and keeps
+// list focus; detail side focuses the detail pane), wheel scrolls whichever
+// pane the cursor is over regardless of current focus. A list-side selection
+// change (click or wheel) schedules the debounced detail follow so the
+// detail pane catches up, mirroring the keyboard nav wrapper in
+// handleKeyMsg -- but only when the selection actually moved: a click on
+// the already-selected row, or a wheel at a boundary where the move
+// clamps in place, must not reset reviewScroll via scheduleDetailFollow.
+// List-side wheel routes through the shared queueNavUp/queueNavDown
+// helpers (handlers.go), so it prefetches near the end of loaded data and
+// resumes pagination at the bottom boundary exactly like keyboard
+// navigation; the nav cmd is batched with the detail-follow cmd.
+func (m model) handleSplitMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	mouse := msg.Mouse()
+	footerRows := m.splitFooterRows()
+	g := splitGeometry(m.width, m.height, len(reflowHelpRows(footerRows, m.width)))
+
+	switch msg.(type) {
+	case tea.MouseWheelMsg:
+		if mouse.X < g.listOuterW {
+			prevSelected := m.selectedJobID
+			var navCmd tea.Cmd
+			switch mouse.Button {
+			case tea.MouseWheelUp:
+				m, navCmd = m.queueNavUp()
+			case tea.MouseWheelDown:
+				m, navCmd = m.queueNavDown()
+			default:
+				return m, nil
+			}
+			mm, followCmd := m.followSelectionChange(prevSelected)
+			return mm, tea.Batch(navCmd, followCmd)
+		}
+		var delta int
+		switch mouse.Button {
+		case tea.MouseWheelUp:
+			delta = -3
+		case tea.MouseWheelDown:
+			delta = 3
+		default:
+			return m, nil
+		}
+		m.reviewScroll += delta
+		if m.reviewScroll < 0 {
+			m.reviewScroll = 0
+		}
+		if m.mdCache != nil && m.reviewScroll > m.mdCache.lastReviewMaxScroll {
+			m.reviewScroll = m.mdCache.lastReviewMaxScroll
+		}
+		return m, nil
+	case tea.MouseClickMsg:
+		if mouse.Button != tea.MouseLeft {
+			return m, nil
+		}
+		if mouse.X < g.listOuterW {
+			rows := m.visibleQueueRows()
+			idx := m.splitListRowAt(rows, mouse.Y, g)
+			if idx < 0 || idx >= len(rows) {
+				return m, nil
+			}
+			prevSelected := m.selectedJobID
+			m = m.moveSelectionToJobID(rows[idx].job.ID)
+			m.focus = focusList
+			m.currentView = viewQueue
+			return m.followSelectionChange(prevSelected)
+		}
+		if m.selectedReviewLoaded() {
+			// Same reasoning as handleTabKey's split branch: this click
+			// enters viewReview from a review the follow-fetch already
+			// loaded, not a fresh dispatch, so stamp the origin explicitly
+			// rather than leave a stale reviewFromView in place. The
+			// selectedReviewLoaded guard (rather than a bare
+			// currentReview != nil check) additionally rules out a stale
+			// review left over from a previously selected job -- see
+			// handleTabKey's identical guard for the full rationale.
+			m.reviewFromView = viewQueue
+			m.focus = focusDetail
+			m.currentView = viewReview
+		}
+		return m, nil
+	default:
+		return m, nil
+	}
+}
+
+// queuePaneRowCapacity returns the number of queue data rows the split list
+// pane can currently display. Mirrors renderQueuePaneBody's row BUDGET
+// exactly: `max(innerH-2, 1)`, passed to renderQueueTable unconditionally --
+// even in compact mode, where the 2-line header/separator isn't actually
+// drawn on screen but the freed rows are padded with blank lines rather
+// than repurposed for more data rows (see renderQueuePaneBody). There is
+// deliberately no compact-mode special case here: that would overestimate
+// capacity by 2 relative to what's actually rendered, one root cause behind
+// the pagination-refill bug this helper was introduced to fix. Contrast
+// with splitListRowAt's OWN (unrelated) compact adjustment below, which is
+// about the on-screen y-offset of the header that IS or ISN'T drawn, not
+// about the row budget.
+func (m model) queuePaneRowCapacity() int {
+	footerRows := m.splitFooterRows()
+	g := splitGeometry(m.width, m.height, len(reflowHelpRows(footerRows, m.width)))
+	return max(g.listInnerH-2, 1)
+}
+
+// splitListRowAt maps a screen row y to the index of the visible queue row
+// drawn there (into rows, the caller's m.visibleQueueRows()), or -1 when y
+// misses the data rows. Mirrors handleQueueMouseClick's window math
+// (handlers_queue.go) with split pane offsets: title band (1) + pane top
+// border (1) + the table header/separator lines renderQueueTable actually
+// draws on screen before the data rows (2 normally, 0 in compact mode --
+// see renderQueueTable's compact stripping). This tableHeaderLines is
+// distinct from queuePaneRowCapacity's row budget (which stays innerH-2
+// regardless of compact mode, matching what renderQueuePaneBody actually
+// passes to renderQueueTable) -- it's purely about where the data rows
+// start on screen.
+func (m model) splitListRowAt(rows []queueRow, y int, g splitGeom) int {
+	if len(rows) == 0 {
+		return -1
+	}
+	tableHeaderLines := 2
+	if m.queueCompact() {
+		tableHeaderLines = 0
+	}
+	visibleRows := m.queuePaneRowCapacity()
+	start, end := queueWindowStart(len(rows), visibleSelectedRowIndex(rows, m.selectedJobID), visibleRows)
+
+	offset := 1 + 1 + tableHeaderLines // title + pane border + table header/separator
+	row := y - offset
+	if row < 0 || row >= visibleRows {
+		return -1
+	}
+	idx := start + row
+	if idx < start || idx >= end {
+		return -1
+	}
+	return idx
+}

--- a/cmd/roborev/tui/split_test.go
+++ b/cmd/roborev/tui/split_test.go
@@ -6205,7 +6205,7 @@ func TestCommentOnSynthesizedFailedReviewAppendsLocally(t *testing.T) {
 		jobID: 1, responder: "wes", comment: "known flake, not a regression",
 	})
 	got := res.(model)
-	assert.Nil(cmd, "no refresh fetch can succeed for a review with no persisted row")
+	assert.NotNil(cmd, "the append dispatches a reconciling comments refetch")
 	require.Len(got.currentResponses, 1)
 	assert.Equal("known flake, not a regression", got.currentResponses[0].Response)
 	assert.Equal("wes", got.currentResponses[0].Responder)
@@ -6213,6 +6213,48 @@ func TestCommentOnSynthesizedFailedReviewAppendsLocally(t *testing.T) {
 	lines := strings.Join(got.renderDetailPane(88, 25), "\n")
 	assert.Contains(lines, "known flake, not a regression",
 		"the appended comment must render under the failure review")
+}
+
+// TestStaleFailedCommentsResponseCannotOverwriteNewerState: the comments
+// side channel carries its own request identity. A pre-post fetch's
+// response landing after the post-success local append must be dropped
+// (the append's own reconciling refetch bumped the seq), and an older
+// dispatch's response landing after a newer dispatch's must be dropped
+// too -- synthesized reviews all share ID 0, so nothing else tells the
+// two requests apart.
+func TestStaleFailedCommentsResponseCannotOverwriteNewerState(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(2, 1)) // job 1: failed, selected
+
+	// First display dispatches fetch #1 (pre-post: server has no comments).
+	m, cmd := m.splitReconcileDetail()
+	require.NotNil(cmd)
+	preP0stSeq := m.failedCommentsSeq
+
+	// The user's comment posts successfully: local append + refetch #2.
+	res, cmd2 := m.handleCommentResultMsg(commentResultMsg{
+		jobID: 1, responder: "wes", comment: "fresh comment",
+	})
+	m = res.(model)
+	require.NotNil(cmd2)
+	require.Len(m.currentResponses, 1)
+
+	// Fetch #1's response (empty, served before the POST) lands late:
+	// it must not wipe the appended comment.
+	res, _ = m.handleFailedCommentsMsg(failedCommentsMsg{jobID: 1, seq: preP0stSeq})
+	m = res.(model)
+	require.Len(m.currentResponses, 1,
+		"a stale pre-post response must not wipe the just-appended comment")
+	assert.Equal("fresh comment", m.currentResponses[0].Response)
+
+	// Refetch #2's response (server truth, includes the comment) lands.
+	res, _ = m.handleFailedCommentsMsg(failedCommentsMsg{
+		jobID: 1, seq: m.failedCommentsSeq,
+		responses: []storage.Response{{Responder: "wes", Response: "fresh comment"}},
+	})
+	m = res.(model)
+	assert.Len(m.currentResponses, 1, "server truth replaces the optimistic copy exactly once")
 }
 
 // TestFailedReviewCommentsSurviveNavigationRoundTrip: every synthesized
@@ -6228,7 +6270,7 @@ func TestFailedReviewCommentsSurviveNavigationRoundTrip(t *testing.T) {
 	m, cmd := m.splitReconcileDetail()
 	require.NotNil(cmd)
 	res, _ := m.handleFailedCommentsMsg(failedCommentsMsg{
-		jobID:     1,
+		jobID: 1, seq: m.failedCommentsSeq,
 		responses: []storage.Response{{Responder: "wes", Response: "known flake"}},
 	})
 	m = res.(model)
@@ -6238,7 +6280,7 @@ func TestFailedReviewCommentsSurviveNavigationRoundTrip(t *testing.T) {
 	m = m.moveSelectionToJobID(3)
 	m, _ = m.followSelectionChange(1)
 	res, _ = m.handleFailedCommentsMsg(failedCommentsMsg{
-		jobID:     1,
+		jobID: 1, seq: m.failedCommentsSeq,
 		responses: []storage.Response{{Responder: "eve", Response: "should not land"}},
 	})
 	m = res.(model)
@@ -6255,7 +6297,7 @@ func TestFailedReviewCommentsSurviveNavigationRoundTrip(t *testing.T) {
 
 	// The fetch response restores them and they render.
 	res, _ = m.handleFailedCommentsMsg(failedCommentsMsg{
-		jobID:     1,
+		jobID: 1, seq: m.failedCommentsSeq,
 		responses: []storage.Response{{Responder: "wes", Response: "known flake"}},
 	})
 	m = res.(model)

--- a/cmd/roborev/tui/split_test.go
+++ b/cmd/roborev/tui/split_test.go
@@ -6190,6 +6190,31 @@ func TestEligibleReviewRowExcludesLiveJobs(t *testing.T) {
 	assert.True(eligibleReviewRow(storage.ReviewJob{Status: storage.JobStatusFailed}))
 }
 
+// TestCommentOnSynthesizedFailedReviewAppendsLocally: a synthesized
+// failed-job review has no persisted review row, so the comment refresh's
+// /api/review fetch would 404 and the created comment would never appear.
+// The handler must append the posted comment directly instead.
+func TestCommentOnSynthesizedFailedReviewAppendsLocally(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(2, 1)) // job 1: failed
+	m.currentReview = synthesizeFailedReview(&m.jobs[2], nil)
+	require.Zero(m.currentReview.ID, "sanity: synthesized reviews have no persisted row")
+
+	res, cmd := m.handleCommentResultMsg(commentResultMsg{
+		jobID: 1, responder: "wes", comment: "known flake, not a regression",
+	})
+	got := res.(model)
+	assert.Nil(cmd, "no refresh fetch can succeed for a review with no persisted row")
+	require.Len(got.currentResponses, 1)
+	assert.Equal("known flake, not a regression", got.currentResponses[0].Response)
+	assert.Equal("wes", got.currentResponses[0].Responder)
+
+	lines := strings.Join(got.renderDetailPane(88, 25), "\n")
+	assert.Contains(lines, "known flake, not a regression",
+		"the appended comment must render under the failure review")
+}
+
 // TestClosingLastVisibleJobClearsSelection: with hide-closed on, closing
 // the only visible job must clear the selection (like the cancel twin) --
 // left pointing at the now-hidden job, the list shows "No jobs" while the

--- a/cmd/roborev/tui/split_test.go
+++ b/cmd/roborev/tui/split_test.go
@@ -6190,6 +6190,59 @@ func TestEligibleReviewRowExcludesLiveJobs(t *testing.T) {
 	assert.True(eligibleReviewRow(storage.ReviewJob{Status: storage.JobStatusFailed}))
 }
 
+// TestClosingLastVisibleJobClearsSelection: with hide-closed on, closing
+// the only visible job must clear the selection (like the cancel twin) --
+// left pointing at the now-hidden job, the list shows "No jobs" while the
+// detail pane stays actionable for the invisible review. The rollback
+// restores by msg.jobID, so a server rejection still re-selects it.
+func TestClosingLastVisibleJobClearsSelection(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	closed := false
+	finishedAt := splitTestFinishedAt
+	only := storage.ReviewJob{
+		ID: 2, GitRef: "bbbb222", RepoName: "repoA", Agent: "codex",
+		Status: storage.JobStatusDone, Closed: &closed, FinishedAt: &finishedAt,
+	}
+	m := splitModel(withTestJobs(only), withSelection(0, 2))
+	m.hideClosed = true
+
+	res, cmd := m.handleCloseKey()
+	got := res.(model)
+	require.NotNil(cmd)
+	assert.Equal(int64(0), got.selectedJobID, "no visible replacement: the selection must clear")
+	assert.Equal(-1, got.selectedIdx)
+
+	// A server rejection rolls the selection back onto the job.
+	res, _ = got.handleClosedResultMsg(closedResultMsg{
+		jobID: 2, restoreSelection: true, oldState: false, newState: true,
+		seq: got.closedSeq, err: errors.New("daemon unreachable"),
+	})
+	assert.Equal(int64(2), res.(model).selectedJobID,
+		"the rollback must restore the selection from the cleared state")
+}
+
+// TestNormalizeSelectionClearsWhenNothingVisible: returning to the queue
+// with the selection on a hidden job and no visible job anywhere must
+// clear the selection, matching normalizeSelectionIfHidden's own
+// out-of-bounds branch.
+func TestNormalizeSelectionClearsWhenNothingVisible(t *testing.T) {
+	assert := assert.New(t)
+	closed := true
+	finishedAt := splitTestFinishedAt
+	only := storage.ReviewJob{
+		ID: 2, GitRef: "bbbb222", RepoName: "repoA", Agent: "codex",
+		Status: storage.JobStatusDone, Closed: &closed, FinishedAt: &finishedAt,
+	}
+	m := splitModel(withTestJobs(only), withSelection(0, 2))
+	m.hideClosed = true
+
+	m.normalizeSelectionIfHidden()
+	assert.Equal(int64(0), m.selectedJobID,
+		"a hidden selection with no visible replacement must clear")
+	assert.Equal(-1, m.selectedIdx)
+}
+
 // TestRunningTaskPromptNotOverwrittenByReconcile: opening a running task's
 // prompt moves the selection to the fix job like the completed-task path.
 // Left on the previous queue job, split reconciliation would keep

--- a/cmd/roborev/tui/split_test.go
+++ b/cmd/roborev/tui/split_test.go
@@ -1,0 +1,7608 @@
+package tui
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/storage"
+)
+
+func splitModel(opts ...testModelOption) model {
+	base := []testModelOption{
+		withCurrentView(viewQueue),
+		withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...),
+		withSelection(1, 2),
+	}
+	m := initTestModel(append(base, opts...)...)
+	m.layout = layoutSplit
+	return m
+}
+
+func TestRenderSplitShowsBothPanes(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview()))
+	out := m.renderSplit()
+	assert.Contains(out, "JobID")         // list pane header
+	assert.Contains(out, "first finding") // detail pane body
+	assert.Contains(out, "│")             // pane borders present
+	// Every screen line fits the terminal width.
+	for line := range strings.SplitSeq(out, "\n") {
+		assert.LessOrEqual(lipgloss.Width(line), 150)
+	}
+}
+
+func TestViewContentDispatchesToSplit(t *testing.T) {
+	m := splitModel(withReview(splitTestReview()))
+	assert.Contains(t, m.viewContent(), "first finding")
+
+	// Stacked mode still renders the plain queue.
+	m.layout = layoutStacked
+	assert.NotContains(t, m.viewContent(), "first finding")
+}
+
+func TestDetailPaneStates(t *testing.T) {
+	assert := assert.New(t)
+
+	// Failed job: error text.
+	m := splitModel(withSelection(2, 1))
+	m.currentReview = nil
+	lines := strings.Join(m.renderDetailPane(88, 25), "\n")
+	assert.Contains(lines, "boom")
+
+	// Running job: status card.
+	m = splitModel(withSelection(0, 3))
+	m.currentReview = nil
+	lines = strings.Join(m.renderDetailPane(88, 25), "\n")
+	assert.Contains(lines, "running")
+	assert.Contains(lines, "codex")
+
+	// Done job, review not yet fetched: loading placeholder.
+	m = splitModel(withSelection(1, 2))
+	m.currentReview = nil
+	lines = strings.Join(m.renderDetailPane(88, 25), "\n")
+	assert.Contains(lines, "Loading")
+}
+
+// TestSplitInfoLineStaleReview covers a stale m.currentReview: focus is on
+// the detail pane, but the loaded review belongs to job 2 while selection has
+// since moved to job 3 (running, no review at all). renderDetailPane
+// correctly falls back to the status card in this case; splitInfoLine must
+// not compute a scroll indicator from the stale review either.
+func TestSplitInfoLineStaleReview(t *testing.T) {
+	m := splitModel(withReview(splitTestReview()), withSelection(0, 3))
+	m.focus = focusDetail
+
+	footerRows := m.splitFooterRows()
+	footerLines := len(reflowHelpRows(footerRows, m.width))
+	g := splitGeometry(m.width, m.height, footerLines)
+
+	info := m.splitInfoLine(g)
+	assert.NotContains(t, info, "of")
+}
+
+func TestStateSnapshotIncludesLayout(t *testing.T) {
+	m := splitModel()
+	resp := m.buildStateResponse()
+	snap, ok := resp.Data.(stateSnapshot)
+	require.True(t, ok)
+	assert.Equal(t, "split", snap.Layout)
+	assert.Equal(t, "list", snap.Focus)
+
+	m.layout = layoutStacked
+	snap = m.buildStateResponse().Data.(stateSnapshot)
+	assert.Equal(t, "stacked", snap.Layout)
+	assert.Empty(t, snap.Focus)
+}
+
+func mouseClickAt(x, y int) tea.MouseMsg {
+	return tea.MouseClickMsg(tea.Mouse{
+		X:      x,
+		Y:      y,
+		Button: tea.MouseLeft,
+	})
+}
+
+func mouseWheelAt(x, y int, btn tea.MouseButton) tea.MouseMsg {
+	return tea.MouseWheelMsg(tea.Mouse{
+		X:      x,
+		Y:      y,
+		Button: btn,
+	})
+}
+
+// splitFirstDataRowY renders the split screen and locates the on-screen row
+// index of the first queue data row (identified by a marker unique to it,
+// e.g. a job's GitRef) rather than hardcoding the chrome offset, so a future
+// change to the title/border/header chrome desyncs this test loudly instead
+// of silently.
+func splitFirstDataRowY(t *testing.T, m model, marker string) int {
+	t.Helper()
+	lines := strings.Split(m.renderSplit(), "\n")
+	idx := -1
+	for i, line := range lines {
+		if strings.Contains(line, marker) {
+			idx = i
+			break
+		}
+	}
+	require.NotEqual(t, -1, idx, "marker not found in rendered split output")
+	return idx
+}
+
+func TestSplitMouseClickSelectsAndFocuses(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview()))
+	g := splitGeometry(150, 40, len(reflowHelpRows(m.splitFooterRows(), 150)))
+
+	// Click a list row: selects it, keeps/sets list focus.
+	firstDataY := splitFirstDataRowY(t, m, "cccc333") // job 3's GitRef, first visible row
+	res, _ := m.handleSplitMouse(mouseClickAt(5, firstDataY))
+	got := res.(model)
+	assert.Equal(focusList, got.focus)
+	assert.Equal(int64(3), got.selectedJobID) // first visible row
+
+	// Click in the detail pane while the loaded review still belongs to
+	// job 2 (the follow-fetch for job 3 hasn't landed): no-op, per the
+	// stale-review guard (Finding 2, selectedReviewLoaded).
+	res, _ = got.handleSplitMouse(mouseClickAt(g.listOuterW+5, 10))
+	stale := res.(model)
+	assert.Equal(focusList, stale.focus, "must not enter detail focus with a stale review for a different job")
+	assert.Equal(viewQueue, stale.currentView)
+
+	// Select the row matching the loaded review's job (2): detail click
+	// now focuses detail.
+	dataY2 := splitFirstDataRowY(t, got, "bbbb222")
+	res, _ = got.handleSplitMouse(mouseClickAt(5, dataY2))
+	got = res.(model)
+	res, _ = got.handleSplitMouse(mouseClickAt(g.listOuterW+5, 10))
+	got = res.(model)
+	assert.Equal(focusDetail, got.focus)
+	assert.Equal(viewReview, got.currentView)
+}
+
+func TestSplitMouseWheelScrollsPaneUnderCursor(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview()))
+	m.reviewScroll = 5
+	g := splitGeometry(150, 40, len(reflowHelpRows(m.splitFooterRows(), 150)))
+
+	// Wheel over detail pane scrolls the review, regardless of focus.
+	res, _ := m.handleSplitMouse(mouseWheelAt(g.listOuterW+5, 10, tea.MouseWheelUp))
+	assert.Less(res.(model).reviewScroll, 5)
+
+	// Wheel over list pane moves the queue selection.
+	prev := m.selectedJobID
+	res, _ = m.handleSplitMouse(mouseWheelAt(5, 10, tea.MouseWheelDown))
+	assert.NotEqual(prev, res.(model).selectedJobID)
+}
+
+// TestSplitMouseUnchangedSelectionPreservesScroll:
+// scheduleDetailFollow (which zeroes reviewScroll) must only fire when a
+// list-side click or wheel actually moves the selection -- not on a click on
+// the already-selected row, nor on a wheel at a boundary where
+// moveQueueSelection clamps in place. Otherwise scrolling the detail pane and
+// then incidentally re-clicking/re-wheeling the same list row would silently
+// discard the reader's scroll position.
+func TestSplitMouseUnchangedSelectionPreservesScroll(t *testing.T) {
+	assert := assert.New(t)
+
+	// (a) Wheel up while already at the topmost row: selection clamps in
+	// place, reviewScroll (and detailFollowGen) must be untouched.
+	m := splitModel(withSelection(0, 3)) // job 3 is the first/topmost row
+	m.reviewScroll = 42
+	prevGen := m.detailFollowGen
+	prevSelected := m.selectedJobID
+
+	res, cmd := m.handleSplitMouse(mouseWheelAt(5, 10, tea.MouseWheelUp))
+	got := res.(model)
+	assert.Nil(cmd)
+	assert.Equal(prevSelected, got.selectedJobID)
+	assert.Equal(42, got.reviewScroll)
+	assert.Equal(prevGen, got.detailFollowGen)
+
+	// (b) Click the already-selected row: same guarantees.
+	m2 := splitModel(withReview(splitTestReview())) // selection on job 2
+	m2.reviewScroll = 42
+	prevGen2 := m2.detailFollowGen
+	firstDataY := splitFirstDataRowY(t, m2, "bbbb222") // job 2's GitRef, its own row
+
+	res2, cmd2 := m2.handleSplitMouse(mouseClickAt(5, firstDataY))
+	got2 := res2.(model)
+	assert.Nil(cmd2)
+	assert.Equal(int64(2), got2.selectedJobID)
+	assert.Equal(42, got2.reviewScroll)
+	assert.Equal(prevGen2, got2.detailFollowGen)
+
+	// (c) Click a DIFFERENT row: follow scheduled (gen bumped) and
+	// scheduleDetailFollow's reviewScroll reset takes effect.
+	firstDataY3 := splitFirstDataRowY(t, m2, "cccc333") // job 3's row, different from selection
+	res3, cmd3 := m2.handleSplitMouse(mouseClickAt(5, firstDataY3))
+	got3 := res3.(model)
+	assert.NotNil(cmd3)
+	assert.Equal(int64(3), got3.selectedJobID)
+	assert.Equal(0, got3.reviewScroll)
+	assert.Greater(got3.detailFollowGen, prevGen2)
+}
+
+// TestSplitMouseWheelOverListDisarmsPendingReviewOpen covers roborev item
+// (5): handleSplitMouse's wheel-in-list branch is one of the two direct
+// scheduleDetailFollow callers (split_render.go) that must call
+// disarmPendingReviewOpen when the wheel genuinely moves the selection.
+func TestSplitMouseWheelOverListDisarmsPendingReviewOpen(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withReview(splitTestReview())) // job 2 selected
+	cmd := m.dispatchReviewFetch(2)
+	require.NotNil(cmd)
+	require.Equal(int64(2), m.pendingReviewOpenJobID)
+
+	res, followCmd := m.handleSplitMouse(mouseWheelAt(5, 10, tea.MouseWheelDown))
+	got := res.(model)
+	require.NotNil(followCmd, "sanity: the wheel must have moved the selection")
+	assert.NotEqual(int64(2), got.selectedJobID)
+	assert.Equal(int64(0), got.pendingReviewOpenJobID,
+		"a genuine mouse-wheel selection change must disarm the pending-open intent")
+}
+
+// TestSplitMouseClickOnDifferentRowDisarmsPendingReviewOpen is the click
+// counterpart to TestSplitMouseWheelOverListDisarmsPendingReviewOpen,
+// covering handleSplitMouse's other direct scheduleDetailFollow call site.
+func TestSplitMouseClickOnDifferentRowDisarmsPendingReviewOpen(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withReview(splitTestReview())) // job 2 selected
+	cmd := m.dispatchReviewFetch(2)
+	require.NotNil(cmd)
+	require.Equal(int64(2), m.pendingReviewOpenJobID)
+
+	firstDataY3 := splitFirstDataRowY(t, m, "cccc333") // job 3's row, different from selection
+	res, followCmd := m.handleSplitMouse(mouseClickAt(5, firstDataY3))
+	got := res.(model)
+	require.NotNil(followCmd)
+	require.Equal(int64(3), got.selectedJobID)
+	assert.Equal(int64(0), got.pendingReviewOpenJobID,
+		"a genuine mouse-click selection change must disarm the pending-open intent")
+}
+
+// TestSplitWheelDownPaginatesAtBottom: the split list pane's wheel routes
+// through the shared queueNavDown helper, so a wheel-down that clamps at the
+// last loaded row resumes pagination exactly like keyboard navigation
+// (previously the wheel called moveQueueSelection bare and wheel users could
+// never load older jobs past the final loaded row).
+func TestSplitWheelDownPaginatesAtBottom(t *testing.T) {
+	assert := assert.New(t)
+
+	m := splitModel(withSelection(2, 1)) // job 1, the last loaded row
+	m.hasMore = true
+	m.loadingJobs = false
+	res, cmd := m.handleSplitMouse(mouseWheelAt(5, 10, tea.MouseWheelDown))
+	got := res.(model)
+	assert.Equal(int64(1), got.selectedJobID, "clamped in place at the bottom")
+	assert.True(got.loadingMore)
+	assert.NotNil(cmd)
+
+	// Nothing more to load: flash the boundary like the keyboard path, no fetch.
+	m = splitModel(withSelection(2, 1))
+	m.hasMore = false
+	m.loadingJobs = false
+	res, cmd = m.handleSplitMouse(mouseWheelAt(5, 10, tea.MouseWheelDown))
+	got = res.(model)
+	assert.False(got.loadingMore)
+	assert.Nil(cmd)
+	assertFlashMessage(t, got, viewQueue, "No older review")
+}
+
+// TestSplitWheelDownPrefetchesNearEnd: a wheel-down that moves the selection
+// near the end of loaded data triggers the same prefetch as keyboard
+// navigation (maybePrefetch), batched with the detail-follow cmd.
+func TestSplitWheelDownPrefetchesNearEnd(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview())) // job 2 selected
+	m.hasMore = true
+	m.loadingJobs = false
+
+	res, cmd := m.handleSplitMouse(mouseWheelAt(5, 10, tea.MouseWheelDown))
+	got := res.(model)
+	assert.Equal(int64(1), got.selectedJobID)
+	assert.True(got.loadingMore, "moving within prefetch range of the end must start a page fetch")
+	assert.NotNil(cmd)
+}
+
+// TestSplitExternalRerunBlocksStaleReviewActions: an EXTERNAL rerun (another
+// client) arrives as a plain jobs-refresh status change -- no local
+// handleRerunResultMsg runs to clear the loaded review. Once
+// splitReconcileDetail observes the selected job back in queued/running,
+// selectedReviewLoaded must report the loaded review stale so tab and the
+// detail-pane click stop handing review actions to the replaced attempt.
+func TestSplitExternalRerunBlocksStaleReviewActions(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withReview(splitTestReview())) // job 2 (done) selected
+	require.True(m.selectedReviewLoaded(), "sanity: fresh review is actionable")
+
+	// External rerun observed: job 2 back to queued on a jobs refresh.
+	m.jobs[1].Status = storage.JobStatusQueued
+	got, _ := m.splitReconcileDetail()
+	require.Equal(int64(2), got.paneReviewSeenNonTerminalJob)
+	assert.False(got.selectedReviewLoaded())
+
+	// Tab must refuse to enter detail focus on the stale review.
+	res, _ := got.handleTabKey()
+	tabbed := res.(model)
+	assert.Equal(viewQueue, tabbed.currentView)
+	assert.Equal(focusList, tabbed.focus)
+
+	// A detail-pane click must refuse as well.
+	g := splitGeometry(got.width, got.height,
+		len(reflowHelpRows(got.splitFooterRows(), got.width)))
+	res, _ = got.handleSplitMouse(mouseClickAt(g.listOuterW+5, 10))
+	clicked := res.(model)
+	assert.Equal(viewQueue, clicked.currentView)
+	assert.Equal(focusList, clicked.focus)
+
+	// The rerun completing does not restore actionability by itself: the
+	// flag stays set until the fresh review is ACCEPTED (handleReviewMsg).
+	later := splitTestFinishedAt.Add(time.Minute)
+	got.jobs[1].Status = storage.JobStatusDone
+	got.jobs[1].FinishedAt = &later
+	assert.False(got.selectedReviewLoaded())
+}
+
+// TestDetailPaneHidesStaleAttemptReview: the done-job branch renders the
+// review only when selectedReviewLoaded confirms attempt freshness. A
+// stale attempt's review (same reused job ID) must show the loading state
+// while the refetch is in flight -- and must not mask splitDetailErr when
+// that refetch fails, or obsolete output would display indefinitely.
+func TestDetailPaneHidesStaleAttemptReview(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview())) // job 2 (done) selected
+	require.Contains(t, strings.Join(m.renderDetailPane(88, 25), "\n"), "first finding",
+		"sanity: a fresh review renders")
+
+	// A rerun of job 2 was observed; the loaded review is a previous
+	// attempt's.
+	m.paneReviewSeenNonTerminalJob = 2
+	lines := strings.Join(m.renderDetailPane(88, 25), "\n")
+	assert.NotContains(lines, "first finding", "a stale attempt's review must not render")
+	assert.Contains(lines, "Loading review...")
+
+	// The refetch fails: the error must show, not the stale review.
+	m.splitDetailErr = errors.New("connection refused")
+	lines = strings.Join(m.renderDetailPane(88, 25), "\n")
+	assert.NotContains(lines, "first finding")
+	assert.Contains(lines, "Failed to load review")
+}
+
+// TestTasksExitRestoresQueueSelection: opening a task's review points
+// selectedJobID at the fix job (absent from m.jobs); every tasks-to-queue
+// exit must repair the selection or the queue renders no highlighted row
+// and the split pane "No job selected" until a refresh heals it.
+func TestTasksExitRestoresQueueSelection(t *testing.T) {
+	assert := assert.New(t)
+
+	taskSelected := func() model {
+		m := splitModel()
+		m.tasksEnabled = true
+		m.currentView = viewTasks
+		m.selectedJobID = 99 // fix job: absent from m.jobs/panelMembers
+		return m
+	}
+
+	// esc from the tasks view.
+	res, cmd := taskSelected().handleTasksKey(keySpecialMsg(tea.KeyEscape))
+	got := res.(model)
+	assert.Equal(viewQueue, got.currentView)
+	assert.Equal(int64(2), got.selectedJobID, "restored from the untouched selectedIdx")
+	assert.NotNil(cmd, "the shared follow transition must re-point the split pane")
+
+	// Control-socket set-view queue.
+	got, _, _ = taskSelected().handleCtrlSetView(json.RawMessage(`{"view":"queue"}`))
+	assert.Equal(viewQueue, got.currentView)
+	assert.Equal(int64(2), got.selectedJobID)
+
+	// A selection that still resolves is left alone -- including a
+	// side-fetched panel member, which selectedIdx-based repair would
+	// wrongly clobber.
+	m := splitModel()
+	m.tasksEnabled = true
+	m.currentView = viewTasks
+	m.panelMembers["u1"] = []storage.ReviewJob{{ID: 77, PanelRunUUID: "u1"}}
+	m.selectedJobID = 77
+	m.selectedIdx = -1
+	res, _ = m.handleTasksKey(keySpecialMsg(tea.KeyEscape))
+	got = res.(model)
+	assert.Equal(int64(77), got.selectedJobID, "a resolvable member selection must survive the exit")
+}
+
+// TestCrossJobRerunObservationDoesNotBlockFailedReview: the non-terminal
+// observation is scoped per job. Observing job 2's external rerun and then
+// selecting the FAILED job 1 (whose failure review handleDetailFollowTick
+// synthesizes from current state) must not mark job 1's fresh review stale
+// -- previously a global flag bled across the selection change and blocked
+// detail focus until the next jobs refresh. Job 2's own observation
+// survives for when the user returns to it.
+func TestCrossJobRerunObservationDoesNotBlockFailedReview(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withReview(splitTestReview())) // job 2 (done) selected, review loaded
+
+	m.jobs[1].Status = storage.JobStatusQueued
+	m, _ = m.splitReconcileDetail()
+	require.Equal(int64(2), m.paneReviewSeenNonTerminalJob)
+
+	// Select the failed job 1; the debounced follow synthesizes its review.
+	m = m.moveSelectionToJobID(1)
+	m, _ = m.scheduleDetailFollow()
+	res, _ := m.handleDetailFollowTick(detailFollowTickMsg{gen: m.detailFollowGen})
+	m = res.(model)
+	require.NotNil(m.currentReview)
+	require.Equal(int64(1), m.currentReview.JobID)
+
+	assert.True(m.selectedReviewLoaded(), "job 1's synthesized failure review is current")
+	res, _ = m.handleTabKey()
+	assert.Equal(viewReview, res.(model).currentView, "tab must enter detail focus")
+	assert.Equal(int64(2), m.paneReviewSeenNonTerminalJob,
+		"job 2's observation survives for when the user returns to it")
+
+	// A same-job observation IS cleared by the tick's synchronous rebuild:
+	// that rebuild is an acceptance for the failed job itself.
+	m.paneReviewSeenNonTerminalJob = 1
+	res, _ = m.handleDetailFollowTick(detailFollowTickMsg{gen: m.detailFollowGen})
+	assert.Equal(int64(0), res.(model).paneReviewSeenNonTerminalJob)
+}
+
+// TestSelectedReviewLoadedDetectsMissedRerunCompletion: if the rerun's whole
+// queued/running window fell between two jobs refreshes,
+// paneReviewSeenNonTerminal was never set -- the completion-timestamp
+// comparison (reviewJobCompletionChanged) is the fallback that still marks
+// the loaded review stale.
+func TestSelectedReviewLoadedDetectsMissedRerunCompletion(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview())) // job 2 (done) selected
+	assert.True(m.selectedReviewLoaded())
+
+	later := splitTestFinishedAt.Add(time.Minute)
+	m.jobs[1].FinishedAt = &later
+	assert.False(m.selectedReviewLoaded(),
+		"a completion newer than the loaded review's snapshot means a rerun landed")
+}
+
+// TestSplitExternalRerunClosesFixPanel: a fix panel bound to a job observed
+// back in queued/running is bound to an attempt being replaced -- and a
+// FOCUSED panel keeps capturing every keystroke (handleKeyMsg's panel
+// capture runs before any staleness guard) even though renderDetailPane now
+// shows a status card. splitReconcileDetail must close it, mirroring
+// handleRerunResultMsg's close on the local-rerun path.
+func TestSplitExternalRerunClosesFixPanel(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview())) // job 2 (done) selected
+	m.reviewFixPanelOpen = true
+	m.reviewFixPanelFocused = true
+	m.fixPromptJobID = 2
+	m.fixPromptText = "half-typed instructions"
+
+	m.jobs[1].Status = storage.JobStatusQueued
+	got, _ := m.splitReconcileDetail()
+	assert.False(got.reviewFixPanelOpen)
+	assert.False(got.reviewFixPanelFocused)
+	assert.Equal(int64(0), got.fixPromptJobID)
+	assert.Empty(got.fixPromptText)
+
+	// A PENDING panel intent for the reran job is abandoned the same way.
+	m = splitModel(withReview(splitTestReview()))
+	m.reviewFixPanelPending = true
+	m.fixPromptJobID = 2
+	m.jobs[1].Status = storage.JobStatusRunning
+	got, _ = m.splitReconcileDetail()
+	assert.False(got.reviewFixPanelPending)
+	assert.Equal(int64(0), got.fixPromptJobID)
+
+	// A panel bound to a DIFFERENT job is left alone.
+	m = splitModel(withReview(splitTestReview()))
+	m.reviewFixPanelOpen = true
+	m.fixPromptJobID = 1
+	m.jobs[1].Status = storage.JobStatusQueued
+	got, _ = m.splitReconcileDetail()
+	assert.True(got.reviewFixPanelOpen)
+	assert.Equal(int64(1), got.fixPromptJobID)
+}
+
+// TestSplitSameRowClickUnfocusesFixPanel: a list-pane click on the
+// already-selected row moves currentView to viewQueue but takes
+// followSelectionChange's unchanged-selection no-op, so nothing closes or
+// unfocuses the panel -- leaving it rendered as an active input box while
+// every keystroke lands on the queue keymap ('q' quits, 'a' closes the
+// review). normalizeSplitState's focus invariant (repair 3) must clear the
+// focus; the panel itself stays open with its typed text preserved.
+func TestSplitSameRowClickUnfocusesFixPanel(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview())) // job 2 selected, review loaded
+	m.currentView = viewReview
+	m.focus = focusDetail
+	m.reviewFixPanelOpen = true
+	m.reviewFixPanelFocused = true
+	m.fixPromptJobID = 2
+	m.fixPromptText = "half-typed"
+
+	firstDataY := splitFirstDataRowY(t, m, "bbbb222") // job 2's own row
+	res, _ := m.handleSplitMouse(mouseClickAt(5, firstDataY))
+	got := res.(model).normalizeSplitState() // Update applies this before rendering
+
+	assert.Equal(viewQueue, got.currentView)
+	assert.False(got.reviewFixPanelFocused,
+		"a focused panel must not survive the move off viewReview")
+	assert.True(got.reviewFixPanelOpen, "the panel and its text are preserved")
+	assert.Equal("half-typed", got.fixPromptText)
+}
+
+// TestPendingFixPanelConsumedUnderTransientViewIsNotLeftFocused: when
+// acceptReview consumes the pending queue-'F' panel while a transient view
+// is open, openReviewViewFrom declines the switch -- the panel must not be
+// left FOCUSED (handleKeyMsg would never route keys to it outside
+// viewReview, misrouting keystrokes typed into the apparently-active input
+// to whatever view is current). normalizeSplitState's focus invariant
+// clears it; the open panel itself survives for tab to re-focus later.
+func TestPendingFixPanelConsumedUnderTransientViewIsNotLeftFocused(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := initTestModel(
+		withCurrentView(viewQueue),
+		withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...),
+		withSelection(1, 2), // job 2: done
+	)
+	m.tasksEnabled = true
+
+	res, cmd := m.handleFixKey()
+	m = res.(model)
+	require.NotNil(cmd)
+	require.True(m.reviewFixPanelPending)
+
+	res, _ = m.handleCommentOpenKey()
+	m = res.(model)
+	require.Equal(viewKindComment, m.currentView)
+
+	res, _ = m.handleReviewMsg(reviewMsg{review: splitTestReview(), jobID: 2, fetchSeq: m.reviewFetchSeq})
+	got := res.(model).normalizeSplitState() // Update applies this before rendering
+
+	assert.Equal(viewKindComment, got.currentView, "still not yanked out of the comment editor")
+	assert.True(got.reviewFixPanelOpen)
+	assert.False(got.reviewFixPanelFocused,
+		"a panel the keyboard cannot reach must not render as focused")
+}
+
+// TestFixPanelPaneLinesLongInputKeepsHelpLine: lipgloss v2's Width is
+// border-box, so the input caps must keep the box content within boxW-2 or
+// the box wraps past its 3-line budget and the 5-line pane cap silently
+// drops the help line.
+func TestFixPanelPaneLinesLongInputKeepsHelpLine(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview()))
+	m.reviewFixPanelOpen = true
+	m.fixPromptText = strings.Repeat("x", 300)
+
+	m.reviewFixPanelFocused = true
+	lines := m.renderReviewFixPanelPaneLines(96)
+	assert.Len(lines, reviewFixPanelPaneReserve)
+	assert.Contains(lines[len(lines)-1], "esc: cancel",
+		"help line must survive a long input")
+
+	m.reviewFixPanelFocused = false
+	lines = m.renderReviewFixPanelPaneLines(96)
+	assert.Len(lines, reviewFixPanelPaneReserve)
+	assert.Contains(lines[len(lines)-1], "tab: focus fix panel",
+		"help line must survive a long input")
+}
+
+// TestResizeRefillsDuringPaneTailRestart: the resize handler's pane-tail
+// restart previously early-returned before the "terminal grew, refill the
+// job list" check, leaving the list pane underfilled until the next SSE
+// event or fallback poll. The refill must be batched with the tail restart.
+func TestResizeRefillsDuringPaneTailRestart(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running
+	m.paneLogJobID, m.paneLogStreaming = 3, true
+	m.hasMore = true
+	m.loadingJobs = false
+
+	res, cmd := m.handleWindowSizeMsg(tea.WindowSizeMsg{Width: 180, Height: 60})
+	got := res.(model)
+	assert.True(got.loadingJobs,
+		"a resize that grows the pane past the loaded rows must refill even while restarting the tail")
+	assert.NotNil(cmd)
+	assert.True(got.paneLogStreaming, "the tail restart itself still happens")
+}
+
+// TestSplitEngageKeepsTasksOriginReviewScroll: a tasks-origin fix-job review
+// renders full-screen even when split engages (splitActive excludes it) and
+// its job never resolves in m.jobs -- maybeBootstrapDetail must not
+// schedule a follow for the unrendered pane, since scheduleDetailFollow
+// zeroes the reviewScroll of the review the user is reading.
+func TestSplitEngageKeepsTasksOriginReviewScroll(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel()
+	m.currentView = viewReview
+	m.reviewFromView = viewTasks
+	m.currentReview = &storage.Review{JobID: 99, Output: "fix job review"}
+	m.selectedJobID = 99 // fix job: absent from m.jobs/panelMembers
+	m.reviewScroll = 7
+
+	got, cmd := m.maybeBootstrapDetail()
+	assert.Nil(cmd)
+	assert.Equal(7, got.reviewScroll, "the displayed review's scroll must survive split engaging")
+}
+
+// TestPanelMembersMsgReconcilesSelectedMemberDetail: panel members are
+// absent from the main jobs response, so the members side-fetch is the only
+// carrier of a selected member's status transition -- handlePanelMembersMsg
+// must reconcile the detail pane itself or the pane stalls (no review
+// fetch, no log tail) until an unrelated SSE event or the fallback poll.
+func TestPanelMembersMsgReconcilesSelectedMemberDetail(t *testing.T) {
+	assert := assert.New(t)
+	finishedAt := splitTestFinishedAt
+	queuedMember := storage.ReviewJob{
+		ID: 42, PanelRunUUID: "u1", PanelRole: storage.PanelRoleMember,
+		Status: storage.JobStatusQueued,
+	}
+	doneMember := queuedMember
+	doneMember.Status = storage.JobStatusDone
+	doneMember.FinishedAt = &finishedAt
+
+	m := splitModel()
+	m.panelMembers["u1"] = []storage.ReviewJob{queuedMember}
+	m.selectedJobID = 42
+	m.selectedIdx = -1
+
+	res, cmd := m.handlePanelMembersMsg(panelMembersMsg{
+		runUUID: "u1", members: []storage.ReviewJob{doneMember},
+	})
+	got := res.(model)
+	assert.NotNil(cmd, "the member's queued->done transition must dispatch its review fetch now")
+	assert.Equal(int64(42), got.reconcileFetchJobID)
+}
+
+// TestSplitReconcileSyncsExternallyToggledClosed: Closed changes
+// independently of completion (another TUI or the CLI), arriving as
+// refreshed m.jobs state with no new FinishedAt -- the reconcile fast path
+// must sync it into the loaded review, or the [CLOSED] badge goes stale and
+// the next local toggle submits the already-current state.
+func TestSplitReconcileSyncsExternallyToggledClosed(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview())) // job 2 done, review loaded, Closed=false
+	closed := true
+	m.jobs[1].Closed = &closed
+
+	got, cmd := m.splitReconcileDetail()
+	assert.Nil(cmd, "a closed-state change alone must not refetch")
+	assert.True(got.currentReview.Closed)
+
+	// And back: an external unclose syncs too.
+	unclosed := false
+	got.jobs[1].Closed = &unclosed
+	got, cmd = got.splitReconcileDetail()
+	assert.Nil(cmd)
+	assert.False(got.currentReview.Closed)
+}
+
+// TestFollowFailureRetriesPendingReviewOpen covers the roborev repro
+// "ordinary request -> newer follow failure -> ordinary success": the
+// follow failure must not clear the pending-open intent while its
+// originating dispatch can still be served -- it retries once, and the
+// retry's success serves the explicit open.
+func TestFollowFailureRetriesPendingReviewOpen(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel() // job 2 (done) selected
+	m.currentView = viewTasks
+
+	cmd := m.dispatchReviewFetch(2) // the explicit request (tasks 'P')
+	require.NotNil(cmd)
+	seqOrdinary := m.reviewFetchSeq
+	require.Equal(int64(2), m.pendingReviewOpenJobID)
+
+	_ = m.dispatchReviewFollow(2) // a newer reconcile follow supersedes it
+
+	// The follow FAILS: the intent must survive, with one retry dispatched.
+	res, retryCmd := m.handleReviewFollowErrMsg(reviewFollowErrMsg{
+		jobID: 2, err: errors.New("boom"),
+		gen: m.detailFollowGen, fetchSeq: m.reviewFetchSeq,
+	})
+	m = res.(model)
+	assert.NotNil(retryCmd, "first follow failure with an armed open intent must retry")
+	require.Equal(int64(2), m.pendingReviewOpenJobID,
+		"the intent must survive the first follow failure")
+	assert.Equal(m.reviewFetchSeq, m.pendingReviewOpenSeq,
+		"identity re-stamped at the retry's own dispatch")
+
+	// The ORIGINAL ordinary success lands, superseded: dropped, but the
+	// intent stays armed for the retry to serve.
+	res, _ = m.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2,
+		gen: m.detailFollowGen, fetchSeq: seqOrdinary, dispatchedFrom: viewTasks,
+	})
+	m = res.(model)
+	require.Equal(int64(2), m.pendingReviewOpenJobID)
+
+	// The retry's success serves the explicit open.
+	res, _ = m.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2, follow: true,
+		gen: m.detailFollowGen, fetchSeq: m.reviewFetchSeq,
+	})
+	m = res.(model)
+	assert.Equal(viewReview, m.currentView, "the user's explicit open must be served")
+	assert.Equal(int64(0), m.pendingReviewOpenJobID)
+	require.NotNil(m.currentReview)
+}
+
+// TestSecondFollowFailureClearsPendingReviewOpen: the retry is bounded --
+// a second follow failure clears the intent with a warning flash targeted
+// at the origin view.
+func TestSecondFollowFailureClearsPendingReviewOpen(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel()
+	m.currentView = viewTasks
+
+	require.NotNil(m.dispatchReviewFetch(2))
+	_ = m.dispatchReviewFollow(2)
+
+	res, retryCmd := m.handleReviewFollowErrMsg(reviewFollowErrMsg{
+		jobID: 2, err: errors.New("boom"),
+		gen: m.detailFollowGen, fetchSeq: m.reviewFetchSeq,
+	})
+	m = res.(model)
+	require.NotNil(retryCmd)
+
+	res, cmd := m.handleReviewFollowErrMsg(reviewFollowErrMsg{
+		jobID: 2, err: errors.New("boom again"),
+		gen: m.detailFollowGen, fetchSeq: m.reviewFetchSeq,
+	})
+	m = res.(model)
+	assert.Nil(cmd)
+	assert.Equal(int64(0), m.pendingReviewOpenJobID, "second failure is terminal")
+	assertFlashMessage(t, m, viewTasks, "Could not open review for job #2: boom again")
+}
+
+// splitTestFinishedAt is the completion time shared by testQueueJobs' done
+// job and splitTestReview's embedded Job snapshot. Production done/failed
+// jobs always carry FinishedAt (the daemon stamps it on every completion),
+// and selectedReviewLoaded's attempt-freshness check treats a nil as stale
+// -- so fixtures must model it, and the two copies must MATCH for the
+// loaded review to count as current (a job timestamp strictly after the
+// review's snapshot means a rerun completed since the review was fetched).
+var splitTestFinishedAt = time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+
+func splitTestReview() *storage.Review {
+	verdictP := "P"
+	finishedAt := splitTestFinishedAt
+	return &storage.Review{
+		ID: 10, JobID: 2, Agent: "codex",
+		Output: "## Findings\n\n1. first finding\n2. second finding\n",
+		Job: &storage.ReviewJob{
+			ID: 2, GitRef: "bbbb222", RepoName: "repoA",
+			Agent: "codex", Verdict: &verdictP, FinishedAt: &finishedAt,
+		},
+	}
+}
+
+func testQueueJobs() []storage.ReviewJob {
+	verdictP := "P"
+	finishedAt := splitTestFinishedAt
+	return []storage.ReviewJob{
+		{
+			ID: 3, GitRef: "cccc333", Branch: "main", RepoName: "repoA",
+			Agent: "codex", Status: storage.JobStatusRunning,
+		},
+		{
+			ID: 2, GitRef: "bbbb222", Branch: "feat/x", RepoName: "repoA",
+			Agent: "codex", Status: storage.JobStatusDone, Verdict: &verdictP,
+			FinishedAt: &finishedAt,
+		},
+		{
+			ID: 1, GitRef: "aaaa111", Branch: "main", RepoName: "repoB",
+			Agent: "claude-code", Status: storage.JobStatusFailed, Error: "boom",
+			FinishedAt: &finishedAt,
+		},
+	}
+}
+
+func TestRenderQueueTableAtNarrowWidth(t *testing.T) {
+	m := initTestModel(
+		withCurrentView(viewQueue),
+		withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...),
+		withSelection(1, 2),
+	)
+	rows := m.visibleQueueRows()
+	require.NotEmpty(t, rows)
+	visCols := m.visibleColumns()
+	cw := m.queueContentWidths(rows, visCols, false, false)
+
+	lines := m.renderQueueTable(rows, 48, 10, visCols, cw)
+	require.NotEmpty(t, lines)
+	joined := strings.Join(lines, "\n")
+	assert.Contains(t, joined, "JobID")
+	assert.NotContains(t, joined, "\x1b[K")
+}
+
+func TestQueuePaneColumnsNarrowing(t *testing.T) {
+	assert := assert.New(t)
+	m := initTestModel(
+		withCurrentView(viewQueue),
+		withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...),
+		withSelection(0, 3),
+	)
+	rows := m.visibleQueueRows()
+	cw := m.queueContentWidths(rows, m.visibleColumns(), false, false)
+
+	// Wide pane: everything visible fits.
+	wide := m.queuePaneColumns(200, cw)
+	assert.ElementsMatch(m.visibleColumns(), wide)
+
+	// Narrow pane: columns dropped from the end of columnOrder,
+	// core columns always survive.
+	narrow := m.queuePaneColumns(30, cw)
+	assert.Contains(narrow, colSel)
+	assert.Contains(narrow, colJobID)
+	assert.Contains(narrow, colRef)
+	assert.Less(len(narrow), len(wide))
+
+	// A user-hidden column stays hidden even when it would fit.
+	m.hiddenColumns = map[int]bool{colAgent: true}
+	cols := m.queuePaneColumns(200, cw)
+	assert.NotContains(cols, colAgent)
+}
+
+// TestQueuePaneColumnsDropOrder pins down the drop ORDER explicitly: when a
+// pane width forces exactly one column to drop, it must be the LAST entry of
+// m.columnOrder among the currently-visible columns, not the first. Widths
+// are supplied directly (not derived from real rows) so the exact boundary
+// between "everything fits" and "one drop" is deterministic.
+func TestQueuePaneColumnsDropOrder(t *testing.T) {
+	assert := assert.New(t)
+	m := initTestModel(withCurrentView(viewQueue))
+	m.columnOrder = []int{colRef, colBranch, colRepo, colAgent}
+	m.hiddenColumns = map[int]bool{}
+
+	cw := map[int]int{
+		colJobID:  5,
+		colRef:    6,
+		colBranch: 6,
+		colRepo:   6,
+		colAgent:  6,
+	}
+
+	wide := m.queuePaneColumns(36, cw)
+	assert.ElementsMatch([]int{colSel, colJobID, colRef, colBranch, colRepo, colAgent}, wide)
+
+	// One char narrower than the exact fit forces exactly one drop.
+	narrow := m.queuePaneColumns(35, cw)
+	assert.Len(narrow, len(wide)-1)
+
+	// The dropped column must be colAgent (last in columnOrder), not an
+	// earlier-configured one — a front-first-dropping regression would drop
+	// colRef/colBranch/colRepo instead and fail these assertions.
+	assert.NotContains(narrow, colAgent)
+	assert.Contains(narrow, colRef)
+	assert.Contains(narrow, colBranch)
+	assert.Contains(narrow, colRepo)
+}
+
+func TestRenderQueuePaneBody(t *testing.T) {
+	assert := assert.New(t)
+	m := initTestModel(
+		withCurrentView(viewQueue),
+		withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...),
+		withSelection(1, 2),
+	)
+	lines := m.renderQueuePaneBody(48, 20)
+	assert.Len(lines, 20)
+	joined := strings.Join(lines, "\n")
+	assert.Contains(joined, "2") // selected job id visible
+	assert.NotContains(joined, "\x1b[K")
+
+	// Empty queue renders a placeholder, still exactly innerH lines.
+	m.jobs = nil
+	lines = m.renderQueuePaneBody(48, 20)
+	assert.Len(lines, 20)
+}
+
+func TestRenderReviewPaneBody(t *testing.T) {
+	assert := assert.New(t)
+	m := initTestModel(
+		withCurrentView(viewQueue),
+		withDimensions(150, 40),
+		withReview(splitTestReview()),
+	)
+	lines := m.renderReviewPaneBody(88, 25)
+	assert.Len(lines, 25)
+	joined := strings.Join(lines, "\n")
+	assert.Contains(joined, "Review #2")
+	assert.Contains(joined, "Verdict: Pass")
+	assert.Contains(joined, "first finding")
+	assert.NotContains(joined, "\x1b[K")
+}
+
+func TestRenderReviewPaneBodyScrolls(t *testing.T) {
+	rev := splitTestReview()
+	// Content must be non-repeating: a periodic body (e.g. the same line
+	// repeated) can make two different scroll offsets land on the same
+	// phase and render byte-identical windows, which would make this test
+	// pass or fail by accident rather than by actually exercising scroll.
+	var sb strings.Builder
+	for i := range 60 {
+		fmt.Fprintf(&sb, "line %d of output\n\n", i)
+	}
+	rev.Output = sb.String()
+	m := initTestModel(withDimensions(150, 40), withReview(rev))
+
+	top := strings.Join(m.renderReviewPaneBody(88, 10), "\n")
+	m.reviewScroll = 20
+	scrolled := strings.Join(m.renderReviewPaneBody(88, 10), "\n")
+	assert.NotEqual(t, top, scrolled)
+
+	// Scroll far past the end: clamps, never panics.
+	m.reviewScroll = 10000
+	assert.Len(t, m.renderReviewPaneBody(88, 10), 10)
+}
+
+func TestWindowResizeSwitchesLayout(t *testing.T) {
+	assert := assert.New(t)
+	m := initTestModel(withCurrentView(viewQueue), withDimensions(80, 24),
+		withTestJobs(testQueueJobs()...), withSelection(1, 2))
+
+	res, _ := m.handleWindowSizeMsg(tea.WindowSizeMsg{Width: 150, Height: 40})
+	m = res.(model)
+	assert.Equal(layoutSplit, m.layout)
+	assert.Equal(focusList, m.focus)
+
+	res, _ = m.handleWindowSizeMsg(tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = res.(model)
+	assert.Equal(layoutStacked, m.layout)
+	assert.Equal(viewQueue, m.currentView)
+}
+
+// TestWindowResizeRestartsPaneLogAtNewWidth:
+// an active pane log tail's persistent formatter keeps its old width across
+// incremental polls, so a resize must restart the tail (bumped seq, reset
+// offset/lines, rebuilt formatter, a fresh fetch) or the live log stays
+// wrapped for the previous pane size.
+func TestWindowResizeRestartsPaneLogAtNewWidth(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+	m.paneLogLines = []logLine{{text: "stale-width line"}}
+	m.paneLogOffset = 42
+
+	res, cmd := m.handleWindowSizeMsg(tea.WindowSizeMsg{Width: 180, Height: 45})
+	got := res.(model)
+	assert.Equal(layoutSplit, got.layout)
+	assert.Greater(got.paneLogSeq, uint64(5))
+	assert.Equal(int64(0), got.paneLogOffset)
+	assert.Empty(got.paneLogLines)
+	assert.NotNil(got.paneLogFmtr)
+	assert.NotNil(cmd)
+}
+
+// TestWindowResizeLeavesPaneLogAloneInStacked covers the other half of
+// Finding A: pane log state is only meaningful in split (it's not rendered
+// in stacked), so a resize landing in/staying in stacked layout must not
+// touch it.
+func TestWindowResizeLeavesPaneLogAloneInStacked(t *testing.T) {
+	assert := assert.New(t)
+	m := initTestModel(
+		withCurrentView(viewQueue),
+		withDimensions(80, 24), // below the split breakpoint
+		withTestJobs(testQueueJobs()...),
+		withSelection(0, 3),
+	)
+	m.layout = layoutStacked
+	m.preferredLayout = layoutStacked
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+	m.paneLogLines = []logLine{{text: "line"}}
+
+	res, _ := m.handleWindowSizeMsg(tea.WindowSizeMsg{Width: 100, Height: 30})
+	got := res.(model)
+	assert.Equal(layoutStacked, got.layout)
+	assert.Equal(uint64(5), got.paneLogSeq)
+	assert.Equal([]logLine{{text: "line"}}, got.paneLogLines)
+}
+
+// TestWindowResizeRunsLogViewBehindActivePaneLog:
+// a transient full-screen log view (viewLog) open on top of
+// split layout must still get its own resize re-render even while a
+// background pane log tail is streaming for a different, still-running
+// job. The pane restart branch must not steal the early return meant for
+// viewLog's re-render below it (splitActive() is false here since
+// currentView is viewLog, not queue/review); it should instead just
+// invalidate the stale-width background tail (bump seq, stop streaming)
+// without touching the buffered lines or issuing its own fetch.
+func TestWindowResizeRunsLogViewBehindActivePaneLog(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+	m.paneLogLines = []logLine{{text: "pane tail line"}}
+
+	m.currentView = viewLog
+	m.logJobID = 1
+	m.logLines = []logLine{{text: "full log line"}}
+	m.logFetchSeq = 2
+
+	res, cmd := m.handleWindowSizeMsg(tea.WindowSizeMsg{Width: 180, Height: 45})
+	got := res.(model)
+
+	// viewLog's own resize re-render ran (existing behavior).
+	assert.Greater(got.logFetchSeq, uint64(2))
+	assert.Nil(got.logLines)
+	assert.True(got.logLoading)
+	assert.NotNil(cmd)
+
+	// The pane restart branch invalidated the background tail instead of
+	// firing its own fetch or clobbering the buffered lines.
+	assert.Equal(uint64(6), got.paneLogSeq)
+	assert.False(got.paneLogStreaming)
+	assert.Equal([]logLine{{text: "pane tail line"}}, got.paneLogLines)
+}
+
+func TestToggleLayoutKey(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel()
+	m.width, m.height = 150, 40
+
+	res, _ := m.handleToggleLayoutKey()
+	m = res.(model)
+	assert.Equal(layoutStacked, m.layout)
+	assert.True(m.layoutLocked)
+
+	res, _ = m.handleToggleLayoutKey()
+	m = res.(model)
+	assert.Equal(layoutSplit, m.layout)
+
+	// Too small: stays stacked, flashes.
+	m.layout = layoutStacked
+	m.preferredLayout = layoutStacked
+	m.width, m.height = 100, 30
+	res, _ = m.handleToggleLayoutKey()
+	m = res.(model)
+	assert.Equal(layoutStacked, m.layout)
+	assert.NotEmpty(m.flashMessage)
+}
+
+// TestBootstrapDetailPreservesScrollOnMatchingReview covers entering split
+// (via L) when a full-screen review is already open and matches the current
+// selection: nothing needs fetching, so maybeBootstrapDetail must not
+// schedule a follow tick or reset reviewScroll.
+func TestBootstrapDetailPreservesScrollOnMatchingReview(t *testing.T) {
+	assert := assert.New(t)
+	m := initTestModel(
+		withCurrentView(viewReview),
+		withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...),
+		withSelection(1, 2),
+		withReview(splitTestReview()), // JobID 2, matches selection
+	)
+	m.layout = layoutStacked
+	m.preferredLayout = layoutStacked
+	m.reviewScroll = 15
+	prevGen := m.detailFollowGen
+
+	res, cmd := m.handleToggleLayoutKey()
+	got := res.(model)
+	assert.Equal(layoutSplit, got.layout)
+	assert.Equal(15, got.reviewScroll)
+	assert.Equal(prevGen, got.detailFollowGen)
+	assert.Nil(cmd)
+}
+
+// TestBootstrapDetailSchedulesWhenNoMatchingReview covers the still-needed
+// bootstrap path: no review loaded for the current selection, so entering
+// split must schedule a follow tick as before.
+func TestBootstrapDetailSchedulesWhenNoMatchingReview(t *testing.T) {
+	assert := assert.New(t)
+	m := initTestModel(
+		withCurrentView(viewQueue),
+		withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...),
+		withSelection(1, 2),
+	)
+	m.layout = layoutStacked
+	m.preferredLayout = layoutStacked
+	prevGen := m.detailFollowGen
+
+	res, cmd := m.handleToggleLayoutKey()
+	got := res.(model)
+	assert.Equal(layoutSplit, got.layout)
+	assert.Greater(got.detailFollowGen, prevGen)
+	assert.NotNil(cmd)
+}
+
+func TestSplitFocusKeys(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview()))
+
+	// tab: list -> detail (only when a review is loaded).
+	res, _ := m.handleTabKey()
+	m = res.(model)
+	assert.Equal(focusDetail, m.focus)
+	assert.Equal(viewReview, m.currentView)
+
+	// esc: detail -> list, review kept for the pane.
+	res, _ = m.handleEscKey()
+	m = res.(model)
+	assert.Equal(focusList, m.focus)
+	assert.Equal(viewQueue, m.currentView)
+	assert.NotNil(m.currentReview)
+
+	// q in detail focus: back to list, not quit.
+	m.focus = focusDetail
+	m.currentView = viewReview
+	res, cmd := m.handleQuitKey()
+	m = res.(model)
+	assert.Equal(focusList, m.focus)
+	assert.Nil(cmd)
+
+	// tab with no review loaded: no-op.
+	m.currentReview = nil
+	m.focus = focusList
+	m.currentView = viewQueue
+	res, _ = m.handleTabKey()
+	m = res.(model)
+	assert.Equal(focusList, m.focus)
+}
+
+func TestReviewMsgFocusesDetailInSplit(t *testing.T) {
+	m := splitModel()
+	res, _ := m.handleReviewMsg(reviewMsg{review: splitTestReview(), jobID: 2})
+	got := res.(model)
+	assert.Equal(t, focusDetail, got.focus)
+	assert.Equal(t, viewReview, got.currentView)
+}
+
+func TestFollowScheduledOnCursorMove(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel() // selection on job 2
+	prevGen := m.detailFollowGen
+
+	res, cmd := m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyDown})
+	got := res.(model)
+	assert.NotEqual(int64(2), got.selectedJobID) // cursor moved
+	assert.Greater(got.detailFollowGen, prevGen)
+	assert.NotNil(cmd)
+
+	// A second immediate move bumps the gen again — the first tick is stale.
+	gen1 := got.detailFollowGen
+	res, _ = got.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyUp})
+	got = res.(model)
+	assert.Greater(got.detailFollowGen, gen1)
+}
+
+func TestFollowTickFetchesForDoneJob(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(1, 2)) // job 2: done
+	m.detailFollowGen = 7
+
+	// Stale tick: dropped.
+	_, cmd := m.handleDetailFollowTick(detailFollowTickMsg{gen: 6})
+	assert.Nil(cmd)
+
+	// Current tick: fetch issued.
+	_, cmd = m.handleDetailFollowTick(detailFollowTickMsg{gen: 7})
+	assert.NotNil(cmd)
+
+	// Review already loaded for this job: no refetch.
+	m.currentReview = splitTestReview() // JobID 2
+	_, cmd = m.handleDetailFollowTick(detailFollowTickMsg{gen: 7})
+	assert.Nil(cmd)
+}
+
+func TestFollowTickSynthesizesFailedReview(t *testing.T) {
+	m := splitModel(withSelection(2, 1)) // job 1: failed
+	m.detailFollowGen = 1
+	res, _ := m.handleDetailFollowTick(detailFollowTickMsg{gen: 1})
+	got := res.(model)
+	require.NotNil(t, got.currentReview)
+	assert.Equal(t, int64(1), got.currentReview.JobID)
+	assert.Contains(t, got.currentReview.Output, "boom")
+}
+
+func TestFollowReviewMsgKeepsListFocus(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(1, 2))
+	res, _ := m.handleReviewMsg(reviewMsg{review: splitTestReview(), jobID: 2, follow: true})
+	got := res.(model)
+	assert.Equal(focusList, got.focus)
+	assert.Equal(viewQueue, got.currentView)
+	assert.NotNil(got.currentReview)
+}
+
+// TestResizeAcrossBreakpointPreservesCommentEditor covers a resize that
+// crosses the split breakpoint while the comment editor is open: applyLayout
+// must update m.layout but leave the transient view and its in-progress
+// text alone.
+func TestResizeAcrossBreakpointPreservesCommentEditor(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel()
+	m.width, m.height = 150, 40
+	m.currentView = viewKindComment
+	m.commentText = "in progress comment"
+
+	res, _ := m.handleWindowSizeMsg(tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = res.(model)
+	assert.Equal(viewKindComment, m.currentView)
+	assert.Equal("in progress comment", m.commentText)
+	assert.Equal(layoutStacked, m.layout)
+}
+
+// TestResizeAcrossBreakpointPreservesLogView is the same as
+// TestResizeAcrossBreakpointPreservesCommentEditor but for the log view.
+func TestResizeAcrossBreakpointPreservesLogView(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel()
+	m.width, m.height = 150, 40
+	m.currentView = viewLog
+	m.logLines = nil
+
+	res, _ := m.handleWindowSizeMsg(tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = res.(model)
+	assert.Equal(viewLog, m.currentView)
+	assert.Equal(layoutStacked, m.layout)
+}
+
+// TestTransientViewExitReconcilesSplitFocus covers a transient view (help)
+// that outlives a resize crossing the breakpoint twice (so the layout
+// changes underneath it while it's open), then exits via esc. Update()'s
+// normalizeSplitState step must reconcile focus against the resulting view
+// with no panic, for both the queue and the review destinations.
+func TestTransientViewExitReconcilesSplitFocus(t *testing.T) {
+	assert := assert.New(t)
+
+	// Exit into viewQueue: focus reconciles to focusList.
+	m := splitModel()
+	m.width, m.height = 150, 40
+	m.helpFromView = viewQueue
+	m.currentView = viewHelp
+
+	res, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = res.(model)
+	assert.Equal(viewHelp, m.currentView)
+	assert.Equal(layoutStacked, m.layout)
+
+	res, _ = m.Update(tea.WindowSizeMsg{Width: 150, Height: 40})
+	m = res.(model)
+	assert.Equal(viewHelp, m.currentView)
+	assert.Equal(layoutSplit, m.layout)
+
+	m, cmd := pressSpecial(m, tea.KeyEscape)
+	assert.Nil(cmd)
+	assert.Equal(viewQueue, m.currentView)
+	assert.Equal(focusList, m.focus)
+
+	// Exit into viewReview with a review loaded: focus reconciles to
+	// focusDetail.
+	m2 := splitModel(withReview(splitTestReview()))
+	m2.helpFromView = viewReview
+	m2.currentView = viewHelp
+	m2.focus = focusList
+
+	m2, _ = pressSpecial(m2, tea.KeyEscape)
+	assert.Equal(viewReview, m2.currentView)
+	assert.Equal(focusDetail, m2.focus)
+}
+
+// TestStartPaneLogInitializesState covers the running-job branch of
+// handleDetailFollowTick: startPaneLog resets the pane's log state
+// and kicks off the first fetch.
+func TestStartPaneLogInitializesState(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running
+	job, _ := m.selectedJob()
+	res, cmd := m.startPaneLog(*job)
+	got := res.(model)
+	assert.Equal(int64(3), got.paneLogJobID)
+	assert.True(got.paneLogStreaming)
+	assert.NotNil(cmd)
+}
+
+// TestPaneLogWidthUsesDetailPaneNotTerminalWidth pins startPaneLog's and
+// fetchPaneLog's shared width source (paneLogWidth) to the split detail
+// pane's inner width, not the full terminal width -- a regression here
+// wraps log text for the terminal and then hard-truncates it to the pane.
+func TestPaneLogWidthUsesDetailPaneNotTerminalWidth(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3))
+	footerRows := m.splitFooterRows()
+	g := splitGeometry(m.width, m.height, len(reflowHelpRows(footerRows, m.width)))
+	assert.Equal(g.detailInnerW, m.paneLogWidth())
+	assert.NotEqual(m.width, m.paneLogWidth())
+}
+
+// TestPaneLogOutputAppendsAndSchedulesTick covers the streaming path: a
+// stale seq is dropped, a live seq appends lines and schedules the next
+// poll, and the appended text shows up in the rendered detail pane.
+func TestPaneLogOutputAppendsAndSchedulesTick(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3))
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+
+	// Stale seq: dropped.
+	res, cmd := m.handlePaneLogOutputMsg(paneLogOutputMsg{jobID: 3, seq: 4, lines: []logLine{{text: "old"}}})
+	assert.Empty(res.(model).paneLogLines)
+	assert.Nil(cmd)
+
+	// Live seq: appended, tick scheduled while running.
+	res, cmd = m.handlePaneLogOutputMsg(paneLogOutputMsg{
+		jobID: 3, seq: 5, hasMore: true, append: true, lines: []logLine{{text: "Analyzing diff..."}},
+	})
+	got := res.(model)
+	assert.Len(got.paneLogLines, 1)
+	assert.NotNil(cmd)
+
+	// Render shows the tail.
+	out := strings.Join(got.renderDetailPane(88, 25), "\n")
+	assert.Contains(out, "Analyzing diff...")
+}
+
+// TestPaneLogOutputReplacesOnNonIncrementalFetch covers a server-side log
+// offset reset (truncation/rotation): fetchPaneLog re-fetches the complete
+// log from offset 0 and sets append=false, so the pane must replace its
+// buffered lines rather than mix stale pre-reset lines in with the
+// replacement log. append=true still appends, and
+// the buffer still trims to the 500-line cap.
+func TestPaneLogOutputReplacesOnNonIncrementalFetch(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3))
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+	m.paneLogLines = []logLine{{text: "stale line 1"}, {text: "stale line 2"}}
+
+	// append=false: replaces, stale lines gone.
+	res, _ := m.handlePaneLogOutputMsg(paneLogOutputMsg{
+		jobID: 3, seq: 5, hasMore: true, append: false, lines: []logLine{{text: "fresh line"}},
+	})
+	got := res.(model)
+	assert.Equal([]logLine{{text: "fresh line"}}, got.paneLogLines)
+
+	// append=true: appends onto the (now fresh-only) buffer.
+	res, _ = got.handlePaneLogOutputMsg(paneLogOutputMsg{
+		jobID: 3, seq: 5, hasMore: true, append: true, lines: []logLine{{text: "more"}},
+	})
+	got = res.(model)
+	assert.Equal([]logLine{{text: "fresh line"}, {text: "more"}}, got.paneLogLines)
+
+	// append=true past the cap: trims from the front.
+	big := make([]logLine, paneLogMaxLines+10)
+	for i := range big {
+		big[i] = logLine{text: fmt.Sprintf("line %d", i)}
+	}
+	res, _ = got.handlePaneLogOutputMsg(paneLogOutputMsg{jobID: 3, seq: 5, hasMore: true, append: true, lines: big})
+	got = res.(model)
+	assert.Len(got.paneLogLines, paneLogMaxLines)
+	assert.Equal(fmt.Sprintf("line %d", len(big)-1), got.paneLogLines[len(got.paneLogLines)-1].text)
+}
+
+// TestPaneLogCompletionTriggersReviewFetch covers the running->done swap:
+// once the job stops streaming, the pane reconciles via a review fetch.
+func TestPaneLogCompletionTriggersReviewFetch(t *testing.T) {
+	m := splitModel(withSelection(0, 3))
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+	// hasMore=false: job stopped streaming -- reconcile via a review fetch.
+	res, cmd := m.handlePaneLogOutputMsg(paneLogOutputMsg{jobID: 3, seq: 5, hasMore: false})
+	assert.False(t, res.(model).paneLogStreaming)
+	assert.NotNil(t, cmd)
+}
+
+// TestPaneLogTickRefetchesWhileRunning covers handlePaneLogTickMsg: a
+// current-seq tick for the still-running, still-selected job re-issues the
+// fetch; a stale seq or a job that's moved on is a silent no-op.
+func TestPaneLogTickRefetchesWhileRunning(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3))
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+
+	// Stale seq: no-op.
+	_, cmd := m.handlePaneLogTickMsg(paneLogTickMsg{seq: 4})
+	assert.Nil(cmd)
+
+	// Current seq, job still running and selected: refetch.
+	_, cmd = m.handlePaneLogTickMsg(paneLogTickMsg{seq: 5})
+	assert.NotNil(cmd)
+
+	// Selection moved to a different job: no-op.
+	m.paneLogJobID = 999
+	_, cmd = m.handlePaneLogTickMsg(paneLogTickMsg{seq: 5})
+	assert.Nil(cmd)
+}
+
+// TestSplitReconcileDetailOnJobsUpdate covers handleJobsMsg's running->done
+// swap: when the highlighted job in split view finishes but the
+// pane still shows something else (e.g. a stale log tail), the jobs refresh
+// triggers a review fetch to swap the pane over.
+func TestSplitReconcileDetailOnJobsUpdate(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running
+	m.paneLogJobID, m.paneLogStreaming = 3, true
+
+	doneJobs := testQueueJobs()
+	doneJobs[0].Status = storage.JobStatusDone // job 3 finished
+	res, cmd := m.handleJobsMsg(jobsMsg{jobs: doneJobs, stats: storage.JobStats{}})
+	got := res.(model)
+	assert.Equal(int64(3), got.selectedJobID)
+	assert.NotNil(cmd)
+}
+
+// TestPaneLogTickClearsStreamingWhenJobStopsRunning covers
+// handlePaneLogTickMsg's second guard: when the tailed job stops
+// running out from under a poll tick (it flips to failed/canceled/done in
+// m.jobs, e.g. via an SSE push landing between ticks), the tick must stop
+// claiming an active tail rather than just silently dropping the fetch.
+// Pre-fix, paneLogStreaming stayed true here, which made both
+// splitReconcileDetail's running-branch restart guard and startPaneLog's
+// already-tailing no-op guard believe the tail was still alive -- freezing
+// the pane permanently once a rerun reused this job ID and returned it to
+// running (see TestSplitReconcileDetailRestartsTailAfterRerunReusesJobID).
+func TestPaneLogTickClearsStreamingWhenJobStopsRunning(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running, selected
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+
+	m.jobs[0].Status = storage.JobStatusFailed // job 3 stopped running
+
+	res, cmd := m.handlePaneLogTickMsg(paneLogTickMsg{seq: 5})
+	got := res.(model)
+	assert.Nil(cmd)
+	assert.False(got.paneLogStreaming)
+	assert.Greater(got.paneLogSeq, uint64(5))
+}
+
+// TestPaneLogTickStaleSeqLeavesActiveTailAlone is the negative case for the
+// fix above: a stale-seq tick (superseded by a later restart, e.g. via
+// scheduleDetailFollow or startPaneLog) must not touch a live tail's state.
+// The first guard alone handles staleness and returns before reaching the
+// job-status check, so a live tail's paneLogStreaming/paneLogSeq must be
+// untouched.
+func TestPaneLogTickStaleSeqLeavesActiveTailAlone(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running, selected
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+
+	res, cmd := m.handlePaneLogTickMsg(paneLogTickMsg{seq: 4}) // stale
+	got := res.(model)
+	assert.Nil(cmd)
+	assert.True(got.paneLogStreaming)
+	assert.Equal(uint64(5), got.paneLogSeq)
+}
+
+// TestSplitReconcileDetailRestartsTailAfterRerunReusesJobID is the freeze
+// repro for the handlePaneLogTickMsg fix above: a tailed job stops running
+// (the tick fix clears paneLogStreaming), then a rerun reuses the same job
+// ID and the job returns to running in a later jobs refresh.
+// splitReconcileDetail's running-branch restart guard must see the cleared
+// paneLogStreaming and restart the tail. Pre-fix, handlePaneLogTickMsg left
+// paneLogStreaming true, so the guard (paneLogJobID == job.ID &&
+// paneLogStreaming) stayed satisfied and the tail was never restarted,
+// freezing the pane on stale output indefinitely.
+func TestSplitReconcileDetailRestartsTailAfterRerunReusesJobID(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running, selected
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+	m.jobs[0].Status = storage.JobStatusFailed // job 3 stopped running
+
+	res, _ := m.handlePaneLogTickMsg(paneLogTickMsg{seq: 5})
+	m = res.(model)
+	require.False(t, m.paneLogStreaming)
+	seqAfterTick := m.paneLogSeq
+
+	// Rerun reuses job ID 3, back to running.
+	m.jobs[0].Status = storage.JobStatusRunning
+	res2, cmd := m.handleJobsMsg(jobsMsg{jobs: m.jobs, stats: storage.JobStats{}})
+	got := res2.(model)
+	assert.NotNil(cmd)
+	assert.True(got.paneLogStreaming)
+	assert.Greater(got.paneLogSeq, seqAfterTick)
+}
+
+// TestSplitReconcileDetailSynthesizesFailedReviewAndStopsTail covers
+// splitReconcileDetail's JobStatusFailed case: when
+// the selected job transitions running->failed during a jobs refresh, the
+// pane must get a synthesized failed review (so it renders through the
+// scrollable review-body path instead of the card+wrapped-error fallback)
+// and any active tail for that job must be stopped so it can't keep polling
+// a job that no longer exists in running state.
+func TestSplitReconcileDetailSynthesizesFailedReviewAndStopsTail(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running, selected
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+
+	failedJobs := testQueueJobs()
+	failedJobs[0].Status = storage.JobStatusFailed
+	failedJobs[0].Error = "agent crashed"
+
+	res, _ := m.handleJobsMsg(jobsMsg{jobs: failedJobs, stats: storage.JobStats{}})
+	got := res.(model)
+
+	require.NotNil(t, got.currentReview)
+	assert.Equal(int64(3), got.currentReview.JobID)
+	assert.Contains(got.currentReview.Output, "agent crashed")
+	assert.False(got.paneLogStreaming)
+	assert.Greater(got.paneLogSeq, uint64(5))
+}
+
+// TestFailedReviewFromReconcileRendersThroughReviewPaneBody covers the
+// render side of the same fix: the synthesized failed review must be picked
+// up by renderDetailPane's currentReview-match branch and rendered via
+// renderReviewPaneBody (scrollable, focusable) -- not the card+wrapped-error
+// fallback that only shows until the next selection change.
+func TestFailedReviewFromReconcileRendersThroughReviewPaneBody(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running, selected
+	m.paneLogJobID, m.paneLogStreaming = 3, true
+
+	failedJobs := testQueueJobs()
+	failedAt := splitTestFinishedAt
+	failedJobs[0].Status = storage.JobStatusFailed
+	failedJobs[0].Error = "agent crashed"
+	failedJobs[0].FinishedAt = &failedAt
+	res, _ := m.handleJobsMsg(jobsMsg{jobs: failedJobs, stats: storage.JobStats{}})
+	got := res.(model)
+
+	lines := strings.Join(got.renderDetailPane(88, 25), "\n")
+	assert.Contains(lines, "agent crashed")
+	// "Review #<id>" is only emitted by renderReviewPaneBody's title line,
+	// never by the card+wrapped-error fallback -- confirms the pane-body
+	// path, not the card path, rendered this.
+	assert.Contains(lines, "Review #3")
+}
+
+// TestSplitReconcileDetailFailedIdempotent covers the idempotency
+// requirement of the same fix: once the failed review has been synthesized
+// and the tail stopped, a second identical jobsMsg must not rebuild the
+// review or churn paneLogSeq again (mirroring the Done branch's existing
+// currentReview-match guard).
+func TestSplitReconcileDetailFailedIdempotent(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running, selected
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+
+	failedJobs := testQueueJobs()
+	failedAt := splitTestFinishedAt
+	failedJobs[0].Status = storage.JobStatusFailed
+	failedJobs[0].Error = "agent crashed"
+	failedJobs[0].FinishedAt = &failedAt
+	m.jobs = failedJobs
+
+	got, cmd := m.splitReconcileDetail()
+	require.NotNil(t, got.currentReview)
+	assert.Nil(cmd)
+	assert.False(got.paneLogStreaming)
+	firstReview := got.currentReview
+	seqAfterFirst := got.paneLogSeq
+
+	got2, cmd2 := got.splitReconcileDetail()
+	assert.Nil(cmd2)
+	assert.Same(firstReview, got2.currentReview)
+	assert.Equal(seqAfterFirst, got2.paneLogSeq)
+}
+
+// TestSplitReconcileDetailReplacesStaleFailedReviewFromRerun covers
+// splitReconcileDetail's Failed branch: job IDs are reused across reruns,
+// so an idempotency
+// guard on JobID match alone could treat an OLD attempt's synthesized
+// review as "already current" when a NEW failure for the same job ID
+// arrives -- e.g. a rerun's Running/Failed observations outrunning
+// handleRerunResultMsg's own currentReview-invalidating clear. A stale
+// review carrying different error text, with its tail still marked
+// active, must be replaced with the fresh synthesis and the tail stopped.
+func TestSplitReconcileDetailReplacesStaleFailedReviewFromRerun(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(2, 1)) // job 1: failed, current error "boom"
+	m.currentReview = synthesizeFailedReview(&storage.ReviewJob{
+		ID: 1, Agent: "claude-code", Error: "stale error from a previous attempt",
+	}, nil)
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 1, 5, true
+
+	got, cmd := m.splitReconcileDetail()
+	assert.Nil(cmd)
+	require.NotNil(got.currentReview)
+	assert.Contains(got.currentReview.Output, "boom", "must rebuild with the CURRENT job.Error, not keep the stale attempt's text")
+	assert.NotContains(got.currentReview.Output, "stale error from a previous attempt")
+	assert.False(got.paneLogStreaming, "a failed job's tail must be stopped")
+	assert.Greater(got.paneLogSeq, uint64(5))
+}
+
+// TestSplitReconcileDetailFailedStopsTailEvenWhenReviewAlreadyCurrent covers
+// part 1 of the same fix in isolation: even when the loaded review already
+// reflects the CURRENT failure (no rebuild needed), an active tail for that
+// job must still be stopped -- stopping it only on the rebuild path
+// would let a tail that was (however it got there) still marked active
+// when the review already looked current survive this branch
+// indefinitely.
+func TestSplitReconcileDetailFailedStopsTailEvenWhenReviewAlreadyCurrent(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(2, 1)) // job 1: failed, "boom"
+	m.currentReview = synthesizeFailedReview(&m.jobs[2], nil)
+	firstReview := m.currentReview
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 1, 5, true // tail somehow still active
+
+	got, cmd := m.splitReconcileDetail()
+	assert.Nil(cmd)
+	assert.Same(firstReview, got.currentReview, "an already-current review must not be rebuilt")
+	assert.False(got.paneLogStreaming, "a failed job's tail must be stopped even when the review needs no rebuild")
+	assert.Greater(got.paneLogSeq, uint64(5))
+}
+
+// TestSplitReconcileDetailFailedIdempotentWhenErrorUnchanged is part 2's
+// non-regression/idempotency case: when the loaded review's Output already
+// matches what synthesizeFailedReview would build for the job's current
+// state (same job ID, same error text) and no tail is active, reconcile
+// must not rebuild the review or churn paneLogSeq.
+func TestSplitReconcileDetailFailedIdempotentWhenErrorUnchanged(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(2, 1)) // job 1: failed, "boom"
+	m.currentReview = synthesizeFailedReview(&m.jobs[2], nil)
+	firstReview := m.currentReview
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 1, 5, false
+
+	got, cmd := m.splitReconcileDetail()
+	assert.Nil(cmd)
+	assert.Same(firstReview, got.currentReview)
+	assert.Equal(uint64(5), got.paneLogSeq)
+	assert.False(got.paneLogStreaming)
+}
+
+// TestSplitReconcileDetailRefetchesDoneReviewWhenCompletionChanged covers
+// the symmetric question raised alongside the Failed-branch fix: does the
+// Done branch have the same stale-same-job-ID hole? Within a single
+// session, a self-initiated rerun is protected by handleRerunResultMsg's
+// clear/attempt bump on confirm, which fires well before a real
+// review job could plausibly complete again. But that machinery is
+// session-local -- it only fires for a rerun THIS session dispatched and
+// saw confirmed. A rerun triggered by another client sharing the same
+// daemon (another TUI instance, the CLI, a CI poller) is invisible to it:
+// this session never sees a rerunResultMsg, so currentReview is never
+// cleared, and the next jobs refresh reporting the job done again would
+// hit the JobID-only guard and leave the OLD review shown indefinitely.
+// This IS reachable, so the Done branch gets the same class of fix:
+// job.FinishedAt (stamped fresh by the daemon on every completion,
+// already tracked in memory, no new persisted state) distinguishes this
+// completion from a previous one when the loaded review's embedded Job
+// disagrees with the freshly-polled job.
+func TestSplitReconcileDetailRefetchesDoneReviewWhenCompletionChanged(t *testing.T) {
+	assert := assert.New(t)
+	oldFinish := time.Now().Add(-time.Hour)
+	m := splitModel(withSelection(1, 2)) // job 2: done
+	oldReview := splitTestReview()
+	oldReview.Job.FinishedAt = &oldFinish
+	m.currentReview = oldReview
+
+	newFinish := time.Now()
+	jobs := testQueueJobs()
+	jobs[1].FinishedAt = &newFinish // job 2 completed again (e.g. an external rerun)
+	m.jobs = jobs
+
+	got, cmd := m.splitReconcileDetail()
+	assert.NotNil(cmd, "a job that completed again (different FinishedAt) must trigger a fresh fetch even though currentReview.JobID still matches")
+	assert.Same(oldReview, got.currentReview, "the stale review isn't replaced synchronously -- the fetch does that once it lands")
+}
+
+// TestSplitReconcileDetailDoneIdempotentWhenCompletionUnchanged is the
+// non-regression counterpart: when the loaded review's embedded
+// job.FinishedAt matches the freshly-polled job's FinishedAt (the review
+// already reflects this exact completion), reconcile must not refetch.
+func TestSplitReconcileDetailDoneIdempotentWhenCompletionUnchanged(t *testing.T) {
+	assert := assert.New(t)
+	finish := time.Now()
+	m := splitModel(withSelection(1, 2)) // job 2: done
+	review := splitTestReview()
+	review.Job.FinishedAt = &finish
+	m.currentReview = review
+
+	jobs := testQueueJobs()
+	jobs[1].FinishedAt = &finish
+	m.jobs = jobs
+
+	got, cmd := m.splitReconcileDetail()
+	assert.Nil(cmd, "matching FinishedAt means the loaded review already reflects this completion -- no refetch needed")
+	assert.Same(review, got.currentReview)
+}
+
+// TestSplitReconcileDetailDoneNoRefetchWhenPolledSnapshotIsOlder:
+// reviewJobCompletionChanged must not be a plain (symmetric) inequality,
+// which would fire whenever the freshly-polled job's FinishedAt DIFFERED
+// from the loaded review's, in either direction.
+// selectedJob falls through to m.panelMembers for a panel member, a cache
+// refreshed only while a member is queued/running and frozen once all
+// members go terminal -- so the polled snapshot can be OLDER than the one
+// already embedded in the loaded review (e.g. currentReview was fetched at
+// a completion the frozen snapshot predates: an external rerun of a
+// member, review opened via stacked Enter, then L into split). With a
+// plain inequality this fires on EVERY jobs refresh forever -- a reconcile
+// loop: one fetchReviewFollow per SSE event and per poll, each landing
+// resetting reviewScroll to 0, i.e. a permanently unscrollable pane. This
+// is the loop repro, and must NOT refetch under the fixed, forward-only
+// comparison.
+func TestSplitReconcileDetailDoneNoRefetchWhenPolledSnapshotIsOlder(t *testing.T) {
+	assert := assert.New(t)
+	newer := time.Now()
+	older := newer.Add(-time.Hour)
+	m := splitModel(withSelection(1, 2)) // job 2: done
+	review := splitTestReview()
+	review.Job.FinishedAt = &newer // the loaded review reflects the NEWER completion
+	m.currentReview = review
+
+	jobs := testQueueJobs()
+	jobs[1].FinishedAt = &older // freshly-polled snapshot is OLDER (e.g. a frozen panelMembers cache)
+	m.jobs = jobs
+
+	got, cmd := m.splitReconcileDetail()
+	assert.Nil(cmd, "a polled snapshot older than the loaded review must never trigger a refetch -- this is the reconcile-loop repro")
+	assert.Same(review, got.currentReview)
+}
+
+// ---------------------------------------------------------------------------
+// Integration sweep: cross-cutting behaviors across the split feature.
+// ---------------------------------------------------------------------------
+
+// TestArrowKeysStepReviewNavInSplitDetailFocus: with
+// focus on the detail pane (currentView == viewReview while split is
+// active), left/right route through handleLeftKey/handleRightKey ->
+// stepReviewNav, which must move BOTH the displayed review and the queue
+// cursor (selectedJobID/selectedIdx) -- keeping list/detail selection in
+// sync even though the list pane isn't focused.
+func TestArrowKeysStepReviewNavInSplitDetailFocus(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	// testQueueJobs order: job 3 (running, idx0), job 2 (done, idx1),
+	// job 1 (failed, idx2).
+	m := splitModel(withReview(splitTestReview()), withSelection(1, 2))
+	m.focus = focusDetail
+	m.currentView = viewReview
+
+	// Left = older: job 2 -> job 1 (failed, synthesized inline, no fetch).
+	got, _ := pressSpecial(m, tea.KeyLeft)
+	assert.Equal(int64(1), got.selectedJobID)
+	assert.Equal(2, got.selectedIdx) // testQueueJobs()[2] is job 1
+	require.NotNil(got.currentReview)
+	assert.Equal(int64(1), got.currentReview.JobID)
+	assert.Equal(focusDetail, got.focus)
+	assert.Equal(viewReview, got.currentView)
+
+	// Right = newer: job 1 -> job 2 (done, triggers a fetch); the cursor
+	// moves immediately, before the fetch resolves.
+	got2, cmd2 := pressSpecial(got, tea.KeyRight)
+	assert.Equal(int64(2), got2.selectedJobID)
+	assert.Equal(1, got2.selectedIdx)
+	assert.NotNil(cmd2)
+	assert.Equal(focusDetail, got2.focus)
+	assert.Equal(viewReview, got2.currentView)
+}
+
+// TestSplitTransientRoundTripPrompt covers sweep item 2: from split detail
+// focus, 'p' opens the full-screen prompt view (splitActive() requires
+// currentView in {viewQueue, viewReview}), and 'esc' returns to viewReview
+// with focus/layout/currentReview all intact.
+func TestSplitTransientRoundTripPrompt(t *testing.T) {
+	assert := assert.New(t)
+	rev := splitTestReview()
+	rev.Prompt = "review this diff"
+	m := splitModel(withReview(rev))
+	m.focus = focusDetail
+	m.currentView = viewReview
+
+	got, _ := pressKey(m, 'p')
+	assert.Equal(viewKindPrompt, got.currentView)
+	assert.False(got.splitActive())
+	assert.Contains(got.viewContent(), "review this diff")
+
+	got2, _ := pressSpecial(got, tea.KeyEscape)
+	assert.Equal(viewReview, got2.currentView)
+	assert.Equal(focusDetail, got2.focus)
+	assert.Equal(layoutSplit, got2.layout)
+	require.NotNil(t, got2.currentReview)
+	assert.True(got2.splitActive())
+	assert.Contains(got2.viewContent(), "first finding") // back in the split pane
+}
+
+// TestSplitTransientRoundTripHelp is TestSplitTransientRoundTripPrompt's
+// counterpart for '?' (help).
+func TestSplitTransientRoundTripHelp(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview()))
+	m.focus = focusDetail
+	m.currentView = viewReview
+
+	got, _ := pressKey(m, '?')
+	assert.Equal(viewHelp, got.currentView)
+	assert.False(got.splitActive())
+
+	got2, _ := pressSpecial(got, tea.KeyEscape)
+	assert.Equal(viewReview, got2.currentView)
+	assert.Equal(focusDetail, got2.focus)
+	assert.Equal(layoutSplit, got2.layout)
+	assert.True(got2.splitActive())
+}
+
+// TestResizeBelowBreakpointWhileDetailFocused covers sweep item 3: shrinking
+// the terminal below the split breakpoint while focused on the detail pane
+// must fall back to the full-screen (stacked) review view for the SAME
+// review, and growing back past the breakpoint must restore split with
+// focus back on the detail pane, still showing that review.
+func TestResizeBelowBreakpointWhileDetailFocused(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview()))
+	m.focus = focusDetail
+	m.currentView = viewReview
+
+	res, _ := m.handleWindowSizeMsg(tea.WindowSizeMsg{Width: 100, Height: 30})
+	got := res.(model)
+	assert.Equal(layoutStacked, got.layout)
+	assert.Equal(viewReview, got.currentView)
+	require.NotNil(t, got.currentReview)
+	assert.Equal(int64(2), got.currentReview.JobID)
+	assert.False(got.splitActive())
+
+	res2, _ := got.handleWindowSizeMsg(tea.WindowSizeMsg{Width: 150, Height: 40})
+	got2 := res2.(model)
+	assert.Equal(layoutSplit, got2.layout)
+	assert.Equal(focusDetail, got2.focus)
+	assert.Equal(viewReview, got2.currentView)
+	require.NotNil(t, got2.currentReview)
+	assert.Equal(int64(2), got2.currentReview.JobID)
+	assert.True(got2.splitActive())
+}
+
+// TestWindowResizeRefillsToPaneCapacityInSplit covers sweep item 4:
+// handleWindowSizeMsg's pagination refill check must use the split list
+// pane's own row capacity (queuePaneRowCapacity), not queueVisibleRows'
+// full-screen chrome reservation, or a resize into a taller split pane can
+// leave rows unfilled even though more data is available server-side.
+func TestWindowResizeRefillsToPaneCapacityInSplit(t *testing.T) {
+	assert := assert.New(t)
+	m := initTestModel(
+		withCurrentView(viewQueue),
+		withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...),
+		withSelection(1, 2),
+	)
+	m.layout = layoutSplit
+	m.preferredLayout = layoutSplit
+	m.layoutLocked = true
+	m.hasMore = true
+	m.loadingJobs = false         // newModel starts in a "loading" state; the refill gate requires it clear
+	m.activeBranchFilter = "main" // != branchNone, so canPaginate/refill applies
+
+	paneCapacity := m.queuePaneRowCapacity()
+	fullScreenRows := m.queueVisibleRows()
+	require.Greater(t, paneCapacity, fullScreenRows,
+		"expected the split pane to fit more rows than the full-screen chrome reservation at these dimensions")
+
+	// len(m.jobs)=3 sits strictly between the two thresholds (offset by
+	// queuePrefetchBuffer): a refill keyed to the pane capacity must fire,
+	// even though a refill keyed to the (smaller) full-screen row count
+	// would not need to.
+	m.jobs = make([]storage.ReviewJob, fullScreenRows+queuePrefetchBuffer)
+	for i := range m.jobs {
+		m.jobs[i] = storage.ReviewJob{ID: int64(i + 1), Status: storage.JobStatusDone}
+	}
+	require.Less(t, len(m.jobs), paneCapacity+queuePrefetchBuffer)
+	require.GreaterOrEqual(t, len(m.jobs), fullScreenRows+queuePrefetchBuffer)
+
+	res, cmd := m.handleWindowSizeMsg(tea.WindowSizeMsg{Width: m.width, Height: m.height})
+	got := res.(model)
+	assert.NotNil(cmd, "expected a refetch to fill the taller split pane")
+	assert.True(got.loadingJobs)
+}
+
+// TestSplitInfoLineShowsFlash covers sweep item 5: setFlash(..., viewQueue)
+// while split is active and list-focused must surface on the split info
+// line (splitInfoLine renders m.renderFlash(m.currentView) first).
+func TestSplitInfoLineShowsFlash(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel()
+	m.focus = focusList
+	m.currentView = viewQueue
+	m.setFlash("No older review", 2*time.Second, viewQueue)
+
+	footerRows := m.splitFooterRows()
+	g := splitGeometry(m.width, m.height, len(reflowHelpRows(footerRows, m.width)))
+	info := m.splitInfoLine(g)
+	assert.Contains(info, "No older review")
+
+	// Rendered into the full split screen too.
+	assert.Contains(m.renderSplit(), "No older review")
+}
+
+// TestReviewFollowFetchFailureShowsInPane covers sweep item 6 (the
+// fetchReview-follow half): a follow fetch failure (arriving as
+// reviewFollowErrMsg, tagged with the requested jobID) is recorded in
+// m.splitDetailErr, and renderDetailPane's done-branch surfaces it instead
+// of leaving the "Loading review..." placeholder stuck forever. A stale
+// jobID (selection has since moved on) is dropped.
+func TestReviewFollowFetchFailureShowsInPane(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	_, m := mockServerModel(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	m.layout = layoutSplit
+	m.jobs = testQueueJobs()
+	m.selectedIdx, m.selectedJobID = 1, 2 // job 2: done
+
+	cmd := m.fetchReviewFollow(2, 0)
+	msg := cmd()
+	followErr, ok := msg.(reviewFollowErrMsg)
+	require.True(ok, "expected a reviewFollowErrMsg, got %T", msg)
+	assert.Equal(int64(2), followErr.jobID)
+
+	res, _ := m.handleReviewFollowErrMsg(followErr)
+	got := res.(model)
+	require.Error(got.splitDetailErr)
+
+	lines := strings.Join(got.renderDetailPane(88, 25), "\n")
+	assert.Contains(lines, "Failed to load review")
+	assert.Contains(lines, "re-select the row to retry")
+
+	// A stale jobID (selection moved on) is dropped, leaving splitDetailErr
+	// untouched.
+	m2 := m
+	m2.selectedJobID = 3
+	res2, _ := m2.handleReviewFollowErrMsg(reviewFollowErrMsg{jobID: 2, err: errors.New("boom")})
+	assert.NoError(res2.(model).splitDetailErr)
+}
+
+// TestScheduleDetailFollowClearsSplitDetailErr covers the other half of
+// sweep item 6's contract: a fresh follow (cursor moved to a new job)
+// clears any earlier splitDetailErr so a stale error from a DIFFERENT job
+// doesn't linger and get misattributed once the new job's content loads.
+func TestScheduleDetailFollowClearsSplitDetailErr(t *testing.T) {
+	m := splitModel()
+	m.splitDetailErr = errors.New("stale error from a previous job")
+
+	got, _ := m.scheduleDetailFollow()
+	assert.NoError(t, got.splitDetailErr)
+}
+
+// TestPaneLogOutputErrorShowsInPaneAndStopsTick covers sweep item 6 (the
+// paneLogOutputMsg half): a real fetch error (not the benign errNoLog
+// "job just started" case) in the running-job branch stops the tail
+// (paneLogStreaming=false, no further tick scheduled) and records the error
+// for renderDetailPane's running-branch to show as one line.
+func TestPaneLogOutputErrorShowsInPaneAndStopsTick(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+
+	res, cmd := m.handlePaneLogOutputMsg(paneLogOutputMsg{jobID: 3, seq: 5, err: errors.New("log fetch failed")})
+	got := res.(model)
+	assert.Nil(cmd, "tick loop must stop on a real fetch error")
+	assert.False(got.paneLogStreaming)
+	require.Error(t, got.splitDetailErr)
+
+	lines := strings.Join(got.renderDetailPane(88, 25), "\n")
+	assert.Contains(lines, "Failed to load log")
+}
+
+// TestMdCacheMaxScrollSingleRendererPerFrame covers the ledger carry-over
+// (sweep item 7): viewContent()'s dispatch is a single if/return chain --
+// splitActive() (pane renderer, keyed to the detail pane's inner width) is
+// checked BEFORE the full-screen viewReview branch (keyed to m.width), and
+// the two are mutually exclusive (splitActive() requires layoutSplit;
+// leaving split falls through to the full-screen branch). Only one of the
+// two renderers can run per View() call, so mdCache.lastReviewMaxScroll
+// can't drift between them mid-frame. This regression test locks that in:
+// content long/wide enough to wrap differently at the two window widths
+// produces two DIFFERENT recorded max-scroll values across two separate
+// render passes -- proving each pass computed and wrote its own, not a
+// stale value the other renderer left behind.
+func TestMdCacheMaxScrollSingleRendererPerFrame(t *testing.T) {
+	assert := assert.New(t)
+	rev := splitTestReview()
+	var sb strings.Builder
+	for i := range 80 {
+		fmt.Fprintf(&sb, "line %d of the review body\n\n", i)
+	}
+	rev.Output = sb.String()
+
+	m := splitModel(withReview(rev))
+	m.focus = focusDetail
+	m.currentView = viewReview
+
+	require.True(t, m.splitActive())
+	_ = m.viewContent() // pane renderer: keyed to the detail pane's inner width
+	paneMaxScroll := m.mdCache.lastReviewMaxScroll
+	assert.Positive(paneMaxScroll)
+
+	m.layout = layoutStacked
+	require.False(t, m.splitActive())
+	_ = m.viewContent() // full-screen renderer: keyed to m.width
+	fullMaxScroll := m.mdCache.lastReviewMaxScroll
+
+	assert.NotEqual(paneMaxScroll, fullMaxScroll)
+}
+
+// TestReviewMsgDoesNotClobberTransientView covers sweep item 8: a non-follow
+// reviewMsg (from enterReviewCmd, Enter on a done job in the queue) must not
+// yank the user into the review view if a transient view (e.g. the comment
+// editor) was opened after the fetch was dispatched but before it resolved.
+// The msg.jobID != selectedJobID staleness gate does NOT protect against
+// this -- the selection hasn't moved, only currentView has. The review data
+// is still stored so it's ready once the user returns from the transient
+// view.
+func TestReviewMsgDoesNotClobberTransientView(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := initTestModel(
+		withCurrentView(viewQueue),
+		withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...),
+		withSelection(1, 2), // job 2: done
+	)
+
+	// Enter dispatches the async fetch; currentView stays viewQueue until
+	// it resolves.
+	res, cmd := m.handleEnterKey()
+	m = res.(model)
+	require.NotNil(cmd)
+	assert.Equal(viewQueue, m.currentView)
+
+	// Before the fetch resolves, the user opens the comment editor.
+	res, _ = m.handleCommentOpenKey()
+	m = res.(model)
+	require.Equal(viewKindComment, m.currentView)
+	m.commentText = "in progress comment"
+
+	// The fetch now resolves for the same job (selection unchanged).
+	res, _ = m.handleReviewMsg(reviewMsg{review: splitTestReview(), jobID: 2, fetchSeq: m.reviewFetchSeq})
+	got := res.(model)
+	assert.Equal(viewKindComment, got.currentView, "must not be yanked out of the comment editor")
+	assert.Equal("in progress comment", got.commentText)
+	require.NotNil(got.currentReview)
+	assert.Equal(int64(2), got.currentReview.JobID) // loaded and ready for later
+}
+
+// ---------------------------------------------------------------------------
+// Tasks-view navigation into the review view.
+// ---------------------------------------------------------------------------
+
+// TestTasksViewEnterSwitchesToReviewView: handleTasksKey's
+// Enter/ctrl+j path on a done fix task (handlers_modal.go) dispatches
+// fetchReview while staying on viewTasks until it resolves -- the
+// handleReviewMsg view-switch guard added for sweep item 8 must include
+// viewTasks in its allowed set, or this legitimate switch silently stops
+// happening.
+func TestTasksViewEnterSwitchesToReviewView(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := initTestModel(withCurrentView(viewTasks), withDimensions(150, 40))
+	m.fixJobs = []storage.ReviewJob{
+		{ID: 101, Status: storage.JobStatusDone},
+	}
+	m.fixSelectedIdx = 0
+
+	got, cmd := pressSpecial(m, tea.KeyEnter)
+	require.NotNil(cmd)
+	assert.Equal(viewTasks, got.currentView) // fetch still in flight
+	assert.Equal(int64(101), got.selectedJobID)
+	assert.Equal(viewTasks, got.reviewFromView)
+
+	res, _ := got.handleReviewMsg(reviewMsg{
+		review: makeReview(20, &storage.ReviewJob{ID: 101}), jobID: 101,
+		dispatchedFrom: viewTasks, // what fetchReview stamps from currentView here
+		fetchSeq:       got.reviewFetchSeq,
+	})
+	final := res.(model)
+	assert.Equal(viewReview, final.currentView)
+	require.NotNil(final.currentReview)
+}
+
+// TestTasksViewParentShortcutSwitchesToReviewView is
+// TestTasksViewEnterSwitchesToReviewView's counterpart for 'P' (open parent
+// review for a fix task).
+func TestTasksViewParentShortcutSwitchesToReviewView(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	parentID := int64(77)
+	m := initTestModel(withCurrentView(viewTasks), withDimensions(150, 40))
+	m.fixJobs = []storage.ReviewJob{
+		{ID: 101, Status: storage.JobStatusDone, ParentJobID: &parentID},
+	}
+	m.fixSelectedIdx = 0
+
+	got, cmd := pressKey(m, 'P')
+	require.NotNil(cmd)
+	assert.Equal(viewTasks, got.currentView)
+	assert.Equal(parentID, got.selectedJobID)
+
+	res, _ := got.handleReviewMsg(reviewMsg{
+		review: makeReview(20, &storage.ReviewJob{ID: parentID}), jobID: parentID,
+		dispatchedFrom: viewTasks, fetchSeq: got.reviewFetchSeq,
+	})
+	final := res.(model)
+	assert.Equal(viewReview, final.currentView)
+	require.NotNil(final.currentReview)
+}
+
+// TestReviewMsgConsumesPendingFixPanelEvenWithTransientViewOpen covers
+// Finding B: 'F' from the queue sets reviewFixPanelPending and dispatches a
+// fetch while remaining on viewQueue; if the user opens a transient view
+// (e.g. the comment editor) before the fetch resolves, the fix panel state
+// must still be consumed when it lands -- the view-switch guard (sweep item
+// 8 / Finding A) must not also block the pending-fix-panel consumption, or
+// it's stranded forever (nothing else ever reopens it).
+func TestReviewMsgConsumesPendingFixPanelEvenWithTransientViewOpen(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := initTestModel(
+		withCurrentView(viewQueue),
+		withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...),
+		withSelection(1, 2), // job 2: done
+	)
+	m.tasksEnabled = true
+
+	res, cmd := m.handleFixKey()
+	m = res.(model)
+	require.NotNil(cmd)
+	require.True(m.reviewFixPanelPending)
+	assert.Equal(viewQueue, m.currentView)
+
+	// Before the fix-triggered fetch resolves, the user opens the comment
+	// editor.
+	res, _ = m.handleCommentOpenKey()
+	m = res.(model)
+	require.Equal(viewKindComment, m.currentView)
+
+	// The fetch resolves.
+	res, _ = m.handleReviewMsg(reviewMsg{review: splitTestReview(), jobID: 2, fetchSeq: m.reviewFetchSeq})
+	got := res.(model)
+	assert.Equal(viewKindComment, got.currentView, "must not be yanked out of the comment editor")
+	assert.False(got.reviewFixPanelPending, "pending fix panel must be consumed")
+	assert.True(got.reviewFixPanelOpen)
+	assert.True(got.reviewFixPanelFocused)
+	require.NotNil(got.currentReview)
+}
+
+// TestScheduleDetailFollowInvalidatesStalePaneLogTail covers Finding C:
+// paneLogOutputMsg/paneLogTickMsg are validated by paneLogSeq alone, with no
+// jobID check, so moving the queue selection off a running job whose log is
+// being tailed must invalidate that tail (bump paneLogSeq) or an in-flight
+// response for the OLD job -- including a failure -- can still land after
+// the fact and set splitDetailErr for whatever job is newly selected.
+func TestScheduleDetailFollowInvalidatesStalePaneLogTail(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running, tailed
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+
+	// Moving the selection to job 2 (down from job 3) goes through the
+	// real handleKeyMsg -> scheduleDetailFollow path.
+	got, cmd := pressSpecial(m, tea.KeyDown)
+	assert.Equal(int64(2), got.selectedJobID)
+	assert.NotNil(cmd)
+	assert.Greater(got.paneLogSeq, uint64(5))
+	assert.False(got.paneLogStreaming)
+
+	// A stale response for job 3, correctly tagged jobID: 3 (it genuinely
+	// came from that in-flight fetch) but the OLD (now-invalid) seq, must
+	// still be dropped on the seq check alone -- no splitDetailErr leaks
+	// through for job 2.
+	res, cmd2 := got.handlePaneLogOutputMsg(paneLogOutputMsg{jobID: 3, seq: 5, err: errors.New("stale failure from job 3")})
+	assert.Nil(cmd2)
+	assert.NoError(res.(model).splitDetailErr)
+}
+
+// TestScheduleDetailFollowLeavesTailAloneWhenSelectionUnchanged is
+// TestScheduleDetailFollowInvalidatesStalePaneLogTail's negative case: a
+// follow reschedule that does NOT change the selection (e.g. re-selecting
+// the same job) must not disturb an in-progress tail for that same job.
+func TestScheduleDetailFollowLeavesTailAloneWhenSelectionUnchanged(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running, tailed
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+
+	got, _ := m.scheduleDetailFollow()
+	assert.Equal(uint64(5), got.paneLogSeq)
+	assert.True(got.paneLogStreaming)
+}
+
+// TestSplitReconcileDetailRestartsStalledRunningTail covers Finding D: the
+// "invalidate, don't restart" resize path (handleWindowSizeMsg, when a
+// transient view is covering the split pane) leaves a running job's pane
+// tail stopped until something restarts it. splitReconcileDetail, called
+// from handleJobsMsg on every jobs refresh (SSE push or the periodic poll),
+// must notice a running selected job whose tail isn't active and restart it
+// -- recovering automatically within one refresh cycle.
+func TestSplitReconcileDetailRestartsStalledRunningTail(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running, selected
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, false
+
+	res, cmd := m.handleJobsMsg(jobsMsg{jobs: testQueueJobs(), stats: storage.JobStats{}})
+	got := res.(model)
+	assert.NotNil(cmd)
+	assert.True(got.paneLogStreaming)
+	assert.Greater(got.paneLogSeq, uint64(5))
+	assert.Equal(int64(3), got.paneLogJobID)
+}
+
+// TestSplitReconcileDetailLeavesActiveTailAlone is the negative case for
+// Finding D: a running job whose tail is already active must not be
+// restarted (that would reset paneLogLines/offset and drop buffered log
+// content for no reason).
+func TestSplitReconcileDetailLeavesActiveTailAlone(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running, selected
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+	m.paneLogLines = []logLine{{text: "already buffered"}}
+
+	got, cmd := m.splitReconcileDetail()
+	assert.Nil(cmd)
+	assert.Equal(uint64(5), got.paneLogSeq)
+	assert.Equal([]logLine{{text: "already buffered"}}, got.paneLogLines)
+}
+
+// TestSplitReconcileDetailClearsStaleSplitDetailErr and
+// TestPaneLogCompletionClearsStaleSplitDetailErr cover Finding E:
+// splitDetailErr must be cleared before splitReconcileDetail's and
+// handlePaneLogOutputMsg's running->done handoff's fetchReviewFollow calls,
+// or a stale error from an earlier failed attempt can render for one frame
+// against the freshly-resolving job before the new fetch lands.
+func TestSplitReconcileDetailClearsStaleSplitDetailErr(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(1, 2)) // job 2: done
+	m.splitDetailErr = errors.New("stale error from a previous attempt")
+
+	got, cmd := m.splitReconcileDetail()
+	assert.NotNil(cmd)
+	assert.NoError(got.splitDetailErr)
+}
+
+func TestPaneLogCompletionClearsStaleSplitDetailErr(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+	m.splitDetailErr = errors.New("stale log error")
+
+	res, cmd := m.handlePaneLogOutputMsg(paneLogOutputMsg{jobID: 3, seq: 5, hasMore: false})
+	got := res.(model)
+	assert.NotNil(cmd)
+	assert.NoError(got.splitDetailErr)
+}
+
+// TestQueuePaneRowCapacityMatchesRenderInCompactMode covers Finding F:
+// queuePaneRowCapacity must equal the number of data rows
+// renderQueuePaneBody actually draws, in compact mode too. It previously
+// subtracted 0 (instead of 2) for the table header/separator budget in
+// compact mode, overestimating by 2 -- renderQueuePaneBody always reserves
+// those 2 lines in its call to renderQueueTable regardless of compact mode
+// (the header just isn't drawn there; the 2 freed lines come back as blank
+// padding, not extra data rows). This renders the real pane, packed with
+// far more jobs than fit, and counts the actual non-blank rows rather than
+// re-deriving the same formula the fix uses, so a regression that changes
+// renderQueuePaneBody's budget without updating this helper would still be
+// caught.
+func TestQueuePaneRowCapacityMatchesRenderInCompactMode(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withDimensions(150, 14)) // height < 15 -> queueCompact() true
+	require.True(t, m.queueCompact())
+
+	jobs := make([]storage.ReviewJob, 100)
+	for i := range jobs {
+		jobs[i] = storage.ReviewJob{ID: int64(i + 1), Status: storage.JobStatusDone}
+	}
+	m.jobs = jobs
+
+	footerRows := m.splitFooterRows()
+	g := splitGeometry(m.width, m.height, len(reflowHelpRows(footerRows, m.width)))
+	lines := m.renderQueuePaneBody(g.listInnerW, g.listInnerH)
+
+	nonBlank := 0
+	for _, l := range lines {
+		if strings.TrimSpace(l) != "" {
+			nonBlank++
+		}
+	}
+	assert.Equal(nonBlank, m.queuePaneRowCapacity())
+	assert.Less(m.queuePaneRowCapacity(), g.listInnerH, "compact mode still reserves the header/separator budget even though it isn't drawn")
+}
+
+// ---------------------------------------------------------------------------
+// Review responses respect their dispatch origin.
+// ---------------------------------------------------------------------------
+
+// TestReviewMsgRespectsDispatchOriginQueueThenTasks: widening
+// handleReviewMsg's view-switch
+// guard to an allowlist (viewQueue|viewReview|viewTasks) to let the
+// tasks-view fetchReview paths resolve correctly. But viewQueue and
+// viewTasks are mutually reachable via 'T'/Esc while a fetch from EITHER
+// one is still in flight, so the allowlist let a fetch dispatched from the
+// queue resolve into viewReview even after the user explicitly switched to
+// Tasks in the meantime. The fix replaces the allowlist with dispatch-origin
+// tracking via m.reviewFromView (already set at every relevant dispatch
+// site): the switch only fires when currentView is still the origin the
+// fetch was dispatched from, or already viewReview.
+func TestReviewMsgRespectsDispatchOriginQueueThenTasks(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := initTestModel(
+		withCurrentView(viewQueue),
+		withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...),
+		withSelection(1, 2), // job 2: done
+	)
+	m.tasksEnabled = true
+
+	// Enter dispatches the fetch from the queue.
+	res, cmd := m.handleEnterKey()
+	m = res.(model)
+	require.NotNil(cmd)
+	assert.Equal(viewQueue, m.reviewFromView)
+	assert.Equal(viewQueue, m.currentView)
+
+	// Before it resolves, the user switches to the Tasks view.
+	res, _ = m.handleToggleTasksKey()
+	m = res.(model)
+	require.Equal(viewTasks, m.currentView)
+
+	// The queue-origin fetch resolves for the same job (selection
+	// unchanged, so the staleness gate alone doesn't catch this).
+	res, _ = m.handleReviewMsg(reviewMsg{review: splitTestReview(), jobID: 2, fetchSeq: m.reviewFetchSeq})
+	got := res.(model)
+	assert.Equal(viewTasks, got.currentView, "must not be yanked into viewReview while the user is on Tasks")
+	require.NotNil(got.currentReview)
+}
+
+// TestReviewMsgRespectsDispatchOriginTasksThenQueue is
+// TestReviewMsgRespectsDispatchOriginQueueThenTasks's mirror case: a fetch
+// dispatched from the Tasks view (Enter on a done fix task) must not
+// resolve into viewReview if the user has since backed out to the queue
+// (Esc/T from handleTasksKey).
+func TestReviewMsgRespectsDispatchOriginTasksThenQueue(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := initTestModel(withCurrentView(viewTasks), withDimensions(150, 40))
+	m.tasksEnabled = true
+	m.fixJobs = []storage.ReviewJob{
+		{ID: 101, Status: storage.JobStatusDone},
+	}
+	m.fixSelectedIdx = 0
+
+	got, cmd := pressSpecial(m, tea.KeyEnter)
+	require.NotNil(cmd)
+	assert.Equal(viewTasks, got.reviewFromView)
+	assert.Equal(viewTasks, got.currentView)
+
+	// Before it resolves, the user backs out to the queue -- which also
+	// repairs the selection off the fix job (exitTasksToQueue), since no
+	// queue row can resolve a fix job's ID.
+	got2, _ := pressSpecial(got, tea.KeyEscape)
+	require.Equal(viewQueue, got2.currentView)
+	require.NotEqual(int64(101), got2.selectedJobID,
+		"backing out to the queue must move the selection off the fix job")
+
+	res, _ := got2.handleReviewMsg(reviewMsg{
+		review: makeReview(20, &storage.ReviewJob{ID: 101}), jobID: 101,
+		dispatchedFrom: viewTasks,
+		fetchSeq:       got2.reviewFetchSeq,
+	})
+	final := res.(model)
+	assert.Equal(viewQueue, final.currentView, "must not be yanked into viewReview while the user backed out to the queue")
+	assert.Nil(final.currentReview,
+		"the abandoned tasks fetch must not load content for a fix job the exit de-selected")
+}
+
+// ---------------------------------------------------------------------------
+// Tasks-origin reviews render full-screen, outside the split composition.
+// ---------------------------------------------------------------------------
+
+// TestSplitActiveExcludesTasksOriginReview: opening a
+// completed fix task from the Tasks view while split layout is enabled
+// switches currentView to viewReview (per the dispatch-origin
+// guard), which would make splitActive() true and route rendering through
+// renderSplit -- but fix jobs live in m.fixJobs, not m.jobs, so
+// renderDetailPane's m.selectedJob() lookup (m.jobs/panelMembers-only)
+// can't resolve selectedJobID and would show "No job selected" instead of
+// the loaded review. splitActive() now excludes a tasks-origin review
+// (reviewFromView == viewTasks) so it renders full-screen via the ordinary
+// review renderer instead, same as any other transient view.
+func TestSplitActiveExcludesTasksOriginReview(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := initTestModel(withCurrentView(viewTasks), withDimensions(150, 40))
+	m.layout = layoutSplit
+	m.tasksEnabled = true
+	m.fixJobs = []storage.ReviewJob{
+		{ID: 101, Status: storage.JobStatusDone},
+	}
+	m.fixSelectedIdx = 0
+
+	got, cmd := pressSpecial(m, tea.KeyEnter)
+	require.NotNil(cmd)
+	assert.Equal(viewTasks, got.reviewFromView)
+
+	res, _ := got.handleReviewMsg(reviewMsg{
+		review:         makeReview(20, &storage.ReviewJob{ID: 101}, withReviewOutput("fix task review output")),
+		jobID:          101,
+		dispatchedFrom: viewTasks,
+		fetchSeq:       got.reviewFetchSeq,
+	})
+	final := res.(model)
+	assert.Equal(viewReview, final.currentView)
+	assert.False(final.splitActive(), "a tasks-origin review must not route through the split pane")
+
+	content := final.viewContent()
+	assert.Contains(content, "fix task review output")
+	assert.NotContains(content, "No job selected")
+}
+
+// TestSplitEscQuitReturnTasksOriginReviewToTasksView covers Finding 1's
+// knock-on effect (a): the split esc/q shortcuts (handleEscKey/
+// handleQuitKey) that normally jump straight back to viewQueue when
+// layout==layoutSplit && currentView==viewReview must NOT fire for a
+// tasks-origin review -- they must fall through to the general
+// reviewFromView-based return logic instead, landing back on viewTasks.
+func TestSplitEscQuitReturnTasksOriginReviewToTasksView(t *testing.T) {
+	assert := assert.New(t)
+	newTasksOriginReview := func() model {
+		m := initTestModel(withCurrentView(viewReview), withDimensions(150, 40))
+		m.layout = layoutSplit
+		m.reviewFromView = viewTasks
+		m.currentReview = makeReview(20, &storage.ReviewJob{ID: 101}, withReviewOutput("fix output"))
+		return m.normalizeSplitState()
+	}
+
+	esc := newTasksOriginReview()
+	res, _ := esc.handleEscKey()
+	assert.Equal(viewTasks, res.(model).currentView, "esc must return to viewTasks, not viewQueue")
+
+	quit := newTasksOriginReview()
+	res2, cmd := quit.handleQuitKey()
+	assert.Equal(viewTasks, res2.(model).currentView, "q must return to viewTasks, not viewQueue")
+	assert.Nil(cmd)
+}
+
+// TestSplitActiveStillTrueForQueueOriginReview is
+// TestSplitActiveExcludesTasksOriginReview's regression guard: an
+// ordinary queue-origin review (reviewFromView == viewQueue, the zero
+// value) must still render through the split pane, unaffected by the
+// tasks-origin exclusion.
+func TestSplitActiveStillTrueForQueueOriginReview(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview()))
+	assert.True(m.splitActive())
+	assert.Contains(m.viewContent(), "first finding") // pane body content
+}
+
+// TestSplitNormalizeStateHarmlessForTasksOriginReview covers Finding 1's
+// knock-on effect (b): normalizeSplitState unconditionally sets
+// focus=focusDetail for currentView==viewReview while layout==layoutSplit,
+// including for a tasks-origin review that (per splitActive()'s exclusion)
+// renders full-screen rather than via the split pane. Proves the flip is
+// harmless: m.focus is only ever consumed by code gated on splitActive()
+// (rendering/mouse) or by applyLayout's leaving-split branch (which reads
+// it to decide whether to KEEP a loaded review open -- true either way
+// here), so it has no rendering or key-handling impact for a tasks-origin
+// review.
+func TestSplitNormalizeStateHarmlessForTasksOriginReview(t *testing.T) {
+	assert := assert.New(t)
+	m := initTestModel(withCurrentView(viewReview), withDimensions(150, 40))
+	m.layout = layoutSplit
+	m.reviewFromView = viewTasks
+	m.currentReview = makeReview(20, &storage.ReviewJob{ID: 101}, withReviewOutput("fix output"))
+	m.focus = focusList // arbitrary pre-state
+
+	got := m.normalizeSplitState()
+	assert.Equal(focusDetail, got.focus, "the flip happens as documented -- that alone is fine")
+
+	// No rendering impact: still full-screen, review still shown.
+	assert.False(got.splitActive())
+	assert.Contains(got.viewContent(), "fix output")
+	assert.Equal(viewReview, got.currentView)
+
+	// No key-handling impact: esc still returns to viewTasks (the guard
+	// checks reviewFromView, not focus).
+	res, _ := got.handleEscKey()
+	assert.Equal(viewTasks, res.(model).currentView)
+}
+
+// TestSplitTabKeyStampsQueueOriginAfterStaleTasksReview covers Finding 1's
+// knock-on effect (c): handleTabKey's split branch enters viewReview using
+// whatever review the split's background follow-fetch already loaded (not
+// a fresh dispatch through handleReviewMsg's origin-tracking guard), so if
+// m.reviewFromView is left stale from an EARLIER tasks-origin review,
+// splitActive()'s exclusion could misfire and force a genuine queue-origin
+// review full-screen. handleTabKey now stamps reviewFromView = viewQueue
+// on this transition to prevent that.
+func TestSplitTabKeyStampsQueueOriginAfterStaleTasksReview(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview())) // queue-origin review already loaded via follow-fetch
+	m.focus = focusList
+	m.currentView = viewQueue
+	m.reviewFromView = viewTasks // stale, left over from an earlier tasks-origin review
+
+	res, _ := m.handleTabKey()
+	got := res.(model)
+	assert.Equal(viewQueue, got.reviewFromView, "must stamp the real origin, not leave the stale value")
+	assert.Equal(viewReview, got.currentView)
+	assert.Equal(focusDetail, got.focus)
+	assert.True(got.splitActive(), "a genuinely queue-origin review must still render via the split pane")
+}
+
+// TestSplitMouseClickIntoDetailStampsQueueOrigin is
+// TestSplitTabKeyStampsQueueOriginAfterStaleTasksReview's mouse-click
+// counterpart: handleSplitMouse's click-into-the-detail-pane branch has
+// the identical staleness risk (same "already-loaded via follow-fetch, not
+// through the origin-tracking guard" reasoning) and needed the same fix.
+func TestSplitMouseClickIntoDetailStampsQueueOrigin(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview()))
+	m.reviewFromView = viewTasks // stale
+	g := splitGeometry(150, 40, len(reflowHelpRows(m.splitFooterRows(), 150)))
+
+	res, _ := m.handleSplitMouse(mouseClickAt(g.listOuterW+5, 10))
+	got := res.(model)
+	assert.Equal(viewQueue, got.reviewFromView)
+	assert.Equal(focusDetail, got.focus)
+	assert.True(got.splitActive())
+}
+
+// TestPaneLogOutputRejectsMismatchedJobID covers Finding 2: pane-log
+// invalidation previously happened only in scheduleDetailFollow (bumping
+// paneLogSeq on a keyboard/mouse selection change); a selection-mutation
+// path that doesn't call it -- e.g. the control socket's select-job
+// command -- leaves an in-flight pane-log fetch's response for the OLD job
+// still passing the seq-alone gate. paneLogOutputMsg now carries jobID
+// (set in fetchPaneLog from the jobID it was dispatched for), and
+// handlePaneLogOutputMsg requires it to match m.paneLogJobID in addition
+// to seq -- an independent, message-level invariant that doesn't depend on
+// every selection-mutation call site remembering to invalidate the tail.
+func TestPaneLogOutputRejectsMismatchedJobID(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running, tailed
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+
+	// paneLogJobID has moved on to job 2, but the seq wasn't bumped in
+	// lockstep (simulating any path that reassigns paneLogJobID without
+	// going through scheduleDetailFollow's seq-bump invalidation).
+	m.paneLogJobID = 2
+
+	// An in-flight error response tagged for the OLD job (3), with the
+	// still-current seq, must be dropped: jobID mismatches even though seq
+	// matches.
+	res, cmd := m.handlePaneLogOutputMsg(paneLogOutputMsg{jobID: 3, seq: 5, err: errors.New("stale failure from job 3")})
+	got := res.(model)
+	assert.Nil(cmd)
+	require.NoError(t, got.splitDetailErr)
+	assert.Empty(got.paneLogLines)
+	assert.True(got.paneLogStreaming, "a rejected message must not touch any paneLog* state")
+}
+
+// TestSplitReconcileDetailClearsSplitDetailErrOnTailRestart and
+// TestPaneLogOutputSuccessClearsStaleSplitDetailErr cover the round-4
+// finding: splitDetailErr could stick indefinitely when the selection
+// landed on a RUNNING job through a path that bypasses
+// scheduleDetailFollow (e.g. the control socket's select-job, which
+// mutates selectedIdx/selectedJobID directly). splitReconcileDetail
+// cleared it only in its done branch, and handlePaneLogOutputMsg only on
+// the hasMore==false completion path -- so renderDetailPane's running
+// branch, which renders splitDetailErr unconditionally, showed a dead
+// "Failed to load log" from a PREVIOUS job over the new job's live tail
+// forever.
+func TestSplitReconcileDetailClearsSplitDetailErrOnTailRestart(t *testing.T) {
+	assert := assert.New(t)
+	jobs := []storage.ReviewJob{
+		{
+			ID: 4, GitRef: "dddd444", Branch: "main", RepoName: "repoA",
+			Agent: "codex", Status: storage.JobStatusRunning,
+		},
+		{
+			ID: 3, GitRef: "cccc333", Branch: "main", RepoName: "repoA",
+			Agent: "codex", Status: storage.JobStatusRunning,
+		},
+	}
+	m := splitModel(withTestJobs(jobs...), withSelection(1, 3))
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+
+	// Job 3's tail fails: splitDetailErr is recorded for job 3.
+	res, _ := m.handlePaneLogOutputMsg(paneLogOutputMsg{
+		jobID: 3, seq: 5, err: errors.New("tail failed for job 3"),
+	})
+	m = res.(model)
+	require.Error(t, m.splitDetailErr)
+
+	// Control-socket-style selection mutation onto running job 4: no
+	// scheduleDetailFollow, so nothing on this path clears the error.
+	m.selectedIdx, m.selectedJobID = 0, 4
+
+	got, cmd := m.splitReconcileDetail()
+	assert.NotNil(cmd, "a tail restart command must be issued for the newly selected running job")
+	require.NoError(t, got.splitDetailErr, "job 3's error is stale once job 4's tail restarts")
+	assert.Equal(int64(4), got.paneLogJobID)
+	assert.True(got.paneLogStreaming)
+	assert.NotContains(strings.Join(got.renderDetailPane(88, 25), "\n"), "Failed to load log")
+}
+
+func TestPaneLogOutputSuccessClearsStaleSplitDetailErr(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running, tailed
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+	m.splitDetailErr = errors.New("stale error from a previous job")
+
+	// A successful still-running fetch (hasMore == true) proves the pane is
+	// healthy, so the stale error must go even though the tail continues.
+	res, cmd := m.handlePaneLogOutputMsg(paneLogOutputMsg{
+		jobID: 3, seq: 5, hasMore: true, lines: []logLine{{text: "live line"}},
+	})
+	got := res.(model)
+	assert.NotNil(cmd, "a still-running fetch re-arms the poll tick")
+	require.NoError(t, got.splitDetailErr)
+	assert.Equal([]logLine{{text: "live line"}}, got.paneLogLines)
+	assert.True(got.paneLogStreaming)
+}
+
+// ---------------------------------------------------------------------------
+// Control-socket selection changes take the shared detail-follow transition.
+// ---------------------------------------------------------------------------
+
+// TestCtrlSelectJobRoutesThroughDetailFollowInSplit: the control
+// socket's select-job used to mutate
+// selectedIdx/selectedJobID directly, bypassing scheduleDetailFollow. In
+// split layout that left the detail pane tailing the PREVIOUS job (and
+// showing its splitDetailErr) until the next jobs refresh reconciled it,
+// and left the old job's in-flight pane-log fetches able to land, because
+// handlePaneLogOutputMsg's seq and jobID gates both still referenced the
+// old job. handleCtrlSelectJob now routes a real selection change through
+// scheduleDetailFollow when split layout is on.
+func TestCtrlSelectJobRoutesThroughDetailFollowInSplit(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running, tailed
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+	m.paneLogLines = []logLine{{text: "job 3 tail"}}
+	m.splitDetailErr = errors.New("job 3 log error")
+
+	params, err := json.Marshal(map[string]int64{"job_id": 2})
+	require.NoError(err)
+	got, resp, cmd := m.handleCtrlSelectJob(params)
+	require.True(resp.OK, "expected OK, got error: %s", resp.Error)
+	assert.Equal(int64(2), got.selectedJobID)
+	assert.Equal(1, got.selectedIdx)
+	require.NotNil(cmd, "split layout must arm the debounced detail follow")
+	assert.Equal(uint64(6), got.paneLogSeq,
+		"the tail for the job we navigated away from must be invalidated")
+	assert.False(got.paneLogStreaming)
+	require.NoError(got.splitDetailErr, "job 3's error must not stick to job 2")
+
+	// The returned cmd is scheduleDetailFollow's debounce tick, tagged with
+	// the generation the model now carries.
+	tick, ok := cmd().(detailFollowTickMsg)
+	require.True(ok, "expected a detailFollowTickMsg")
+	assert.Equal(got.detailFollowGen, tick.gen)
+}
+
+// TestCtrlSelectJobRejectsInFlightTailResponseFromOldJob: an
+// in-flight pane-log response for the job select-job navigated AWAY from
+// must fail the seq gate, or a SUCCESSFUL one would clear a
+// splitDetailErr that belongs to the newly selected job. Routing select-job
+// through scheduleDetailFollow bumps paneLogSeq, so it is now rejected.
+func TestCtrlSelectJobRejectsInFlightTailResponseFromOldJob(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running, tailed
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+
+	params, err := json.Marshal(map[string]int64{"job_id": 2}) // job 2: done
+	require.NoError(err)
+	got, resp, _ := m.handleCtrlSelectJob(params)
+	require.True(resp.OK, "expected OK, got error: %s", resp.Error)
+
+	// Job 2's own review follow fetch fails: that error belongs to the pane.
+	// gen matches what a REAL follow fetch dispatched for job 2 (after the
+	// reselect above already bumped it via scheduleDetailFollow) would
+	// have captured at dispatch time.
+	res0, _ := got.handleReviewFollowErrMsg(reviewFollowErrMsg{
+		jobID: 2, gen: got.detailFollowGen, err: errors.New("review fetch failed for job 2"),
+	})
+	got = res0.(model)
+	require.Error(got.splitDetailErr)
+
+	// Job 3's successful in-flight tail response lands late, carrying the
+	// pre-select-job seq.
+	res, cmd := got.handlePaneLogOutputMsg(paneLogOutputMsg{
+		jobID: 3, seq: 5, hasMore: true, lines: []logLine{{text: "job 3 line"}},
+	})
+	final := res.(model)
+	assert.Nil(cmd)
+	assert.Empty(final.paneLogLines, "a rejected response applies no lines")
+	assert.Error(final.splitDetailErr, "job 2's error must survive job 3's stale response")
+}
+
+// TestCtrlSelectJobStackedLeavesPaneLogAlone: outside split layout there is
+// no detail pane to follow, so select-job behaves exactly as before -- no
+// follow cmd, no tail invalidation.
+func TestCtrlSelectJobStackedLeavesPaneLogAlone(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(0, 3))
+	m.layout = layoutStacked
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+
+	params, err := json.Marshal(map[string]int64{"job_id": 2})
+	require.NoError(err)
+	got, resp, cmd := m.handleCtrlSelectJob(params)
+	require.True(resp.OK, "expected OK, got error: %s", resp.Error)
+	assert.Nil(cmd)
+	assert.Equal(int64(2), got.selectedJobID)
+	assert.Equal(uint64(5), got.paneLogSeq)
+	assert.True(got.paneLogStreaming)
+}
+
+// reviewNavJobs returns two done jobs so stepReviewNav has somewhere to
+// step to.
+func reviewNavJobs() []storage.ReviewJob {
+	verdictP := "P"
+	return []storage.ReviewJob{
+		{
+			ID: 6, GitRef: "ffff666", Branch: "main", RepoName: "repoA",
+			Agent: "codex", Status: storage.JobStatusDone, Verdict: &verdictP,
+		},
+		{
+			ID: 2, GitRef: "bbbb222", Branch: "feat/x", RepoName: "repoA",
+			Agent: "codex", Status: storage.JobStatusDone, Verdict: &verdictP,
+		},
+	}
+}
+
+// TestStepReviewNavFetchDoesNotReopenReviewAfterEsc: handleReviewMsg's
+// view-switch guard must not compare currentView against
+// m.reviewFromView, which is the Esc RETURN target rather than the fetch's
+// dispatch origin. stepReviewNav dispatches from INSIDE viewReview while
+// reviewFromView still says viewQueue, so escaping back to the queue before
+// the fetch resolved satisfied the guard (queue == queue) and yanked the
+// user back into the review view. The guard now compares against
+// msg.dispatchedFrom, stamped by fetchReview from currentView at
+// command-creation time.
+func TestStepReviewNavFetchDoesNotReopenReviewAfterEsc(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := initTestModel(
+		withCurrentView(viewReview),
+		withDimensions(150, 40),
+		withTestJobs(reviewNavJobs()...),
+		withSelection(1, 2),
+	)
+	m.reviewFromView = viewQueue
+	m.currentReview = makeReview(20, &storage.ReviewJob{ID: 2})
+
+	res, cmd := m.stepReviewNav(-1)
+	got := res.(model)
+	require.NotNil(cmd, "stepping onto a done job dispatches a review fetch")
+	require.Equal(int64(6), got.selectedJobID)
+	assert.Equal(viewReview, got.currentView, "dispatched from inside the review view")
+	assert.Equal(viewQueue, got.reviewFromView, "reviewFromView is the RETURN target, not the origin")
+
+	// The user escapes back to the queue before the fetch resolves.
+	got2, _ := pressSpecial(got, tea.KeyEscape)
+	require.Equal(viewQueue, got2.currentView)
+
+	final, _ := got2.handleReviewMsg(reviewMsg{
+		review: makeReview(20, &storage.ReviewJob{ID: 6}), jobID: 6,
+		dispatchedFrom: viewReview, fetchSeq: got2.reviewFetchSeq,
+	})
+	fm := final.(model)
+	assert.Equal(viewQueue, fm.currentView,
+		"a review-view-dispatched fetch must not re-open the review the user just left")
+	require.NotNil(fm.currentReview, "content is still updated, ready for a return to the review")
+}
+
+// TestStepReviewNavFetchUpdatesInPlaceWhenStillInReview is the counterpart:
+// the user who stays in the review view gets the stepped-to review, exactly
+// as before.
+func TestStepReviewNavFetchUpdatesInPlaceWhenStillInReview(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := initTestModel(
+		withCurrentView(viewReview),
+		withDimensions(150, 40),
+		withTestJobs(reviewNavJobs()...),
+		withSelection(1, 2),
+	)
+	m.reviewFromView = viewQueue
+	m.currentReview = makeReview(20, &storage.ReviewJob{ID: 2})
+
+	res, cmd := m.stepReviewNav(-1)
+	got := res.(model)
+	require.NotNil(cmd)
+
+	final, _ := got.handleReviewMsg(reviewMsg{
+		review: makeReview(21, &storage.ReviewJob{ID: 6}), jobID: 6,
+		dispatchedFrom: viewReview, fetchSeq: got.reviewFetchSeq,
+	})
+	fm := final.(model)
+	assert.Equal(viewReview, fm.currentView)
+	require.NotNil(fm.currentReview)
+	assert.Equal(int64(6), fm.currentReview.JobID)
+}
+
+// TestReviewMsgStampsDispatchOriginFromCurrentView pins the other half of
+// the fix: fetchReview must capture currentView at command-CREATION time
+// (the model is a value snapshot there), not read it when the response is
+// built, so the origin reflects where the user actually was when the fetch
+// was issued.
+func TestReviewMsgStampsDispatchOriginFromCurrentView(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"job_id": 7}`))
+		},
+	))
+	defer ts.Close()
+
+	for _, view := range []viewKind{viewQueue, viewReview, viewTasks} {
+		m := newModel(testEndpointFromURL(ts.URL), withExternalIODisabled())
+		m.currentView = view
+		cmd := m.fetchReview(7, 1)
+		// Navigating away after the command was built must not change the
+		// stamped origin.
+		m.currentView = viewLog
+		msg, ok := cmd().(reviewMsg)
+		require.True(t, ok, "expected a reviewMsg for view %v", view)
+		assert.Equal(t, view, msg.dispatchedFrom)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Layout transitions invalidate and restore pane state.
+// ---------------------------------------------------------------------------
+
+// TestToggleLayoutInvalidatesTailWhenLeavingSplit: leaving
+// split (L) left paneLogStreaming true with paneLogSeq unbumped, while the
+// pending paneLogTickMsg was silently dropped by handlePaneLogTickMsg's
+// layout gate -- the poll chain was dead but the model still claimed an
+// active tail. Toggling back with the same running job selected then found
+// startPaneLog's "already tailing this job" early return satisfied, so the
+// pane sat on frozen stale lines until the job completed (a resize rescued
+// it; L never did). applyLayout now invalidates the tail on the way out.
+// Mirrors TestSplitReconcileDetailRestartsStalledRunningTail's shape.
+func TestToggleLayoutInvalidatesTailWhenLeavingSplit(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running, tailed
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+	m.paneLogLines = []logLine{{text: "line from the abandoned tail"}}
+
+	// L: split -> stacked.
+	res, _ := m.handleToggleLayoutKey()
+	stacked := res.(model)
+	require.Equal(layoutStacked, stacked.layout)
+	assert.Equal(uint64(6), stacked.paneLogSeq, "the abandoned tail must be invalidated")
+	assert.False(stacked.paneLogStreaming, "state must not claim a tail whose poll chain is dead")
+
+	// The tick left over from that tail is now rejected on seq alone.
+	_, deadCmd := stacked.handlePaneLogTickMsg(paneLogTickMsg{seq: 5})
+	assert.Nil(deadCmd)
+
+	// L: back to split, same running job still selected.
+	res2, cmd2 := stacked.handleToggleLayoutKey()
+	split := res2.(model)
+	require.Equal(layoutSplit, split.layout)
+	require.NotNil(cmd2, "returning to split must arm the detail follow")
+	tick, ok := cmd2().(detailFollowTickMsg)
+	require.True(ok, "expected a detailFollowTickMsg")
+
+	res3, cmd3 := split.handleDetailFollowTick(tick)
+	restarted := res3.(model)
+	assert.NotNil(cmd3, "the tail must restart rather than no-op on the stale streaming flag")
+	assert.Greater(restarted.paneLogSeq, stacked.paneLogSeq)
+	assert.True(restarted.paneLogStreaming)
+	assert.Equal(int64(3), restarted.paneLogJobID)
+	assert.Empty(restarted.paneLogLines, "a restart drops the frozen stale lines")
+}
+
+// TestPaneLogPaginateNavFailedReviewCarriesJobID covers Finding 2: the
+// failed-review synthesized by handleJobsMsg's pagination auto-navigate was
+// the one such site missing the JobID stamp, so the split detail pane's
+// dispatcher (which matches currentReview.JobID against the selection)
+// could not recognize it as the selected job's review.
+func TestPaneLogPaginateNavFailedReviewCarriesJobID(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(
+		withCurrentView(viewReview),
+		withTestJobs(storage.ReviewJob{
+			ID: 3, GitRef: "cccc333", Branch: "main", RepoName: "repoA",
+			Agent: "codex", Status: storage.JobStatusRunning,
+		}),
+		withSelection(0, 3),
+	)
+	m.paginateNav = viewReview
+	m.loadingMore = true
+
+	// The appended page's next eligible row is a failed job.
+	res, _ := m.handleJobsMsg(jobsMsg{
+		append: true,
+		jobs: []storage.ReviewJob{
+			{
+				ID: 1, GitRef: "aaaa111", Branch: "main", RepoName: "repoB",
+				Agent: "claude-code", Status: storage.JobStatusFailed, Error: "boom",
+			},
+		},
+	})
+	got := res.(model)
+	require.NotNil(got.currentReview, "auto-navigate synthesizes the failed review")
+	assert.Equal(got.selectedJobID, got.currentReview.JobID,
+		"the synthesized review must be attributable to the job it describes")
+	assert.Contains(got.currentReview.Output, "boom")
+}
+
+// ---------------------------------------------------------------------------
+// handleJobsMsg's pagination auto-navigate block and the fix panel:
+// closeFixPanelIfJobChanged() runs once, near the top
+// of handleJobsMsg (gated on splitActive()), BEFORE this block mutates
+// m.selectedIdx/selectedJobID to step to the newly appended job. A fix panel
+// still open/pending for the job selected BEFORE that step survives the jump
+// bound to the wrong job -- an unfocused panel whose later submission would
+// fix the wrong review. The fix calls closeFixPanelIfJobChanged() again
+// immediately after each of the two mutating branches (viewReview,
+// viewKindPrompt); the viewLog branch already gets this via
+// followSelectionChange, which it calls itself.
+// ---------------------------------------------------------------------------
+
+// TestPaginationAutoNavClosesStaleFixPanelViewReviewFailedJob covers the
+// viewReview arm's Failed-job sub-case, the one the reviewer named
+// explicitly: pagination lands on a failed job and installs a synthesized
+// review while a fix panel bound to the PREVIOUS job is still open.
+func TestPaginationAutoNavClosesStaleFixPanelViewReviewFailedJob(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(
+		withCurrentView(viewReview),
+		withTestJobs(storage.ReviewJob{ID: 2, Status: storage.JobStatusDone}),
+		withSelection(0, 2),
+	)
+	m.paginateNav = viewReview
+	m.loadingMore = true
+	// A fix panel is open, bound to job 2 -- the job pagination is about to
+	// navigate AWAY from.
+	m.reviewFixPanelOpen = true
+	m.fixPromptJobID = 2
+	m.fixPromptText = "unsubmitted fix prompt"
+
+	res, _ := m.handleJobsMsg(jobsMsg{
+		append: true,
+		jobs: []storage.ReviewJob{
+			{ID: 5, Status: storage.JobStatusFailed, Error: "boom"},
+		},
+	})
+	got := res.(model)
+
+	require.Equal(int64(5), got.selectedJobID, "pagination must have navigated to the new job")
+	require.NotNil(got.currentReview)
+	assert.Equal(int64(5), got.currentReview.JobID)
+	assert.False(got.reviewFixPanelOpen,
+		"a fix panel bound to the job pagination navigated AWAY from must not survive the jump")
+	assert.Equal(int64(0), got.fixPromptJobID,
+		"must not stay bound to the stale job -- a later submission would target the wrong review")
+}
+
+// TestPaginationAutoNavClosesStaleFixPanelViewReviewDoneJob covers the
+// viewReview arm's Done-job sub-case, which dispatches a fetch and RETURNS
+// EARLY -- verifying the fix panel is still closed on that early-return path,
+// not only the Failed sub-case that falls through to the function's end.
+func TestPaginationAutoNavClosesStaleFixPanelViewReviewDoneJob(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(
+		withCurrentView(viewReview),
+		withTestJobs(storage.ReviewJob{ID: 2, Status: storage.JobStatusDone}),
+		withSelection(0, 2),
+	)
+	m.paginateNav = viewReview
+	m.loadingMore = true
+	m.reviewFixPanelOpen = true
+	m.fixPromptJobID = 2
+
+	res, cmd := m.handleJobsMsg(jobsMsg{
+		append: true,
+		jobs:   []storage.ReviewJob{{ID: 5, Status: storage.JobStatusDone}},
+	})
+	got := res.(model)
+
+	require.NotNil(cmd, "the Done sub-case dispatches a review fetch and returns early")
+	require.Equal(int64(5), got.selectedJobID)
+	assert.False(got.reviewFixPanelOpen, "the early return must not skip the panel cleanup")
+	assert.Equal(int64(0), got.fixPromptJobID)
+}
+
+// TestPaginationAutoNavClosesStaleFixPanelPromptView covers the
+// viewKindPrompt arm -- the second switch case the reviewer asked to audit
+// alongside viewReview.
+func TestPaginationAutoNavClosesStaleFixPanelPromptView(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(
+		withCurrentView(viewKindPrompt),
+		withTestJobs(storage.ReviewJob{ID: 2, Status: storage.JobStatusDone}),
+		withSelection(0, 2),
+	)
+	m.paginateNav = viewKindPrompt
+	m.loadingMore = true
+	m.reviewFixPanelOpen = true
+	m.fixPromptJobID = 2
+
+	res, _ := m.handleJobsMsg(jobsMsg{
+		append: true,
+		jobs:   []storage.ReviewJob{{ID: 5, Status: storage.JobStatusDone}},
+	})
+	got := res.(model)
+
+	require.Equal(int64(5), got.selectedJobID)
+	assert.False(got.reviewFixPanelOpen,
+		"the prompt-view arm must not leave a panel bound to the job pagination navigated away from")
+	assert.Equal(int64(0), got.fixPromptJobID)
+}
+
+// TestPaginationAutoNavKeepsFixPanelBoundToNewSelection is the negative
+// case: a panel already bound to the job pagination is ABOUT TO select must
+// be left alone -- closeFixPanelIfJobChanged only acts when the job actually
+// changed. Uses the viewKindPrompt arm deliberately: splitActive() excludes
+// viewKindPrompt, so the EARLIER splitActive()-gated closeFixPanelIfJobChanged
+// call near the top of handleJobsMsg (which compares against the selection
+// BEFORE this pagination jump, still job 2 here) does not run and cannot
+// interfere -- the panel reaches this block still bound to job 5 so the fix's
+// own guard is what's actually under test.
+func TestPaginationAutoNavKeepsFixPanelBoundToNewSelection(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(
+		withCurrentView(viewKindPrompt),
+		withTestJobs(storage.ReviewJob{ID: 2, Status: storage.JobStatusDone}),
+		withSelection(0, 2),
+	)
+	m.paginateNav = viewKindPrompt
+	m.loadingMore = true
+	// Panel already bound to job 5 -- the job pagination is about to select.
+	m.reviewFixPanelOpen = true
+	m.fixPromptJobID = 5
+
+	res, _ := m.handleJobsMsg(jobsMsg{
+		append: true,
+		jobs:   []storage.ReviewJob{{ID: 5, Status: storage.JobStatusDone}},
+	})
+	got := res.(model)
+
+	require.Equal(int64(5), got.selectedJobID)
+	assert.True(got.reviewFixPanelOpen, "a panel already bound to the newly selected job must be left alone")
+	assert.Equal(int64(5), got.fixPromptJobID)
+}
+
+// ---------------------------------------------------------------------------
+// Enter is a no-op with the queue focused in split layout -- the
+// detail pane already follows the cursor, so focusing the detail pane on
+// Enter (the old behavior, same as tab) read as "nothing happened".
+// ---------------------------------------------------------------------------
+
+// TestEnterKeyNoOpInSplitListFocus covers the split, list-focus case: Enter
+// on a done job must not move focus, change the view, dispatch a fetch, or
+// flash anything -- the pane already shows the review for the selected job.
+func TestEnterKeyNoOpInSplitListFocus(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(1, 2)) // job 2: done
+	m.focus = focusList
+	prevFlash := m.flashMessage
+
+	res, cmd := m.handleEnterKey()
+	got := res.(model)
+
+	assert.Nil(cmd, "no fetch should be dispatched")
+	assert.Equal(focusList, got.focus)
+	assert.Equal(viewQueue, got.currentView)
+	assert.Equal(prevFlash, got.flashMessage, "no flash message")
+}
+
+// TestEnterKeyNoOpInSplitListFocusRunningJob covers the same no-op for a
+// queued/running job -- previously Enter would flash "no review yet" even
+// though the split pane already shows the job's live status/log.
+func TestEnterKeyNoOpInSplitListFocusRunningJob(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running
+	m.focus = focusList
+
+	res, cmd := m.handleEnterKey()
+	got := res.(model)
+
+	assert.Nil(cmd)
+	assert.Equal(focusList, got.focus)
+	assert.Equal(viewQueue, got.currentView)
+	assert.Empty(got.flashMessage, "the now-pointless 'no review yet' flash must be suppressed in split")
+}
+
+// TestEnterKeyNoOpInSplitListFocusFailedJob covers the failed-job branch:
+// Enter must not synthesize the failed-job error review or stamp focusDetail
+// in split -- that branch becomes unreachable from the queue via Enter in
+// split layout.
+func TestEnterKeyNoOpInSplitListFocusFailedJob(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(2, 1)) // job 1: failed
+	m.focus = focusList
+
+	res, cmd := m.handleEnterKey()
+	got := res.(model)
+
+	assert.Nil(cmd)
+	assert.Equal(focusList, got.focus)
+	assert.Equal(viewQueue, got.currentView)
+	assert.Nil(got.currentReview)
+}
+
+// TestEnterKeyStillDispatchesFetchInStackedLayout is a companion assertion
+// to TestReviewMsgDoesNotClobberTransientView / TestReviewMsgRespectsDispatchOriginQueueThenTasks
+// above: those already cover Enter dispatching the review fetch on a done
+// job in the (default) stacked layout. This test names that behavior
+// directly and pins it against the split no-op added in this task.
+func TestEnterKeyStillDispatchesFetchInStackedLayout(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := initTestModel(
+		withCurrentView(viewQueue),
+		withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...),
+		withSelection(1, 2), // job 2: done
+	)
+	require.Equal(layoutStacked, m.layout)
+
+	res, cmd := m.handleEnterKey()
+	got := res.(model)
+
+	require.NotNil(cmd, "stacked layout must still dispatch the review fetch")
+	assert.Equal(viewQueue, got.currentView, "view flips once the fetch resolves, not synchronously")
+}
+
+// TestSplitFooterListFocusOmitsEnterHint covers the footer side of the same
+// change: the split, list-focus footer must not advertise "review" on
+// enter (it's now a no-op there) but must still show the tab hint used to
+// focus the detail pane.
+func TestSplitFooterListFocusOmitsEnterHint(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(1, 2))
+	m.focus = focusList
+
+	rows := m.splitFooterRows()
+
+	var sawEnter, sawTab bool
+	for _, row := range rows {
+		for _, item := range row {
+			if item.key == "↵" {
+				sawEnter = true
+			}
+			if item.key == "tab" {
+				sawTab = true
+				assert.Equal("focus detail", item.desc)
+			}
+		}
+	}
+	assert.False(sawEnter, "split list-focus footer must not advertise enter/review")
+	assert.True(sawTab, "split list-focus footer must still advertise tab as the focus affordance")
+}
+
+// ---------------------------------------------------------------------------
+// PR feedback fixes: fix panel visibility, stale-review guards on detail
+// focus entry, stale review after rerun, and error text sanitization.
+// ---------------------------------------------------------------------------
+
+// TestReviewPaneFixPanelFocusedRendersInline covers Finding 1: the split
+// detail pane previously ignored m.reviewFixPanelOpen entirely, so pressing
+// F while detail-focused opened the fix prompt (handleKeyMsg routes
+// keystrokes to handleReviewFixPanelKey) but the pane kept showing only the
+// review body -- the user typed blind. The panel must now render inline,
+// below the review body, with the body's window shrunk to make room.
+func TestReviewPaneFixPanelFocusedRendersInline(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview()), withFixPanel(true, true))
+	m.fixPromptText = "add nil check"
+
+	lines := m.renderDetailPane(88, 25)
+	assert.Len(lines, 25, "total pane height must stay exactly innerH")
+	joined := strings.Join(lines, "\n")
+	assert.Contains(joined, "first finding", "review body must still render above the panel")
+	assert.Contains(joined, " > add nil check_", "focused input line must show the prompt text and cursor")
+	assert.Contains(joined, "tab: scroll review | enter: submit | esc: cancel")
+}
+
+// TestReviewPaneFixPanelUnfocusedRendersDimmed covers the unfocused variant
+// of Finding 1: panel open but keyboard focus still on the pane/list, shown
+// dimmed with the default-prompt hint.
+func TestReviewPaneFixPanelUnfocusedRendersDimmed(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview()), withFixPanel(true, false))
+
+	lines := m.renderDetailPane(88, 25)
+	assert.Len(lines, 25)
+	joined := strings.Join(lines, "\n")
+	assert.Contains(joined, "Fix (Tab to focus)")
+	assert.Contains(joined, "(blank = default)")
+	assert.Contains(joined, "F: fix | tab: focus fix panel")
+}
+
+// TestReviewPaneFixPanelClosedRendersUnchanged is the Finding 1 baseline:
+// with the panel closed, rendering must be byte-identical to before this
+// fix (no panel markers, no height change).
+func TestReviewPaneFixPanelClosedRendersUnchanged(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview()))
+	baseline := m.renderDetailPane(88, 25)
+
+	m.reviewFixPanelOpen = false
+	m.reviewFixPanelFocused = false
+	closed := m.renderDetailPane(88, 25)
+
+	assert.Equal(baseline, closed, "panel closed must render identically to the no-panel baseline")
+	joined := strings.Join(closed, "\n")
+	assert.NotContains(joined, "Fix (Tab to focus)")
+	assert.NotContains(joined, "tab: scroll review")
+}
+
+// TestReviewPaneFixPanelReservesHeightFromScrollInfo checks that
+// reviewPaneScrollInfo's line math (shared with renderReviewPaneBody via
+// reviewPaneHeaderLines/reviewPaneBodyLines) accounts for the panel's
+// reserved rows, so the split info line's "[x-y of z lines]" stays honest
+// once the panel is showing.
+func TestReviewPaneFixPanelReservesHeightFromScrollInfo(t *testing.T) {
+	assert := assert.New(t)
+	rev := splitTestReview()
+	var sb strings.Builder
+	for i := range 60 {
+		fmt.Fprintf(&sb, "line %d of output\n\n", i)
+	}
+	rev.Output = sb.String()
+
+	closedM := splitModel(withReview(rev))
+	_, closedEnd, closedTotal := closedM.reviewPaneScrollInfo(88, 25)
+
+	openM := splitModel(withReview(rev), withFixPanel(true, true))
+	_, openEnd, openTotal := openM.reviewPaneScrollInfo(88, 25)
+
+	assert.Equal(closedTotal, openTotal, "total line count is unaffected by the panel")
+	assert.Less(openEnd, closedEnd, "the panel must shrink the visible body window")
+}
+
+// TestSplitTabKeyNoOpWhenSelectedReviewStale covers Finding 2: after
+// selecting a running/queued job, m.currentReview can still hold a
+// PREVIOUSLY selected job's review (the follow-fetch hasn't caught up, or
+// never will for a job with no review). tab must not enter detail focus in
+// that case -- doing so would hand review actions (close/comment/fix) to
+// the wrong job.
+func TestSplitTabKeyNoOpWhenSelectedReviewStale(t *testing.T) {
+	assert := assert.New(t)
+	// currentReview is for job 2; selection is on job 3 (running).
+	m := splitModel(withReview(splitTestReview()), withSelection(0, 3))
+
+	res, _ := m.handleTabKey()
+	got := res.(model)
+	assert.Equal(focusList, got.focus, "must not enter detail focus with a stale review for a different job")
+	assert.Equal(viewQueue, got.currentView)
+
+	// Selection back on the matching job: tab works normally again.
+	got.selectedIdx, got.selectedJobID = 1, 2
+	res2, _ := got.handleTabKey()
+	got2 := res2.(model)
+	assert.Equal(focusDetail, got2.focus)
+	assert.Equal(viewReview, got2.currentView)
+}
+
+// TestSplitMouseClickIntoDetailNoOpWhenSelectedReviewStale is the mouse
+// counterpart of TestSplitTabKeyNoOpWhenSelectedReviewStale: a click into
+// the detail pane must not enter detail focus either while the loaded
+// review belongs to a different job than the one currently selected.
+func TestSplitMouseClickIntoDetailNoOpWhenSelectedReviewStale(t *testing.T) {
+	assert := assert.New(t)
+	// currentReview is for job 2; selection is on job 3 (running).
+	m := splitModel(withReview(splitTestReview()), withSelection(0, 3))
+	g := splitGeometry(150, 40, len(reflowHelpRows(m.splitFooterRows(), 150)))
+
+	res, _ := m.handleSplitMouse(mouseClickAt(g.listOuterW+5, 10))
+	got := res.(model)
+	assert.Equal(focusList, got.focus, "detail-side click must not enter detail focus with a stale review")
+	assert.Equal(viewQueue, got.currentView)
+}
+
+// TestRerunResultClearsStaleCurrentReview covers Finding 3: a rerun reuses
+// the same job ID, so once the rerun completes `currentReview.JobID ==
+// job.ID` would wrongly keep matching the review from the PREVIOUS attempt.
+// On a confirmed-successful rerun of the job whose review is currently
+// loaded, currentReview (and its dependent state) must be cleared so the
+// follow/reconcile machinery refetches once the rerun finishes.
+func TestRerunResultClearsStaleCurrentReview(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview()), withSelection(1, 2)) // job 2 done, review loaded
+	m.currentResponses = []storage.Response{{ID: 1}}
+	m.reviewScroll = 12
+	m.splitDetailErr = errors.New("stale")
+
+	res, _ := m.handleRerunResultMsg(rerunResultMsg{jobID: 2})
+	got := res.(model)
+	assert.Nil(got.currentReview)
+	assert.Nil(got.currentResponses)
+	assert.Equal(0, got.reviewScroll)
+	assert.NoError(got.splitDetailErr)
+}
+
+// TestRerunResultMsgErrRetainsCurrentReview covers Finding 3's failure
+// path: a failed rerun request must leave the previously loaded review in
+// place (only the optimistic job-state fields are rolled back).
+func TestRerunResultMsgErrRetainsCurrentReview(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview()), withSelection(1, 2))
+
+	res, _ := m.handleRerunResultMsg(rerunResultMsg{jobID: 2, err: errors.New("boom")})
+	got := res.(model)
+	assert.NotNil(got.currentReview)
+	assert.Equal(int64(2), got.currentReview.JobID)
+}
+
+// TestRerunResultMsgLeavesUnrelatedReviewAlone covers Finding 3's JobID
+// guard: a rerun confirmation for a DIFFERENT job than the one currently
+// loaded (e.g. rerunning from the queue while a different review is open)
+// must not clear currentReview.
+func TestRerunResultMsgLeavesUnrelatedReviewAlone(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview()), withSelection(1, 2)) // review for job 2
+
+	res, _ := m.handleRerunResultMsg(rerunResultMsg{jobID: 3}) // rerunning job 3, unrelated
+	got := res.(model)
+	require.NotNil(t, got.currentReview)
+	assert.Equal(int64(2), got.currentReview.JobID)
+}
+
+// TestRerunResultThenJobDoneTriggersFollowFetch is the reviewer's
+// queued-to-done transition scenario for Finding 3: after a rerun
+// confirmation clears the stale review, the job later reappearing as done
+// in a jobsMsg must make splitReconcileDetail issue a fresh follow fetch
+// rather than silently doing nothing (which is what the stale JobID match
+// used to cause).
+func TestRerunResultThenJobDoneTriggersFollowFetch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withReview(splitTestReview()), withSelection(1, 2)) // job 2 done, review loaded
+
+	res, _ := m.handleRerunResultMsg(rerunResultMsg{jobID: 2})
+	m = res.(model)
+	require.Nil(m.currentReview)
+
+	// The job later reports done again (rerun completed).
+	jobs := testQueueJobs()
+	res2, cmd := m.handleJobsMsg(jobsMsg{jobs: jobs, stats: storage.JobStats{}})
+	got := res2.(model)
+	assert.Equal(int64(2), got.selectedJobID)
+	assert.NotNil(cmd, "splitReconcileDetail must issue a follow fetch to reload the review after rerun")
+}
+
+// TestDetailPaneFailedJobSanitizesError covers Finding 4: job.Error is
+// untrusted process/agent output rendered directly in the failed-job
+// branch (before any follow-fetch has synthesized a sanitized pseudo-
+// review). It must be run through sanitizeForDisplay so it can't inject
+// terminal escapes -- OSC clipboard writes, CSI cursor/screen control, or
+// \r/\b overwrite tricks.
+func TestDetailPaneFailedJobSanitizesError(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(2, 1)) // job 1: failed
+	m.currentReview = nil
+	m.jobs[2].Error = "boom \x1b]52;c;evil\x07 \x1b[2Jmore\rtext\x08here"
+
+	lines := m.renderDetailPane(88, 25)
+	joined := strings.Join(lines, "\n")
+	assert.Contains(joined, "boom")
+	assert.Contains(joined, "moretexthere")
+	// The pane's own chrome (titleStyle, failStyle, ...) legitimately emits
+	// SGR color codes, so assert on the malicious payload specifically
+	// rather than banning \x1b outright: no OSC/CSI injection sequences,
+	// and no raw \r/\x08 survive anywhere in the rendered output.
+	assert.NotContains(joined, "\x1b]52")
+	assert.NotContains(joined, "\x1b[2J")
+	assert.NotContains(joined, "\r")
+	assert.NotContains(joined, "\x08")
+}
+
+// ---------------------------------------------------------------------------
+// Follow-up: normalizeSplitState's viewReview/currentReview repair must
+// hold regardless of layout, not just in split. Scoped review finding: a
+// rerun-success clear (Finding 3) has no view guard, and a control-socket
+// rerun (unlike the interactive rerun key, which requires currentView ==
+// viewQueue) can complete while a full-screen review of the SAME job is
+// open in STACKED layout. Split self-heals via normalizeSplitState's
+// existing viewReview branch; stacked previously had no equivalent, so
+// currentView was left dangling on viewReview with a nil currentReview --
+// viewContent's nil guard silently falls back to rendering the queue while
+// currentView (and therefore key routing) stays on viewReview, so
+// arrow/page keys keep manipulating the invisible reviewScroll instead of
+// the queue until the user presses esc.
+// ---------------------------------------------------------------------------
+
+// TestNormalizeSplitStateRepairsStaleReviewViewStacked is scenario (a) from
+// the review: stacked layout, full-screen review of job X open, a
+// rerunResultMsg success for X arrives (e.g. via the control socket, which
+// unlike the interactive rerun key has no currentView guard). Going through
+// the full Update() chokepoint (which calls normalizeSplitState after every
+// handler), currentView must land back on viewQueue -- a visible, coherent
+// view -- rather than staying on viewReview with nothing loaded, and a
+// subsequent down-key must move the queue cursor, not the orphaned
+// reviewScroll.
+func TestNormalizeSplitStateRepairsStaleReviewViewStacked(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := initTestModel(
+		withCurrentView(viewReview),
+		withDimensions(80, 24),
+		withTestJobs(testQueueJobs()...),
+		withSelection(1, 2), // job 2: done, review open
+		withReview(splitTestReview()),
+	)
+	m.layout = layoutStacked
+
+	res, _ := m.Update(rerunResultMsg{jobID: 2})
+	got, ok := res.(model)
+	require.True(ok)
+	assert.Equal(viewQueue, got.currentView, "must repair to a visible, coherent view even in stacked layout")
+	assert.Nil(got.currentReview)
+	assert.Equal(0, got.reviewScroll)
+
+	// A down-key now moves the queue cursor, not the (now-meaningless)
+	// reviewScroll -- proving key routing actually followed the repaired
+	// view rather than a redraw-only fix.
+	prevSelected := got.selectedJobID
+	res2, _ := got.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	got2, ok := res2.(model)
+	require.True(ok)
+	assert.NotEqual(prevSelected, got2.selectedJobID, "down must move the queue cursor now that the view is repaired")
+	assert.Equal(0, got2.reviewScroll, "reviewScroll must not have absorbed the down-key")
+}
+
+// TestNormalizeSplitStateRerunStillHealsInSplit is scenario (b): the split
+// equivalent of the stacked repair above must keep behaving exactly as it
+// did before this fix -- the detail pane falls back to its loading/status
+// rendering and focus is normalized back to the list.
+func TestNormalizeSplitStateRerunStillHealsInSplit(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withReview(splitTestReview()), withSelection(1, 2)) // job 2 done, review loaded
+	m.focus = focusDetail
+	m.currentView = viewReview
+
+	res, _ := m.Update(rerunResultMsg{jobID: 2})
+	got, ok := res.(model)
+	require.True(ok)
+	assert.Equal(viewQueue, got.currentView)
+	assert.Equal(focusList, got.focus, "split focus must be normalized back to the list")
+	assert.Nil(got.currentReview)
+
+	// The detail pane renders its fallback (loading/status card) rather
+	// than panicking or showing stale content -- job 2 still reports done
+	// in m.jobs, so this is the "loading" branch pending a fresh
+	// follow-fetch.
+	lines := strings.Join(got.renderDetailPane(88, 20), "\n")
+	assert.Contains(lines, "Loading")
+}
+
+// TestNormalizeSplitStateRerunOfDifferentJobLeavesReviewOpen is scenario
+// (c): a stacked full-screen review of job X must stay open, untouched,
+// when a DIFFERENT job's rerun is confirmed -- the JobID guard in
+// handleRerunResultMsg (Finding 3) must not over-fire.
+func TestNormalizeSplitStateRerunOfDifferentJobLeavesReviewOpen(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := initTestModel(
+		withCurrentView(viewReview),
+		withDimensions(80, 24),
+		withTestJobs(testQueueJobs()...),
+		withSelection(1, 2), // job 2: done, review open
+		withReview(splitTestReview()),
+	)
+	m.layout = layoutStacked
+
+	res, _ := m.Update(rerunResultMsg{jobID: 3}) // unrelated job
+	got, ok := res.(model)
+	require.True(ok)
+	assert.Equal(viewReview, got.currentView, "an unrelated job's rerun must not touch the open review")
+	require.NotNil(got.currentReview)
+	assert.Equal(int64(2), got.currentReview.JobID)
+}
+
+// ---------------------------------------------------------------------------
+// A race in the rerun invalidation above: clearing currentReview on rerun
+// success does not by itself invalidate an ALREADY IN-FLIGHT follow fetch
+// for the same job:
+//
+//   1. Follow fetch for job X dispatched (75ms debounce fired), stamped
+//      with the gen it was dispatched at.
+//   2. Rerun of X confirms -- handleRerunResultMsg's clear nils
+//      currentReview.
+//   3. The OLD fetch's reviewMsg lands. Its jobID staleness gate
+//      (jobID == selectedJobID) still passes -- selection never moved --
+//      so the follow path restored the PREVIOUS attempt's review right
+//      back into currentReview.
+//   4. When the rerun completes, splitReconcileDetail sees
+//      currentReview.JobID == X and skips fetching the new result: the
+//      stale review is shown indefinitely.
+//
+// Fixed by tagging follow fetches with m.detailFollowGen at dispatch
+// (reviewMsg.gen, stamped in fetchReviewFollow) and rejecting a follow
+// response in handleReviewMsg whose gen no longer matches
+// m.detailFollowGen -- which handleRerunResultMsg's rerun-success clear now
+// also bumps, so step 3's stale response is dropped instead of landing.
+// ---------------------------------------------------------------------------
+
+// TestFollowRejectsPreRerunAttemptAfterRerunClear reproduces the exact
+// race: a follow fetch's response, stamped at its dispatch time, arrives
+// AFTER a rerun-success clear for the same job. It must be rejected
+// (currentReview stays nil, not resurrected), and the subsequent done
+// transition must still trigger a fresh fetch rather than being skipped as
+// "already loaded."
+//
+// The rejecting mechanism is the per-job attempt stamp, not
+// detailFollowGen, which a confirmed rerun does not bump.
+func TestFollowRejectsPreRerunAttemptAfterRerunClear(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(1, 2), withReview(splitTestReview())) // job 2 done, review loaded
+
+	// A follow fetch for job 2 was dispatched earlier and is still in
+	// flight -- capture the gen it was stamped with at dispatch time, the
+	// same way fetchReviewFollow does (m.detailFollowGen at call time).
+	oldGen := m.detailFollowGen
+
+	// The rerun for job 2 is confirmed while that fetch is still in
+	// flight: the clear nils currentReview and bumps job 2's attempt
+	// counter.
+	res, _ := m.handleRerunResultMsg(rerunResultMsg{jobID: 2})
+	m = res.(model)
+	require.Nil(m.currentReview)
+	require.Positive(m.jobAttemptGen[2])
+
+	// The stale fetch's response lands now, still tagged with the
+	// pre-rerun gen and (implicitly) the pre-rerun attempt 0. jobID ==
+	// selectedJobID still holds (selection never moved), so only an
+	// attempt/gen check can catch it.
+	res2, _ := m.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2, follow: true, gen: oldGen,
+	})
+	got := res2.(model)
+	assert.Nil(got.currentReview, "a follow response dispatched before the rerun-success gen bump must not resurrect the stale review")
+
+	// The job later reports done again (rerun completed): splitReconcileDetail
+	// must issue a fresh follow fetch, not skip it thinking the (correctly
+	// nil) currentReview is already loaded.
+	res3, cmd := got.handleJobsMsg(jobsMsg{jobs: testQueueJobs(), stats: storage.JobStats{}})
+	got2 := res3.(model)
+	assert.Equal(int64(2), got2.selectedJobID)
+	assert.NotNil(cmd, "must fetch the fresh review instead of leaving the stale one cleared forever")
+}
+
+// TestFollowAtCurrentGenLandsNormally is the non-regression counterpart:
+// a follow fetch dispatched at (and still tagged with) the current
+// generation must land exactly as before this fix.
+func TestFollowAtCurrentGenLandsNormally(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(1, 2))
+	// A real selection move bumps detailFollowGen; the fetch dispatched
+	// for the new selection is stamped with the post-bump value.
+	m, _ = m.scheduleDetailFollow()
+
+	res, _ := m.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2, follow: true, gen: m.detailFollowGen,
+	})
+	got := res.(model)
+	require.NotNil(t, got.currentReview, "a follow response at the current gen must still land")
+	assert.Equal(int64(2), got.currentReview.JobID)
+}
+
+// TestFetchReviewFollowStampsCurrentGen is a direct unit check on the
+// stamping half of the fix: fetchReviewFollow's dispatched reviewMsg
+// carries whatever m.detailFollowGen was at call time.
+func TestFetchReviewFollowStampsCurrentGen(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	_, m := mockServerModel(t, mockReviewHandler(*splitTestReview(), nil))
+	m.layout = layoutSplit
+	m.jobs = testQueueJobs()
+	m.selectedIdx, m.selectedJobID = 1, 2
+	m.detailFollowGen = 7
+
+	cmd := m.fetchReviewFollow(2, 9)
+	msg := cmd()
+	rm, ok := msg.(reviewMsg)
+	require.True(ok, "expected a reviewMsg, got %T", msg)
+	assert.True(rm.follow)
+	assert.Equal(uint64(7), rm.gen)
+	assert.Equal(uint64(9), rm.fetchSeq, "fetchSeq must be stamped through verbatim")
+}
+
+// TestFetchReviewStampsCurrentGen is TestFetchReviewFollowStampsCurrentGen's
+// counterpart for every
+// fetchReview call, not just the follow wrapper: a regular (non-follow)
+// fetch also carries whatever m.detailFollowGen was at call time.
+func TestFetchReviewStampsCurrentGen(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	_, m := mockServerModel(t, mockReviewHandler(*splitTestReview(), nil))
+	m.jobs = testQueueJobs()
+	m.selectedIdx, m.selectedJobID = 1, 2
+	m.detailFollowGen = 9
+
+	cmd := m.fetchReview(2, 1)
+	msg := cmd()
+	rm, ok := msg.(reviewMsg)
+	require.True(ok, "expected a reviewMsg, got %T", msg)
+	assert.False(rm.follow)
+	assert.Equal(uint64(9), rm.gen)
+	assert.Equal(uint64(1), rm.fetchSeq, "an ordinary fetch is stamped with the shared epoch too")
+}
+
+// TestQueueEnterLandsAtUnchangedGenInStackedMode is the non-regression case
+// for widening the gen check to non-follow fetches: a plain queue Enter in
+// stacked mode (detailFollowGen is a split-only mechanism, so nothing ever
+// bumps it here) must still open the review normally when the response
+// lands.
+func TestQueueEnterLandsAtUnchangedGenInStackedMode(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	_, m := mockServerModel(t, mockReviewHandler(*splitTestReview(), nil))
+	m.currentView = viewQueue
+	m.jobs = testQueueJobs()
+	m.selectedIdx, m.selectedJobID = 1, 2 // job 2: done
+	require.Equal(layoutStacked, m.layout)
+
+	cmd := m.enterReviewCmd(m.jobs[1])
+	msg := cmd()
+	rm, ok := msg.(reviewMsg)
+	require.True(ok, "expected a reviewMsg, got %T", msg)
+	assert.Equal(uint64(0), rm.gen, "gen must be unchanged (0) -- nothing bumps detailFollowGen in stacked mode")
+
+	res, _ := m.handleReviewMsg(rm)
+	got := res.(model)
+	require.NotNil(got.currentReview, "a legitimate stacked-mode fetch must still land")
+	assert.Equal(viewReview, got.currentView)
+}
+
+// TestNonFollowFetchRejectedAfterInterveningSelectionChange is the stale
+// case for the same fix: a non-follow fetch dispatched for job 2, with a
+// split-mode selection change (which bumps detailFollowGen) landing before
+// the response arrives, must be rejected -- even though the response's
+// jobID still equals the (now-restored) selectedJobID, so the pre-existing
+// jobID-only check alone would have let it through.
+func TestNonFollowFetchRejectedAfterInterveningSelectionChange(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(1, 2)) // job 2 selected
+
+	// A non-follow fetch for job 2 (e.g. stepReviewNav) was dispatched and
+	// is still in flight, stamped with the gen at that time.
+	oldGen := m.detailFollowGen
+
+	// The cursor moves away and back to job 2 before the fetch resolves --
+	// each move goes through the real handleKeyMsg -> scheduleDetailFollow
+	// path (the production mechanism, per handlers.go's post-processing
+	// wrapper: a split-mode selection change bumps detailFollowGen), so by
+	// the time the cursor lands back on job 2 the gen has moved even though
+	// the selected job hasn't.
+	m, _ = pressSpecial(m, tea.KeyDown)
+	m, _ = pressSpecial(m, tea.KeyUp)
+	require.Equal(int64(2), m.selectedJobID)
+	require.Greater(m.detailFollowGen, oldGen)
+
+	res, _ := m.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2, gen: oldGen,
+	})
+	got := res.(model)
+	assert.Nil(got.currentReview, "a non-follow fetch dispatched before an intervening away-and-back gen bump must be rejected")
+}
+
+// TestNonFollowFetchRejectedAfterSameJobRerunConfirms is Finding A's core
+// repro: a regular (non-follow) fetchReview for job 2 -- e.g. a queue Enter
+// or stepReviewNav re-fetch -- is still in flight when a rerun of that same
+// selected job is confirmed. Pre-fix, only fetchReviewFollow stamped gen, so
+// this response passed the jobID==selectedJobID check alone (a rerun
+// doesn't move the selection) and resurrected the previous attempt's
+// review.
+func TestNonFollowFetchRejectedAfterSameJobRerunConfirms(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(1, 2), withReview(splitTestReview())) // job 2, review loaded
+	m.currentView = viewQueue
+
+	oldGen := m.detailFollowGen
+
+	// Rerun of job 2 (the currently displayed job) confirms while the
+	// stale fetch is still in flight.
+	res, _ := m.handleRerunResultMsg(rerunResultMsg{jobID: 2})
+	m = res.(model)
+	require.Nil(m.currentReview)
+	require.Positive(m.jobAttemptGen[2])
+
+	// The stale (pre-rerun) fetch's response lands now, still tagged with
+	// oldGen and the pre-rerun attempt 0.
+	res2, _ := m.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2, gen: oldGen, dispatchedFrom: viewQueue,
+	})
+	got := res2.(model)
+	assert.Nil(got.currentReview, "a non-follow fetch dispatched before the rerun must not resurrect the stale review")
+}
+
+// TestSelectedJobRerunInvalidatesFetchEvenWhileReviewLoading covers Finding
+// B: the invalidation on a confirmed rerun used to be gated on
+// m.currentReview already matching the reran job, so a rerun confirmed
+// while the pane was still LOADING (currentReview nil, an earlier follow
+// fetch in flight) invalidated nothing at all. The stale in-flight fetch's
+// response would then pass every check unchanged, populate currentReview
+// with the OLD attempt's content, and block the rerun's real result from
+// ever being fetched. (The invalidation is the per-job attempt counter,
+// which is what the assertion below names.)
+func TestSelectedJobRerunInvalidatesFetchEvenWhileReviewLoading(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running, selected
+	m.currentReview = nil                // pane still loading -- no review yet
+
+	oldGen := m.detailFollowGen
+
+	res, _ := m.handleRerunResultMsg(rerunResultMsg{jobID: 3})
+	got := res.(model)
+	assert.Positive(got.jobAttemptGen[3],
+		"the attempt counter must bump for a confirmed rerun even while currentReview is still nil")
+
+	// The stale in-flight follow response lands, tagged with the pre-rerun
+	// gen and attempt.
+	res2, _ := got.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 3, follow: true, gen: oldGen,
+	})
+	got2 := res2.(model)
+	assert.Nil(got2.currentReview, "the stale follow response must be rejected, not populate currentReview with the old attempt")
+
+	// The job later reports done: reconcile must fetch fresh, not skip
+	// thinking a nil currentReview is somehow already the answer.
+	doneJobs := testQueueJobs()
+	doneJobs[0].Status = storage.JobStatusDone // job 3
+	res3, cmd := got2.handleJobsMsg(jobsMsg{jobs: doneJobs, stats: storage.JobStats{}})
+	got3 := res3.(model)
+	require.Equal(int64(3), got3.selectedJobID)
+	assert.NotNil(cmd, "must fetch the fresh review instead of leaving currentReview nil forever")
+}
+
+// TestRerunClearsFixPanelForRerunJob covers Finding C: the inline fix panel
+// is scoped to whatever review is on screen (fixPromptJobID stamped from
+// that review's job), so invalidating currentReview on rerun success must
+// also close the panel -- otherwise, once the view repairs back to the
+// queue and the user opens a DIFFERENT review, the stale panel renders over
+// it and submitting would target the reran job instead of the one
+// displayed. handleRerunResultMsg is reached identically whether the rerun
+// was dispatched via the key handler (handleRerunKey) or the control-socket
+// path (handleCtrlRerunJob) -- both just call rerunJob, whose returned cmd
+// produces the rerunResultMsg this handler processes -- so exercising the
+// handler directly covers both dispatch paths.
+func TestRerunClearsFixPanelForRerunJob(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(1, 2), withReview(splitTestReview())) // job 2 review loaded
+	m.reviewFixPanelOpen = true
+	m.reviewFixPanelFocused = true
+	m.fixPromptText = "some in-progress fix text"
+	m.fixPromptJobID = 2
+
+	res, _ := m.handleRerunResultMsg(rerunResultMsg{jobID: 2})
+	got := res.(model)
+
+	assert.False(got.reviewFixPanelOpen)
+	assert.False(got.reviewFixPanelFocused)
+	assert.False(got.reviewFixPanelPending)
+	assert.Equal(int64(0), got.fixPromptJobID)
+	assert.Empty(got.fixPromptText)
+}
+
+// TestFixPanelPendingNotClearedWhenSuperseded: handleReviewMsg's
+// early-reject branch clears reviewFixPanelPending
+// (and pendingReviewOpenJobID) ONLY on a genuine jobID mismatch, never on
+// a gen-mismatch-alone rejection with the selected job UNCHANGED -- a gen
+// bump alone does not mean the underlying 'F' request was abandoned (see
+// that branch's doc comment for the full derivation: scheduleDetailFollow
+// can bump gen via a same-job bootstrap that is explicitly NOT
+// abandonment, and handleRerunResultMsg -- the other gen-bumper -- now
+// disarms both intents itself at the point it confirms a genuine
+// abandonment, rather than leaving it to this reactive path).
+//
+// The retired test used a real down-then-up cursor move to produce the gen
+// bump, believing it isolated "gen mismatch alone" -- it did not: each
+// move is ALSO a genuine (if transient) selection change, and
+// closeFixPanelIfJobChanged (called from scheduleDetailFollow on the
+// intermediate "down" move, before "up" restores the selection) already
+// clears the panel via that entirely different, job-comparison-based path
+// before handleReviewMsg ever sees the stale response. This test uses a
+// direct gen bump
+// instead, so it actually isolates handleReviewMsg's OWN rejection logic
+// from closeFixPanelIfJobChanged's independent one.
+//
+// Note on the rescue interaction:
+// reviewIntentRescuable serves a gen-stale response for the
+// SAME job when it's still the single freshest dispatch (fetchSeq
+// matches) AND an intent is armed for it -- so "gen-mismatch alone never
+// touches the panel" is not quite true, and would
+// be a lie to keep as the test's name. What this pins NOW is narrower but
+// still real: a gen-mismatched response that is ALSO NOT the freshest
+// dispatch (something newer went out since -- simulated here by advancing
+// m.reviewFetchSeq past the message's own fetchSeq) is neither cleared NOR
+// served -- it's simply dropped, exactly like a superseded response would
+// be, leaving the panel exactly as it was for whatever IS the freshest
+// dispatch to eventually resolve. See
+// TestFixPanelPendingRescuedOnGenMismatchWhenStillFreshest for the
+// sibling case this test no longer covers (rescue).
+func TestFixPanelPendingNotClearedWhenSuperseded(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(1, 2)) // job 2 selected
+	m.reviewFixPanelPending = true
+	m.fixPromptJobID = 2
+
+	oldGen := m.detailFollowGen
+	oldSeq := m.reviewFetchSeq
+	// A same-job bootstrap (e.g. maybeBootstrapDetail on a resize/L) or a
+	// same-job rerun confirmation -- either way, gen bumps with the
+	// selection unchanged. A newer dispatch (e.g. a fresh 'F' or Enter) has
+	// ALSO since gone out, superseding this message's own fetchSeq -- so
+	// it is not the single freshest one anymore, and must not be rescued.
+	m.detailFollowGen++
+	m.reviewFetchSeq++
+
+	res, _ := m.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2, gen: oldGen, fetchSeq: oldSeq,
+	})
+	got := res.(model)
+	assert.True(got.reviewFixPanelPending,
+		"a gen-mismatched, non-freshest response must NOT clear a still-valid pending fix panel")
+	assert.Equal(int64(2), got.fixPromptJobID)
+	assert.Nil(got.currentReview, "the stale response must still not populate currentReview")
+}
+
+// TestFixPanelPendingRescuedOnGenMismatchWhenStillFreshest pins the rescue
+// half of the same fix: a gen-mismatched response for the SAME still-
+// selected job that IS still the single freshest dispatch (nothing newer
+// went out since) must be served -- not silently discarded -- because
+// nothing else is guaranteed to ever serve the pending fix panel
+// otherwise (a same-job maybeBootstrapDetail bump's own
+// debounced follow can be dropped, e.g. if the layout flips back before it
+// fires).
+func TestFixPanelPendingRescuedOnGenMismatchWhenStillFreshest(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(1, 2)) // job 2 selected
+	m.reviewFixPanelPending = true
+	m.fixPromptJobID = 2
+
+	oldGen := m.detailFollowGen
+	seq := m.reviewFetchSeq // nothing newer dispatched since
+	// A same-job bootstrap bumps gen; nothing else has been dispatched.
+	m.detailFollowGen++
+
+	res, _ := m.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2, gen: oldGen, fetchSeq: seq, dispatchedFrom: viewQueue,
+	})
+	got := res.(model)
+	assert.True(got.reviewFixPanelOpen,
+		"the gen-stale response must be rescued -- nothing else was going to serve this pending fix panel")
+	assert.False(got.reviewFixPanelPending)
+	assert.NotNil(got.currentReview, "the rescued response's content must be accepted")
+}
+
+// ---------------------------------------------------------------------------
+// Actions taken while the split LIST is focused mutate queue state and
+// must keep currentReview in sync, because currentView stays viewQueue so
+// the review-view-only code paths are skipped.
+// ---------------------------------------------------------------------------
+
+// TestSplitListCloseFlipsCurrentReviewClosedState covers Finding 1: closing
+// a review from the split list (list focus, currentView still viewQueue)
+// updated job.Closed/pendingClosed/stats, but never touched
+// currentReview.Closed -- so the detail pane's header kept showing the old
+// closed state, and reconciliation had no reason to fix it (the job ID
+// still matched). A failing closedResultMsg must roll BOTH back together,
+// keyed by the same seq.
+func TestSplitListCloseFlipsCurrentReviewClosedState(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withReview(splitTestReview())) // job 2 selected+loaded, list focus
+	m.jobs[1].Closed = new(false)
+
+	res, _ := m.handleCloseKey()
+	got := res.(model)
+	require.NotNil(got.currentReview)
+	assert.True(got.currentReview.Closed, "currentReview.Closed must flip alongside the job when closing from the split list")
+	require.NotNil(got.jobs[1].Closed)
+	assert.True(*got.jobs[1].Closed)
+
+	lines := strings.Join(got.renderDetailPane(88, 25), "\n")
+	assert.Contains(lines, "[CLOSED]", "the pane header must reflect the optimistic close immediately")
+
+	pending, ok := got.pendingClosed[2]
+	require.True(ok)
+	res2, _ := got.handleClosedResultMsg(closedResultMsg{
+		jobID: 2, oldState: false, newState: true, seq: pending.seq,
+		err: errors.New("server error"),
+	})
+	got2 := res2.(model)
+	require.NotNil(got2.jobs[1].Closed)
+	assert.False(*got2.jobs[1].Closed, "job.Closed must roll back on failure")
+	require.NotNil(got2.currentReview)
+	assert.False(got2.currentReview.Closed, "currentReview.Closed must roll back alongside the job, not half-apply")
+}
+
+// TestSplitListCommentResultRefreshesViaFollow covers Finding 2: a comment
+// submitted from the split list (currentView still viewQueue, 'c' works
+// from the queue too) never refreshed currentResponses, because
+// handleCommentResultMsg's refresh was gated on currentView == viewReview.
+// The fix dispatches via fetchReviewFollow (not fetchReview) so the
+// response lands through the follow path without switching view or
+// stealing focus.
+func TestSplitListCommentResultRefreshesViaFollow(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	responses := []storage.Response{{ID: 1, Response: "a new comment"}}
+	_, m := mockServerModel(t, mockReviewHandler(*splitTestReview(), responses))
+	m.layout = layoutSplit
+	m.currentView = viewQueue
+	m.focus = focusList
+	m.jobs = testQueueJobs()
+	m.selectedIdx, m.selectedJobID = 1, 2 // job 2
+	m.currentReview = splitTestReview()
+
+	res, cmd := m.handleCommentResultMsg(commentResultMsg{jobID: 2})
+	got := res.(model)
+	require.NotNil(cmd, "a comment for the selected job in split list focus must trigger a refresh")
+	assert.Equal(viewQueue, got.currentView)
+	assert.Equal(focusList, got.focus)
+
+	msg := cmd()
+	rm, ok := msg.(reviewMsg)
+	require.True(ok, "expected a follow reviewMsg, got %T", msg)
+	assert.True(rm.follow, "must use fetchReviewFollow (not fetchReview) so landing it doesn't switch view or steal focus")
+
+	res2, _ := got.handleReviewMsg(rm)
+	got2 := res2.(model)
+	require.Len(got2.currentResponses, 1)
+	assert.Equal("a new comment", got2.currentResponses[0].Response)
+	assert.Equal(viewQueue, got2.currentView, "landing the follow response must not switch view")
+	assert.Equal(focusList, got2.focus, "landing the follow response must not steal focus")
+}
+
+// TestFailedJobViaJobsMsgArrivalFocusableThroughReviewPaneBody covers
+// A selection landing on a failed job via
+// a filter change or initial load -- a jobsMsg-driven arrival, not a
+// cursor move -- is handled by the JobStatusFailed case in
+// splitReconcileDetail, which runs from handleJobsMsg regardless of how
+// the selection got there. This test pins that path explicitly.
+func TestFailedJobViaJobsMsgArrivalFocusableThroughReviewPaneBody(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	// Selection already on the failed job (job 1) with no currentReview
+	// loaded -- as if just arrived via a filter change or initial load,
+	// never having gone through a cursor move (scheduleDetailFollow).
+	m := splitModel(withSelection(2, 1))
+	m.currentReview = nil
+
+	res, _ := m.handleJobsMsg(jobsMsg{jobs: testQueueJobs(), stats: storage.JobStats{}})
+	got := res.(model)
+	require.NotNil(got.currentReview, "splitReconcileDetail's Failed branch must synthesize the review on a jobsMsg-driven arrival, not just a cursor move")
+	assert.Equal(int64(1), got.currentReview.JobID)
+
+	res2, _ := got.handleTabKey()
+	got2 := res2.(model)
+	assert.Equal(focusDetail, got2.focus)
+	assert.Equal(viewReview, got2.currentView)
+
+	lines := strings.Join(got2.renderDetailPane(88, 25), "\n")
+	assert.Contains(lines, "Review #1", "must render through renderReviewPaneBody's scrollable pane-body path, not the card fallback")
+	assert.Contains(lines, "boom")
+}
+
+// TestSplitPromptEscPreservesCurrentReview and
+// TestSplitPromptQuitPreservesCurrentReview cover Finding 4: every
+// queue-origin prompt exit (esc, q, and the 'p' toggle) used to nil
+// currentReview unconditionally, blanking the split pane to "Loading
+// review..." until the next periodic refresh (up to ~15s) even though
+// nothing about the review changed.
+func TestSplitPromptEscPreservesCurrentReview(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withReview(splitTestReview())) // job 2 selected+loaded
+	m.currentView = viewKindPrompt
+	m.promptFromQueue = true
+
+	res, _ := m.handleEscKey()
+	got := res.(model)
+	assert.Equal(viewQueue, got.currentView)
+	require.NotNil(got.currentReview, "the review must be retained, not nil'd, so the pane doesn't blank")
+	assert.Equal(int64(2), got.currentReview.JobID)
+
+	lines := strings.Join(got.renderDetailPane(88, 25), "\n")
+	assert.NotContains(lines, "Loading review")
+}
+
+func TestSplitPromptQuitPreservesCurrentReview(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withReview(splitTestReview())) // job 2 selected+loaded
+	m.currentView = viewKindPrompt
+	m.promptFromQueue = true
+
+	res, _ := m.handleQuitKey()
+	got := res.(model)
+	assert.Equal(viewQueue, got.currentView)
+	require.NotNil(got.currentReview, "the review must be retained, not nil'd, so the pane doesn't blank")
+	assert.Equal(int64(2), got.currentReview.JobID)
+
+	lines := strings.Join(got.renderDetailPane(88, 25), "\n")
+	assert.NotContains(lines, "Loading review")
+}
+
+// TestSplitPromptToggleKeyPreservesCurrentReview covers the third exit site
+// (handlePromptKey's own viewKindPrompt branch, reached by pressing 'p'
+// again while already in the prompt view) with the same fix.
+func TestSplitPromptToggleKeyPreservesCurrentReview(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withReview(splitTestReview())) // job 2 selected+loaded
+	m.currentView = viewKindPrompt
+	m.promptFromQueue = true
+
+	res, _ := m.handlePromptKey()
+	got := res.(model)
+	assert.Equal(viewQueue, got.currentView)
+	require.NotNil(got.currentReview, "the review must be retained, not nil'd, so the pane doesn't blank")
+	assert.Equal(int64(2), got.currentReview.JobID)
+}
+
+// TestStackedPromptEscStillClearsCurrentReview is the non-regression
+// control for Finding 4: stacked layout has no persistent pane to retain a
+// review for, so it must keep the prior nil-and-reload behavior.
+func TestStackedPromptEscStillClearsCurrentReview(t *testing.T) {
+	assert := assert.New(t)
+	m := initTestModel(
+		withCurrentView(viewKindPrompt),
+		withTestJobs(testQueueJobs()...),
+		withSelection(1, 2),
+	)
+	m.layout = layoutStacked
+	m.promptFromQueue = true
+	m.currentReview = splitTestReview()
+
+	res, _ := m.handleEscKey()
+	got := res.(model)
+	assert.Equal(viewQueue, got.currentView)
+	assert.Nil(got.currentReview, "stacked layout must keep the prior nil-and-reload behavior")
+}
+
+// TestSplitReconcileDetailDetectsSameSecondRerunViaNonTerminalObservation:
+// reviewJobCompletionChanged
+// compares job.FinishedAt at whole-second (RFC3339) resolution, so a rerun
+// that completes within the SAME wall-clock second as the attempt it
+// replaced compared equal and the stale review survived. The job must be
+// observed queued/running in between (the rerun's non-terminal window) for
+// the state-machine signal to catch what the timestamp comparison alone
+// cannot.
+func TestSplitReconcileDetailDetectsSameSecondRerunViaNonTerminalObservation(t *testing.T) {
+	assert := assert.New(t)
+	finish := time.Now().Truncate(time.Second) // whole-second, matching storage precision
+	m := splitModel(withSelection(1, 2))       // job 2: done
+	review := splitTestReview()
+	review.Job.FinishedAt = &finish
+	m.currentReview = review
+
+	// Observed running again -- the rerun's non-terminal window.
+	runningJobs := testQueueJobs()
+	runningJobs[1].Status = storage.JobStatusRunning
+	m.jobs = runningJobs
+	m, _ = m.splitReconcileDetail()
+
+	// Completes within the SAME wall-clock second as the previous attempt.
+	doneJobs := testQueueJobs()
+	doneJobs[1].FinishedAt = &finish
+	m.jobs = doneJobs
+	_, cmd := m.splitReconcileDetail()
+	assert.NotNil(cmd, "a same-second rerun completion, observed running in between, must still be detected as changed")
+}
+
+// TestSplitReconcileDetailReplacesFailedReviewWithChangedMetadataDespiteSameErrorText
+// covers Finding 5(b): the Failed branch's idempotency check compared
+// rendered error text only, so a rerun that fails with the SAME message but
+// different execution metadata (e.g. resolved agent) retained the stale
+// synthetic review, including its embedded job snapshot. Output text is
+// identical either way (it's built from job.Error alone), so only the
+// observed-non-terminal signal can catch this.
+func TestSplitReconcileDetailReplacesFailedReviewWithChangedMetadataDespiteSameErrorText(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(2, 1)) // job 1: failed, "boom", agent claude-code
+	m.currentReview = synthesizeFailedReview(&m.jobs[2], nil)
+	require.Equal("claude-code", m.currentReview.Job.Agent)
+
+	// Observed running again -- the rerun's non-terminal window.
+	runningJobs := testQueueJobs()
+	runningJobs[2].Status = storage.JobStatusRunning
+	m.jobs = runningJobs
+	m, _ = m.splitReconcileDetail()
+
+	// Fails again with the SAME error text but a different resolved agent.
+	failedJobs := testQueueJobs()
+	failedJobs[2].Agent = "codex"
+	m.jobs = failedJobs
+	got, cmd := m.splitReconcileDetail()
+	assert.Nil(cmd, "the Failed branch rebuilds locally, not via a fetch")
+	require.NotNil(got.currentReview)
+	assert.Equal("codex", got.currentReview.Job.Agent, "must rebuild with the CURRENT job metadata despite identical rendered error text")
+}
+
+// ---------------------------------------------------------------------------
+// Prompt-view navigation and the split pane's sibling state.
+// ---------------------------------------------------------------------------
+
+// TestPromptNavToDifferentJobClearsStaleSiblings covers a hazard of
+// preserveOrClearReviewOnQueueReturn:
+// split, job X selected with X's review AND X's comments loaded via the
+// pane's own follow fetch; 'p' opens the prompt; stepPromptNav (<-/->)
+// walks to job Y's prompt, whose fetch (fetchReviewForPrompt) lands in
+// handlePromptMsg with currentReview replaced by Y's review while
+// currentResponses is still X's -- handlePromptMsg only ever touched
+// currentReview. Esc then goes through preserveOrClearReviewOnQueueReturn,
+// whose guard only compares currentReview.JobID (now Y) against
+// selectedJobID (now Y) and retains it, rendering Y's review with X's
+// stale comments underneath. Nothing else catches this: reconcile's
+// idempotency checks only ever examine currentReview, never its siblings.
+func TestPromptNavToDifferentJobClearsStaleSiblings(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	// Job X (2) selected+loaded with X's review AND X's comments.
+	m := splitModel(withReview(splitTestReview())) // JobID: 2
+	m.currentResponses = []storage.Response{{ID: 1, Response: "X's comment"}}
+	m.currentView = viewKindPrompt
+	m.promptFromQueue = true
+
+	// stepPromptNav walked to job Y (1)'s prompt (moveSelectionToJobID
+	// already ran); its fetchReviewForPrompt(1) now lands here.
+	m.selectedJobID = 1
+	yFinishedAt := splitTestFinishedAt
+	yReview := &storage.Review{
+		ID: 20, JobID: 1, Agent: "codex", Output: "Y's output",
+		Job: &storage.ReviewJob{ID: 1, FinishedAt: &yFinishedAt},
+	}
+	res, _ := m.handlePromptMsg(promptMsg{review: yReview, jobID: 1})
+	got := res.(model)
+	require.NotNil(got.currentReview)
+	assert.Equal(int64(1), got.currentReview.JobID)
+	assert.Empty(got.currentResponses, "stale comments from the PREVIOUS job must be cleared when the loaded review's job changes")
+
+	// esc: preserveOrClearReviewOnQueueReturn's guard passes (both sides
+	// are job 1 now) and retains the review.
+	res2, _ := got.handleEscKey()
+	got2 := res2.(model)
+	assert.Equal(viewQueue, got2.currentView)
+	require.NotNil(got2.currentReview)
+	assert.Equal(int64(1), got2.currentReview.JobID)
+
+	lines := strings.Join(got2.renderDetailPane(88, 25), "\n")
+	assert.Contains(lines, "Y's output")
+	assert.NotContains(lines, "X's comment", "must not render the PREVIOUS job's comments under the new job's review")
+}
+
+// TestSplitReconcileDetailRetriesAfterFollowFetchFails:
+// paneReviewSeenNonTerminal must clear when the fetch is actually
+// ACCEPTED, not at the DECISION to dispatch it. If
+// that fetch then fails (handleReviewFollowErrMsg records splitDetailErr
+// but leaves currentReview/the flag alone), the fallback signal
+// (FinishedAt.After) is blind to a same-second completion and the flag was
+// already cleared, so no later reconcile pass would retry -- a stuck stale
+// review plus a stuck pane error until manual reselection.
+func TestSplitReconcileDetailRetriesAfterFollowFetchFails(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	finish := time.Now().Truncate(time.Second)
+	m := splitModel(withSelection(1, 2)) // job 2: done
+	review := splitTestReview()
+	review.Job.FinishedAt = &finish
+	m.currentReview = review
+
+	// Observed running again -- the rerun's non-terminal window.
+	runningJobs := testQueueJobs()
+	runningJobs[1].Status = storage.JobStatusRunning
+	m.jobs = runningJobs
+	m, _ = m.splitReconcileDetail()
+
+	// Completes within the SAME wall-clock second: only the
+	// observed-non-terminal signal catches this, so a fetch is dispatched.
+	doneJobs := testQueueJobs()
+	doneJobs[1].FinishedAt = &finish
+	m.jobs = doneJobs
+	m, cmd := m.splitReconcileDetail()
+	require.NotNil(cmd, "the same-second completion, observed running in between, must dispatch a fetch")
+
+	// That fetch FAILS. fetchSeq must match the dispatch's for this error
+	// to be accepted rather than dropped as superseded -- m.reviewFetchSeq
+	// still holds the value splitReconcileDetail just stamped on the
+	// outgoing request above (the suppression slot is released before
+	// any staleness check).
+	res, _ := m.handleReviewFollowErrMsg(reviewFollowErrMsg{jobID: 2, fetchSeq: m.reviewFetchSeq, err: errors.New("network error")})
+	m = res.(model)
+	require.Error(m.splitDetailErr)
+	require.NotNil(m.currentReview, "a failed fetch must not clear the stale review")
+
+	// A later reconcile pass, nothing new observed, must still retry --
+	// the flag must not have been lost when the fetch failed.
+	_, cmd2 := m.splitReconcileDetail()
+	assert.NotNil(cmd2, "a failed follow fetch must not lose the observed-non-terminal signal -- a later pass must retry")
+}
+
+// TestSplitReconcileDetailResetsSignalExactlyOnceOnSuccess is Issue 2's
+// non-regression companion: the reset must still happen, exactly once, when
+// the follow fetch actually succeeds -- not at every reconcile pass
+// thereafter.
+func TestSplitReconcileDetailResetsSignalExactlyOnceOnSuccess(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	finish := time.Now().Truncate(time.Second)
+	freshReview := *splitTestReview()
+	freshReview.Job.FinishedAt = &finish
+	_, m := mockServerModel(t, mockReviewHandler(freshReview, nil))
+	m.layout = layoutSplit
+	m.jobs = testQueueJobs()
+	m.selectedIdx, m.selectedJobID = 1, 2
+	oldReview := splitTestReview()
+	oldReview.Job.FinishedAt = &finish
+	m.currentReview = oldReview
+
+	runningJobs := testQueueJobs()
+	runningJobs[1].Status = storage.JobStatusRunning
+	m.jobs = runningJobs
+	m, _ = m.splitReconcileDetail()
+
+	doneJobs := testQueueJobs()
+	doneJobs[1].FinishedAt = &finish
+	m.jobs = doneJobs
+	m, cmd := m.splitReconcileDetail()
+	require.NotNil(cmd)
+
+	msg := cmd()
+	rm, ok := msg.(reviewMsg)
+	require.True(ok, "expected a follow reviewMsg, got %T", msg)
+
+	res, _ := m.handleReviewMsg(rm)
+	m = res.(model)
+	require.NotNil(m.currentReview)
+
+	_, cmd2 := m.splitReconcileDetail()
+	assert.Nil(cmd2, "the reset must happen exactly once, on acceptance -- a subsequent pass with no new observation must not refetch again")
+}
+
+// TestStepReviewNavFailedReviewClearsStaleResponses covers Issue 3: of the
+// five synthesizeFailedReview call sites, three (stepReviewNav here,
+// handleEnterKey, the pagination auto-nav) cleared only currentBranch, not
+// currentResponses -- so a failed job's synthetic review (which has no
+// comments of its own) could render the PREVIOUS job's stale comments.
+// This test covers stepReviewNav as the representative site.
+func TestStepReviewNavFailedReviewClearsStaleResponses(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	// Job 2 (done) selected with stale comments loaded; stepReviewNav
+	// walks to job 1 (failed, dir=1 is "older" per its doc comment).
+	m := splitModel(withReview(splitTestReview()), withSelection(1, 2))
+	m.currentView = viewReview
+	m.currentResponses = []storage.Response{{ID: 1, Response: "stale comment for job 2"}}
+
+	res, _ := m.stepReviewNav(1)
+	got := res.(model)
+	require.NotNil(got.currentReview)
+	assert.Equal(int64(1), got.currentReview.JobID)
+	assert.Empty(got.currentResponses, "a synthetic failed review has no comments of its own -- stale siblings must be cleared")
+}
+
+// TestControlSocketCloseFlipsCurrentReviewClosedState covers Issue 5: the
+// control-socket close route (handleCtrlCloseReview) sets pendingClosed
+// and must also flip currentReview.Closed, like the key path does.
+func TestControlSocketCloseFlipsCurrentReviewClosedState(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withReview(splitTestReview())) // job 2 selected+loaded
+	m.jobs[1].Closed = new(false)
+
+	params, err := json.Marshal(map[string]any{"job_id": int64(2), "closed": true})
+	require.NoError(err)
+	got, resp, cmd := m.handleCtrlCloseReview(params)
+	require.True(resp.OK, "expected OK, got error: %s", resp.Error)
+	assert.NotNil(cmd)
+	require.NotNil(got.currentReview)
+	assert.True(got.currentReview.Closed, "currentReview.Closed must flip via the control-socket close route too")
+}
+
+// ---------------------------------------------------------------------------
+// Keeping paneReviewSeenNonTerminal set until a response
+// lands means every intervening jobs refresh before
+// that response arrives re-dispatches ANOTHER fetchReviewFollow for the
+// same completion -- concurrent requests sharing the same jobID and
+// detailFollowGen, both passing handleReviewMsg's staleness gates, so an
+// older response landing after a newer accepted one can overwrite it, and
+// a slow daemon accumulates unbounded duplicate requests.
+// ---------------------------------------------------------------------------
+
+// TestSplitReconcileDetailSuppressesDuplicateFollowDispatch is the
+// duplicate-dispatch repro (test a): a same-second rerun is observed
+// running, then completes; two consecutive jobs refreshes arrive before
+// any response lands -- only the FIRST issues a fetch cmd.
+func TestSplitReconcileDetailSuppressesDuplicateFollowDispatch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	finish := time.Now().Truncate(time.Second)
+	m := splitModel(withSelection(1, 2)) // job 2: done
+	review := splitTestReview()
+	review.Job.FinishedAt = &finish
+	m.currentReview = review
+
+	// Observed running again -- the rerun's non-terminal window.
+	runningJobs := testQueueJobs()
+	runningJobs[1].Status = storage.JobStatusRunning
+	m.jobs = runningJobs
+	m, _ = m.splitReconcileDetail()
+
+	// Completes within the SAME wall-clock second.
+	doneJobs := testQueueJobs()
+	doneJobs[1].FinishedAt = &finish
+	m.jobs = doneJobs
+
+	m, cmd1 := m.splitReconcileDetail()
+	require.NotNil(cmd1, "the first refresh after completion must dispatch a fetch")
+
+	// A second refresh arrives before the first fetch's response lands --
+	// nothing about the job changed in between.
+	_, cmd2 := m.splitReconcileDetail()
+	assert.Nil(cmd2, "a second refresh while the first fetch is still in flight must NOT dispatch another")
+}
+
+// TestSplitReconcileDetailRejectsOlderFollowResponseAfterNewerAccepted is
+// the out-of-order protection test (test b): even if two follow fetches
+// somehow end up in flight for the same job (simulated here by letting the
+// first fail so a second goes out, rather than manufacturing a fetchSeq
+// literal -- this test never references the tracking fields directly),
+// accepting the newer one first must make a later-arriving older response
+// get dropped instead of overwriting currentReview.
+func TestSplitReconcileDetailRejectsOlderFollowResponseAfterNewerAccepted(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	finish := time.Now().Truncate(time.Second)
+
+	olderReview := *splitTestReview()
+	olderReview.Output = "OLDER content"
+	olderReview.Job.FinishedAt = &finish
+	newerReview := *splitTestReview()
+	newerReview.Output = "NEWER content"
+	newerReview.Job.FinishedAt = &finish
+
+	callCount := 0
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/review":
+			callCount++
+			if callCount == 1 {
+				json.NewEncoder(w).Encode(olderReview)
+			} else {
+				json.NewEncoder(w).Encode(newerReview)
+			}
+		case "/api/comments":
+			json.NewEncoder(w).Encode(map[string]any{"responses": []storage.Response{}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}
+	_, m := mockServerModel(t, handler)
+	m.layout = layoutSplit
+	m.jobs = testQueueJobs()
+	m.selectedIdx, m.selectedJobID = 1, 2
+	review := splitTestReview()
+	review.Job.FinishedAt = &finish
+	m.currentReview = review
+
+	// First dispatch -- will fetch "older" when eventually run.
+	runningJobs := testQueueJobs()
+	runningJobs[1].Status = storage.JobStatusRunning
+	m.jobs = runningJobs
+	m, _ = m.splitReconcileDetail()
+
+	doneJobs := testQueueJobs()
+	doneJobs[1].FinishedAt = &finish
+	m.jobs = doneJobs
+	m, cmd1 := m.splitReconcileDetail()
+	require.NotNil(cmd1)
+	msg1 := cmd1() // the "older" response -- held aside, not delivered yet
+	_, ok := msg1.(reviewMsg)
+	require.True(ok, "expected a reviewMsg from the mock server, got %T", msg1)
+
+	// That first request is abandoned (fails) so a second can go out --
+	// fetchSeq must match the dispatch's (m.reviewFetchSeq, still holding
+	// what the first splitReconcileDetail call above just stamped) for
+	// this error to be recorded rather than dropped as superseded.
+	res, _ := m.handleReviewFollowErrMsg(reviewFollowErrMsg{jobID: 2, fetchSeq: m.reviewFetchSeq})
+	m = res.(model)
+
+	m, cmd2 := m.splitReconcileDetail()
+	require.NotNil(cmd2, "a second dispatch must go out now that the first is no longer tracked as in flight")
+	msg2 := cmd2() // the "newer" response
+
+	// Accept the NEWER response first.
+	res2, _ := m.handleReviewMsg(msg2.(reviewMsg))
+	got := res2.(model)
+	require.NotNil(got.currentReview)
+	require.Equal("NEWER content", got.currentReview.Output)
+
+	// The OLDER response (from the first dispatch) now lands late.
+	res3, _ := got.handleReviewMsg(msg1.(reviewMsg))
+	got2 := res3.(model)
+	assert.Equal("NEWER content", got2.currentReview.Output, "an older follow response arriving after a newer accepted one must be rejected, not overwrite currentReview")
+}
+
+// TestSplitReconcileDetailRetriesAfterFollowFetchFailsAndInFlightClears is
+// test (c): a failed follow fetch must clear in-flight tracking (not
+// just keep the retry signal set), so a later refresh actually dispatches
+// again instead of being suppressed by a stuck in-flight flag.
+func TestSplitReconcileDetailRetriesAfterFollowFetchFailsAndInFlightClears(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	finish := time.Now().Truncate(time.Second)
+	_, m := mockServerModel(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	m.layout = layoutSplit
+	m.jobs = testQueueJobs()
+	m.selectedIdx, m.selectedJobID = 1, 2
+	review := splitTestReview()
+	review.Job.FinishedAt = &finish
+	m.currentReview = review
+
+	runningJobs := testQueueJobs()
+	runningJobs[1].Status = storage.JobStatusRunning
+	m.jobs = runningJobs
+	m, _ = m.splitReconcileDetail()
+
+	doneJobs := testQueueJobs()
+	doneJobs[1].FinishedAt = &finish
+	m.jobs = doneJobs
+	m, cmd := m.splitReconcileDetail()
+	require.NotNil(cmd)
+
+	_, cmdWhileInFlight := m.splitReconcileDetail()
+	require.Nil(cmdWhileInFlight, "a refresh while the first fetch is in flight must not dispatch another")
+
+	msg := cmd()
+	errMsgVal, ok := msg.(reviewFollowErrMsg)
+	require.True(ok, "expected a reviewFollowErrMsg, got %T", msg)
+	res, _ := m.handleReviewFollowErrMsg(errMsgVal)
+	m = res.(model)
+
+	_, cmd2 := m.splitReconcileDetail()
+	assert.NotNil(cmd2, "a failed follow fetch must clear in-flight tracking so a later pass can retry")
+}
+
+// TestSplitReconcileDetailNormalDonePathDispatchesSingleFetch is test (d):
+// the ordinary running->done transition (no rerun, no prior review loaded)
+// is unaffected by the in-flight suppression -- it still dispatches
+// exactly one fetch.
+func TestSplitReconcileDetailNormalDonePathDispatchesSingleFetch(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running, selected
+	m.currentReview = nil
+
+	doneJobs := testQueueJobs()
+	doneJobs[0].Status = storage.JobStatusDone
+	m.jobs = doneJobs
+
+	_, cmd := m.splitReconcileDetail()
+	assert.NotNil(cmd, "a normal running->done transition must still dispatch a follow fetch")
+}
+
+// ---------------------------------------------------------------------------
+// reconcileFetchJobID/Seq must be scoped to the request they track -- a
+// single global flag has two "stuck forever" gaps.
+// ---------------------------------------------------------------------------
+
+// TestSplitReconcileDetailStalePendingForOldJobDoesNotBlockDifferentJob is
+// test (a): the stuck-forever repro. A tracked follow fetch is left
+// outstanding for job A (never resolved -- e.g. its response was consumed
+// while a different job was selected, or is simply still in flight); the
+// selection is mutated to a DIFFERENT job B without going through
+// scheduleDetailFollow (exactly what handleCtrlSelectJob does while
+// layout != layoutSplit: selectedJobID changes directly, no gen bump, no
+// tracking clear -- control_handlers.go). Re-entering split,
+// maybeBootstrapDetail's JobID-only bootstrap-skip (layout.go) doesn't
+// consult the tracking at all, so it can't help either. Job B then
+// genuinely needs a rebuild -- this must not be blocked by job A's stale,
+// unresolved tracked-request slot.
+func TestSplitReconcileDetailStalePendingForOldJobDoesNotBlockDifferentJob(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	t1 := time.Now().Truncate(time.Second)
+
+	jobA := storage.ReviewJob{ID: 2, Status: storage.JobStatusDone, FinishedAt: &t1, Agent: "codex"}
+	jobB := storage.ReviewJob{ID: 3, Status: storage.JobStatusDone, FinishedAt: &t1, Agent: "codex"}
+	m := splitModel(withTestJobs(jobA, jobB), withSelection(0, 2))
+	reviewA := &storage.Review{ID: 20, JobID: 2, Agent: "codex", Output: "A v1", Job: &storage.ReviewJob{ID: 2, FinishedAt: &t1}}
+	m.currentReview = reviewA
+
+	// Job A observed running again (a same-second rerun window), then
+	// completes -- dispatches a TRACKED follow
+	// fetch that this test deliberately leaves unresolved (no response is
+	// ever delivered for it).
+	runningA := []storage.ReviewJob{{ID: 2, Status: storage.JobStatusRunning}, jobB}
+	m.jobs = runningA
+	m, _ = m.splitReconcileDetail()
+
+	doneAAgain := []storage.ReviewJob{{ID: 2, Status: storage.JobStatusDone, FinishedAt: &t1, Agent: "codex"}, jobB}
+	m.jobs = doneAAgain
+	m, cmd := m.splitReconcileDetail()
+	require.NotNil(cmd, "tracked fetch dispatched for job A")
+
+	// Selection is mutated to job B WITHOUT going through
+	// scheduleDetailFollow, the way handleCtrlSelectJob does while
+	// layout != layoutSplit. currentReview is left untouched by that
+	// mutation (it's a raw selectedJobID change, not a review load).
+	m.selectedIdx, m.selectedJobID = 1, 3
+
+	// Re-entering split, maybeBootstrapDetail's JobID-only match skips --
+	// contrived directly here (currentReview already "shows" job B): the
+	// guard only compares JobIDs and doesn't care how that came to be.
+	reviewB := &storage.Review{ID: 21, JobID: 3, Agent: "codex", Output: "B v1", Job: &storage.ReviewJob{ID: 3, FinishedAt: &t1}}
+	m.currentReview = reviewB
+	m, bootstrapCmd := m.maybeBootstrapDetail()
+	require.Nil(bootstrapCmd, "bootstrap correctly skips -- currentReview already matches the selected job")
+
+	// Job B now genuinely needs a rebuild (observed running, then done
+	// again with a newer completion) -- must NOT be blocked by job A's
+	// stale, never-resolved tracked-request slot.
+	runningB := []storage.ReviewJob{{ID: 2, Status: storage.JobStatusDone, FinishedAt: &t1, Agent: "codex"}, {ID: 3, Status: storage.JobStatusRunning}}
+	m.jobs = runningB
+	m, _ = m.splitReconcileDetail()
+
+	t2 := t1.Add(time.Hour)
+	doneBAgain := []storage.ReviewJob{{ID: 2, Status: storage.JobStatusDone, FinishedAt: &t1, Agent: "codex"}, {ID: 3, Status: storage.JobStatusDone, FinishedAt: &t2, Agent: "codex"}}
+	m.jobs = doneBAgain
+	_, cmd2 := m.splitReconcileDetail()
+	assert.NotNil(cmd2, "job B's genuine rebuild must not be blocked by job A's stale tracked-request slot")
+}
+
+// TestUntrackedFollowResponseForDifferentJobDoesNotClearTrackedPending:
+// an untracked follow response (e.g.
+// from handleDetailFollowTick reacting to a selection change) lands for a
+// DIFFERENT job while a TRACKED request is genuinely still outstanding for
+// the original job -- accepting it (its fetchSeq is a real, current one
+// now, not a 0 sentinel) must not release the tracked slot just because
+// SOME response landed, or reconcile would dispatch a duplicate on top of
+// the still-outstanding one once the original job needs another rebuild.
+func TestUntrackedFollowResponseForDifferentJobDoesNotClearTrackedPending(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	t1 := time.Now().Truncate(time.Second)
+
+	jobA := storage.ReviewJob{ID: 2, Status: storage.JobStatusDone, FinishedAt: &t1, Agent: "codex"}
+	jobB := storage.ReviewJob{ID: 3, Status: storage.JobStatusDone, FinishedAt: &t1, Agent: "codex"}
+	m := splitModel(withTestJobs(jobA, jobB), withSelection(0, 2))
+	reviewA := &storage.Review{ID: 20, JobID: 2, Agent: "codex", Output: "A v1", Job: &storage.ReviewJob{ID: 2, FinishedAt: &t1}}
+	m.currentReview = reviewA
+
+	// Job A observed running, then completes -- a TRACKED fetch is
+	// dispatched for A and left unresolved (never delivered in this
+	// test, simulating it still being genuinely in flight).
+	runningA := []storage.ReviewJob{{ID: 2, Status: storage.JobStatusRunning}, jobB}
+	m.jobs = runningA
+	m, _ = m.splitReconcileDetail()
+	doneAAgain := []storage.ReviewJob{{ID: 2, Status: storage.JobStatusDone, FinishedAt: &t1, Agent: "codex"}, jobB}
+	m.jobs = doneAAgain
+	m, cmd := m.splitReconcileDetail()
+	require.NotNil(cmd, "tracked fetch dispatched for job A")
+
+	// An UNTRACKED follow response lands for a DIFFERENT job (B) -- as if
+	// handleDetailFollowTick reacted to a selection change to B in the
+	// meantime. Every fetchReviewFollow dispatch is sequenced,
+	// so this simulates the real untracked-dispatch
+	// pattern (bump the shared seq, stamp it on the outgoing request)
+	// rather than a special 0 sentinel -- there is no more such sentinel.
+	m.selectedIdx, m.selectedJobID = 1, 3
+	m.reviewFetchSeq++
+	untrackedReviewB := &storage.Review{ID: 99, JobID: 3, Agent: "codex", Output: "B content", Job: &storage.ReviewJob{ID: 3, FinishedAt: &t1}}
+	res, _ := m.handleReviewMsg(reviewMsg{review: untrackedReviewB, jobID: 3, follow: true, fetchSeq: m.reviewFetchSeq})
+	m = res.(model)
+	require.NotNil(m.currentReview)
+	require.Equal(int64(3), m.currentReview.JobID, "the untracked response for job B lands normally")
+
+	// Selection returns to job A -- its review still shows the OLD
+	// content (reviewA), and job A completed AGAIN (a newer FinishedAt)
+	// while the pane was on B, so a rebuild is genuinely due.
+	m.selectedIdx, m.selectedJobID = 0, 2
+	m.currentReview = reviewA
+	t2 := t1.Add(time.Hour)
+	doneAAgainNewer := []storage.ReviewJob{{ID: 2, Status: storage.JobStatusDone, FinishedAt: &t2, Agent: "codex"}, jobB}
+	m.jobs = doneAAgainNewer
+
+	_, cmd2 := m.splitReconcileDetail()
+	assert.Nil(cmd2, "the ORIGINAL tracked fetch for job A must still be considered outstanding -- the untracked B landing must not have cleared it, so reconcile must not dispatch a duplicate")
+}
+
+// TestReviewFollowErrMsgDiscardsStaleGen: a follow fetch failure matched
+// on jobID alone, unlike its success counterpart
+// (gen-gated), would let a stale error from a fetch dispatched before the
+// user moved away and back to the same job could overwrite splitDetailErr
+// for the reselected job. Both a stale-gen error (discarded) and a
+// current-gen error (recorded) are covered (test e).
+func TestReviewFollowErrMsgDiscardsStaleGen(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(1, 2)) // job 2 selected
+
+	oldGen := m.detailFollowGen
+	// The selection moves away and back (bumping gen via the real
+	// handleKeyMsg -> scheduleDetailFollow path) before the stale error
+	// arrives.
+	m, _ = pressSpecial(m, tea.KeyDown)
+	m, _ = pressSpecial(m, tea.KeyUp)
+	require.Greater(t, m.detailFollowGen, oldGen)
+	require.Equal(t, int64(2), m.selectedJobID)
+
+	res, _ := m.handleReviewFollowErrMsg(reviewFollowErrMsg{
+		jobID: 2, gen: oldGen, err: errors.New("stale error from the abandoned fetch"),
+	})
+	got := res.(model)
+	require.NoError(t, got.splitDetailErr, "a stale-gen error must be discarded, not overwrite splitDetailErr for the reselected job")
+
+	// The current-gen counterpart must still be recorded.
+	res2, _ := m.handleReviewFollowErrMsg(reviewFollowErrMsg{
+		jobID: 2, gen: m.detailFollowGen, err: errors.New("current error"),
+	})
+	got2 := res2.(model)
+	assert.Error(got2.splitDetailErr, "a current-gen error must still be recorded")
+}
+
+// ---------------------------------------------------------------------------
+// Follow-up scoped review: two more findings, plus doc corrections applied
+// as code comments above (not tested directly).
+// ---------------------------------------------------------------------------
+
+// TestScheduleDetailFollowClosesFixPanelOnDifferentJobSelection covers
+// Finding 1(a): a mouse click selecting a DIFFERENT row while the inline
+// fix panel is open must close it (and clear fixPromptJobID), since mouse
+// selection changes route through scheduleDetailFollow without ever
+// passing through the panel's own close paths.
+func TestScheduleDetailFollowClosesFixPanelOnDifferentJobSelection(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withReview(splitTestReview())) // job 2 selected+loaded
+	m.reviewFixPanelOpen = true
+	m.reviewFixPanelFocused = true
+	m.fixPromptText = "fix instructions for job 2"
+	m.fixPromptJobID = 2
+
+	firstDataY := splitFirstDataRowY(t, m, "cccc333") // job 3's row
+	res, _ := m.handleSplitMouse(mouseClickAt(5, firstDataY))
+	got := res.(model)
+	require.Equal(int64(3), got.selectedJobID, "the click must have selected a different job")
+	assert.False(got.reviewFixPanelOpen, "the fix panel must close when the selection moves to a different job")
+	assert.False(got.reviewFixPanelFocused)
+	assert.Equal(int64(0), got.fixPromptJobID)
+	assert.Empty(got.fixPromptText)
+}
+
+// TestCtrlSelectJobClosesFixPanelOnDifferentJobSelection covers Finding
+// 1(b): the control-socket select-job path goes through the same
+// scheduleDetailFollow call and must close the panel identically.
+func TestCtrlSelectJobClosesFixPanelOnDifferentJobSelection(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withReview(splitTestReview())) // job 2 selected+loaded
+	m.reviewFixPanelOpen = true
+	m.fixPromptJobID = 2
+	m.fixPromptText = "fix instructions"
+
+	params, err := json.Marshal(map[string]int64{"job_id": 3})
+	require.NoError(err)
+	got, resp, _ := m.handleCtrlSelectJob(params)
+	require.True(resp.OK, "expected OK, got error: %s", resp.Error)
+	require.Equal(int64(3), got.selectedJobID)
+	assert.False(got.reviewFixPanelOpen, "control-socket reselect to a different job must close the fix panel")
+	assert.Equal(int64(0), got.fixPromptJobID)
+}
+
+// TestScheduleDetailFollowLeavesFixPanelAloneForSameJob covers Finding
+// 1(c): a selection "change" that lands on the SAME job the panel is
+// already scoped to must not close it.
+func TestScheduleDetailFollowLeavesFixPanelAloneForSameJob(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview())) // job 2 selected+loaded
+	m.reviewFixPanelOpen = true
+	m.reviewFixPanelFocused = true
+	m.fixPromptJobID = 2 // matches m.selectedJobID already
+
+	got, _ := m.scheduleDetailFollow()
+	assert.True(got.reviewFixPanelOpen, "a panel already scoped to the still-selected job must not be closed")
+	assert.True(got.reviewFixPanelFocused)
+	assert.Equal(int64(2), got.fixPromptJobID)
+}
+
+// TestReconcilePassLeavesFixPanelAloneWhenJobUnchanged covers Finding
+// 1(d): an open panel on the still-selected job must survive an unrelated
+// reconcile pass (splitReconcileDetail/handleJobsMsg never call
+// scheduleDetailFollow, so this should hold trivially -- verified
+// explicitly per the request).
+func TestReconcilePassLeavesFixPanelAloneWhenJobUnchanged(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(1, 2)) // job 2: done, selected
+	m.currentReview = splitTestReview()
+	m.reviewFixPanelOpen = true
+	m.reviewFixPanelFocused = true
+	m.fixPromptJobID = 2
+
+	res, _ := m.handleJobsMsg(jobsMsg{jobs: testQueueJobs(), stats: storage.JobStats{}})
+	got := res.(model)
+	assert.True(got.reviewFixPanelOpen, "an open panel on the still-selected job must survive an unrelated reconcile pass")
+	assert.Equal(int64(2), got.fixPromptJobID)
+}
+
+// TestPaneLogOutputRejectsLateResponseAfterVanishedSelectionReassignment
+// covers Finding 2's first named path: handleJobsMsg reassigns the
+// selection when the tailed job vanishes from a refresh (e.g. filtered
+// out), bypassing scheduleDetailFollow entirely -- paneLogSeq is never
+// bumped, so a late response for the OLD job, still matching paneLogJobID
+// and seq, used to satisfy the old guard even though the selection (and
+// the pane's actual content) had already moved on.
+func TestPaneLogOutputRejectsLateResponseAfterVanishedSelectionReassignment(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running, tailed
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+
+	// Job 3 vanishes from the refreshed list.
+	newJobs := []storage.ReviewJob{
+		{ID: 2, GitRef: "bbbb222", RepoName: "repoA", Agent: "codex", Status: storage.JobStatusDone},
+	}
+	res, _ := m.handleJobsMsg(jobsMsg{jobs: newJobs, stats: storage.JobStats{}})
+	got := res.(model)
+	require.NotEqual(int64(3), got.selectedJobID, "selection must have moved off job 3")
+	require.Equal(uint64(5), got.paneLogSeq, "seq must NOT have been bumped by this bypass path -- that's the gap")
+
+	res2, cmd := got.handlePaneLogOutputMsg(paneLogOutputMsg{
+		jobID: 3, seq: 5, hasMore: true, lines: []logLine{{text: "job 3 line"}},
+	})
+	final := res2.(model)
+	assert.Nil(cmd)
+	assert.Empty(final.paneLogLines, "a rejected response must apply no lines")
+	assert.NoError(final.splitDetailErr)
+}
+
+// TestPaneLogOutputRejectsLateResponseAfterCloseRollbackRestoreSelection
+// covers Finding 2's second named path: closedResultMsg's restoreSelection
+// rollback (handleClosedResultMsg) moves the selection back via
+// selectJobByID, also bypassing scheduleDetailFollow.
+func TestPaneLogOutputRejectsLateResponseAfterCloseRollbackRestoreSelection(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	// Selection was on job 3 (tailed, running) -- e.g. after optimistically
+	// moving there when job 2 was closed with hideClosed active.
+	m := splitModel(withSelection(0, 3), withTestJobs(
+		storage.ReviewJob{ID: 3, Status: storage.JobStatusRunning},
+		storage.ReviewJob{ID: 2, Status: storage.JobStatusDone, Closed: new(false)},
+	))
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+	m.pendingClosed[2] = pendingState{newState: true, seq: 1}
+
+	// The close request for job 2 FAILS: the rollback restores selection
+	// back to job 2 via selectJobByID, bypassing scheduleDetailFollow.
+	res, _ := m.handleClosedResultMsg(closedResultMsg{
+		jobID: 2, restoreSelection: true, oldState: false, newState: true, seq: 1,
+		err: errors.New("server error"),
+	})
+	got := res.(model)
+	require.Equal(int64(2), got.selectedJobID, "rollback must restore selection to job 2")
+	// The rollback now routes through the shared detail-follow transition
+	// (followSelectionChange -> scheduleDetailFollow), which invalidates
+	// the tail for the job the selection moved off -- so the late response
+	// below is rejected by the seq gate rather than only by the jobID
+	// comparison. This is the gap this path used to have.
+	require.Greater(got.paneLogSeq, uint64(5), "the restored selection must invalidate the old job's tail")
+	require.False(got.paneLogStreaming)
+
+	res2, cmd := got.handlePaneLogOutputMsg(paneLogOutputMsg{
+		jobID: 3, seq: 5, hasMore: true, lines: []logLine{{text: "job 3 line"}},
+	})
+	final := res2.(model)
+	assert.Nil(cmd)
+	assert.Empty(final.paneLogLines, "a rejected response must apply no lines")
+	assert.NoError(final.splitDetailErr)
+}
+
+// TestPaneLogOutputAcceptsNormalSameJobResponse is the non-regression
+// control: a response for the job that's both currently tailed AND
+// currently selected must still be accepted normally.
+func TestPaneLogOutputAcceptsNormalSameJobResponse(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running, tailed, selected
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+
+	res, cmd := m.handlePaneLogOutputMsg(paneLogOutputMsg{
+		jobID: 3, seq: 5, hasMore: true, lines: []logLine{{text: "job 3 line"}},
+	})
+	got := res.(model)
+	assert.NotNil(cmd, "a normal same-job response must still schedule the next poll")
+	require.Len(t, got.paneLogLines, 1)
+	assert.Equal("job 3 line", got.paneLogLines[0].text)
+}
+
+// ---------------------------------------------------------------------------
+// Follow fetches come in two classes -- tracked
+// (splitReconcileDetail) and untracked (handleDetailFollowTick, the
+// pane-log completion handoff, the split-list comment refresh) -- and
+// they must be orderable against each other: an
+// untracked response landing must not clear the tracked slot without
+// invalidating the still-outstanding tracked request, whose fetchSeq
+// still matched m.reviewFetchSeq. An older tracked response (fetched
+// BEFORE a comment, say) could then land AFTER a newer untracked one and
+// overwrite its fresher content.
+// ---------------------------------------------------------------------------
+
+// TestOlderTrackedResponseDoesNotOverwriteNewerUntrackedCommentRefresh is
+// test (a): the exact repro. A tracked reconcile fetch is outstanding for
+// job X; a comment is submitted for X, dispatching an UNTRACKED refresh
+// that lands first with the new comment; the OLDER tracked response
+// (dispatched before the comment) then finally lands -- currentResponses
+// must still contain the new comment.
+func TestOlderTrackedResponseDoesNotOverwriteNewerUntrackedCommentRefresh(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	t1 := time.Now().Truncate(time.Second)
+
+	m := splitModel(withSelection(1, 2)) // job 2: done, selected
+	review := splitTestReview()
+	review.Job.FinishedAt = &t1
+	m.currentReview = review
+	m.currentResponses = []storage.Response{{ID: 1, Response: "old comment"}}
+
+	// A tracked reconcile fetch for job 2 is dispatched (a same-second
+	// rerun window) and left unresolved.
+	runningJobs := testQueueJobs()
+	runningJobs[1].Status = storage.JobStatusRunning
+	m.jobs = runningJobs
+	m, _ = m.splitReconcileDetail()
+	doneJobs := testQueueJobs()
+	doneJobs[1].FinishedAt = &t1
+	m.jobs = doneJobs
+	m, cmd := m.splitReconcileDetail()
+	require.NotNil(cmd, "tracked fetch dispatched for job 2")
+	trackedFollowSeq := m.reviewFetchSeq // this dispatch's own seq, captured before anything supersedes it
+
+	// The user submits a comment for job 2: handleCommentResultMsg
+	// dispatches its own UNTRACKED follow refresh.
+	res, commentCmd := m.handleCommentResultMsg(commentResultMsg{jobID: 2})
+	m = res.(model)
+	require.NotNil(commentCmd, "the comment refresh must dispatch")
+
+	// That untracked refresh lands FIRST, with the new comment.
+	freshWithComment := &storage.Review{ID: 20, JobID: 2, Agent: "codex", Output: review.Output, Job: &storage.ReviewJob{ID: 2, FinishedAt: &t1}}
+	res2, _ := m.handleReviewMsg(reviewMsg{
+		review: freshWithComment, jobID: 2, follow: true, gen: m.detailFollowGen,
+		responses: []storage.Response{{ID: 1, Response: "old comment"}, {ID: 2, Response: "the user's new comment"}},
+		fetchSeq:  m.reviewFetchSeq,
+	})
+	m = res2.(model)
+	require.Len(m.currentResponses, 2, "the new comment must be visible after the untracked refresh lands")
+
+	// The OLDER tracked response (dispatched before the comment) now
+	// finally lands, carrying pre-comment data.
+	staleReview := &storage.Review{ID: 19, JobID: 2, Agent: "codex", Output: review.Output, Job: &storage.ReviewJob{ID: 2, FinishedAt: &t1}}
+	res3, _ := m.handleReviewMsg(reviewMsg{
+		review: staleReview, jobID: 2, follow: true, gen: m.detailFollowGen,
+		responses: []storage.Response{{ID: 1, Response: "old comment"}},
+		fetchSeq:  trackedFollowSeq,
+	})
+	got := res3.(model)
+	assert.Len(got.currentResponses, 2, "the user's comment must NOT disappear -- the older tracked response must be rejected as superseded")
+}
+
+// TestUntrackedAcceptanceBlocksLaterStaleTrackedResponse is test (b): the
+// general ordering property, using a DIFFERENT untracked source (the
+// pane-log completion handoff) than test (a)'s comment refresh, to confirm
+// this isn't specific to one caller. Once an untracked response has been
+// accepted, a stale tracked response landing afterward must not be able
+// to overwrite it.
+func TestUntrackedAcceptanceBlocksLaterStaleTrackedResponse(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	t1 := time.Now().Truncate(time.Second)
+	m := splitModel(withSelection(1, 2)) // job 2: done, selected
+	review := splitTestReview()
+	review.Job.FinishedAt = &t1
+	m.currentReview = review
+
+	// Tracked reconcile fetch dispatched and left unresolved.
+	runningJobs := testQueueJobs()
+	runningJobs[1].Status = storage.JobStatusRunning
+	m.jobs = runningJobs
+	m, _ = m.splitReconcileDetail()
+	doneJobs := testQueueJobs()
+	doneJobs[1].FinishedAt = &t1
+	m.jobs = doneJobs
+	m, cmd := m.splitReconcileDetail()
+	require.NotNil(cmd)
+	trackedFollowSeq := m.reviewFetchSeq
+
+	// A DIFFERENT untracked caller (the pane-log completion handoff)
+	// dispatches its own follow fetch afterward.
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 2, 5, true
+	res, tickCmd := m.handlePaneLogOutputMsg(paneLogOutputMsg{jobID: 2, seq: 5, hasMore: false})
+	m = res.(model)
+	require.NotNil(tickCmd, "the pane-log completion handoff must still dispatch its own follow fetch")
+
+	// That untracked fetch resolves first.
+	newerReview := &storage.Review{ID: 30, JobID: 2, Agent: "codex", Output: "NEWER content", Job: &storage.ReviewJob{ID: 2, FinishedAt: &t1}}
+	res2, _ := m.handleReviewMsg(reviewMsg{review: newerReview, jobID: 2, follow: true, gen: m.detailFollowGen, fetchSeq: m.reviewFetchSeq})
+	m = res2.(model)
+	require.Equal("NEWER content", m.currentReview.Output)
+
+	// The OLDER tracked response (dispatched before the handoff) now
+	// lands.
+	staleReview := &storage.Review{ID: 29, JobID: 2, Agent: "codex", Output: "STALE content", Job: &storage.ReviewJob{ID: 2, FinishedAt: &t1}}
+	res3, _ := m.handleReviewMsg(reviewMsg{review: staleReview, jobID: 2, follow: true, gen: m.detailFollowGen, fetchSeq: trackedFollowSeq})
+	got := res3.(model)
+	assert.Equal("NEWER content", got.currentReview.Output, "a stale tracked response arriving after a newer untracked one must not overwrite it")
+}
+
+// TestUntrackedCallersStillDispatchWhileTrackedRequestOutstanding is test
+// (c): sequencing every fetchReviewFollow dispatch must not
+// make the three untracked call sites start suppressing each other or the
+// reconcile path -- they each fire on a genuine, one-shot event and must
+// remain free to dispatch regardless of whether a tracked request happens
+// to be outstanding. The suppression guard (reconcileFetchJobID) stays
+// scoped to splitReconcileDetail's own dispatches only.
+func TestUntrackedCallersStillDispatchWhileTrackedRequestOutstanding(t *testing.T) {
+	assert := assert.New(t)
+
+	// handleDetailFollowTick.
+	mTick := splitModel(withSelection(1, 2))
+	mTick.currentReview = nil // pane still loading -- its own guard would dispatch
+	mTick.reconcileFetchJobID = 2
+	mTick.reviewFetchSeq = 5
+	resTick, cmdTick := mTick.handleDetailFollowTick(detailFollowTickMsg{gen: mTick.detailFollowGen})
+	gotTick := resTick.(model)
+	assert.NotNil(cmdTick, "handleDetailFollowTick must still be able to dispatch while a tracked request is outstanding")
+	assert.Equal(int64(2), gotTick.reconcileFetchJobID, "the tracked slot must be untouched by this dispatch")
+
+	// The pane-log completion handoff.
+	mLog := splitModel(withSelection(1, 2))
+	mLog.paneLogJobID, mLog.paneLogSeq, mLog.paneLogStreaming = 2, 5, true
+	mLog.reconcileFetchJobID = 2
+	mLog.reviewFetchSeq = 7
+	resLog, cmdLog := mLog.handlePaneLogOutputMsg(paneLogOutputMsg{jobID: 2, seq: 5, hasMore: false})
+	gotLog := resLog.(model)
+	assert.NotNil(cmdLog, "the pane-log completion handoff must still be able to dispatch while a tracked request is outstanding")
+	assert.Equal(int64(2), gotLog.reconcileFetchJobID, "the tracked slot must be untouched by this dispatch")
+
+	// The split-list comment refresh.
+	mComment := splitModel(withReview(splitTestReview())) // job 2 loaded, list focus
+	mComment.reconcileFetchJobID = 2
+	mComment.reviewFetchSeq = 9
+	resComment, cmdComment := mComment.handleCommentResultMsg(commentResultMsg{jobID: 2})
+	gotComment := resComment.(model)
+	assert.NotNil(cmdComment, "the comment refresh must still be able to dispatch while a tracked request is outstanding")
+	assert.Equal(int64(2), gotComment.reconcileFetchJobID, "the tracked slot must be untouched by this dispatch")
+}
+
+// ---------------------------------------------------------------------------
+// Pane-log staleness rejections and their consequences for the tail.
+// ---------------------------------------------------------------------------
+
+// TestPaneLogOutputInvalidatesLiveTailWhenSelectionMovedElsewhere:
+// handlePaneLogOutputMsg's msg.jobID != m.selectedJobID rejection must
+// also invalidate the tail, not leave paneLogStreaming true. If the
+// selection later returns to that same running job via a path that
+// bypasses scheduleDetailFollow, splitReconcileDetail's Running-branch
+// restart guard would see the dead tail as still active and never
+// restart it -- the live log freezes permanently.
+func TestPaneLogOutputInvalidatesLiveTailWhenSelectionMovedElsewhere(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running, tailed
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+	// Selection moved to job 2 via a bypass path (e.g. handleCtrlSelectJob
+	// while stacked, or handleJobsMsg's vanished-selection reassignment) --
+	// paneLogSeq never bumped.
+	m.selectedIdx, m.selectedJobID = 1, 2
+
+	// A late response for job 3 arrives, still matching the tail's own
+	// bookkeeping (seq and paneLogJobID).
+	res, cmd := m.handlePaneLogOutputMsg(paneLogOutputMsg{
+		jobID: 3, seq: 5, hasMore: true, lines: []logLine{{text: "job 3 line"}},
+	})
+	got := res.(model)
+	assert.Nil(cmd)
+	assert.Empty(got.paneLogLines, "a rejected response must apply no lines")
+	assert.False(got.paneLogStreaming, "the tail must be invalidated, not left claiming to be active")
+	assert.Greater(got.paneLogSeq, uint64(5))
+
+	// Reselecting job 3 later: reconcile must restart the tail now that
+	// it's correctly marked stopped.
+	m2 := got
+	m2.selectedIdx, m2.selectedJobID = 0, 3
+	_, cmd2 := m2.splitReconcileDetail()
+	assert.NotNil(cmd2, "reconcile must restart the tail for job 3 now that it's correctly marked stopped")
+}
+
+// TestPaneLogOutputStaleSeqLeavesLiveTailAlone is the negative control:
+// a response that's stale by SEQ (not by selection) must be rejected
+// without touching a live tail at all -- the same distinction
+// handlePaneLogTickMsg's second guard draws.
+func TestPaneLogOutputStaleSeqLeavesLiveTailAlone(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running, tailed, selected
+	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 3, 5, true
+
+	res, cmd := m.handlePaneLogOutputMsg(paneLogOutputMsg{
+		jobID: 3, seq: 4, hasMore: true, lines: []logLine{{text: "stale"}},
+	})
+	got := res.(model)
+	assert.Nil(cmd)
+	assert.Empty(got.paneLogLines)
+	assert.True(got.paneLogStreaming, "a stale-seq response must not invalidate a live tail")
+	assert.Equal(uint64(5), got.paneLogSeq)
+}
+
+// TestCommentResultSkipsDispatchForJobNoLongerSelected: the comment
+// refresh is the
+// only one of the four fetchReviewFollow/fetchReview dispatchers not tied
+// to the selection -- it keyed purely on m.currentReview.JobID, and
+// currentReview is not cleared on a selection change. A comment result for
+// a job that's no longer selected must not dispatch at all, and must not
+// disturb the ordering seq an ALREADY-outstanding legitimate fetch for the
+// CURRENTLY selected job depends on.
+func TestCommentResultSkipsDispatchForJobNoLongerSelected(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	// Split, job X (2) was showing when the comment was submitted; the
+	// cursor has since moved to job Y (3), and a follow fetch is already
+	// outstanding for Y.
+	m := splitModel(withSelection(1, 2)) // starts on job X (2)
+	m.currentReview = splitTestReview()  // JobID: 2
+	m.selectedIdx, m.selectedJobID = 0, 3
+	m.reviewFetchSeq++
+	outstandingSeqForY := m.reviewFetchSeq // stand-in for Y's own already-dispatched request
+
+	res, cmd := m.handleCommentResultMsg(commentResultMsg{jobID: 2})
+	got := res.(model)
+	assert.Nil(cmd, "no dispatch for job X, which is no longer selected")
+
+	// Y's own (legitimate, already-dispatched) response must still be
+	// accepted normally afterward -- confirming the X dispatch never
+	// bumped reviewFetchSeq out from under it.
+	reviewY := &storage.Review{ID: 40, JobID: 3, Agent: "codex", Output: "Y content", Job: &storage.ReviewJob{ID: 3}}
+	res2, _ := got.handleReviewMsg(reviewMsg{review: reviewY, jobID: 3, follow: true, gen: got.detailFollowGen, fetchSeq: outstandingSeqForY})
+	got2 := res2.(model)
+	require.NotNil(got2.currentReview)
+	assert.Equal(int64(3), got2.currentReview.JobID, "Y's legitimate response must still be accepted")
+	assert.Equal("Y content", got2.currentReview.Output)
+}
+
+// TestCommentResultFromSplitDetailFocusUsesSequencedPath: commenting
+// from the split DETAIL pane
+// (commentFromView == viewReview, handleCommentKey restores currentView
+// synchronously before dispatch) must not fall through to the
+// STACKED-mode branch's plain fetchReview instead of the sequenced follow
+// path -- reachable because that branch had no layout check. A tracked
+// reconcile fetch dispatched before the comment could then land AFTER it
+// and wipe currentResponses back to pre-comment content: the same
+// "comment disappears" symptom, just reachable from detail focus too.
+func TestCommentResultFromSplitDetailFocusUsesSequencedPath(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	t1 := time.Now().Truncate(time.Second)
+
+	m := splitModel(withSelection(1, 2)) // job 2: done, selected
+	m.focus = focusDetail
+	m.currentView = viewReview // detail focus
+	review := splitTestReview()
+	review.Job.FinishedAt = &t1
+	m.currentReview = review
+
+	// A tracked reconcile fetch for job 2 is dispatched and left
+	// unresolved.
+	runningJobs := testQueueJobs()
+	runningJobs[1].Status = storage.JobStatusRunning
+	m.jobs = runningJobs
+	m, _ = m.splitReconcileDetail()
+	doneJobs := testQueueJobs()
+	doneJobs[1].FinishedAt = &t1
+	m.jobs = doneJobs
+	m, cmd := m.splitReconcileDetail()
+	require.NotNil(cmd, "tracked fetch dispatched for job 2")
+	trackedFollowSeq := m.reviewFetchSeq
+
+	// The user comments from the split DETAIL pane -- this must dispatch
+	// via the SEQUENCED follow path (bumping the shared ordering seq),
+	// not the stacked-mode branch's plain fetchReview.
+	res, commentCmd := m.handleCommentResultMsg(commentResultMsg{jobID: 2})
+	m = res.(model)
+	require.NotNil(commentCmd, "the comment refresh must dispatch")
+	require.Greater(m.reviewFetchSeq, trackedFollowSeq, "the comment refresh from detail focus must bump the shared ordering seq -- the whole point of routing it through the sequenced follow path")
+
+	// The comment's own refresh lands with the new comment.
+	m.currentResponses = []storage.Response{{ID: 1, Response: "old comment"}, {ID: 2, Response: "the user's new comment"}}
+
+	// The OLDER tracked response (dispatched before the comment) now
+	// finally lands.
+	staleReview := &storage.Review{ID: 19, JobID: 2, Agent: "codex", Output: review.Output, Job: &storage.ReviewJob{ID: 2, FinishedAt: &t1}}
+	res3, _ := m.handleReviewMsg(reviewMsg{
+		review: staleReview, jobID: 2, follow: true, gen: m.detailFollowGen,
+		responses: []storage.Response{{ID: 1, Response: "old comment"}},
+		fetchSeq:  trackedFollowSeq,
+	})
+	got := res3.(model)
+	assert.Len(got.currentResponses, 2, "the user's comment must NOT disappear -- the older tracked response must be rejected as superseded")
+	assert.Equal(viewReview, got.currentView, "must not switch view -- the pane already shows the review")
+	assert.Equal(focusDetail, got.focus, "must not steal focus")
+}
+
+// TestCommentResultStackedSkipsRefreshOnceTheSelectionMovedOn records
+// why the selection gate on the stacked comment refresh is worth its
+// cost. isReviewAnchored()
+// (helpers.go) only protects handleJobsMsg's vanished-selection
+// reassignment, NOT handleCtrlSelectJob, which in stacked mode overwrites
+// m.selectedJobID directly and touches nothing else -- currentView/
+// currentReview keep showing the previously selected job. So gating the
+// stacked comment refresh on msg.jobID == m.selectedJobID dropped the
+// refresh for the DISPLAYED review, which is why that gate was reverted.
+//
+// What changed since: the dispatch that the revert restored could never be
+// ACCEPTED in this state anyway -- handleReviewMsg's own msg.jobID !=
+// m.selectedJobID gate drops the response on arrival -- so it was merely
+// useless. Now that every review fetch advances the SHARED ordering epoch,
+// the same useless dispatch is destructive: it supersedes a concurrent,
+// legitimate fetch for the job that IS selected (see
+// TestStackedCommentRefreshForUnselectedJobDoesNotDestroyConcurrentFetch,
+// where the user arrows to another review mid-POST and that review is
+// silently skipped). The gate is therefore back, and this test now pins
+// the deliberate consequence rather than treating it as a regression: in
+// stacked mode a comment submitted for a review the selection has since
+// moved off does not refresh -- the same outcome as before, since the
+// response was dropped on arrival, just reached without collateral damage.
+func TestCommentResultStackedSkipsRefreshOnceTheSelectionMovedOn(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	job2 := storage.ReviewJob{ID: 2, Status: storage.JobStatusDone}
+	job3 := storage.ReviewJob{ID: 3, Status: storage.JobStatusDone}
+	m := initTestModel(
+		withCurrentView(viewReview),
+		withTestJobs(job2, job3),
+		withSelection(0, 2),
+	)
+	m.layout = layoutStacked
+	m.currentReview = &storage.Review{ID: 20, JobID: 2, Agent: "codex", Output: "job 2 review"}
+
+	// A control-socket select-job to a DIFFERENT job (3) arrives before
+	// the comment POST resolves. In stacked mode, handleCtrlSelectJob
+	// overwrites m.selectedJobID directly and touches nothing else.
+	params, err := json.Marshal(map[string]int64{"job_id": 3})
+	require.NoError(err)
+	got, resp, cmd := m.handleCtrlSelectJob(params)
+	require.True(resp.OK, "expected OK, got error: %s", resp.Error)
+	assert.Nil(cmd, "no follow cmd is scheduled in stacked mode")
+	require.Equal(int64(3), got.selectedJobID)
+	require.Equal(viewReview, got.currentView, "currentView is untouched by the control-socket reselect")
+	require.NotNil(got.currentReview)
+	require.Equal(int64(2), got.currentReview.JobID, "currentReview still shows job 2, not the newly selected job 3")
+
+	// The comment result for job 2 (the DISPLAYED review, not the
+	// now-selected job 3) now arrives.
+	_, refreshCmd := got.handleCommentResultMsg(commentResultMsg{jobID: 2})
+	assert.Nil(refreshCmd, "a refresh whose response handleReviewMsg would drop on arrival must not be dispatched -- under the shared epoch it would supersede whatever legitimate fetch is outstanding for the selected job")
+}
+
+// TestCommentResultTasksOriginReviewUsesNonFollowPathEvenInSplit: the
+// split comment-refresh branch covers viewReview (detail focus), but a
+// TASKS-ORIGIN review is deliberately rendered FULL-SCREEN even on a
+// split-capable terminal (splitActive() returns false for it), so the
+// sequenced follow path's failures -- recorded only in m.splitDetailErr,
+// which only the split detail pane renders -- would be completely silent
+// for it. The refresh must take the plain, non-follow fetchReview path
+// instead, whose failures surface through the ordinary full-screen error
+// mechanism.
+func TestCommentResultTasksOriginReviewUsesNonFollowPathEvenInSplit(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withCurrentView(viewReview), withReview(splitTestReview())) // job 2's review loaded, split-capable terminal
+	m.reviewFromView = viewTasks                                                // tasks-origin -- rendered full-screen even in split
+
+	res, cmd := m.handleCommentResultMsg(commentResultMsg{jobID: 2})
+	got := res.(model)
+	require.NotNil(cmd, "the refresh must still dispatch")
+	// Every review fetch is ordered now, so the epoch bump no longer
+	// distinguishes the two paths -- the follow TAG does. A tasks-origin
+	// review must take the non-follow path, whose failures surface through
+	// the ordinary full-screen error mechanism rather than splitDetailErr.
+	assert.Greater(got.reviewFetchSeq, m.reviewFetchSeq, "every review fetch is stamped from the one shared epoch")
+	msg := cmd()
+	rm, ok := msg.(reviewMsg)
+	if ok {
+		assert.False(rm.follow, "a tasks-origin review must take the NON-follow path")
+	} else {
+		// A failed non-follow fetch
+		// surfaces as the typed reviewErrMsg (handled by
+		// handleReviewErrMsg), not reviewFollowErrMsg -- see
+		// reviewErrMsg's doc comment (types.go).
+		_, isErr := msg.(reviewErrMsg)
+		assert.True(isErr, "a failed non-follow fetch surfaces as reviewErrMsg, not reviewFollowErrMsg: %T", msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PR review finding (handlers.go:27): log-view navigation changed
+// selectedJobID without ever routing through followSelectionChange.
+// stepLogNav mutates the selection via moveSelectionToJobID -- a THIRD path
+// distinct from stepReviewNav/stepPromptNav -- but unlike those, the log
+// view's content lives entirely in logLines/paneLog* fields, never in
+// currentReview, so the split detail pane was left pointed at the job the
+// user navigated away from until an unrelated jobs refresh reconciled it.
+// ---------------------------------------------------------------------------
+
+// TestLogNavInSplitSchedulesDetailFollow is the reviewer's exact repro: split
+// mode, log view opened from the queue, arrow-key log navigation to a
+// different job. The detail pane must target the NEW job (follow scheduled:
+// gen bumped and a fetch cmd issued), not the one the log view was opened
+// for -- confirmed both immediately (gen bump, non-nil cmd, a real fetch
+// from the resulting tick) and after esc back to the queue.
+func TestLogNavInSplitSchedulesDetailFollow(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	// testQueueJobs order: job 3 (running, idx0), job 2 (done, idx1),
+	// job 1 (failed, idx2).
+	m := splitModel(withSelection(1, 2)) // job 2: done
+	m.currentView = viewLog
+	m.logFromView = viewQueue
+	m.logJobID = 2
+	m.logStreaming = false
+	prevGen := m.detailFollowGen
+
+	// Right = newer (see TestArrowKeysStepReviewNavInSplitDetailFocus):
+	// job 2 -> job 3 (running).
+	res, cmd := m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyRight})
+	got := res.(model)
+
+	assert.Equal(int64(3), got.selectedJobID, "the queue selection must move to the new job")
+	assert.Equal(int64(3), got.logJobID, "the log view opens the new job's log")
+	assert.Equal(viewLog, got.currentView)
+	assert.Greater(got.detailFollowGen, prevGen,
+		"detail follow must be scheduled for the new job (this is what stepLogNav skipped pre-fix)")
+	require.NotNil(cmd, "a command (log fetch batched with the detail follow) must be issued")
+
+	// The scheduled follow, once its debounce tick fires, targets the NEW
+	// job (3, running) -- not the one the log view was opened for.
+	_, followTickCmd := got.handleDetailFollowTick(detailFollowTickMsg{gen: got.detailFollowGen})
+	assert.NotNil(followTickCmd,
+		"the follow tick must dispatch a fetch for the new job (startPaneLog, since job 3 is running)")
+
+	// esc back to the queue: the pane's follow state already targets job 3,
+	// not job 2 (the job the log view was opened for).
+	res2, _ := got.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyEscape})
+	final := res2.(model)
+	assert.Equal(viewQueue, final.currentView)
+	assert.Equal(int64(3), final.selectedJobID,
+		"the detail pane's target on return to the queue is the NEW job, not the one the log view was opened for")
+}
+
+// TestLogNavFromTasksDoesNotScheduleDetailFollow confirms tasks-origin log
+// nav (logFromView == viewTasks) is unaffected by the stepLogNav fix: it
+// never reaches stepLogNav at all (handleNextKey/handlePrevKey route it to
+// nextFixLog/prevFixLog instead, which walk m.fixJobs via fixSelectedIdx),
+// so it must not touch selectedJobID or schedule a detail follow.
+func TestLogNavFromTasksDoesNotScheduleDetailFollow(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(1, 2)) // job 2 selected in the queue
+	m.currentView = viewLog
+	m.logFromView = viewTasks
+	m.logJobID = 20
+	m.fixSelectedIdx = 1
+	m.fixJobs = []storage.ReviewJob{
+		{ID: 10, Status: storage.JobStatusDone},
+		{ID: 20, Status: storage.JobStatusRunning},
+		{ID: 30, Status: storage.JobStatusFailed},
+	}
+	prevGen := m.detailFollowGen
+	prevSelected := m.selectedJobID
+
+	res, cmd := m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyLeft})
+	got := res.(model)
+
+	require.NotNil(cmd, "expected a command from tasks-origin log nav")
+	assert.Equal(2, got.fixSelectedIdx, "tasks-origin log nav steps m.fixJobs, unaffected by the stepLogNav fix")
+	assert.Equal(prevSelected, got.selectedJobID, "tasks-origin log nav must not touch the queue selection")
+	assert.Equal(prevGen, got.detailFollowGen, "tasks-origin log nav must not schedule a detail follow")
+}
+
+// TestLogNavInStackedDoesNotScheduleDetailFollow confirms the stepLogNav fix
+// is a no-op outside split layout: followSelectionChange gates on
+// m.layout != layoutSplit, so stacked-mode log nav still moves
+// selectedJobID/opens the new job's log exactly as before, with no follow
+// side effects -- there is no persistent detail pane to follow.
+func TestLogNavInStackedDoesNotScheduleDetailFollow(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := initTestModel(
+		withCurrentView(viewLog),
+		withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...),
+		withSelection(1, 2),
+	)
+	m.layout = layoutStacked
+	m.logFromView = viewQueue
+	m.logJobID = 2
+	prevGen := m.detailFollowGen
+
+	res, cmd := m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyRight})
+	got := res.(model)
+
+	assert.Equal(int64(3), got.selectedJobID, "selection still moves to the new job")
+	assert.Equal(int64(3), got.logJobID)
+	// A genuine selection change is an abandonment in any layout: the gen
+	// bump invalidates the old job's in-flight dispatch. What stays
+	// split-only is the follow TICK -- none is scheduled here, the only
+	// cmd is the log-open.
+	assert.Greater(got.detailFollowGen, prevGen,
+		"the selection change abandons the old job's dispatch even in stacked")
+	require.NotNil(cmd, "the log-open command is still issued")
+}
+
+// TestLogPaginateNavSchedulesDetailFollow covers a SECOND instance of the
+// same bug class, found by auditing every path that moves selectedJobID
+// during log-view content nav (not just stepLogNav by name): handleJobsMsg's
+// paginateNav-triggered auto-navigate, reached when log-view nav hits the
+// end of the currently loaded page and resumes after fetchMoreJobs lands.
+// This branch used to `return` early with only openLogView's cmd, bypassing
+// BOTH followSelectionChange and the splitReconcileDetail call at the
+// bottom of handleJobsMsg -- so the split detail pane had no self-healing
+// path at all until the next unrelated jobs refresh.
+func TestLogPaginateNavSchedulesDetailFollow(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(
+		withCurrentView(viewLog),
+		withTestJobs(storage.ReviewJob{
+			ID: 3, GitRef: "cccc333", Branch: "main", RepoName: "repoA",
+			Agent: "codex", Status: storage.JobStatusDone,
+		}),
+		withSelection(0, 3),
+	)
+	m.logFromView = viewQueue
+	m.logJobID = 3
+	m.paginateNav = viewLog
+	m.loadingMore = true
+	prevGen := m.detailFollowGen
+
+	// The appended page's next eligible row (older) is job 1, running.
+	res, cmd := m.handleJobsMsg(jobsMsg{
+		append: true,
+		jobs: []storage.ReviewJob{
+			{
+				ID: 1, GitRef: "aaaa111", Branch: "main", RepoName: "repoB",
+				Agent: "claude-code", Status: storage.JobStatusRunning,
+			},
+		},
+	})
+	got := res.(model)
+
+	require.NotNil(cmd)
+	assert.Equal(int64(1), got.selectedJobID, "auto-navigate must move selection to the newly loaded job")
+	assert.Equal(int64(1), got.logJobID)
+	assert.Greater(got.detailFollowGen, prevGen,
+		"detail follow must be scheduled for the newly loaded job (skipped pre-fix by the early return)")
+
+	_, followTickCmd := got.handleDetailFollowTick(detailFollowTickMsg{gen: got.detailFollowGen})
+	assert.NotNil(followTickCmd,
+		"the follow tick must dispatch a fetch (startPaneLog) for the newly selected running job")
+}
+
+// ---------------------------------------------------------------------------
+// A pending queue-'F' request can be stranded when a NEWER
+// follow fetch that superseded it then FAILS. reviewFixPanelPending is
+// deliberately left armed on supersession (handleReviewMsg's fetchSeq
+// branch), trusting the newer dispatch to eventually resolve it --
+// acceptReview's success-only consume handles that dispatch landing
+// successfully, but handleReviewFollowErrMsg didn't handle it FAILING, so a
+// follow failure left the flag armed with nothing left in flight to serve
+// it. Combined with an older (merely stale) review already loaded for the
+// job, splitReconcileDetail's Done-branch idempotency check then skips
+// re-fetching entirely, so nothing else would ever retry either: the panel
+// is silently, permanently stranded, and the user's deliberate 'F' vanishes.
+//
+// This is the third variant of the stranded-pending-panel class (after the
+// gen-mismatch strand and the wrong-origin strand): the FAILURE-path
+// strand. The fix retries the follow once (bounded, so a persistently
+// failing fetch can't loop forever) before clearing the pending flag with
+// user-visible feedback.
+// ---------------------------------------------------------------------------
+
+// TestPendingFixPanelRetriesThenClearsAfterFollowFetchFails is the
+// reviewer's exact repro: 'F' armed from the queue, its own ordinary fetch
+// superseded by a follow fetch (as a reconcile pass or debounce tick would
+// dispatch), which then fails -- with an OLDER review already loaded for
+// the job, so splitReconcileDetail alone would never retry. After the
+// first failure the pending flag must still be armed, but now with a NEW
+// fetch actually in flight to serve it (not stranded). After a SECOND
+// failure (the retry's own), the pending flag must be cleared with a
+// user-visible flash instead of left armed with nothing in flight.
+func TestPendingFixPanelRetriesThenClearsAfterFollowFetchFails(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// job 2: done, with an OLDER review already loaded -- exactly the
+	// condition under which splitReconcileDetail's idempotency check would
+	// never retry on its own.
+	m := splitModel(withReview(splitTestReview()), withSelection(1, 2), withTasksEnabled(true))
+
+	// 'F' from the queue arms the pending panel and dispatches its own
+	// ordinary fetch.
+	res, ordinaryCmd := m.handleFixKey()
+	got := res.(model)
+	require.NotNil(ordinaryCmd, "'F' must dispatch its own ordinary fetch")
+	require.True(got.reviewFixPanelPending)
+	require.Equal(int64(2), got.fixPromptJobID)
+	require.False(got.fixPromptFollowRetried)
+
+	// A reconcile pass (or the debounce tick) dispatches a FOLLOW fetch for
+	// the same job, superseding 'F's own fetch -- exactly what
+	// splitReconcileDetail/handleDetailFollowTick do on an ordinary jobs
+	// refresh while 'F's fetch is still outstanding.
+	followCmd := got.dispatchReviewFollow(2)
+	require.NotNil(followCmd)
+
+	// That follow fetch FAILS.
+	firstFail := reviewFollowErrMsg{
+		jobID: 2, gen: got.detailFollowGen, fetchSeq: got.reviewFetchSeq,
+		err: errors.New("network blip"),
+	}
+	res2, retryCmd := got.handleReviewFollowErrMsg(firstFail)
+	afterFirstFail := res2.(model)
+
+	require.NotNil(retryCmd,
+		"the first follow failure must retry -- the pending panel must not be left armed with nothing in flight")
+	assert.True(afterFirstFail.reviewFixPanelPending, "still armed: the retry is now in flight to serve it")
+	assert.Equal(int64(2), afterFirstFail.fixPromptJobID)
+	assert.True(afterFirstFail.fixPromptFollowRetried, "the retry must be marked so a second failure doesn't loop")
+	require.Error(afterFirstFail.splitDetailErr, "the failure is still recorded for the pane, as before")
+
+	// The retry ALSO fails.
+	secondFail := reviewFollowErrMsg{
+		jobID: 2, gen: afterFirstFail.detailFollowGen, fetchSeq: afterFirstFail.reviewFetchSeq,
+		err: errors.New("network blip again"),
+	}
+	res3, cmd3 := afterFirstFail.handleReviewFollowErrMsg(secondFail)
+	final := res3.(model)
+
+	assert.Nil(cmd3, "bounded to one retry -- must not loop forever")
+	assert.False(final.reviewFixPanelPending, "the pending flag must be resolved, not left stranded")
+	assert.Zero(final.fixPromptJobID)
+	assert.False(final.fixPromptFollowRetried)
+	assert.NotEmpty(final.flashMessage, "the user must be told 'F' could not be served")
+	assert.Equal(final.currentView, final.flashView, "the flash must be visible on the view the user is actually on")
+	assert.True(final.flashWarning, "a failure flash should render as a warning")
+}
+
+// TestPendingFixPanelUnaffectedByOrdinaryFlowSuccess confirms the
+// ordinary (non-superseded, non-retried) 'F' flow is unaffected by the
+// retry machinery: the panel still opens the instant ITS OWN fetch's
+// response lands.
+func TestPendingFixPanelUnaffectedByOrdinaryFlowSuccess(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(1, 2), withTasksEnabled(true)) // job 2: done, nothing loaded yet
+	m.currentReview = nil
+
+	res, cmd := m.handleFixKey()
+	got := res.(model)
+	require.NotNil(cmd)
+	require.True(got.reviewFixPanelPending)
+	require.Equal(int64(2), got.fixPromptJobID)
+
+	review := splitTestReview()
+	final := applyReviewMsg(t, got, reviewMsg{
+		review: review, jobID: 2, fetchSeq: got.reviewFetchSeq, dispatchedFrom: viewQueue,
+	})
+	assert.True(final.reviewFixPanelOpen, "the ordinary flow still opens the panel on its own response")
+	assert.False(final.reviewFixPanelPending)
+	assert.False(final.fixPromptFollowRetried)
+}
+
+// TestReviewFollowErrMsgNoPendingPanelUnaffected confirms a failed
+// follow fetch with NO pending 'F' request just records splitDetailErr
+// -- no retry is dispatched and no flash is shown, since there is
+// nothing pending to resolve.
+func TestReviewFollowErrMsgNoPendingPanelUnaffected(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(1, 2)) // job 2: done, no pending fix panel
+	require.False(m.reviewFixPanelPending)
+	prevFlash := m.flashMessage
+
+	res, cmd := m.handleReviewFollowErrMsg(reviewFollowErrMsg{
+		jobID: 2, gen: m.detailFollowGen, fetchSeq: m.reviewFetchSeq, err: errors.New("network error"),
+	})
+	got := res.(model)
+
+	assert.Nil(cmd, "no pending fix panel means nothing to retry")
+	require.Error(got.splitDetailErr, "the failure is still recorded exactly as before")
+	assert.False(got.reviewFixPanelPending)
+	assert.Equal(prevFlash, got.flashMessage, "no new flash when there was nothing pending to resolve")
+}
+
+// ---------------------------------------------------------------------------
+// Per-job attempt invalidation (m.jobAttemptGen).
+//
+// A rerun invalidation via a
+// detailFollowGen bump would have to be gated on the reran job being SELECTED --
+// because detailFollowGen is one global counter, so an unconditional bump
+// would have invalidated a legitimate in-flight fetch for whatever job was
+// actually selected. The gate's cost: a pre-rerun response for a job that
+// was NOT selected at rerun-confirm time stayed fresh on every axis and was
+// accepted as CONTENT the moment the user landed back on that job.
+// ---------------------------------------------------------------------------
+
+// TestStackedPreRerunResponseRejectedAfterReturnToJob is the exact repro:
+// stacked, start loading job X, rerun X, navigate to Y before the rerun
+// confirmation lands, return to X, and X's PRE-rerun response finally
+// arrives. Nothing on the pre-fix code path invalidated it -- the selection
+// never moved in a way that bumps gen (stacked selection changes don't
+// touch it), the rerun's own bump was skipped because X wasn't selected
+// when the confirmation landed, and no newer dispatch superseded the epoch
+// -- so the previous attempt's review was accepted as current content and
+// the view switched to it.
+func TestStackedPreRerunResponseRejectedAfterReturnToJob(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	_, m := mockServerModel(t, mockReviewHandler(*splitTestReview(), nil))
+	m.currentView = viewQueue
+	m.jobs = testQueueJobs()
+	m.selectedIdx, m.selectedJobID = 1, 2 // X = job 2 (done), selected
+	require.Equal(layoutStacked, m.layout)
+
+	// 1. Start loading X. The real dispatcher stamps the request with X's
+	//    attempt counter as it stands right now (0 -- no rerun observed).
+	cmd := m.dispatchReviewFetch(2)
+	require.NotNil(cmd)
+	staleMsg, ok := cmd().(reviewMsg)
+	require.True(ok, "expected a reviewMsg, got %T", cmd())
+	require.Equal(uint64(0), staleMsg.attempt, "sanity: dispatched before any rerun of X")
+
+	// 2/3. Rerun X, then navigate to Y (job 3) before the confirmation
+	//      lands. Stacked, so this dispatches nothing and bumps nothing.
+	m = m.moveSelectionToJobID(3)
+	require.Equal(int64(3), m.selectedJobID)
+	require.Equal(staleMsg.fetchSeq, m.reviewFetchSeq, "sanity: nothing superseded the in-flight fetch")
+
+	// 4. The rerun confirmation lands while Y is selected.
+	res, _ := m.handleRerunResultMsg(rerunResultMsg{jobID: 2})
+	m = res.(model)
+
+	// 5. Return to X. Again nothing dispatches or bumps in stacked mode.
+	m = m.moveSelectionToJobID(2)
+	require.Equal(staleMsg.gen, m.detailFollowGen, "sanity: gen never moved -- gen alone cannot catch this")
+	require.Equal(staleMsg.fetchSeq, m.reviewFetchSeq, "sanity: the epoch never moved either")
+
+	// 6. X's pre-rerun response finally arrives.
+	res2, _ := m.handleReviewMsg(staleMsg)
+	got := res2.(model)
+
+	assert.Nil(got.currentReview,
+		"a response from the attempt the rerun superseded must not become the pane's content")
+	assert.Equal(viewQueue, got.currentView,
+		"and it must not open the review view for the superseded attempt either")
+}
+
+// TestUnrelatedJobRerunDoesNotInvalidateSelectedJobFetch is the property the
+// old selection gate existed to protect, now protected by construction: a
+// rerun of job X must leave a legitimate in-flight fetch for the SELECTED
+// job Y completely alone. This is what made an unconditional detailFollowGen
+// bump unacceptable; a per-job counter has no such cross-job cost.
+func TestUnrelatedJobRerunDoesNotInvalidateSelectedJobFetch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(0, 3)) // Y = job 3 selected
+
+	// A legitimate follow fetch for Y is in flight, stamped now.
+	inflight := reviewMsg{
+		review: &storage.Review{
+			ID: 30, JobID: 3, Agent: "codex",
+			Job: &storage.ReviewJob{ID: 3, Status: storage.JobStatusDone},
+		},
+		jobID: 3, follow: true, gen: m.detailFollowGen,
+		fetchSeq: m.reviewFetchSeq, attempt: m.jobAttemptGen[3],
+	}
+
+	// An unrelated job X (2) is reran -- via the control socket, say.
+	res, _ := m.handleRerunResultMsg(rerunResultMsg{jobID: 2})
+	m = res.(model)
+	require.Positive(m.jobAttemptGen[2], "sanity: X's counter moved")
+	require.Equal(uint64(0), m.jobAttemptGen[3], "Y's counter must be untouched by X's rerun")
+
+	res2, _ := m.handleReviewMsg(inflight)
+	got := res2.(model)
+	require.NotNil(got.currentReview, "Y's in-flight fetch must still land normally")
+	assert.Equal(int64(3), got.currentReview.JobID)
+}
+
+// TestPostRerunFetchForSameJobAccepted covers the other half: once the rerun
+// is confirmed, a FRESH fetch for that job is stamped with the new attempt
+// value and must be accepted normally. The counter invalidates the old
+// attempt, not the job.
+func TestPostRerunFetchForSameJobAccepted(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	_, m := mockServerModel(t, mockReviewHandler(*splitTestReview(), nil))
+	m.currentView = viewQueue
+	m.jobs = testQueueJobs()
+	m.selectedIdx, m.selectedJobID = 1, 2
+
+	res, _ := m.handleRerunResultMsg(rerunResultMsg{jobID: 2})
+	m = res.(model)
+	require.Equal(uint64(1), m.jobAttemptGen[2])
+
+	cmd := m.dispatchReviewFetch(2)
+	require.NotNil(cmd)
+	fresh, ok := cmd().(reviewMsg)
+	require.True(ok, "expected a reviewMsg, got %T", cmd())
+	assert.Equal(uint64(1), fresh.attempt, "a post-rerun dispatch carries the post-rerun attempt")
+
+	res2, _ := m.handleReviewMsg(fresh)
+	got := res2.(model)
+	require.NotNil(got.currentReview, "the rerun's own fetch must land")
+	assert.Equal(int64(2), got.currentReview.JobID)
+}
+
+// TestPreRerunFollowErrRejectedForUnselectedRerun is the failure-path twin of
+// the repro above: a follow fetch that FAILS for an attempt a rerun has since
+// superseded must not reach splitDetailErr. Same shape for the ordinary
+// fetch's typed failure, so both error handlers are covered.
+func TestPreRerunFollowErrRejectedForUnselectedRerun(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(1, 2))
+
+	staleErr := reviewFollowErrMsg{
+		jobID: 2, err: errors.New("fetch for the superseded attempt failed"),
+		gen: m.detailFollowGen, fetchSeq: m.reviewFetchSeq,
+		attempt: m.jobAttemptGen[2],
+	}
+	staleOrdinaryErr := reviewErrMsg{
+		jobID: 2, err: errors.New("ordinary fetch for the superseded attempt failed"),
+		gen: m.detailFollowGen, fetchSeq: m.reviewFetchSeq,
+		attempt: m.jobAttemptGen[2],
+	}
+
+	// The selection moves away, the rerun of job 2 confirms, the selection
+	// returns -- the pre-fix path that left the response fully "fresh".
+	m = m.moveSelectionToJobID(3)
+	res, _ := m.handleRerunResultMsg(rerunResultMsg{jobID: 2})
+	m = res.(model)
+	m = m.moveSelectionToJobID(2)
+	require.Greater(m.jobAttemptGen[2], staleErr.attempt)
+
+	res2, _ := m.handleReviewFollowErrMsg(staleErr)
+	require.NoError(res2.(model).splitDetailErr,
+		"a follow failure belonging to a superseded attempt must not reach the pane")
+
+	res3, _ := m.handleReviewErrMsg(staleOrdinaryErr)
+	assert.NoError(res3.(model).err,
+		"an ordinary failure belonging to a superseded attempt must not become the global error")
+}
+
+// TestFetchReviewStampsJobAttempt is the direct unit check on the stamping
+// half (jobAttemptGen contract clause 3): fetchReview stamps the attempt
+// counter of the job it is FETCHING -- not of the selected job -- and
+// fetchReviewFollow carries it through onto the follow failure it re-tags.
+func TestFetchReviewStampsJobAttempt(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	_, m := mockServerModel(t, mockReviewHandler(*splitTestReview(), nil))
+	m.jobs = testQueueJobs()
+	m.selectedIdx, m.selectedJobID = 0, 3
+	m.jobAttemptGen[2] = 4
+	m.jobAttemptGen[3] = 9
+
+	msg := m.fetchReview(2, 1)()
+	rm, ok := msg.(reviewMsg)
+	require.True(ok, "expected a reviewMsg, got %T", msg)
+	assert.Equal(uint64(4), rm.attempt,
+		"the stamp is the FETCHED job's attempt count, not the selected job's")
+
+	// The failure path (a server that 500s) carries the same stamp through
+	// fetchReviewFollow's re-tag.
+	_, mErr := mockServerModel(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	mErr.jobAttemptGen[2] = 4
+	fmsg := mErr.fetchReviewFollow(2, 1)()
+	fe, ok := fmsg.(reviewFollowErrMsg)
+	require.True(ok, "expected a reviewFollowErrMsg, got %T", fmsg)
+	assert.Equal(uint64(4), fe.attempt, "the follow re-tag must carry the attempt stamp")
+}
+
+// ---------------------------------------------------------------------------
+// Every path that moves selectedJobID must
+// make the split detail pane FOLLOW the new job, not merely avoid stranding
+// a pending intent. stepPromptNav and handleJobsMsg's pagination
+// viewKindPrompt arm both changed the selection without the shared
+// transition, so a prompt-view walk between two RUNNING jobs (which
+// eligiblePromptRow admits) left the previous job's live-log buffer and
+// splitDetailErr rendering beneath the new job's status card, and never
+// started the new job's tail until an unrelated jobs refresh reconciled it.
+// ---------------------------------------------------------------------------
+
+// promptNavJobs returns two RUNNING jobs that both carry a prompt, so
+// eligiblePromptRow admits both and prompt-view nav can step between them.
+func promptNavJobs() []storage.ReviewJob {
+	return []storage.ReviewJob{
+		{
+			ID: 5, GitRef: "eeee555", Branch: "main", RepoName: "repoA",
+			Agent: "codex", Status: storage.JobStatusRunning, Prompt: "prompt for 5",
+		},
+		{
+			ID: 4, GitRef: "dddd444", Branch: "main", RepoName: "repoA",
+			Agent: "codex", Status: storage.JobStatusRunning, Prompt: "prompt for 4",
+		},
+	}
+}
+
+// tailingPromptModel is a split-layout prompt view on running job 4, whose
+// live tail is active in the detail pane and has already buffered a line and
+// recorded an error.
+func tailingPromptModel() model {
+	m := splitModel(
+		withCurrentView(viewKindPrompt),
+		withTestJobs(promptNavJobs()...),
+		withSelection(1, 4),
+	)
+	m.promptFromQueue = true
+	m.paneLogJobID = 4
+	m.paneLogStreaming = true
+	m.paneLogSeq = 3
+	m.paneLogLines = []logLine{{text: "job 4 buffered log line"}}
+	m.splitDetailErr = errors.New("job 4 tail failure")
+	return m
+}
+
+func TestPromptNavInSplitFollowsSelection(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := tailingPromptModel()
+	prevGen := m.detailFollowGen
+
+	// Right = newer: job 4 -> job 5, both running.
+	res, cmd := m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyRight})
+	got := res.(model)
+
+	require.Equal(int64(5), got.selectedJobID, "the queue selection must move to the new job")
+	assert.Greater(got.detailFollowGen, prevGen,
+		"the detail follow must be scheduled for the new job (this is what stepPromptNav skipped pre-fix)")
+	require.NotNil(cmd, "the scheduled follow must be returned as a command")
+	assert.False(got.paneLogStreaming, "the previous job's tail must be stopped")
+	assert.Greater(got.paneLogSeq, uint64(3),
+		"an in-flight pane-log fetch for the previous job must be invalidated")
+	require.NoError(got.splitDetailErr, "the previous job's error must not survive under the new job")
+	assert.NotContains(got.renderSplit(), "job 4 tail failure",
+		"the previous job's error must not render beneath the new job's status")
+
+	// The new job's tail starts off the scheduled follow, with no jobs
+	// refresh needed.
+	res2, tickCmd := got.handleDetailFollowTick(detailFollowTickMsg{gen: got.detailFollowGen})
+	got2 := res2.(model)
+	require.NotNil(tickCmd, "the follow tick must start the newly selected running job's tail")
+	assert.Equal(int64(5), got2.paneLogJobID)
+	assert.True(got2.paneLogStreaming)
+	assert.Empty(got2.paneLogLines, "the previous job's buffered log must be dropped")
+	assert.NotContains(got2.renderSplit(), "job 4 buffered log line")
+}
+
+// TestPromptPaginateNavInSplitFollowsSelection is the same property for the
+// pagination auto-nav arm, reached when prompt-view nav runs past the end of
+// the loaded page and resumes once fetchMoreJobs lands. The newly loaded job
+// is DONE here, which is the arm's early-return branch: pre-fix it returned
+// with only the prompt fetch, bypassing BOTH the follow transition and the
+// splitReconcileDetail call at the bottom of handleJobsMsg, so the pane had
+// no path back to the new job at all until some later, unrelated refresh --
+// meanwhile still tailing (and still showing the error of) the job the user
+// navigated away from.
+func TestPromptPaginateNavInSplitFollowsSelection(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(
+		withCurrentView(viewKindPrompt),
+		withTestJobs(promptNavJobs()[0]), // only job 5 (running) loaded so far
+		withSelection(0, 5),
+	)
+	m.promptFromQueue = true
+	m.paginateNav = viewKindPrompt
+	m.loadingMore = true
+	m.paneLogJobID = 5
+	m.paneLogStreaming = true
+	m.paneLogSeq = 3
+	m.splitDetailErr = errors.New("job 5 tail failure")
+	prevGen := m.detailFollowGen
+
+	res, cmd := m.handleJobsMsg(jobsMsg{append: true, jobs: []storage.ReviewJob{
+		{
+			ID: 4, GitRef: "dddd444", Branch: "main", RepoName: "repoA",
+			Agent: "codex", Status: storage.JobStatusDone, Prompt: "prompt for 4",
+		},
+	}})
+	got := res.(model)
+
+	require.NotNil(cmd)
+	require.Equal(int64(4), got.selectedJobID, "auto-navigate must move the selection to the newly loaded job")
+	assert.Greater(got.detailFollowGen, prevGen,
+		"the detail follow must be scheduled for the newly loaded job")
+	assert.False(got.paneLogStreaming, "the previous job's tail must be stopped")
+	assert.Greater(got.paneLogSeq, uint64(3),
+		"an in-flight pane-log fetch for the previous job must be invalidated")
+	require.NoError(got.splitDetailErr, "the previous job's error must not survive under the new job")
+
+	res2, tickCmd := got.handleDetailFollowTick(detailFollowTickMsg{gen: got.detailFollowGen})
+	require.NotNil(tickCmd,
+		"the follow tick must fetch the newly selected done job's review")
+	assert.Equal(int64(4), res2.(model).selectedJobID)
+}
+
+// TestPromptNavInStackedUnaffected confirms the fix is inert outside split:
+// followSelectionChange gates on m.layout, so stacked prompt nav still just
+// moves the selection and installs the new job's prompt.
+func TestPromptNavInStackedUnaffected(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := initTestModel(
+		withCurrentView(viewKindPrompt),
+		withDimensions(150, 40),
+		withTestJobs(promptNavJobs()...),
+		withSelection(1, 4),
+	)
+	m.promptFromQueue = true
+	m.paneLogJobID = 4
+	m.paneLogStreaming = true
+	m.paneLogSeq = 3
+	prevGen := m.detailFollowGen
+	require.Equal(layoutStacked, m.layout)
+
+	res, _ := m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyRight})
+	got := res.(model)
+
+	assert.Equal(int64(5), got.selectedJobID, "the selection still moves")
+	// Abandonment is layout-independent (gen bump on a genuine selection
+	// change); the split-only parts -- the follow tick and the pane-log
+	// invalidation -- must still not run in stacked.
+	assert.Greater(got.detailFollowGen, prevGen,
+		"the selection change abandons the old job's dispatch even in stacked")
+	assert.True(got.paneLogStreaming, "stacked mode must not touch pane-log state")
+	assert.Equal(uint64(3), got.paneLogSeq)
+	require.NotNil(got.currentReview)
+	assert.Equal("prompt for 5", got.currentReview.Prompt)
+}
+
+// ---------------------------------------------------------------------------
+// handleJobsMsg's selection normalization changes
+// selectedJobID and must disarm the
+// pending-open intent, not only close the fix panel. "Reactive-only" is
+// not safe here: a stale intent is only cleared
+// reactively when a message for the old job arrives with a mismatched jobID.
+// That argument fails when NOTHING is in flight for the old job -- nothing
+// arrives, nothing clears, and the intent waits for the selection to come
+// back, at which point reconciliation's follow response consumes it and
+// opens the review unbidden.
+// ---------------------------------------------------------------------------
+
+// TestNormalizationDisarmsPendingOpenForDeselectedJob is the repro: 'F' arms
+// an intent for job 2, a jobs refresh drops job 2 (so normalization moves the
+// selection off it), a later refresh selects job 2 again, and then a follow
+// response for job 2 lands. The review must NOT open and no panel may spring
+// open.
+func TestNormalizationDisarmsPendingOpenForDeselectedJob(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(1, 2)) // split, viewQueue, job 2 selected
+	m.tasksEnabled = true
+
+	// 'F' on job 2 arms both intents and dispatches an ordinary fetch.
+	res, cmd := m.handleFixKey()
+	m = res.(model)
+	require.NotNil(cmd)
+	require.Equal(int64(2), m.pendingReviewOpenJobID)
+
+	// A refresh drops job 2 from the list: normalization moves the
+	// selection off it. Nothing is in flight for job 2 that could clear
+	// the intent reactively -- its own fetch is the only outstanding
+	// request, and it is exactly what the test does NOT deliver.
+	res2, _ := m.handleJobsMsg(jobsMsg{
+		jobs:  []storage.ReviewJob{testQueueJobs()[0]}, // job 3 only
+		stats: storage.JobStats{},
+	})
+	m = res2.(model)
+	require.NotEqual(int64(2), m.selectedJobID, "sanity: normalization moved the selection off job 2")
+	assert.Equal(int64(0), m.pendingReviewOpenJobID,
+		"normalization moving the selection off the intent's job abandons that intent")
+
+	// A later refresh brings job 2 back as the only row, so normalization
+	// reselects it.
+	res3, _ := m.handleJobsMsg(jobsMsg{
+		jobs:  []storage.ReviewJob{testQueueJobs()[1]}, // job 2 only
+		stats: storage.JobStats{},
+	})
+	m = res3.(model)
+	require.Equal(int64(2), m.selectedJobID, "sanity: the selection came back to job 2")
+
+	// Reconciliation's follow response for job 2 lands.
+	res4, _ := m.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2, follow: true,
+		gen: m.detailFollowGen, fetchSeq: m.reviewFetchSeq,
+		attempt: m.jobAttemptGen[2], dispatchedFrom: viewQueue,
+	})
+	got := res4.(model)
+
+	assert.Equal(viewQueue, got.currentView,
+		"a follow response must not open the review view for an intent abandoned by normalization")
+	assert.Equal(focusList, got.focus, "and must not steal focus")
+	assert.False(got.reviewFixPanelOpen, "no panel may spring open")
+	assert.False(got.reviewFixPanelPending)
+}
+
+// TestNormalizationKeepsIntentWhenSelectionUnchanged is the property
+// this must not regress: a refresh that leaves the selection where it is
+// abandons nothing, so the armed intent is still served when its own
+// response arrives.
+func TestNormalizationKeepsIntentWhenSelectionUnchanged(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(1, 2))
+	m.tasksEnabled = true
+
+	res, cmd := m.handleFixKey()
+	m = res.(model)
+	require.NotNil(cmd)
+	require.Equal(int64(2), m.pendingReviewOpenJobID)
+
+	// A perfectly ordinary refresh: job 2 is still there and still selected.
+	res2, _ := m.handleJobsMsg(jobsMsg{jobs: testQueueJobs(), stats: storage.JobStats{}})
+	m = res2.(model)
+	require.Equal(int64(2), m.selectedJobID)
+	assert.Equal(int64(2), m.pendingReviewOpenJobID,
+		"a refresh that does not move the selection must not disarm the intent")
+	assert.True(m.reviewFixPanelPending, "nor close the pending fix panel")
+
+	// The 'F' fetch's own response still serves it.
+	res3, _ := m.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2,
+		gen: m.detailFollowGen, fetchSeq: m.reviewFetchSeq,
+		attempt: m.jobAttemptGen[2], dispatchedFrom: viewQueue,
+	})
+	got := res3.(model)
+	assert.Equal(viewReview, got.currentView, "the intent must still be served")
+	assert.True(got.reviewFixPanelOpen, "and the panel must still open")
+}
+
+// TestNormalizationLeavesForeignIntentArmed guards the keying: the disarm is
+// keyed on the job the selection moved OFF, so an intent armed for some other
+// job -- tasks 'P' on a parent that the queue selection has never sat on, for
+// instance -- is untouched by unrelated normalization.
+func TestNormalizationLeavesForeignIntentArmed(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withSelection(1, 2))
+	// An intent armed for job 9, which is not the selection.
+	m.pendingReviewOpenJobID = 9
+	m.pendingReviewOpenOrigin = viewTasks
+	m.pendingReviewOpenSeq = m.reviewFetchSeq
+
+	res, _ := m.handleJobsMsg(jobsMsg{
+		jobs:  []storage.ReviewJob{testQueueJobs()[0]}, // job 3 only: selection moves off 2
+		stats: storage.JobStats{},
+	})
+	got := res.(model)
+
+	assert.NotEqual(int64(2), got.selectedJobID, "sanity: normalization moved the selection")
+	assert.Equal(int64(9), got.pendingReviewOpenJobID,
+		"an intent for a job the selection never sat on must survive an unrelated normalization")
+}
+
+// TestFilterResetDisarmsPendingOpenForDeselectedJob:
+// resetQueueForFilterChange (filter.go) is the
+// shared chokepoint for every filter mutation -- the filter modal, the queue
+// shortcuts and the control socket all funnel through it -- and it zeroes
+// selectedJobID. The reactive clear does not cover that, because the refetch
+// it triggers can RE-SELECT the intent's own job before any message for that
+// job arrives, at which point the intent looks current again and the next
+// response for it opens the review (or springs the pending panel open) with
+// a filter change as the only thing the user actually asked for.
+func TestFilterResetDisarmsPendingOpenForDeselectedJob(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(1, 2))
+	m.tasksEnabled = true
+
+	res, cmd := m.handleFixKey()
+	m = res.(model)
+	require.NotNil(cmd)
+	require.Equal(int64(2), m.pendingReviewOpenJobID)
+	require.True(m.reviewFixPanelPending)
+
+	m.resetQueueForFilterChange()
+	assert.Equal(int64(0), m.pendingReviewOpenJobID,
+		"zeroing the selection abandons the intent bound to the job it deselected")
+	assert.False(m.reviewFixPanelPending, "and the pending fix panel with it")
+
+	// The post-filter refetch lands with job 2 as the only visible row, so
+	// normalization reselects exactly the job the intent was armed for.
+	res2, _ := m.handleJobsMsg(jobsMsg{
+		seq:   m.fetchSeq,
+		jobs:  []storage.ReviewJob{testQueueJobs()[1]},
+		stats: storage.JobStats{},
+	})
+	m2 := res2.(model)
+	require.Equal(int64(2), m2.selectedJobID, "sanity: the filtered list reselects job 2")
+
+	// Reconciliation's follow response for job 2 lands.
+	res3, _ := m2.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2, follow: true,
+		gen: m2.detailFollowGen, fetchSeq: m2.reviewFetchSeq,
+		attempt: m2.jobAttemptGen[2], dispatchedFrom: viewQueue,
+	})
+	got := res3.(model)
+
+	assert.Equal(viewQueue, got.currentView,
+		"a filter change must not end with the review view opening by itself")
+	assert.False(got.reviewFixPanelOpen, "nor with the fix panel springing open")
+}
+
+// ---------------------------------------------------------------------------
+// Tasks Enter and tasks 'P' move the QUEUE selection
+// from inside the Tasks view. Tasks keys return from handleKeyMsg's early
+// view switch before its followSelectionChange wrapper, so neither site gave
+// the split detail pane the shared transition: it kept tailing (and kept
+// showing the splitDetailErr of) the job the selection moved off, until
+// handlePaneLogTickMsg's own selected-job check killed the tail on a later
+// poll and splitReconcileDetail rebuilt on a later refresh.
+// ---------------------------------------------------------------------------
+
+// tailingTasksModel is the Tasks view over a split layout whose queue
+// selection is running job 3, with the detail pane actively tailing it and
+// an error recorded against that tail.
+func tailingTasksModel() model {
+	m := splitModel(withCurrentView(viewTasks), withSelection(0, 3)) // job 3: running
+	m.tasksEnabled = true
+	m.paneLogJobID = 3
+	m.paneLogStreaming = true
+	m.paneLogSeq = 3
+	m.paneLogLines = []logLine{{text: "job 3 buffered log line"}}
+	m.splitDetailErr = errors.New("job 3 tail failure")
+	m.fixSelectedIdx = 0
+	return m
+}
+
+func TestTasksParentKeyFollowsSelection(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	parentID := int64(2)
+	m := tailingTasksModel()
+	m.fixJobs = []storage.ReviewJob{
+		{ID: 101, Status: storage.JobStatusDone, ParentJobID: &parentID},
+	}
+	prevGen := m.detailFollowGen
+
+	got, cmd := pressKey(m, 'P')
+
+	require.Equal(parentID, got.selectedJobID, "'P' moves the queue selection to the parent job")
+	require.NotNil(cmd, "the follow must be batched with the parent's review fetch")
+	assert.Greater(got.detailFollowGen, prevGen,
+		"the detail follow must be scheduled for the newly selected job")
+	assert.False(got.paneLogStreaming, "the previous job's tail must be stopped")
+	assert.Greater(got.paneLogSeq, uint64(3),
+		"an in-flight pane-log fetch for the previous job must be invalidated")
+	require.NoError(got.splitDetailErr, "the previous job's error must not survive under the new job")
+	assert.Equal(parentID, got.pendingReviewOpenJobID,
+		"the follow's disarm must run BEFORE the dispatch re-arms the intent for the parent")
+}
+
+func TestTasksEnterFollowsSelection(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := tailingTasksModel()
+	m.fixJobs = []storage.ReviewJob{{ID: 101, Status: storage.JobStatusDone}}
+	prevGen := m.detailFollowGen
+
+	res, cmd := m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	got := res.(model)
+
+	require.Equal(int64(101), got.selectedJobID, "Enter moves the queue selection to the fix job")
+	require.NotNil(cmd)
+	assert.Greater(got.detailFollowGen, prevGen,
+		"the detail follow must be scheduled for the newly selected job")
+	assert.False(got.paneLogStreaming, "the previous job's tail must be stopped")
+	assert.Greater(got.paneLogSeq, uint64(3))
+	assert.NoError(got.splitDetailErr)
+}
+
+// TestTasksKeysInStackedUnaffected confirms the site-21 fix is inert outside
+// split layout, like every other followSelectionChange caller.
+func TestTasksKeysInStackedUnaffected(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	parentID := int64(2)
+	m := initTestModel(
+		withCurrentView(viewTasks),
+		withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...),
+		withSelection(0, 3),
+	)
+	m.tasksEnabled = true
+	m.fixJobs = []storage.ReviewJob{
+		{ID: 101, Status: storage.JobStatusDone, ParentJobID: &parentID},
+	}
+	m.paneLogJobID = 3
+	m.paneLogStreaming = true
+	m.paneLogSeq = 3
+	prevGen := m.detailFollowGen
+	require.Equal(layoutStacked, m.layout)
+
+	got, cmd := pressKey(m, 'P')
+
+	require.NotNil(cmd)
+	assert.Equal(parentID, got.selectedJobID, "the selection still moves")
+	// The selection change is an abandonment in any layout (gen bump);
+	// the dispatch that follows immediately re-arms the pending-open
+	// intent at the new gen, so the user's 'P' still opens the parent.
+	// The split-only parts -- the follow tick and pane-log invalidation
+	// -- must still not run in stacked.
+	assert.Greater(got.detailFollowGen, prevGen,
+		"the selection change abandons the old job's dispatch even in stacked")
+	assert.Equal(parentID, got.pendingReviewOpenJobID,
+		"the tasks 'P' dispatch re-arms the open intent after the abandonment")
+	assert.True(got.paneLogStreaming, "stacked mode must not touch pane-log state")
+	assert.Equal(uint64(3), got.paneLogSeq)
+}
+
+// TestEligibleReviewRowExcludesLiveJobs pins the constraint documented on
+// eligibleReviewRow (nav.go): stepReviewNav and handleJobsMsg's pagination
+// viewReview arm move selectedJobID WITHOUT followSelectionChange, and are
+// correct only because this predicate can never land them on a job with a
+// live pane-log tail. Widening it without routing those two consumers
+// through followSelectionChange first would strand the pane on the old
+// job, so this test fails deliberately if the predicate changes.
+func TestEligibleReviewRowExcludesLiveJobs(t *testing.T) {
+	assert := assert.New(t)
+	assert.False(eligibleReviewRow(storage.ReviewJob{Status: storage.JobStatusRunning}),
+		"running jobs must stay out of review nav -- see eligibleReviewRow's constraint comment (nav.go)")
+	assert.False(eligibleReviewRow(storage.ReviewJob{Status: storage.JobStatusQueued}),
+		"queued jobs must stay out of review nav -- see eligibleReviewRow's constraint comment (nav.go)")
+	assert.True(eligibleReviewRow(storage.ReviewJob{Status: storage.JobStatusDone}))
+	assert.True(eligibleReviewRow(storage.ReviewJob{Status: storage.JobStatusFailed}))
+}
+
+// TestRunningTaskPromptNotOverwrittenByReconcile: opening a running task's
+// prompt moves the selection to the fix job like the completed-task path.
+// Left on the previous queue job, split reconciliation would keep
+// following THAT job on every jobs refresh and its follow fetch would
+// replace currentReview -- swapping the displayed prompt's backing review
+// out from under the user.
+func TestRunningTaskPromptNotOverwrittenByReconcile(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withReview(splitTestReview())) // queue selection: job 2
+	m.tasksEnabled = true
+	m.currentView = viewTasks
+	m.fixJobs = []storage.ReviewJob{{
+		ID: 101, Status: storage.JobStatusRunning,
+		Agent: "codex", Prompt: "fix the null deref",
+	}}
+	m.fixSelectedIdx = 0
+
+	res, _ := m.handleTasksKey(keySpecialMsg(tea.KeyEnter))
+	m = res.(model)
+	require.Equal(viewKindPrompt, m.currentView)
+	require.Equal("fix the null deref", m.currentReview.Prompt)
+	assert.Equal(int64(101), m.selectedJobID,
+		"the selection must follow the task job so reconcile has nothing stale to follow")
+
+	// A jobs refresh lands while the prompt is displayed.
+	res, _ = m.handleJobsMsg(jobsMsg{jobs: testQueueJobs(), stats: storage.JobStats{}})
+	got := res.(model)
+	assert.Equal(viewKindPrompt, got.currentView)
+	require.NotNil(got.currentReview)
+	assert.Equal("fix the null deref", got.currentReview.Prompt,
+		"the displayed prompt's backing review must survive the refresh")
+}
+
+// TestAnchoredClosedReviewSurvivesHideClosedPruning: with hide-closed on,
+// closing the displayed review removes its row from the next refresh while
+// handleJobsMsg preserves the review-anchored selection -- the pane must
+// keep rendering the loaded review (and its actions must stay unblocked,
+// e.g. 'a' to unclose) instead of vanishing into "No job selected".
+func TestAnchoredClosedReviewSurvivesHideClosedPruning(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withReview(splitTestReview())) // job 2's review loaded
+	m.currentView = viewReview
+	m.focus = focusDetail
+	m.hideClosed = true
+
+	// The refresh omits the just-closed job 2 entirely.
+	pruned := []storage.ReviewJob{testQueueJobs()[0], testQueueJobs()[2]}
+	res, _ := m.handleJobsMsg(jobsMsg{jobs: pruned, stats: storage.JobStats{}})
+	got := res.(model)
+	require.Equal(int64(2), got.selectedJobID, "sanity: the anchored selection is preserved")
+	_, ok := got.selectedJob()
+	require.False(ok, "sanity: the job row is gone")
+
+	assert.True(got.selectedReviewLoaded(),
+		"the anchored review is the only truth for the pruned job and must count as loaded")
+	lines := strings.Join(got.renderDetailPane(88, 25), "\n")
+	assert.Contains(lines, "first finding", "the review must keep rendering")
+	assert.NotContains(lines, "No job selected")
+
+	_, blocked := got.guardStaleSplitDetailAction(keyPressMsg('a'))
+	assert.False(blocked, "review actions (unclose) must not be blocked")
+}
+
+// TestLeaveSplitClosesPanelWithDiscardedReview: applyLayout's leave-split
+// discard branch nils currentReview -- an open fix panel bound to that
+// review must close with it, or the next review rendered in stacked (e.g.
+// Enter on a failed job, whose synchronous synthesis assigns
+// currentReview directly without acceptReview's wrong-job panel close)
+// shows the stale panel and submitting targets the previous job.
+func TestLeaveSplitClosesPanelWithDiscardedReview(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withReview(splitTestReview())) // job 2's review loaded
+	m.focus = focusList                            // list focus: the leave discards the review
+	m.reviewFixPanelOpen = true
+	m.fixPromptJobID = 2
+	m.fixPromptText = "typed for job 2"
+
+	m.applyLayout(layoutStacked)
+	require.Nil(m.currentReview, "sanity: the leave discarded the review")
+	assert.False(m.reviewFixPanelOpen, "the panel must close with the review it was bound to")
+	assert.Equal(int64(0), m.fixPromptJobID)
+
+	// Selecting a failed job in stacked renders its synthesized review
+	// with no stale panel over it.
+	m.selectedIdx, m.selectedJobID = 2, 1
+	m.currentReview = synthesizeFailedReview(&m.jobs[2], nil)
+	m.currentView = viewReview
+	assert.False(m.reviewFixPanelOpen,
+		"the failed job's review must not inherit the previous job's panel")
+}
+
+// TestSupersededResponseDoesNotReopenAfterEsc: the superseded-branch
+// fallback switch fires only while the matching pending-open intent is
+// still armed. Once a newer response consumed the intent (opening the
+// view) and the user pressed esc back to the queue, a late older response
+// owes nothing -- an unconditional content-present switch would yank the
+// user back into the review with no request outstanding.
+func TestSupersededResponseDoesNotReopenAfterEsc(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel() // job 2 (done) selected, viewQueue
+
+	require.NotNil(m.dispatchReviewFetch(2)) // ordinary fetch, arms the intent
+	staleMsg := reviewMsg{
+		review: splitTestReview(), jobID: 2,
+		gen: m.detailFollowGen, fetchSeq: m.reviewFetchSeq,
+		dispatchedFrom: viewQueue,
+	}
+
+	// A newer follow lands first: consumes the intent, opens the view.
+	require.NotNil(m.dispatchReviewFollow(2))
+	res, _ := m.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2, follow: true,
+		gen: m.detailFollowGen, fetchSeq: m.reviewFetchSeq,
+	})
+	m = res.(model)
+	require.Equal(viewReview, m.currentView, "sanity: the intent was served")
+	require.Equal(int64(0), m.pendingReviewOpenJobID)
+
+	// The user leaves the review.
+	res, _ = pressSpecial(m, tea.KeyEscape)
+	m = res.(model)
+	require.Equal(viewQueue, m.currentView)
+
+	// The old ordinary response finally lands: superseded, no armed
+	// intent -- it must not reopen the review.
+	res, _ = m.handleReviewMsg(staleMsg)
+	assert.Equal(viewQueue, res.(model).currentView,
+		"a late superseded response must not reopen a review the user already left")
+}
+
+// TestRerunDuringPromptViewReturnsToQueue: a control-socket rerun of the
+// prompted job clears currentReview while the prompt view is open;
+// viewContent then silently renders the queue while keys still route as
+// prompt input. normalizeSplitState must repair the view.
+func TestRerunDuringPromptViewReturnsToQueue(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withReview(splitTestReview())) // job 2's review loaded
+	m.currentView = viewKindPrompt
+	m.promptFromQueue = true
+
+	res, _ := m.handleRerunResultMsg(rerunResultMsg{jobID: 2})
+	got := res.(model)
+	require.Nil(got.currentReview, "sanity: the rerun cleared the loaded review")
+
+	got = got.normalizeSplitState() // Update applies this before rendering
+	assert.Equal(viewQueue, got.currentView,
+		"a nil-backed prompt view must return to the queue, not linger over a queue render")
+}
+
+// TestFailedReviewStaleAfterMissedRerunWindow: a rerun whose whole
+// queued/running window fell between refreshes and then failed with
+// IDENTICAL error text leaves the loaded earlier failure matching on
+// JobID and Output -- the completion-identity comparison (FinishedAt) is
+// what marks it stale, in both selectedReviewLoaded and the reconcile
+// fast path.
+func TestFailedReviewStaleAfterMissedRerunWindow(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(2, 1)) // job 1: failed, error "boom"
+	m.currentReview = synthesizeFailedReview(&m.jobs[2], nil)
+	require.True(m.selectedReviewLoaded(), "sanity: the synthesized failure is current")
+
+	// A missed-window rerun fails again at a later time with the SAME text.
+	later := splitTestFinishedAt.Add(time.Minute)
+	m.jobs[2].FinishedAt = &later
+	assert.False(m.selectedReviewLoaded(),
+		"a newer completion with identical text must still read as stale")
+
+	// Reconcile rebuilds rather than treating the old attempt as current.
+	got, _ := m.splitReconcileDetail()
+	require.NotNil(got.currentReview)
+	require.NotNil(got.currentReview.Job.FinishedAt)
+	assert.True(got.currentReview.Job.FinishedAt.Equal(later),
+		"the rebuild must embed the NEW attempt's completion identity")
+}
+
+// TestPreRerunResponseCannotOverwriteSynthesizedFailure: the synchronous
+// failed-job rebuild is routed through the shared ordered acceptance
+// (acceptSynthesizedFailure bumps the fetch epoch). Without the bump, a
+// reviewMsg dispatched BEFORE an external rerun -- which bumps no
+// jobAttemptGen and moves no selection, so every other gate still passes
+// -- would land after the rebuild and replace the synthesized failure
+// with the previous attempt's review until a later refresh corrected it.
+func TestPreRerunResponseCannotOverwriteSynthesizedFailure(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel() // job 2 (done) selected, no review loaded
+
+	// An ordinary fetch for job 2 goes out pre-rerun.
+	require.NotNil(m.dispatchReviewFetch(2))
+	staleMsg := reviewMsg{
+		review: splitTestReview(), jobID: 2,
+		gen: m.detailFollowGen, fetchSeq: m.reviewFetchSeq,
+		dispatchedFrom: viewQueue,
+	}
+
+	// The job is externally rerun and FAILS before that response lands.
+	m.jobs[1].Status = storage.JobStatusFailed
+	m.jobs[1].Error = "rerun exploded"
+	m, _ = m.splitReconcileDetail()
+	require.NotNil(m.currentReview)
+	require.Contains(m.currentReview.Output, "rerun exploded")
+
+	// The pre-rerun response lands afterward: superseded, content dropped.
+	res, _ := m.handleReviewMsg(staleMsg)
+	got := res.(model)
+	require.NotNil(got.currentReview)
+	assert.Contains(got.currentReview.Output, "rerun exploded",
+		"the previous attempt's review must not overwrite the synthesized failure")
+	assert.NotContains(got.currentReview.Output, "first finding")
+}
+
+// TestDetailFollowTickRefetchesStaleAttemptReview: the follow tick's Done
+// fast path treats only a CURRENT review as "already loaded". A
+// stale-but-matching review (the job was rerun and completed since it was
+// loaded) renders as "Loading review..." under renderDetailPane's
+// freshness gate, so skipping the fetch would stall that placeholder until
+// the next fallback poll.
+func TestDetailFollowTickRefetchesStaleAttemptReview(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview())) // job 2 (done) selected
+	later := splitTestFinishedAt.Add(time.Minute)
+	m.jobs[1].FinishedAt = &later // a rerun completed since the review was loaded
+
+	m, _ = m.scheduleDetailFollow()
+	res, cmd := m.handleDetailFollowTick(detailFollowTickMsg{gen: m.detailFollowGen})
+	assert.NotNil(cmd, "a stale-but-matching review must dispatch an immediate refetch")
+	_ = res
+
+	// Control: a fresh review skips the fetch.
+	m2 := splitModel(withReview(splitTestReview()))
+	m2, _ = m2.scheduleDetailFollow()
+	_, cmd2 := m2.handleDetailFollowTick(detailFollowTickMsg{gen: m2.detailFollowGen})
+	assert.Nil(cmd2, "a current review needs no refetch")
+}
+
+// TestBootstrapDetailRefetchesStaleAttemptReview: maybeBootstrapDetail's
+// twin of the follow-tick fast path -- entering split with a
+// stale-but-matching review must schedule the follow rather than leave the
+// pane's loading placeholder stalled.
+func TestBootstrapDetailRefetchesStaleAttemptReview(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel(withReview(splitTestReview()))
+	later := splitTestFinishedAt.Add(time.Minute)
+	m.jobs[1].FinishedAt = &later
+
+	_, cmd := m.maybeBootstrapDetail()
+	assert.NotNil(cmd, "a stale-but-matching review must schedule the follow on split engage")
+
+	// Control: a fresh review schedules nothing.
+	m2 := splitModel(withReview(splitTestReview()))
+	_, cmd2 := m2.maybeBootstrapDetail()
+	assert.Nil(cmd2)
+}
+
+// TestFilterResetAbandonsPromptAndReconcileSlot: resetQueueForFilterChange
+// is an abandonment event like user navigation -- it must doom an
+// in-flight prompt response (a refetch can re-select the same job before
+// it lands, re-satisfying every other handlePromptMsg gate) and release
+// the reconcile suppression slot (left armed, it suppresses the
+// re-selected job's replacement fetch until another refresh).
+func TestFilterResetAbandonsPromptAndReconcileSlot(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// Prompt half.
+	m := splitModel() // job 2 (done) selected
+	require.NotNil(m.dispatchPromptFetch(2))
+	staleSeq := m.promptFetchSeq
+	m.resetQueueForFilterChange()
+	m.jobs = testQueueJobs() // the refetch lands and re-selects job 2
+	m.selectedIdx, m.selectedJobID = 1, 2
+	res, _ := m.handlePromptMsg(promptMsg{
+		review: splitTestReview(), jobID: 2,
+		promptSeq: staleSeq, dispatchedFrom: viewQueue,
+	})
+	got := res.(model)
+	assert.Equal(viewQueue, got.currentView,
+		"an abandoned prompt response must not open the prompt view after a filter reset")
+	assert.Nil(got.currentReview)
+
+	// Reconcile-slot half.
+	m = splitModel()
+	m, cmd := m.splitReconcileDetail() // arms the slot for job 2
+	require.NotNil(cmd)
+	require.Equal(int64(2), m.reconcileFetchJobID)
+	m.resetQueueForFilterChange()
+	assert.Zero(m.reconcileFetchJobID, "the abandoned era's suppression slot must be released")
+	m.jobs = testQueueJobs()
+	m.selectedIdx, m.selectedJobID = 1, 2
+	_, cmd2 := m.splitReconcileDetail()
+	assert.NotNil(cmd2, "the re-selected job's replacement fetch must not be suppressed")
+}
+
+// TestJobsNormalizationAbandonsPromptAndReconcileSlot: handleJobsMsg's
+// selection normalization (the selected job vanished from the refresh) is
+// the same abandonment event -- same request-scoped state to doom.
+func TestJobsNormalizationAbandonsPromptAndReconcileSlot(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel() // job 2 (done) selected
+	require.NotNil(m.dispatchPromptFetch(2))
+	stalePromptSeq := m.promptFetchSeq
+	m, cmd := m.splitReconcileDetail() // arms the slot for job 2
+	require.NotNil(cmd)
+	require.Equal(int64(2), m.reconcileFetchJobID)
+
+	// A refresh without job 2 normalizes the selection off it.
+	remaining := []storage.ReviewJob{testQueueJobs()[0], testQueueJobs()[2]}
+	res, _ := m.handleJobsMsg(jobsMsg{jobs: remaining, stats: storage.JobStats{}})
+	got := res.(model)
+	require.NotEqual(int64(2), got.selectedJobID, "sanity: normalization moved the selection")
+
+	assert.NotEqual(stalePromptSeq, got.promptFetchSeq,
+		"normalization must doom the abandoned prompt request")
+	assert.Zero(got.reconcileFetchJobID,
+		"normalization must release the abandoned era's suppression slot")
+}
+
+// TestLeaveSplitDropsStaleAttemptReview: leaving split with detail focus
+// keeps the full-screen review only when it is the selected job's CURRENT
+// attempt. A stale attempt's review (external rerun observed) must not
+// carry into stacked, where reconcile no longer runs to replace it and
+// review actions would target the obsolete attempt indefinitely.
+func TestLeaveSplitDropsStaleAttemptReview(t *testing.T) {
+	assert := assert.New(t)
+
+	m := splitModel(withReview(splitTestReview())) // job 2 (done) selected
+	m.currentView = viewReview
+	m.focus = focusDetail
+	m.paneReviewSeenNonTerminalJob = 2 // job 2's external rerun was observed
+
+	m.applyLayout(layoutStacked)
+	assert.Equal(viewQueue, m.currentView, "a stale review must not carry into stacked full-screen")
+	assert.Nil(m.currentReview)
+
+	// Control: a fresh review survives the leave.
+	m2 := splitModel(withReview(splitTestReview()))
+	m2.currentView = viewReview
+	m2.focus = focusDetail
+	m2.applyLayout(layoutStacked)
+	assert.Equal(viewReview, m2.currentView)
+	assert.NotNil(m2.currentReview)
+
+	// Control: a tasks-origin review (fix job, never resolvable in m.jobs)
+	// is preserved unconditionally -- the user is reading it.
+	m3 := splitModel()
+	m3.currentView = viewReview
+	m3.reviewFromView = viewTasks
+	m3.focus = focusDetail
+	m3.currentReview = &storage.Review{JobID: 99, Output: "fix review"}
+	m3.selectedJobID = 99
+	m3.applyLayout(layoutStacked)
+	assert.Equal(viewReview, m3.currentView)
+	assert.NotNil(m3.currentReview)
+}
+
+// TestDistractionFreeForcesStackedAtSplitDims: distraction-free is a
+// title-plus-list-only contract; at split-capable dimensions it must
+// disable the split composition (detail pane, borders, info line, footer)
+// entirely, not render split chrome around a compact list. L cannot
+// re-engage split while it is active; toggling D off restores split.
+func TestDistractionFreeForcesStackedAtSplitDims(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withReview(splitTestReview())) // 150x40: split-capable
+	require.True(m.splitActive())
+
+	got, _ := pressKey(m, 'D')
+	assert.True(got.distractionFree)
+	assert.Equal(layoutStacked, got.layout)
+	assert.False(got.splitActive())
+	out := got.viewContent()
+	assert.NotContains(out, "│", "no split pane borders in distraction-free")
+	assert.NotContains(out, "focus detail", "no split help footer in distraction-free")
+
+	// L must not re-engage the split composition while active.
+	got2, _ := pressKey(got, 'L')
+	assert.Equal(layoutStacked, got2.layout)
+	assertFlashMessage(t, got2, viewQueue,
+		"Split layout is unavailable in distraction-free mode (press D to exit)")
+
+	// Toggling D off restores split at these dimensions.
+	got3, _ := pressKey(got2, 'D')
+	assert.False(got3.distractionFree)
+	assert.Equal(layoutSplit, got3.layout)
+}
+
+// TestRunningPromptSurvivesJobFailure: the prompt view over a running job
+// renders a synthetic review built from the row's Prompt, and the daemon
+// strips terminal jobs' prompts from listings (stripJobPrompts) -- so when
+// the job fails, that synthetic review is the LAST copy of the prompt the
+// TUI holds. splitReconcileDetail's failure synthesis must carry it over,
+// or the open prompt view blanks unrecoverably.
+func TestRunningPromptSurvivesJobFailure(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running
+	m.jobs[0].Prompt = "review the diff carefully"
+
+	res, _ := m.handlePromptKey()
+	m = res.(model)
+	require.Equal(viewKindPrompt, m.currentView)
+	require.Equal("review the diff carefully", m.currentReview.Prompt)
+
+	// The job fails; the refreshed row arrives with its prompt stripped.
+	m.jobs[0].Status = storage.JobStatusFailed
+	m.jobs[0].Error = "agent exploded"
+	m.jobs[0].Prompt = ""
+	m, _ = m.splitReconcileDetail()
+
+	assert.Equal(viewKindPrompt, m.currentView, "the prompt view stays put")
+	require.NotNil(m.currentReview)
+	assert.Equal("review the diff carefully", m.currentReview.Prompt,
+		"the displayed prompt must survive the failure synthesis")
+	assert.Contains(m.currentReview.Output, "agent exploded",
+		"the synthesized failure content still replaces the review body")
+}
+
+// TestPromptMsgDoesNotYankTransientView: the queue stays interactive while
+// a 'p' fetch is in flight, so its response can land after the user opened
+// a filter/tasks/help view -- the dispatch-origin guard must drop it
+// rather than replace the view the user is now in.
+func TestPromptMsgDoesNotYankTransientView(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel() // job 2 (done) selected, viewQueue
+	cmd := m.dispatchPromptFetch(2)
+	require.NotNil(t, cmd)
+	msg := promptMsg{
+		review: splitTestReview(), jobID: 2,
+		promptSeq: m.promptFetchSeq, dispatchedFrom: viewQueue,
+	}
+
+	// The user opens the filter view before the response lands.
+	m.currentView = viewFilter
+	res, _ := m.handlePromptMsg(msg)
+	got := res.(model)
+	assert.Equal(viewFilter, got.currentView,
+		"a slow prompt response must not replace the view the user opened")
+	assert.Nil(got.currentReview, "dropped entirely, not loaded in the background")
+}
+
+// TestAbandonedPromptRequestDroppedOnReturn: navigating away and back to
+// the same job re-satisfies the jobID gate, so without its own request
+// identity an abandoned 'p' fetch would pop the prompt view open with no
+// fresh keypress. followSelectionChange bumps promptFetchSeq on every
+// genuine selection change, dooming the in-flight request.
+func TestAbandonedPromptRequestDroppedOnReturn(t *testing.T) {
+	assert := assert.New(t)
+	m := splitModel() // job 2 (done) selected, viewQueue
+	cmd := m.dispatchPromptFetch(2)
+	require.NotNil(t, cmd)
+	staleSeq := m.promptFetchSeq
+
+	// Navigate to job 3 and back to job 2 before the response lands.
+	m = m.moveSelectionToJobID(3)
+	m, _ = m.followSelectionChange(2)
+	m = m.moveSelectionToJobID(2)
+	m, _ = m.followSelectionChange(3)
+
+	res, _ := m.handlePromptMsg(promptMsg{
+		review: splitTestReview(), jobID: 2,
+		promptSeq: staleSeq, dispatchedFrom: viewQueue,
+	})
+	got := res.(model)
+	assert.Equal(viewQueue, got.currentView,
+		"an abandoned prompt request must not open the prompt view on return")
+	assert.Nil(got.currentReview)
+}
+
+// TestPromptFetchRejectedAfterRerunSupersedesAttempt is the prompt
+// path's copy of the attempt-staleness repro, and the reason
+// fetchReviewForPrompt stamps the
+// attempt counter: handlePromptMsg writes the SAME currentReview field the
+// split pane renders and reconcile's idempotency check reads, so a response
+// from a superseded attempt overwrites the nil handleRerunResultMsg just
+// wrote and then blocks the rerun's real result from ever being fetched.
+func TestPromptFetchRejectedAfterRerunSupersedesAttempt(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	_, m := mockServerModel(t, mockReviewHandler(*splitTestReview(), nil))
+	m.currentView = viewQueue
+	m.jobs = testQueueJobs()
+	m.selectedIdx, m.selectedJobID = 1, 2 // job 2: done, selected
+
+	// 'p' on job 2 dispatches the prompt fetch, stamped with job 2's
+	// attempt counter as it stands now.
+	staleMsg, ok := m.dispatchPromptFetch(2)().(promptMsg)
+	require.True(ok, "expected a promptMsg")
+	require.Equal(uint64(0), staleMsg.attempt, "sanity: dispatched before any rerun")
+
+	// A rerun of job 2 confirms while that fetch is in flight.
+	res, _ := m.handleRerunResultMsg(rerunResultMsg{jobID: 2})
+	m = res.(model)
+	require.Nil(m.currentReview, "sanity: the rerun cleared the loaded review")
+
+	// The pre-rerun prompt response lands. The selection never moved, so
+	// the jobID gate alone cannot catch it.
+	res2, _ := m.handlePromptMsg(staleMsg)
+	got := res2.(model)
+
+	assert.Nil(got.currentReview,
+		"a prompt response from the attempt the rerun superseded must not overwrite the cleared review")
+	assert.Equal(viewQueue, got.currentView,
+		"and it must not switch into the prompt view for the superseded attempt")
+}
+
+// TestPromptFetchAcceptedAtCurrentAttempt is the non-regression counterpart:
+// the ordinary path (no rerun in between) still loads the prompt and opens
+// the view, and a post-rerun fetch is stamped with the new value and lands
+// normally.
+func TestPromptFetchAcceptedAtCurrentAttempt(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	_, m := mockServerModel(t, mockReviewHandler(*splitTestReview(), nil))
+	m.currentView = viewQueue
+	m.jobs = testQueueJobs()
+	m.selectedIdx, m.selectedJobID = 1, 2
+
+	msg, ok := m.dispatchPromptFetch(2)().(promptMsg)
+	require.True(ok)
+	res, _ := m.handlePromptMsg(msg)
+	got := res.(model)
+	require.NotNil(got.currentReview, "an ordinary prompt fetch must still land")
+	assert.Equal(viewKindPrompt, got.currentView)
+
+	// After a rerun, a FRESH prompt fetch carries the new attempt value.
+	res2, _ := got.handleRerunResultMsg(rerunResultMsg{jobID: 2})
+	m2 := res2.(model)
+	fresh, ok := m2.dispatchPromptFetch(2)().(promptMsg)
+	require.True(ok)
+	assert.Equal(uint64(1), fresh.attempt, "a post-rerun dispatch carries the post-rerun attempt")
+
+	res3, _ := m2.handlePromptMsg(fresh)
+	require.NotNil(res3.(model).currentReview, "the post-rerun prompt fetch must be accepted")
+}
+
+// ---------------------------------------------------------------------------
+// Rerunning a panel SYNTHESIS parent is not an abandonment of
+// that job's attempt. internal/daemon/server.go routes those to
+// rerunPanelRun, which clones the members and the synthesis row into a
+// brand-new run under a fresh panel_run_uuid with NEW job IDs and leaves the
+// original run -- this job's row and its review -- intact as history. 'r'
+// reaches that case: handleRerunKey blocks only PanelRoleMember.
+//
+// Bumping jobAttemptGen for it would falsify the counter's clause 2 ("a bump
+// is always abandonment"), which clause 4 ("nothing needs disarming on the
+// rejection path") is derived from -- so the exception is enforced in code,
+// decided at dispatch where the job is provably in hand.
+// ---------------------------------------------------------------------------
+
+func panelSynthesisJobs() []storage.ReviewJob {
+	jobs := testQueueJobs()
+	jobs[1].JobType = storage.JobTypeSynthesis // job 2
+	jobs[1].PanelRunUUID = "panel-run-1"
+	return jobs
+}
+
+func TestPanelSynthesisRerunDoesNotSupersedeAttempt(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withTestJobs(panelSynthesisJobs()...), withSelection(1, 2),
+		withReview(splitTestReview()))
+	m.tasksEnabled = true
+	require.True(m.jobs[1].IsSynthesisJob(), "sanity: job 2 is a panel synthesis parent")
+
+	// An 'F' request for job 2 is armed and its fetch is in flight.
+	res, cmd := m.handleFixKey()
+	m = res.(model)
+	require.NotNil(cmd)
+	require.Equal(int64(2), m.pendingReviewOpenJobID)
+	inflight := reviewMsg{
+		review: splitTestReview(), jobID: 2, dispatchedFrom: viewQueue,
+		gen: m.detailFollowGen, fetchSeq: m.reviewFetchSeq,
+		attempt: m.jobAttemptGen[2],
+	}
+	prevFlash := m.flashMessage
+
+	// The rerun confirms. The daemon enqueued a whole new panel run; this
+	// job's row, review and in-flight fetch are all still current.
+	res2, _ := m.handleRerunResultMsg(rerunResultMsg{jobID: 2, spawnsNewRun: true})
+	got := res2.(model)
+
+	assert.Equal(uint64(0), got.jobAttemptGen[2],
+		"a panel rerun spawns new job IDs, so THIS job's attempt was not superseded")
+	assert.NotNil(got.currentReview,
+		"the synthesis parent's review is still the current one and must not be cleared")
+	assert.Equal(int64(2), got.pendingReviewOpenJobID,
+		"the pending open intent must not be cancelled")
+	assert.True(got.reviewFixPanelPending, "nor the pending fix panel")
+	assert.NotContains(got.flashMessage, "open request canceled",
+		"no misleading 'job is rerunning -- open request canceled' flash: nothing was cancelled")
+	assert.Contains(got.flashMessage, "Panel rerun queued",
+		"the accepted rerun is confirmed instead, since this job's own row does not visibly change")
+	_ = prevFlash
+
+	// The in-flight fetch is still correct and must land.
+	res3, _ := got.handleReviewMsg(inflight)
+	final := res3.(model)
+	require.NotNil(final.currentReview)
+	assert.Equal(int64(2), final.currentReview.JobID)
+	assert.True(final.reviewFixPanelOpen, "the still-valid request is served normally")
+}
+
+// TestOrdinaryRerunStillSupersedesAttempt is the counterpart: the exception
+// is scoped to panel synthesis parents and must not weaken the ordinary case.
+func TestOrdinaryRerunStillSupersedesAttempt(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(1, 2), withReview(splitTestReview()))
+
+	res, _ := m.handleRerunResultMsg(rerunResultMsg{jobID: 2})
+	got := res.(model)
+
+	assert.Equal(uint64(1), got.jobAttemptGen[2], "an ordinary rerun still bumps")
+	require.Nil(got.currentReview, "and still clears the superseded review")
+}
+
+// TestRerunDispatchRecordsPanelRunShape pins the half of the fix that decides
+// the flag at DISPATCH -- where the job is provably in hand, unlike when the
+// result lands (by then the job may have left m.jobs).
+func TestRerunDispatchRecordsPanelRunShape(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	rerunOK := func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"success": true})
+	}
+
+	// Synthesis parent: 'r' must mark the rerun as spawning a new run.
+	_, m := mockServerModel(t, rerunOK)
+	m.currentView = viewQueue
+	m.jobs = panelSynthesisJobs()
+	m.selectedIdx, m.selectedJobID = 1, 2
+	res, cmd := m.handleRerunKey()
+	require.NotNil(cmd, "'r' is allowed on a synthesis parent -- only members are blocked")
+	_ = res
+	rm, ok := cmd().(rerunResultMsg)
+	require.True(ok, "expected a rerunResultMsg, got %T", cmd())
+	require.NoError(rm.err)
+	assert.True(rm.spawnsNewRun, "a synthesis parent's rerun spawns a new panel run")
+
+	// Ordinary job: the flag stays false.
+	_, m2 := mockServerModel(t, rerunOK)
+	m2.currentView = viewQueue
+	m2.jobs = testQueueJobs()
+	m2.selectedIdx, m2.selectedJobID = 1, 2
+	_, cmd2 := m2.handleRerunKey()
+	require.NotNil(cmd2)
+	rm2, ok := cmd2().(rerunResultMsg)
+	require.True(ok)
+	require.NoError(rm2.err)
+	assert.False(rm2.spawnsNewRun, "an ordinary rerun re-runs the job in place")
+}
+
+// ---------------------------------------------------------------------------
+// stepReviewNav and the pagination viewReview arm
+// replace currentReview for the new job and must not leave splitDetailErr pointing at
+// the old one. renderDetailPane's done branch renders that error whenever
+// currentReview does not yet match the selected job -- exactly the window
+// both sites create while their fetch is in flight.
+// ---------------------------------------------------------------------------
+
+func TestReviewNavClearsPreviousJobsDetailError(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	// testQueueJobs: job 3 running (idx0), job 2 done (idx1), job 1 failed (idx2).
+	m := splitModel(withCurrentView(viewReview), withSelection(1, 2),
+		withReview(splitTestReview()))
+	m.reviewFromView = viewQueue
+	// A reconcile follow failed while job 2's review was displayed.
+	m.splitDetailErr = errors.New("job 2 follow failure")
+	prevGen := m.detailFollowGen
+
+	// Left = older: job 2 -> job 1 (failed, also review-eligible).
+	res, cmd := m.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyLeft})
+	got := res.(model)
+
+	require.Equal(int64(1), got.selectedJobID, "the selection must move to the older review")
+	require.NoError(got.splitDetailErr,
+		"the previous job's failure must not render under the newly selected job")
+	assert.Greater(got.detailFollowGen, prevGen,
+		"review nav takes the shared detail-follow transition like every other selection move")
+	assert.NotContains(got.renderSplit(), "job 2 follow failure")
+	_ = cmd
+}
+
+func TestReviewPaginateNavClearsPreviousJobsDetailError(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(
+		withCurrentView(viewReview),
+		withTestJobs(storage.ReviewJob{
+			ID: 5, GitRef: "eeee555", Branch: "main", RepoName: "repoA",
+			Agent: "codex", Status: storage.JobStatusDone,
+		}),
+		withSelection(0, 5),
+	)
+	m.reviewFromView = viewQueue
+	m.paginateNav = viewReview
+	m.loadingMore = true
+	m.splitDetailErr = errors.New("job 5 follow failure")
+	prevGen := m.detailFollowGen
+
+	res, cmd := m.handleJobsMsg(jobsMsg{append: true, jobs: []storage.ReviewJob{
+		{
+			ID: 4, GitRef: "dddd444", Branch: "main", RepoName: "repoA",
+			Agent: "codex", Status: storage.JobStatusDone,
+		},
+	}})
+	got := res.(model)
+
+	require.NotNil(cmd)
+	require.Equal(int64(4), got.selectedJobID, "auto-navigate must move to the newly loaded review")
+	require.NoError(got.splitDetailErr,
+		"the previous job's failure must not survive the pagination jump (this arm's early return skips reconcile, so nothing else would clear it)")
+	assert.Greater(got.detailFollowGen, prevGen,
+		"the pagination review arm takes the shared transition too")
+}
+
+// ---------------------------------------------------------------------------
+// The same fact that makes a panel synthesis parent's ATTEMPT
+// survive its "rerun" -- the daemon enqueues a separate run and leaves this
+// row and its review untouched -- also means the row's own state must not be
+// optimistically re-queued. Both dispatchers wrote status=queued and wiped
+// the timestamps, error, closed state and verdict before the request went
+// out, so the parent displayed and behaved as a queued job, with its verdict
+// and closed state gone, while its review was still current.
+// ---------------------------------------------------------------------------
+
+// rerunOKHandler answers /api/job/rerun with a success body.
+func rerunOKHandler(w http.ResponseWriter, r *http.Request) {
+	json.NewEncoder(w).Encode(map[string]any{"success": true})
+}
+
+// assertSynthesisRowIntact checks every field the optimistic re-queue used to
+// clobber, plus the behaviour that a fake queued status breaks.
+func assertSynthesisRowIntact(t *testing.T, m model, jobID int64) {
+	t.Helper()
+	assert := assert.New(t)
+	var job *storage.ReviewJob
+	for i := range m.jobs {
+		if m.jobs[i].ID == jobID {
+			job = &m.jobs[i]
+		}
+	}
+	require.NotNil(t, job, "the synthesis parent must still be in the list")
+	assert.Equal(storage.JobStatusDone, job.Status,
+		"the parent is not re-queued: the daemon enqueues a separate run")
+	require.NotNil(t, job.Verdict, "its verdict must not be wiped")
+	assert.Equal("P", *job.Verdict)
+	require.NotNil(t, job.Closed, "its closed state must not be wiped")
+	assert.True(*job.Closed)
+	assert.NotNil(job.FinishedAt, "its completion timestamp must survive")
+	assert.Empty(job.Error)
+}
+
+func synthesisParentJobs() []storage.ReviewJob {
+	jobs := panelSynthesisJobs()
+	finished := time.Now().Add(-time.Hour)
+	closed := true
+	jobs[1].FinishedAt = &finished
+	jobs[1].Closed = &closed
+	jobs[1].PanelSummary = &storage.PanelSummary{MembersTerminal: 3, MembersTotal: 3}
+	return jobs
+}
+
+func TestRerunKeyLeavesSynthesisParentRowIntact(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	_, m := mockServerModel(t, rerunOKHandler)
+	m.currentView = viewQueue
+	m.jobs = synthesisParentJobs()
+	m.selectedIdx, m.selectedJobID = 1, 2
+	m.currentReview = splitTestReview()
+
+	res, cmd := m.handleRerunKey()
+	got := res.(model)
+	require.NotNil(cmd, "'r' still dispatches the panel rerun")
+
+	assertSynthesisRowIntact(t, got, 2)
+	require.NotNil(got.currentReview, "and the parent's review is still current")
+
+	// The behaviour a fake queued status broke: Enter must still open the
+	// parent's review instead of flashing "Panel still synthesizing".
+	_, handled := got.panelInProgressFlash(got.jobs[1])
+	assert.False(handled,
+		"a completed panel parent must not be treated as still synthesizing after its rerun is dispatched")
+
+	// The confirmation still reports the panel shape, so handleRerunResultMsg
+	// takes the spawnsNewRun branch.
+	rm, ok := cmd().(rerunResultMsg)
+	require.True(ok)
+	require.NoError(rm.err)
+	assert.True(rm.spawnsNewRun)
+
+	res2, _ := got.handleRerunResultMsg(rm)
+	final := res2.(model)
+	assertSynthesisRowIntact(t, final, 2)
+	assert.Contains(final.flashMessage, "Panel rerun queued",
+		"the accepted rerun is confirmed by a flash, since the row itself does not change")
+}
+
+func TestCtrlRerunLeavesSynthesisParentRowIntact(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	_, m := mockServerModel(t, rerunOKHandler)
+	m.currentView = viewQueue
+	m.jobs = synthesisParentJobs()
+	m.selectedIdx, m.selectedJobID = 1, 2
+
+	got, resp, cmd := m.handleCtrlRerunJob(json.RawMessage(`{"job_id":2}`))
+	require.Empty(resp.Error, "the control socket still accepts the rerun")
+	require.NotNil(cmd)
+
+	assertSynthesisRowIntact(t, got, 2)
+
+	rm, ok := cmd().(rerunResultMsg)
+	require.True(ok)
+	require.NoError(rm.err)
+	assert.True(rm.spawnsNewRun, "the control path records the panel shape too")
+}
+
+// TestRerunKeyStillShowsOptimisticQueueForOrdinaryJobs is the counterpart:
+// for a job the daemon really does re-run in place, the optimistic re-queue
+// is correct and must be unchanged.
+func TestRerunKeyStillShowsOptimisticQueueForOrdinaryJobs(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	_, m := mockServerModel(t, rerunOKHandler)
+	m.currentView = viewQueue
+	jobs := testQueueJobs()
+	finished := time.Now().Add(-time.Hour)
+	closed := true
+	jobs[1].FinishedAt = &finished
+	jobs[1].Closed = &closed
+	m.jobs = jobs
+	m.selectedIdx, m.selectedJobID = 1, 2
+
+	res, cmd := m.handleRerunKey()
+	got := res.(model)
+	require.NotNil(cmd)
+
+	assert.Equal(storage.JobStatusQueued, got.jobs[1].Status,
+		"an ordinary rerun still shows the optimistic queued state immediately")
+	assert.Nil(got.jobs[1].Verdict, "and still clears the stale verdict")
+	assert.Nil(got.jobs[1].Closed)
+	assert.Nil(got.jobs[1].FinishedAt)
+}
+
+// ---------------------------------------------------------------------------
+// Two consequences of not mutating a synthesis parent's row.
+//
+// (1) The row stays terminal while the rerun is in flight, so the status
+//     check that suppresses a second 'r' for an ordinary job no longer
+//     suppresses anything here -- and the daemon accepts both requests,
+//     because the status IT checks is this same unchanged row.
+// (2) The error path restored the pre-rerun snapshot unconditionally. For a
+//     job that was never mutated there is nothing to undo, and doing it
+//     anyway overwrites whatever DID change the row while the request was
+//     in flight.
+// ---------------------------------------------------------------------------
+
+func TestPanelRerunSuppressesDuplicateDispatch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	_, m := mockServerModel(t, rerunOKHandler)
+	m.currentView = viewQueue
+	m.jobs = synthesisParentJobs()
+	m.selectedIdx, m.selectedJobID = 1, 2
+
+	res, cmd := m.handleRerunKey()
+	m = res.(model)
+	require.NotNil(cmd, "the first 'r' dispatches")
+	require.True(m.panelRerunInFlight[2], "the dispatch must be recorded as in flight")
+
+	// The row is still terminal (deliberately unmutated), so only the new
+	// set can stop the second press.
+	require.Equal(storage.JobStatusDone, m.jobs[1].Status)
+	res2, cmd2 := m.handleRerunKey()
+	m2 := res2.(model)
+	assert.Nil(cmd2, "a second 'r' must not spawn a second panel run")
+	assert.Contains(m2.flashMessage, "Panel rerun already in progress",
+		"and must say so rather than doing nothing silently")
+
+	// The result releases the slot, so a deliberate later rerun still works.
+	rm, ok := cmd().(rerunResultMsg)
+	require.True(ok)
+	res3, _ := m2.handleRerunResultMsg(rm)
+	m3 := res3.(model)
+	assert.False(m3.panelRerunInFlight[2], "the result must release the slot")
+	_, cmd4 := m3.handleRerunKey()
+	assert.NotNil(cmd4, "a rerun requested after the previous one resolved is allowed")
+}
+
+// TestPanelRerunSlotReleasedOnFailure is the no-leak half: a failed request
+// must not leave the job blocked for the rest of the session.
+func TestPanelRerunSlotReleasedOnFailure(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	_, m := mockServerModel(t, rerunOKHandler)
+	m.currentView = viewQueue
+	m.jobs = synthesisParentJobs()
+	m.selectedIdx, m.selectedJobID = 1, 2
+
+	res, _ := m.handleRerunKey()
+	m = res.(model)
+	require.True(m.panelRerunInFlight[2])
+
+	res2, _ := m.handleRerunResultMsg(rerunResultMsg{
+		jobID: 2, spawnsNewRun: true, err: errors.New("daemon unreachable"),
+	})
+	m2 := res2.(model)
+	assert.False(m2.panelRerunInFlight[2], "a FAILED rerun must release the slot too")
+	require.Error(m2.err, "and still surface the failure")
+
+	_, cmd := m2.handleRerunKey()
+	assert.NotNil(cmd, "the job must not be permanently blocked by its failed rerun")
+}
+
+func TestCtrlPanelRerunSuppressesDuplicateDispatch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	_, m := mockServerModel(t, rerunOKHandler)
+	m.currentView = viewQueue
+	m.jobs = synthesisParentJobs()
+	m.selectedIdx, m.selectedJobID = 1, 2
+
+	got, resp, cmd := m.handleCtrlRerunJob(json.RawMessage(`{"job_id":2}`))
+	require.Empty(resp.Error)
+	require.NotNil(cmd)
+	require.True(got.panelRerunInFlight[2])
+
+	_, resp2, cmd2 := got.handleCtrlRerunJob(json.RawMessage(`{"job_id":2}`))
+	assert.Nil(cmd2, "a second control-socket rerun must not spawn a second panel run")
+	assert.Contains(resp2.Error, "already in flight",
+		"and must report an explicit error so a scripted caller can tell")
+}
+
+// TestOrdinaryRerunUnaffectedBySuppression: an ordinary job's own optimistic
+// re-queue is what suppresses its second press, exactly as before, and it
+// never enters the panel set.
+func TestOrdinaryRerunUnaffectedBySuppression(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	_, m := mockServerModel(t, rerunOKHandler)
+	m.currentView = viewQueue
+	m.jobs = testQueueJobs()
+	m.selectedIdx, m.selectedJobID = 1, 2
+
+	res, cmd := m.handleRerunKey()
+	m = res.(model)
+	require.NotNil(cmd)
+	assert.Empty(m.panelRerunInFlight, "an ordinary rerun uses no suppression slot")
+	assert.Equal(storage.JobStatusQueued, m.jobs[1].Status)
+
+	_, cmd2 := m.handleRerunKey()
+	assert.Nil(cmd2, "the optimistic queued status still suppresses the second press")
+}
+
+// TestFailedPanelRerunKeepsInterleavedRowState is FINDING 2's repro: the row
+// changed while the request was in flight, and the failure must surface
+// without dragging the row back to its pre-rerun snapshot.
+func TestFailedPanelRerunKeepsInterleavedRowState(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	_, m := mockServerModel(t, rerunOKHandler)
+	m.currentView = viewQueue
+	m.jobs = synthesisParentJobs()
+	m.selectedIdx, m.selectedJobID = 1, 2
+	oldClosed := false
+	oldVerdict := "P"
+	m.jobs[1].Closed = &oldClosed
+	m.jobs[1].Verdict = &oldVerdict
+
+	res, _ := m.handleRerunKey()
+	m = res.(model)
+
+	// While the request is in flight, a jobs refresh lands fresh server
+	// state for the same row: now closed, with a different verdict.
+	newClosed := true
+	newVerdict := "F"
+	refreshed := synthesisParentJobs()
+	refreshed[1].Closed = &newClosed
+	refreshed[1].Verdict = &newVerdict
+	res2, _ := m.handleJobsMsg(jobsMsg{jobs: refreshed, stats: storage.JobStats{}})
+	m = res2.(model)
+	require.Equal("F", *m.jobs[1].Verdict, "sanity: the refresh landed")
+
+	// The rerun request then fails, carrying the PRE-rerun snapshot.
+	res3, _ := m.handleRerunResultMsg(rerunResultMsg{
+		jobID: 2, spawnsNewRun: true, err: errors.New("daemon unreachable"),
+		oldState: storage.JobStatusDone, oldClosed: &oldClosed, oldVerdict: &oldVerdict,
+	})
+	got := res3.(model)
+
+	require.NotNil(got.jobs[1].Verdict)
+	assert.Equal("F", *got.jobs[1].Verdict,
+		"a failure for a job that was never mutated must not overwrite state that changed since")
+	require.NotNil(got.jobs[1].Closed)
+	assert.True(*got.jobs[1].Closed,
+		"the interleaved closed state must survive the failed rerun")
+	assert.Error(got.err, "the failure itself is still surfaced")
+}
+
+// TestStackedNavigateAwayAndBackAbandonsPendingOpen covers the stacked half
+// of the abandonment rule: followSelectionChange used to early-return
+// outside split layout, so navigating X -> Y -> X in stacked mode left the
+// pending-open intent armed and the original dispatch gen-fresh -- when the
+// abandoned response finally landed, it was accepted and opened X's review
+// with no fresh keypress. The rule is layout-independent: the selection
+// leaving a job abandons its pending requests, whoever moves it.
+func TestStackedNavigateAwayAndBackAbandonsPendingOpen(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := initTestModel(withCurrentView(viewQueue), withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...), withSelection(1, 2))
+	m.layout = layoutStacked
+
+	// Enter on job 2 (done): dispatches the ordinary fetch, arms the
+	// pending-open intent.
+	res, cmd := m.handleEnterKey()
+	got := res.(model)
+	require.NotNil(cmd)
+	require.Equal(int64(2), got.pendingReviewOpenJobID)
+	seqA := got.reviewFetchSeq
+	genA := got.detailFollowGen
+
+	// Away to job 3 and back to job 2, both before the response lands.
+	away, _ := pressSpecial(got, tea.KeyUp)
+	require.Equal(int64(3), away.selectedJobID, "sanity: selection moved away")
+	assert.Equal(int64(0), away.pendingReviewOpenJobID,
+		"navigating away abandons the pending open, in stacked too")
+	back, _ := pressSpecial(away, tea.KeyDown)
+	require.Equal(int64(2), back.selectedJobID, "sanity: selection returned")
+
+	// The abandoned response lands: jobID matches again, but the two
+	// selection changes each bumped the gen, and with the intent disarmed
+	// the response is un-rescuable -- it must not open the review.
+	res2, _ := back.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2,
+		fetchSeq: seqA, gen: genA, dispatchedFrom: viewQueue,
+	})
+	final := res2.(model)
+	assert.Equal(viewQueue, final.currentView,
+		"an abandoned request's response must not open the review after navigating back")
+}
+
+// TestStackedNavigateAwayAndBackAbandonsPendingFixPanel is the fix-panel
+// twin: F on X, navigate away and back, X's response arrives -- the panel
+// must not spring open for a request the user walked away from.
+func TestStackedNavigateAwayAndBackAbandonsPendingFixPanel(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := initTestModel(withCurrentView(viewQueue), withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...), withSelection(1, 2))
+	m.layout = layoutStacked
+	m.tasksEnabled = true
+
+	res, cmd := m.handleFixKey()
+	got := res.(model)
+	require.NotNil(cmd)
+	require.True(got.reviewFixPanelPending)
+	require.Equal(int64(2), got.fixPromptJobID)
+	seqA := got.reviewFetchSeq
+	genA := got.detailFollowGen
+
+	away, _ := pressSpecial(got, tea.KeyUp)
+	require.Equal(int64(3), away.selectedJobID, "sanity: selection moved away")
+	assert.False(away.reviewFixPanelPending,
+		"navigating away abandons the pending fix panel, in stacked too")
+	assert.Equal(int64(0), away.fixPromptJobID)
+	back, _ := pressSpecial(away, tea.KeyDown)
+	require.Equal(int64(2), back.selectedJobID)
+
+	res2, _ := back.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2,
+		fetchSeq: seqA, gen: genA, dispatchedFrom: viewQueue,
+	})
+	final := res2.(model)
+	assert.False(final.reviewFixPanelOpen,
+		"an abandoned F's response must not spring the fix panel open after navigating back")
+	assert.Equal(viewQueue, final.currentView)
+}
+
+// TestSplitEscNormalizesHiddenSelectionAndRefills: the split-specific esc
+// shortcut back to the list used to bypass normalizeSelectionIfHidden, so
+// after closing a review with hideClosed enabled the selection stayed on
+// the now-invisible job -- later actions targeted a job with no highlighted
+// row. It must normalize exactly as the stacked return path does, follow
+// the resulting selection change, and refill the hideClosed-pruned queue.
+func TestSplitEscNormalizesHiddenSelectionAndRefills(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	jobs := testQueueJobs()
+	closed := true
+	jobs[1].Closed = &closed // job 2: done and closed -> hidden under hideClosed
+	m := splitModel(withTestJobs(jobs...), withSelection(1, 2), withReview(splitTestReview()))
+	m.currentView = viewReview
+	m.focus = focusDetail
+	m.hideClosed = true
+	prevGen := m.detailFollowGen
+
+	got, cmd := pressSpecial(m, tea.KeyEsc)
+	assert.Equal(viewQueue, got.currentView)
+	assert.Equal(focusList, got.focus)
+	assert.NotEqual(int64(2), got.selectedJobID,
+		"the hidden job must not stay selected after returning to the list")
+	assert.Equal(prevGen+1, got.detailFollowGen,
+		"the normalized selection change must be followed exactly once: "+
+			"handleKeyMsg's wrapper owns the transition, the esc branch "+
+			"must not double-bump")
+	assert.True(got.loadingJobs, "the hideClosed refill must be dispatched")
+	require.NotNil(cmd)
+}
+
+// TestSplitQuitNormalizesHiddenSelectionAndRefills is the q-key twin of the
+// esc test above -- both split shortcuts share the same body and had the
+// same gap.
+func TestSplitQuitNormalizesHiddenSelectionAndRefills(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	jobs := testQueueJobs()
+	closed := true
+	jobs[1].Closed = &closed
+	m := splitModel(withTestJobs(jobs...), withSelection(1, 2), withReview(splitTestReview()))
+	m.currentView = viewReview
+	m.focus = focusDetail
+	m.hideClosed = true
+	prevGen := m.detailFollowGen
+
+	got, cmd := pressKey(m, 'q')
+	assert.Equal(viewQueue, got.currentView)
+	assert.Equal(focusList, got.focus)
+	assert.NotEqual(int64(2), got.selectedJobID,
+		"the hidden job must not stay selected after returning to the list")
+	assert.Equal(prevGen+1, got.detailFollowGen,
+		"the normalized selection change must be followed exactly once: "+
+			"handleKeyMsg's wrapper owns the transition, the q branch "+
+			"must not double-bump")
+	assert.True(got.loadingJobs, "the hideClosed refill must be dispatched")
+	require.NotNil(cmd)
+}
+
+// TestStackedMouseWheelAwayAbandonsPendingOpen is the mouse twin of
+// TestStackedNavigateAwayAndBackAbandonsPendingOpen: mouse events never pass
+// through handleKeyMsg's viewQueue wrapper, so the stacked wheel paths used
+// to move the selection while skipping the abandonment chokepoint -- the
+// pending-open intent stayed armed for a job the cursor already left.
+func TestStackedMouseWheelAwayAbandonsPendingOpen(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := initTestModel(withCurrentView(viewQueue), withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...), withSelection(1, 2))
+	m.layout = layoutStacked
+
+	res, cmd := m.handleEnterKey()
+	got := res.(model)
+	require.NotNil(cmd)
+	require.Equal(int64(2), got.pendingReviewOpenJobID)
+	seqA := got.reviewFetchSeq
+	genA := got.detailFollowGen
+
+	away, _ := updateModel(t, got, mouseWheelAt(0, 0, tea.MouseWheelUp))
+	require.Equal(int64(3), away.selectedJobID, "sanity: wheel moved the selection away")
+	assert.Equal(int64(0), away.pendingReviewOpenJobID,
+		"wheel navigation away abandons the pending open, like the arrow keys")
+	back, _ := updateModel(t, away, mouseWheelAt(0, 0, tea.MouseWheelDown))
+	require.Equal(int64(2), back.selectedJobID, "sanity: selection returned")
+
+	res2, _ := back.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2,
+		fetchSeq: seqA, gen: genA, dispatchedFrom: viewQueue,
+	})
+	final := res2.(model)
+	assert.Equal(viewQueue, final.currentView,
+		"an abandoned request's response must not open the review after wheeling back")
+}
+
+// TestStackedMouseClickAwayAbandonsPendingFixPanel is the click/fix-panel
+// twin: F on X, click Y's row, click back to X -- clicks bypassed the
+// chokepoint the same way the wheel did, so X's late response sprang the
+// fix panel open for a request the user walked away from.
+func TestStackedMouseClickAwayAbandonsPendingFixPanel(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := initTestModel(withCurrentView(viewQueue), withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...), withSelection(1, 2))
+	m.layout = layoutStacked
+	m.tasksEnabled = true
+
+	res, cmd := m.handleFixKey()
+	got := res.(model)
+	require.NotNil(cmd)
+	require.True(got.reviewFixPanelPending)
+	require.Equal(int64(2), got.fixPromptJobID)
+	seqA := got.reviewFetchSeq
+	genA := got.detailFollowGen
+
+	// Row y math: 5 chrome rows (title, status, update, header, separator),
+	// then data rows -- job 3 at y=5 (idx 0), job 2 at y=6 (idx 1).
+	away, _ := updateModel(t, got, mouseClickAt(4, 5))
+	require.Equal(int64(3), away.selectedJobID, "sanity: click moved the selection away")
+	assert.False(away.reviewFixPanelPending,
+		"click navigation away abandons the pending fix panel, like the arrow keys")
+	assert.Equal(int64(0), away.fixPromptJobID)
+	back, _ := updateModel(t, away, mouseClickAt(4, 6))
+	require.Equal(int64(2), back.selectedJobID, "sanity: selection returned")
+
+	res2, _ := back.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2,
+		fetchSeq: seqA, gen: genA, dispatchedFrom: viewQueue,
+	})
+	final := res2.(model)
+	assert.False(final.reviewFixPanelOpen,
+		"an abandoned F's response must not spring the fix panel open after clicking back")
+	assert.Equal(viewQueue, final.currentView)
+}
+
+// TestStackedNormalizationDisarmsPendingFixPanel is the stacked twin of
+// the normalization repro for the FIX intent: handleJobsMsg's refresh
+// normalization closed a job-mismatched fix panel only when splitActive(),
+// so in stacked a pending F for job X survived the selection moving off X
+// and sprang the panel open when a later refresh reselected X and the old
+// response finally landed.
+func TestStackedNormalizationDisarmsPendingFixPanel(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := initTestModel(withCurrentView(viewQueue), withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...), withSelection(1, 2))
+	m.layout = layoutStacked
+	m.tasksEnabled = true
+
+	res, cmd := m.handleFixKey()
+	m = res.(model)
+	require.NotNil(cmd)
+	require.True(m.reviewFixPanelPending)
+	require.Equal(int64(2), m.fixPromptJobID)
+	seqA := m.reviewFetchSeq
+	genA := m.detailFollowGen
+
+	// A refresh drops job 2: normalization moves the selection off it, and
+	// nothing is in flight for job 2 that could clear the intent reactively.
+	res2, _ := m.handleJobsMsg(jobsMsg{
+		jobs:  []storage.ReviewJob{testQueueJobs()[0]}, // job 3 only
+		stats: storage.JobStats{},
+	})
+	m = res2.(model)
+	require.NotEqual(int64(2), m.selectedJobID,
+		"sanity: normalization moved the selection off job 2")
+	assert.False(m.reviewFixPanelPending,
+		"normalization moving the selection off the intent's job abandons the pending fix panel, in stacked too")
+	assert.Equal(int64(0), m.fixPromptJobID)
+
+	// A later refresh brings job 2 back as the only row and reselects it.
+	res3, _ := m.handleJobsMsg(jobsMsg{
+		jobs:  []storage.ReviewJob{testQueueJobs()[1]}, // job 2 only
+		stats: storage.JobStats{},
+	})
+	m = res3.(model)
+	require.Equal(int64(2), m.selectedJobID,
+		"sanity: the selection came back to job 2")
+
+	// The armed-era response finally lands: nothing may spring open.
+	res4, _ := m.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2,
+		fetchSeq: seqA, gen: genA, dispatchedFrom: viewQueue,
+	})
+	got := res4.(model)
+	assert.False(got.reviewFixPanelOpen,
+		"an abandoned F's response must not spring the fix panel open after a refresh reselects its job")
+	assert.Equal(viewQueue, got.currentView)
+}
+
+// TestStackedOpenFixPanelSurvivesRefreshNormalization guards what the
+// stacked disarm above must not erode: with the review displayed
+// full-screen, isReviewAnchored keeps the selection pinned to the displayed
+// job even when a refresh drops it from the list, so normalization is a
+// same-selection no-op -- the open panel stays, nothing is disarmed, and
+// the abandonment gen bump must not fire (it is gated on the selection
+// actually moving).
+func TestStackedOpenFixPanelSurvivesRefreshNormalization(t *testing.T) {
+	assert := assert.New(t)
+	m := initTestModel(withCurrentView(viewReview), withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...), withSelection(1, 2),
+		withReview(splitTestReview()))
+	m.layout = layoutStacked
+	m.tasksEnabled = true
+	m.reviewFixPanelOpen = true
+	m.fixPromptJobID = 2
+	prevGen := m.detailFollowGen
+
+	res, _ := m.handleJobsMsg(jobsMsg{
+		jobs:  []storage.ReviewJob{testQueueJobs()[0]}, // job 3 only
+		stats: storage.JobStats{},
+	})
+	got := res.(model)
+	assert.Equal(int64(2), got.selectedJobID,
+		"review-anchored: the selection stays pinned to the displayed job")
+	assert.True(got.reviewFixPanelOpen,
+		"an open panel outside split is review-bound; normalization must not close it")
+	assert.Equal(int64(2), got.fixPromptJobID)
+	assert.Equal(prevGen, got.detailFollowGen,
+		"a same-selection refresh is not an abandonment; the gen must not bump")
+}
+
+// TestFilterResetDoomsArmedEraDispatch: resetQueueForFilterChange
+// disarmed the deselected job's intents but never bumped
+// detailFollowGen, so
+// an armed-era ORDINARY dispatch stayed gen-fresh across the reset -- when
+// the refetch re-selected the same job, the stale response passed every
+// gate and opened the review off a filter change.
+func TestFilterResetDoomsArmedEraDispatch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := initTestModel(withCurrentView(viewQueue), withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...), withSelection(1, 2))
+	m.layout = layoutStacked
+
+	res, cmd := m.handleEnterKey()
+	m = res.(model)
+	require.NotNil(cmd)
+	seqA := m.reviewFetchSeq
+	genA := m.detailFollowGen
+
+	m.resetQueueForFilterChange()
+	assert.Greater(m.detailFollowGen, genA,
+		"zeroing the selection is an abandonment; the armed-era dispatch must be doomed at the gen gate")
+
+	// The refetch lands with job 2 as the only row (stamped with the
+	// reset's own fetch seq), so normalization re-selects the very job
+	// the doomed dispatch was for.
+	res2, _ := m.handleJobsMsg(jobsMsg{
+		jobs:  []storage.ReviewJob{testQueueJobs()[1]}, // job 2 only
+		seq:   m.fetchSeq,
+		stats: storage.JobStats{},
+	})
+	m = res2.(model)
+	require.Equal(int64(2), m.selectedJobID, "sanity: the refetch re-selected job 2")
+
+	res3, _ := m.handleReviewMsg(reviewMsg{
+		review: splitTestReview(), jobID: 2,
+		fetchSeq: seqA, gen: genA, dispatchedFrom: viewQueue,
+	})
+	got := res3.(model)
+	assert.Equal(viewQueue, got.currentView,
+		"a pre-reset response must not open the review after the filter refetch re-selects its job")
+}
+
+// TestSplitBootstrapClosesJobMismatchedPanel: an open panel legitimately
+// survives the selection moving under it in stacked (review-bound), but
+// split re-binds the panel to the selection-following pane -- so engaging
+// split with a panel bound to a job other than the selection must close it,
+// or a focused submit would target a job the pane does not show. A panel
+// on the selected job survives the engage untouched (the same-selection
+// no-disarm rule).
+func TestSplitBootstrapClosesJobMismatchedPanel(t *testing.T) {
+	assert := assert.New(t)
+	m := initTestModel(withCurrentView(viewQueue), withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...), withSelection(0, 3),
+		withReview(splitTestReview())) // review + panel bound to job 2, selection on 3
+	m.reviewFixPanelOpen = true
+	m.reviewFixPanelFocused = true
+	m.fixPromptJobID = 2
+
+	m.layout = layoutSplit
+	got, _ := m.maybeBootstrapDetail()
+	assert.False(got.reviewFixPanelOpen,
+		"engaging split with a panel bound to another job must close it")
+	assert.Zero(got.fixPromptJobID)
+
+	// Same-job case: the panel tracks the selection, so it survives.
+	m2 := initTestModel(withCurrentView(viewQueue), withDimensions(150, 40),
+		withTestJobs(testQueueJobs()...), withSelection(1, 2),
+		withReview(splitTestReview()))
+	m2.reviewFixPanelOpen = true
+	m2.fixPromptJobID = 2
+	m2.layout = layoutSplit
+	got2, _ := m2.maybeBootstrapDetail()
+	assert.True(got2.reviewFixPanelOpen,
+		"a panel bound to the selected job survives the engage")
+	assert.Equal(int64(2), got2.fixPromptJobID)
+}
+
+// TestResizeDuringTransientViewResumesPaneLogOnReturn: a resize that lands
+// while a transient view covers the split panes invalidates the live-log
+// tail (restarting it would poll invisibly at the wrong width). Returning
+// to the split view must resume the tail immediately -- previously nothing
+// did until the next jobs refresh, freezing the log for up to ~15s.
+func TestResizeDuringTransientViewResumesPaneLogOnReturn(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(0, 3)) // job 3: running
+	res, cmd := m.startPaneLog(m.jobs[0])
+	m = res.(model)
+	require.NotNil(cmd)
+	require.True(m.paneLogStreaming)
+
+	// A transient view covers the panes; a resize lands while it is open.
+	m.currentView = viewHelp
+	m2, _ := updateModel(t, m, tea.WindowSizeMsg{Width: 150, Height: 40})
+	require.False(m2.paneLogStreaming, "sanity: the resize invalidates the covered tail")
+	require.True(m2.paneLogPaused)
+
+	// Esc back to the split view: the tail must resume now, not on the
+	// next jobs refresh.
+	got, cmd2 := pressSpecial(m2, tea.KeyEsc)
+	require.Equal(viewQueue, got.currentView, "sanity: back on the split view")
+	assert.True(got.paneLogStreaming, "the paused tail must resume on return")
+	assert.False(got.paneLogPaused)
+	assert.NotNil(cmd2, "the resumed tail's first fetch must be dispatched")
+}

--- a/cmd/roborev/tui/split_test.go
+++ b/cmd/roborev/tui/split_test.go
@@ -1585,7 +1585,7 @@ func TestSplitReconcileDetailFailedIdempotent(t *testing.T) {
 
 	got, cmd := m.splitReconcileDetail()
 	require.NotNil(t, got.currentReview)
-	assert.Nil(cmd)
+	assert.NotNil(cmd, "the rebuild dispatches the persisted-comments fetch")
 	assert.False(got.paneLogStreaming)
 	firstReview := got.currentReview
 	seqAfterFirst := got.paneLogSeq
@@ -1615,7 +1615,7 @@ func TestSplitReconcileDetailReplacesStaleFailedReviewFromRerun(t *testing.T) {
 	m.paneLogJobID, m.paneLogSeq, m.paneLogStreaming = 1, 5, true
 
 	got, cmd := m.splitReconcileDetail()
-	assert.Nil(cmd)
+	assert.NotNil(cmd, "the rebuild dispatches the persisted-comments fetch")
 	require.NotNil(got.currentReview)
 	assert.Contains(got.currentReview.Output, "boom", "must rebuild with the CURRENT job.Error, not keep the stale attempt's text")
 	assert.NotContains(got.currentReview.Output, "stale error from a previous attempt")
@@ -4141,7 +4141,7 @@ func TestSplitReconcileDetailReplacesFailedReviewWithChangedMetadataDespiteSameE
 	failedJobs[2].Agent = "codex"
 	m.jobs = failedJobs
 	got, cmd := m.splitReconcileDetail()
-	assert.Nil(cmd, "the Failed branch rebuilds locally, not via a fetch")
+	assert.NotNil(cmd, "the local rebuild also dispatches the persisted-comments fetch")
 	require.NotNil(got.currentReview)
 	assert.Equal("codex", got.currentReview.Job.Agent, "must rebuild with the CURRENT job metadata despite identical rendered error text")
 }
@@ -6213,6 +6213,54 @@ func TestCommentOnSynthesizedFailedReviewAppendsLocally(t *testing.T) {
 	lines := strings.Join(got.renderDetailPane(88, 25), "\n")
 	assert.Contains(lines, "known flake, not a regression",
 		"the appended comment must render under the failure review")
+}
+
+// TestFailedReviewCommentsSurviveNavigationRoundTrip: every synthesized
+// acceptance dispatches a persisted-comments fetch, so comments on a
+// failed job's review survive navigating away and back (the rebuild
+// clears the in-memory copy; the fetch restores server state).
+func TestFailedReviewCommentsSurviveNavigationRoundTrip(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	m := splitModel(withSelection(2, 1)) // job 1: failed, selected
+
+	// First display: reconcile synthesizes and dispatches the fetch.
+	m, cmd := m.splitReconcileDetail()
+	require.NotNil(cmd)
+	res, _ := m.handleFailedCommentsMsg(failedCommentsMsg{
+		jobID:     1,
+		responses: []storage.Response{{Responder: "wes", Response: "known flake"}},
+	})
+	m = res.(model)
+	require.Len(m.currentResponses, 1)
+
+	// Navigate away: a late comments response for job 1 is stale now.
+	m = m.moveSelectionToJobID(3)
+	m, _ = m.followSelectionChange(1)
+	res, _ = m.handleFailedCommentsMsg(failedCommentsMsg{
+		jobID:     1,
+		responses: []storage.Response{{Responder: "eve", Response: "should not land"}},
+	})
+	m = res.(model)
+	assert.NotContains(strings.Join(m.renderDetailPane(88, 25), "\n"), "should not land")
+
+	// Back to job 1: the tick re-synthesizes and re-dispatches the fetch.
+	m = m.moveSelectionToJobID(1)
+	m, _ = m.followSelectionChange(3)
+	res, tickCmd := m.handleDetailFollowTick(detailFollowTickMsg{gen: m.detailFollowGen})
+	m = res.(model)
+	require.NotNil(m.currentReview)
+	require.NotNil(tickCmd, "the re-synthesis must re-dispatch the comments fetch")
+	require.Empty(m.currentResponses, "sanity: the rebuild cleared the in-memory comments")
+
+	// The fetch response restores them and they render.
+	res, _ = m.handleFailedCommentsMsg(failedCommentsMsg{
+		jobID:     1,
+		responses: []storage.Response{{Responder: "wes", Response: "known flake"}},
+	})
+	m = res.(model)
+	assert.Contains(strings.Join(m.renderDetailPane(88, 25), "\n"), "known flake",
+		"comments must survive the navigation round-trip")
 }
 
 // TestClosingLastVisibleJobClearsSelection: with hide-closed on, closing

--- a/cmd/roborev/tui/tui.go
+++ b/cmd/roborev/tui/tui.go
@@ -1254,6 +1254,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		result, cmd = m.handleReviewErrMsg(msg)
 	case reviewFollowErrMsg:
 		result, cmd = m.handleReviewFollowErrMsg(msg)
+	case failedCommentsMsg:
+		result, cmd = m.handleFailedCommentsMsg(msg)
 	case detailFollowTickMsg:
 		result, cmd = m.handleDetailFollowTick(msg)
 	case promptMsg:

--- a/cmd/roborev/tui/tui.go
+++ b/cmd/roborev/tui/tui.go
@@ -441,6 +441,39 @@ type model struct {
 	reviewFixPanelOpen    bool // true when fix panel is visible in review view
 	reviewFixPanelFocused bool // true when keyboard focus is on the fix panel
 	reviewFixPanelPending bool // true when 'F' from queue; panel opens on review load
+	// fixPromptFollowRetried bounds handleReviewFollowErrMsg's retry for a
+	// pending queue-'F' request: a follow fetch that supersedes 'F's own
+	// ordinary fetch and then FAILS is the one terminal outcome
+	// acceptReview's success-only consume never sees, so without a retry
+	// the pending flag could be left armed with nothing in flight to serve
+	// it. Set true when the first such failure retries; checked on the
+	// next one to clear the flag with a flash instead of retrying forever.
+	// Reset wherever reviewFixPanelPending is (re)armed or disarmed, so it
+	// is only ever meaningful during the one pending request it was set
+	// for.
+	fixPromptFollowRetried bool
+
+	// fixPromptSeq is the reviewFetchSeq value stamped by the dispatch
+	// that most recently armed reviewFixPanelPending (handlers_review.go's
+	// queue-'F' path) -- the pending request's own per-arm IDENTITY, not
+	// just its job. Comparing jobID alone is unsound when the SAME job is
+	// armed twice: navigate away, navigate back, press 'F' again, and an
+	// older in-flight request from before the navigation can finally fail
+	// carrying the same jobID -- clearing on jobID alone would wipe out
+	// the fresh arm whose own fetch is still healthily in flight. So the
+	// stale-rejection branches refuse a clear unless the message is at
+	// least as new as the armed request (msg.fetchSeq >= fixPromptSeq).
+	//
+	// Not needed on the "this message IS the current one" paths
+	// (acceptReview's consume, handleReviewFollowErrMsg's retry-or-clear
+	// block): reviewFetchSeq only increases, so nothing armed there can
+	// exceed the current message's own fetchSeq. Reset alongside
+	// fixPromptJobID wherever that is, so it is only ever meaningful
+	// during the one pending request it was stamped for. The seq check is
+	// a conjunct alongside the jobID gate, not a replacement --
+	// defense-in-depth for dispatchReviewFetch's invariant that it always
+	// sets selectedJobID together with the armed fields.
+	fixPromptSeq uint64
 
 	worktreeConfirmJobID  int64  // Job ID pending worktree-apply confirmation
 	worktreeConfirmBranch string // Branch name for worktree confirmation prompt
@@ -460,6 +493,339 @@ type model struct {
 	queueColGen   int            // bumped when queue data/filters/columns change
 	taskColCache  *colWidthCache // cached per-column max widths for tasks
 	taskColGen    int            // bumped when fixJobs/columns change
+
+	// Split layout state (see layout.go). layout/focus are only consulted
+	// when layout == layoutSplit; stacked mode behaves exactly as before.
+	layout          layoutMode
+	focus           focusPane
+	layoutLocked    bool       // true after a manual L toggle
+	preferredLayout layoutMode // the layout the user chose with L
+
+	// detailFollowGen is a generation guard for in-flight review fetches:
+	// responses are stamped at dispatch, and the response handlers
+	// (handleReviewMsg/handleReviewFollowErrMsg/handleReviewErrMsg) reject
+	// a stale stamp unless reviewIntentRescuable (handlers_msg.go) rescues
+	// it. Selection-scoped only: invalidating a superseded review ATTEMPT
+	// (a rerun) is jobAttemptGen's job, below.
+	//
+	// Contract for any code that bumps this field. Every bumper is one of:
+	//
+	//   - ABANDONMENT: the selection left the job an in-flight dispatch
+	//     was for, and that dispatch must never be served. The bumper must
+	//     also resolve BOTH pending intents (pendingReviewOpen*, the
+	//     pending fix panel) in the same handler -- the gen-mismatch
+	//     rejection paths deliberately resolve nothing -- and each disarm
+	//     must be keyed on the INTENT's own jobID, never on
+	//     m.selectedJobID or other "what's on screen" state, even when the
+	//     bump itself is gated more narrowly. An intent is scoped to a
+	//     job, not a screen.
+	//   - INCIDENTAL REFRESH: bookkeeping for a same-job bootstrap or
+	//     debounce restart. Nothing was abandoned, so it must NOT disarm
+	//     anything.
+	//
+	// Violating either side makes reviewIntentRescuable serve an abandoned
+	// intent (opening content the user never asked for) or strand a live
+	// one.
+	//
+	// Current bumpers: followSelectionChange's stacked branch (layout.go;
+	// abandonment), scheduleDetailFollow (layout.go; abandonment when
+	// reached via followSelectionChange, which has already disarmed --
+	// incidental via maybeBootstrapDetail; the caller determines which),
+	// handleJobsMsg's normalization epilogue (handlers_msg.go;
+	// abandonment), and resetQueueForFilterChange (filter.go;
+	// abandonment).
+	detailFollowGen uint64
+
+	// jobAttemptGen counts confirmed reruns per job (absent == 0). Every
+	// review fetch is stamped at dispatch with the value for its job, and
+	// the response handlers reject a mismatched stamp: the response
+	// belongs to a superseded attempt -- for ANY job, not just the
+	// selected one, which is what the single global detailFollowGen above
+	// cannot express.
+	//
+	// Contract:
+	//
+	//  1. The only bumper is handleRerunResultMsg's success path. Any new
+	//     bumper must be another "this job's current attempt is dead"
+	//     event -- never a repaint, debounce, layout or selection event --
+	//     and must first establish the event really superseded THIS job's
+	//     attempt: rerunning a panel-synthesis parent spawns a fresh run
+	//     with NEW job IDs and leaves this row untouched
+	//     (rerunResultMsg.spawnsNewRun), so it must not bump.
+	//  2. A bump is always abandonment for that job: the bumper must also
+	//     resolve both pending intents for it, keyed on msg.jobID and
+	//     unconditional on the current selection.
+	//  3. Stamping happens at dispatch, never later: fetchReview (fetch.go)
+	//     is the only constructor of reviewMsg/review*ErrMsg and reads the
+	//     counter at command-creation time; fetchReviewForPrompt stamps
+	//     promptMsg the same way. Every ASYNCHRONOUS, message-borne write
+	//     of review content must carry this stamp. Synchronous writers
+	//     that build currentReview from m.jobs in place read current state
+	//     and have no staleness to identify, so they need not.
+	//  4. The check is unconditional and unrescuable: a mismatch is
+	//     rejected after the jobID gate and before the detailFollowGen
+	//     gate, so an attempt-stale response can never reach
+	//     reviewIntentRescuable. Nothing needs disarming on rejection --
+	//     the bumper already disarmed (clause 2), and intents armed after
+	//     the bump carry the post-bump stamp.
+	//
+	// Never pruned: entries come only from explicit operator reruns (16
+	// bytes each), and deleting one would reset the counter to zero --
+	// exactly the stamp a pre-rerun in-flight request carries, silently
+	// re-opening the hole this field closes. Shared by reference across
+	// model value copies (like pendingClosed): a bump is a fact about the
+	// world that an older model copy must not be able to un-say.
+	jobAttemptGen map[int64]uint64
+
+	// panelRerunInFlight holds panel-synthesis parents whose rerun request
+	// is dispatched but unresolved. Duplicate-dispatch suppression only --
+	// never a correctness gate -- consulted by nothing but the two rerun
+	// dispatchers. Ordinary reruns need no such set: their optimistic
+	// re-queue flips the row to queued and the dispatchers only act on
+	// terminal rows. A synthesis parent's row stays terminal (the daemon
+	// enqueues a separate run and leaves it alone), so nothing else stops
+	// a fast second 'r' or duplicate control-socket rerun from spawning a
+	// second full panel run.
+	//
+	// Added at dispatch (handleRerunKey/handleCtrlRerunJob, only when the
+	// snapshot says spawnsNewRun); removed by handleRerunResultMsg as its
+	// FIRST statement, before every early return. rerunJob (actions.go)
+	// has exactly one return statement and it is a rerunResultMsg, so
+	// every add is matched by exactly one delete and an entry cannot leak
+	// (a leaked entry would block that job's rerun for the session).
+	//
+	// Deliberately not a durable fix: another TUI instance or the CLI can
+	// still dispatch a duplicate; rejecting that belongs on the daemon
+	// side. Shared by reference across model value copies, like
+	// jobAttemptGen: an in-flight fact an older model copy must not
+	// un-say.
+	panelRerunInFlight map[int64]bool
+
+	// Live log tail for a running job in the split detail pane.
+	// Independent of the full-screen log view's log* fields above so the
+	// two can't stomp on each other's offset/formatter/seq state.
+	paneLogJobID     int64                // job whose log is being tailed
+	paneLogLines     []logLine            // buffered rendered lines (capped, see paneLogMaxLines)
+	paneLogOffset    int64                // byte offset for next incremental fetch
+	paneLogFmtr      *streamfmt.Formatter // persistent formatter across polls
+	paneLogSeq       uint64               // monotonic seq; drops stale responses
+	paneLogStreaming bool                 // true while the tailed job is still running
+	paneLogPaused    bool                 // tail invalidated while a transient view hid the pane; resume on return
+
+	// splitDetailErr records a failure that struck the split detail pane
+	// while it awaited content in the background (a follow fetchReview
+	// failure, or a live-log fetch failure while a job is running) so
+	// renderDetailPane can surface it instead of leaving "Loading
+	// review..." stuck forever. Cleared on every
+	// scheduleDetailFollow (a fresh follow supersedes any earlier failure).
+	splitDetailErr error
+
+	// paneReviewSeenNonTerminalJob is a state-machine signal for
+	// splitReconcileDetail's Done/Failed idempotency checks, precision-
+	// independent unlike comparing FinishedAt or rendered error text: a
+	// rerun MUST pass through queued/running before completing again, and
+	// splitReconcileDetail observes the selected job on every jobs
+	// refresh, so "was the selected job seen queued/running since the
+	// currently-loaded review was fetched" proves a fresh attempt occurred
+	// regardless of whether its timestamp/output happens to collide with
+	// the previous attempt's. Set to the job's ID when splitReconcileDetail
+	// observes the selected job queued/running while currentReview is
+	// already loaded for it; 0 means no observation is outstanding.
+	//
+	// Scoped to a JOB ID, not a bare bool: the signal is a fact about one
+	// specific job's loaded review, and a global flag bled across
+	// selection changes -- observing job X's rerun and then selecting a
+	// FAILED job Y left the flag set after Y's failure review was
+	// synthesized (handleDetailFollowTick's Failed branch), so
+	// selectedReviewLoaded wrongly treated Y's fresh review as stale and
+	// blocked detail focus until the next jobs refresh. Keyed by job, an
+	// observation for X is inert while Y is displayed and still correct
+	// when the user returns to X.
+	//
+	// Means "a fresh attempt of THIS job has been observed and is not yet
+	// reflected in the loaded review" -- so it must be cleared at
+	// ACCEPTANCE for that job (when currentReview is actually replaced
+	// with fresh content: the fetch landing in acceptReview, or the local
+	// Failed-branch rebuilds in splitReconcileDetail and
+	// handleDetailFollowTick), not at the DECISION to fetch/rebuild. A
+	// Done-branch rebuild dispatches an async fetchReviewFollow that can
+	// itself fail (handleReviewFollowErrMsg) -- clearing at dispatch time
+	// would silently swallow the "fresh attempt observed" fact if that
+	// fetch errors, leaving a stale review and a stuck splitDetailErr with
+	// nothing left to retry it (the fallback FinishedAt/text comparison is
+	// blind to same-second/same-text reruns, which is the whole reason
+	// this signal exists). See splitReconcileDetail's doc comment for the
+	// full reasoning, including the narrow case this alone doesn't cover.
+	paneReviewSeenNonTerminalJob int64
+
+	// fixPromptOrigin is the view the user was on when 'F' ARMED
+	// reviewFixPanelPending (handlers_review.go) -- the origin of the
+	// pending fix REQUEST, not of whatever response ends up serving it.
+	// The consume must compare against the request's origin: any
+	// dispatcher can produce the accepting response (e.g. a reconcile
+	// follow fetch dispatched while the user types in the comment editor
+	// carries dispatchedFrom == viewKindComment), so deciding the view
+	// switch on the response's origin can yank the user out of an
+	// unrelated view they explicitly opened.
+	//
+	// viewKind starts at iota, so this field's zero value happens to be
+	// viewQueue -- but nothing rests on that: the field is written at the
+	// one site that arms reviewFixPanelPending and cleared wherever the
+	// flag is disarmed, so it is only read while holding a value written
+	// on purpose. A renumbering of the viewKind constants would still need
+	// to revisit this field.
+	fixPromptOrigin viewKind
+
+	// pendingReviewOpenJobID/pendingReviewOpenOrigin generalize
+	// fixPromptJobID/fixPromptOrigin's "some other dispatcher's response
+	// may serve this request" pattern to the plain "open the review view"
+	// intent that has no fix panel attached. An ordinary fetch dispatched
+	// by explicit navigation can be superseded by a follow fetch for the
+	// same job (splitReconcileDetail runs on every jobs refresh); a follow
+	// response never switches views by design, so without a recorded
+	// intent the explicit navigation would silently do nothing whenever
+	// the follow's response landed first.
+	//
+	// dispatchReviewFetch arms these fields at every ordinary dispatch
+	// (jobID + m.currentView, matching what fetchReview stamps as
+	// dispatchedFrom), and acceptReview consumes them on the shared
+	// acceptance path regardless of msg.follow -- whichever dispatcher's
+	// response lands the job's content first performs the transition, via
+	// openReviewViewFrom's guard (a no-op if the user has since navigated
+	// elsewhere). jobID 0 means nothing pending. Cleared where consumed
+	// (acceptReview); disarmed proactively on a genuine selection change
+	// (followSelectionChange and the inline sites listed in
+	// disarmPendingReviewOpen's doc) and on a confirmed rerun of this
+	// field's own job (handleRerunResultMsg, keyed on the rerun's jobID,
+	// not on whether it is selected); or superseded by a fresh arm, which
+	// overwrites all three fields.
+	//
+	// pendingReviewOpenSeq is this intent's per-arm IDENTITY -- the
+	// reviewFetchSeq value stamped by the dispatch that (re-)armed it,
+	// the same role fixPromptSeq plays for the fix panel (see that
+	// field's doc): a "clear because stale" check must additionally
+	// require msg.fetchSeq >= pendingReviewOpenSeq, so an old message
+	// sharing a jobID with a just re-armed request cannot erase the fresh
+	// arm. Not needed on acceptReview's consume, where the message is
+	// provably current. The stale-rejection branches gate primarily on
+	// msg.jobID != m.selectedJobID -- a gen-mismatch-only rejection (job
+	// unchanged) clears nothing, since an incidental gen bump does not
+	// mean the request was abandoned.
+	pendingReviewOpenJobID  int64
+	pendingReviewOpenOrigin viewKind
+	pendingReviewOpenSeq    uint64
+
+	// pendingReviewOpenRetried mirrors fixPromptFollowRetried for the plain
+	// open-review intent: a follow fetch FAILING while this intent is armed
+	// resolves the freshest dispatch for the job, but the intent's own
+	// ORIGINATING ordinary dispatch may still be in flight -- and even when
+	// it later SUCCEEDS, its response arrives fetchSeq-superseded and (with
+	// no content loaded, precisely because the follow failed) cannot serve
+	// the open. Clearing the intent at the follow failure would therefore
+	// swallow a deliberate navigation whose own request succeeded. Instead
+	// handleReviewFollowErrMsg retries once (dispatching a fresh follow,
+	// whose success serves the intent via acceptReview's consume) and only
+	// clears with a warning flash on the second failure. Reset at every arm
+	// (dispatchReviewFetch), so each fresh intent gets its own single
+	// retry; a stale true while nothing is armed is unread.
+	pendingReviewOpenRetried bool
+
+	// promptFetchSeq is the prompt path's own request identity, deliberately
+	// separate from the shared review fetch epoch (see handlePromptMsg for
+	// why the prompt path cannot join reviewFetchSeq). Bumped by
+	// dispatchPromptFetch at every prompt fetch and stamped onto the
+	// outgoing promptMsg; handlePromptMsg drops a response whose stamp no
+	// longer matches. Also bumped by followSelectionChange's abandonment
+	// path (both layouts), so a request abandoned by navigating away is
+	// still dropped when the user returns to the same job before the
+	// response lands -- without the bump, the jobID gate alone would
+	// re-accept it and pop the prompt view open with no fresh keypress.
+	promptFetchSeq uint64
+
+	// reviewFetchSeq is the single monotonically increasing epoch stamped
+	// onto every fetch that produces a reviewMsg, follow or not:
+	// fetchReview is the only constructor of that message and
+	// dispatchReviewFetch/dispatchReviewFollow are its only entry points,
+	// so coverage is by construction. One non-fetch bumper exists:
+	// acceptSynthesizedFailure (layout.go) advances the epoch when the
+	// synchronous failed-job rebuild replaces currentReview, ordering that
+	// acceptance like an instant dispatch-plus-landing so older in-flight
+	// responses cannot overwrite it. The handlers accept a response into
+	// currentReview/currentResponses/currentBranch only when its stamp is
+	// still current -- the newest dispatch wins, globally, whichever call
+	// site issued either request. Without this total order an older
+	// ordinary response could land after a newer comment refresh and
+	// overwrite currentResponses (a just-submitted comment disappearing
+	// until something refetched).
+	//
+	// One review-content path is deliberately NOT covered:
+	// fetchReviewForPrompt produces a promptMsg, and handlePromptMsg
+	// writes currentReview with no epoch, gated on jobID == selectedJobID
+	// and the per-job attempt counter. Joining the epoch in either
+	// direction would silently swallow the user's explicit 'p' whenever
+	// another review fetch races it, because the prompt view has no
+	// pending-intent field to re-serve the request -- see
+	// handlePromptMsg's doc comment for the derivation.
+	//
+	// The three guards compose, none substitutes for another:
+	// detailFollowGen rejects responses for a selection the model moved
+	// past, jobAttemptGen rejects responses for a superseded job attempt,
+	// and this epoch orders the responses that are still for the current
+	// job/attempt.
+	reviewFetchSeq uint64
+
+	// reconcileFetchJobID is the job ID of the outstanding review fetch
+	// dispatched by splitReconcileDetail's Done branch (0 = none). It is
+	// purely a duplicate-dispatch SUPPRESSION signal, consulted only by
+	// that branch's own guard: correctness is already guaranteed by the
+	// epoch above, but reconcile re-runs on EVERY jobs refresh while
+	// paneReviewSeenNonTerminal awaits acceptance, so without it a fetch
+	// slower than the refresh interval would be superseded by its own
+	// successor before it could ever land -- the pane would never converge
+	// (a liveness, not a safety, problem), on top of piling up duplicate
+	// in-flight requests against a slow daemon. The other dispatchers each
+	// fire on a discrete one-shot event (a debounce tick, a tail
+	// completing, a comment landing, a keypress) and so neither set nor
+	// consult it.
+	//
+	// Released only by the response to the dispatch that set it, identified
+	// by reconcileFetchSeq below.
+	reconcileFetchJobID int64
+
+	// reconcileFetchSeq is the fetch epoch stamped on the outstanding
+	// reconcile dispatch -- the per-dispatch identity that makes the
+	// suppression slot above releasable by exactly ONE arriving message.
+	// Releasing on jobID alone would defeat suppression's purpose: an
+	// older response for the job could clear a newer reconcile slot, the
+	// next refresh would dispatch again and supersede the still-
+	// outstanding request, and with fetches slower than the refresh
+	// interval the pane would never converge. A real epoch value is never
+	// 0 (pre-incremented before first use) and reconcileFetchSeq is 0
+	// exactly when nothing is outstanding, so a 0-stamped message can
+	// never accidentally match.
+	//
+	// Why the slot can never be left stuck (invariant: no state may be
+	// left set with no arriving response able to clear it):
+	//  1. Both fields are assigned non-zero in exactly one place --
+	//     splitReconcileDetail's Done branch, immediately around the
+	//     dispatch, with reconcileFetchSeq set to the epoch that dispatch
+	//     stamped on its request.
+	//  2. Every dispatch resolves to exactly one message -- a reviewMsg or
+	//     a reviewFollowErrMsg (fetchReviewFollow converts the only other
+	//     possibility, errMsg, into the latter).
+	//  3. Both handlers call releaseReconcileFetch(msg.fetchSeq) as their
+	//     FIRST statement, before the jobID/gen/epoch gates and before
+	//     every early return -- a response rejected for DISPLAY still
+	//     releases, and a superseded reconcile response is exactly the
+	//     case that must.
+	//  4. The epoch is monotonic and each value is handed to exactly one
+	//     dispatch, so the release is unique: no foreign release, no
+	//     missed release.
+	//  5. scheduleDetailFollow (selection change) and handleRerunResultMsg
+	//     (slot belongs to the reran job) additionally clear both fields
+	//     so a fresh dispatch need not wait for a doomed response. Not
+	//     load-bearing given (4).
+	reconcileFetchSeq uint64
 }
 
 // isConnectionError checks if an error indicates a network/connection failure
@@ -641,6 +1007,8 @@ func newModel(ep daemon.DaemonEndpoint, opts ...option) model {
 		branchNames:         make(map[int64]string),       // Cache derived branch names to avoid git calls on render
 		pendingClosed:       make(map[int64]pendingState), // Track pending closed changes (by job ID)
 		pendingReviewClosed: make(map[int64]pendingState), // Track pending closed changes (by review ID)
+		jobAttemptGen:       make(map[int64]uint64),       // Per-job confirmed-rerun counter (see the field's contract)
+		panelRerunInFlight:  make(map[int64]bool),         // Panel reruns awaiting their result (suppression only)
 		clipboard:           newClipboard(),
 		mdCache:             newMarkdownCache(tabWidth),
 		tasksEnabled:        tasksEnabled,
@@ -816,7 +1184,7 @@ func (m *model) getBranchForJob(job storage.ReviewJob) string {
 	if branch == "" {
 		// The commit isn't reachable from any local branch - typically a
 		// commit made on top of a detached HEAD (e.g. mid git-bisect).
-		// Surface that instead of leaving the queue cell blank (#499).
+		// Surface that instead of leaving the queue cell blank.
 		branch = detachedBranchLabel(job)
 	}
 	// Cache result (including "" when neither lookup nor the detached
@@ -882,10 +1250,20 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		result, cmd = m.handleUpdateCheckMsg(msg)
 	case reviewMsg:
 		result, cmd = m.handleReviewMsg(msg)
+	case reviewErrMsg:
+		result, cmd = m.handleReviewErrMsg(msg)
+	case reviewFollowErrMsg:
+		result, cmd = m.handleReviewFollowErrMsg(msg)
+	case detailFollowTickMsg:
+		result, cmd = m.handleDetailFollowTick(msg)
 	case promptMsg:
 		result, cmd = m.handlePromptMsg(msg)
 	case logOutputMsg:
 		result, cmd = m.handleLogOutputMsg(msg)
+	case paneLogOutputMsg:
+		result, cmd = m.handlePaneLogOutputMsg(msg)
+	case paneLogTickMsg:
+		result, cmd = m.handlePaneLogTickMsg(msg)
 	case closedMsg:
 		result, cmd = m.handleClosedToggleMsg(msg)
 	case closedResultMsg:
@@ -955,6 +1333,24 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	if rm, ok := result.(model); ok {
+		rm = rm.normalizeSplitState()
+		// Resume a tail paused by a resize that arrived while a transient
+		// view covered the split panes. splitReconcileDetail handles
+		// whatever the selected job's state is by now: restart the tail if
+		// it is still running, or fetch its review if it finished while
+		// the pane was hidden. Gated on the paused flag so this never
+		// preempts the ordinary debounced follow during navigation.
+		if rm.paneLogPaused && rm.splitActive() {
+			rm.paneLogPaused = false
+			var resumeCmd tea.Cmd
+			rm, resumeCmd = rm.splitReconcileDetail()
+			if resumeCmd != nil {
+				cmd = tea.Batch(cmd, resumeCmd)
+			}
+		}
+		result = rm
+	}
 	return result, cmd
 }
 
@@ -986,6 +1382,9 @@ func (m model) viewContent() string {
 	if m.currentView == viewColumnOptions {
 		return m.renderColumnOptionsView()
 	}
+	if m.splitActive() {
+		return m.renderSplit()
+	}
 	if m.currentView == viewKindPrompt && m.currentReview != nil {
 		return m.renderPromptView()
 	}
@@ -998,7 +1397,11 @@ func (m model) viewContent() string {
 func (m model) View() tea.View {
 	v := tea.NewView(m.viewContent())
 	v.AltScreen = true
-	if mouseCaptureEnabled(m.currentView, m.mouseEnabled) {
+	if m.splitActive() {
+		if m.mouseEnabled {
+			v.MouseMode = tea.MouseModeCellMotion
+		}
+	} else if mouseCaptureEnabled(m.currentView, m.mouseEnabled) {
 		v.MouseMode = tea.MouseModeCellMotion
 	}
 	return v

--- a/cmd/roborev/tui/tui.go
+++ b/cmd/roborev/tui/tui.go
@@ -742,6 +742,18 @@ type model struct {
 	// re-accept it and pop the prompt view open with no fresh keypress.
 	promptFetchSeq uint64
 
+	// failedCommentsSeq is the request identity for the synthesized-review
+	// comments side channel (failedCommentsMsg), the same shape as
+	// promptFetchSeq: bumped by dispatchFailedCommentsFetch at every
+	// dispatch and stamped onto the outgoing request; the handler drops a
+	// response whose stamp is stale. Without it, synthesized reviews all
+	// sharing ID 0 lets an OLDER fetch's response land after a newer one
+	// (navigate away and back re-dispatches) or after the post-success
+	// local append (wiping the just-submitted comment until the next
+	// refresh). The post-success path re-dispatches through the same
+	// bump, so its refetch is always the newest request.
+	failedCommentsSeq uint64
+
 	// reviewFetchSeq is the single monotonically increasing epoch stamped
 	// onto every fetch that produces a reviewMsg, follow or not:
 	// fetchReview is the only constructor of that message and

--- a/cmd/roborev/tui/types.go
+++ b/cmd/roborev/tui/types.go
@@ -381,6 +381,19 @@ type repoBranchesMsg struct {
 	expandOnLoad bool               // Set expanded=true when branches arrive
 	searchSeq    int                // Search generation; stale errors don't set fetchFailed
 }
+
+// failedCommentsMsg delivers persisted comments for a job whose review is
+// SYNTHESIZED (a failed job has no review row, so the ordinary review
+// fetch that normally carries responses 404s and can never load them).
+// Dispatched by acceptSynthesizedFailure alongside every synthesized
+// acceptance; accepted only while that job's synthetic review (ID == 0)
+// is still the loaded, selected content.
+type failedCommentsMsg struct {
+	jobID     int64
+	responses []storage.Response
+	err       error
+}
+
 type commentResultMsg struct {
 	jobID int64
 	err   error

--- a/cmd/roborev/tui/types.go
+++ b/cmd/roborev/tui/types.go
@@ -392,6 +392,11 @@ type failedCommentsMsg struct {
 	jobID     int64
 	responses []storage.Response
 	err       error
+	// seq is m.failedCommentsSeq stamped at dispatch; a mismatch on
+	// arrival means a newer comments fetch has since gone out and this
+	// response must not overwrite its result (or a post-success local
+	// append). See failedCommentsSeq's doc comment (tui.go).
+	seq uint64
 }
 
 type commentResultMsg struct {

--- a/cmd/roborev/tui/types.go
+++ b/cmd/roborev/tui/types.go
@@ -120,6 +120,24 @@ type logOutputMsg struct {
 // logTickMsg triggers a refresh of the log output
 type logTickMsg struct{}
 
+// paneLogOutputMsg delivers output lines for the split detail pane's live
+// log tail. Mirrors logOutputMsg but is keyed to the pane's own
+// paneLog* model fields so it never collides with the full-screen log
+// view's independent offset/formatter/seq state.
+type paneLogOutputMsg struct {
+	jobID     int64 // job this fetch was issued for -- checked alongside seq (see handlePaneLogOutputMsg)
+	lines     []logLine
+	hasMore   bool // true if job is still running
+	err       error
+	newOffset int64                // byte offset for next fetch
+	append    bool                 // true = append lines, false = replace (server-side offset reset)
+	seq       uint64               // fetch sequence number for stale detection
+	fmtr      *streamfmt.Formatter // formatter used for rendering (persist for incremental reuse)
+}
+
+// paneLogTickMsg triggers a poll of the split detail pane's live log tail.
+type paneLogTickMsg struct{ seq uint64 }
+
 // displayTickMsg triggers a local repaint without polling the daemon.
 type displayTickMsg struct{}
 
@@ -147,11 +165,134 @@ type reviewMsg struct {
 	responses  []storage.Response // Responses for this review
 	jobID      int64              // The job ID that was requested (for race condition detection)
 	branchName string             // Pre-computed branch name (empty if not applicable)
+	follow     bool               // true for split-view debounced follow fetches: update content only
+	// gen is m.detailFollowGen captured at dispatch time by fetchReview
+	// (every review fetch, follow or not -- fetchReviewFollow just
+	// inherits it). handleReviewMsg rejects a response whose gen no longer
+	// matches m.detailFollowGen when it lands, so a fetch outlived by a
+	// generation bump (a new split-mode selection, or a rerun-success
+	// bump for the same selected job) can't resurrect stale content --
+	// including a rerun that reuses the job ID, which the jobID-only
+	// staleness check above it can't tell apart from its own predecessor.
+	gen uint64
+	// dispatchedFrom is the view that was current when fetchReview built
+	// this command -- the fetch's true ORIGIN. handleReviewMsg's
+	// view-switch guard compares it against the view the user is on when
+	// the response lands, so a fetch can only pull the user into the
+	// review view from the view it was dispatched from. m.reviewFromView
+	// cannot serve that role: it is the RETURN target (where Esc goes back
+	// to), so a fetch dispatched from inside viewReview by arrow-key nav
+	// carries reviewFromView == viewQueue and would re-open the review
+	// after the user had already escaped back to the queue.
+	dispatchedFrom viewKind
+	// fetchSeq is m.reviewFetchSeq captured at dispatch time by EVERY
+	// review-content fetch, follow or not (both dispatch entry points,
+	// dispatchReviewFetch and dispatchReviewFollow, bump the shared epoch
+	// and stamp the new value). handleReviewMsg applies a response to
+	// currentReview/currentResponses/currentBranch only while its fetchSeq
+	// still equals the CURRENT m.reviewFetchSeq; an older one -- from any
+	// dispatcher, ordinary or follow -- arriving after a newer one was
+	// dispatched is dropped instead of overwriting the fresher content.
+	// See m.reviewFetchSeq's doc comment (tui.go).
+	fetchSeq uint64
+	// attempt is m.jobAttemptGen[jobID] captured at dispatch time by
+	// fetchReview -- the number of reruns of THIS job confirmed before the
+	// fetch went out. A response whose stamp no longer matches the job's
+	// current value belongs to an attempt the user has since superseded and
+	// is rejected outright by all three handlers. Unlike gen (one global
+	// counter, bumped by selection-driven refreshes) this is per job, so a
+	// rerun of job X invalidates X's in-flight fetches without touching a
+	// legitimate one for job Y. See m.jobAttemptGen's contract (tui.go).
+	attempt uint64
 }
-type promptMsg struct {
-	review *storage.Review
-	jobID  int64 // The job ID that was requested (for stale response detection)
+
+// reviewErrMsg carries a fetch failure from an ORDINARY (non-follow)
+// review fetch (fetchReview), fetchReviewFollow's typed-failure
+// counterpart for the path fetchReviewFollow doesn't wrap. A generic,
+// jobID-less errMsg cannot be tied back to pendingReviewOpenJobID or a
+// pending 'F' request, so a genuinely failed ordinary fetch would leave
+// both silently armed indefinitely -- neither the disarm-on-selection-
+// change nor the follow handler's resolve-on-failure block ever runs for
+// it. See handleReviewErrMsg.
+type reviewErrMsg struct {
+	jobID int64
+	err   error
+	// gen/fetchSeq mirror reviewMsg's fields exactly -- captured by
+	// fetchReview at the same point, for the same reason (see
+	// reviewMsg.gen/fetchSeq's doc comments): a stale failure must be
+	// rejected the same way a stale success would be, so a jobID match
+	// alone can't wrongly resolve a fresher, still-in-flight request for
+	// the same job.
+	gen      uint64
+	fetchSeq uint64
+	// attempt mirrors reviewMsg.attempt -- see its doc comment. A failure
+	// belonging to a superseded attempt is dropped just like a success
+	// would be.
+	attempt uint64
 }
+
+// reviewFollowErrMsg carries a fetch failure from a split-view follow fetch
+// (fetchReviewFollow), tagged with the jobID it was fetching for so a stale
+// response (the selection moved on before the fetch resolved) doesn't
+// clobber the detail pane with an outdated error. Kept distinct from the
+// generic errMsg so handleReviewFollowErrMsg can record it in
+// m.splitDetailErr without misattributing unrelated errMsg sources (e.g.
+// branch/repo list fetch failures) to the detail pane.
+type reviewFollowErrMsg struct {
+	jobID int64
+	err   error
+	// gen is m.detailFollowGen captured at dispatch time, mirroring
+	// reviewMsg.gen exactly: without it, a follow fetch's
+	// FAILURE was matched on jobID alone, so a stale error from a fetch
+	// dispatched for a job the user has since navigated away from and
+	// back to could overwrite splitDetailErr for the reselected job --
+	// while its success counterpart was already correctly rejected by
+	// gen. handleReviewFollowErrMsg discards a response whose gen no
+	// longer matches m.detailFollowGen, same as handleReviewMsg does for
+	// reviewMsg.
+	gen uint64
+	// fetchSeq mirrors reviewMsg.fetchSeq -- see its doc comment.
+	// m.reviewFetchSeq captured at dispatch time by every dispatcher.
+	fetchSeq uint64
+	// attempt mirrors reviewMsg.attempt -- see its doc comment. Copied
+	// verbatim from the reviewErrMsg fetchReviewFollow re-tags.
+	attempt uint64
+}
+
+// detailFollowTickMsg fires after the split-view follow debounce; stale
+// generations are dropped.
+type (
+	detailFollowTickMsg struct{ gen uint64 }
+	promptMsg           struct {
+		review *storage.Review
+		jobID  int64 // The job ID that was requested (for stale response detection)
+		// promptSeq is m.promptFetchSeq stamped at dispatch; a mismatch on
+		// arrival means the request was superseded by a newer prompt fetch or
+		// abandoned by a selection change (followSelectionChange bumps the
+		// counter), and the response is dropped. dispatchedFrom is the view the
+		// user was on at dispatch: handlePromptMsg switches into the prompt
+		// view only from that view (or from the prompt view itself, for
+		// stepPromptNav), so a slow response cannot yank the user out of a
+		// filter/tasks/help view they opened while it was in flight -- the same
+		// guard shape as reviewMsg.dispatchedFrom/openReviewView.
+		promptSeq      uint64
+		dispatchedFrom viewKind
+		// attempt is m.jobAttemptGen[jobID] captured at dispatch time by
+		// fetchReviewForPrompt, exactly as fetchReview stamps reviewMsg.attempt
+		// This path loads /api/review into the SAME
+		// currentReview field the split detail pane renders, so a response from
+		// an attempt a confirmed rerun has superseded poisons the pane the same
+		// way -- and worse, it overwrites the nil handleRerunResultMsg just
+		// wrote, after which reconcile's `currentReview.JobID == job.ID`
+		// idempotency check skips refetching the rerun's real result.
+		//
+		// This message deliberately does NOT carry the fetch epoch or
+		// detailFollowGen, unlike reviewMsg -- see handlePromptMsg's doc
+		// comment for the derivation.
+		attempt uint64
+	}
+)
+
 type (
 	closedMsg       bool
 	closedResultMsg struct {
@@ -185,7 +326,12 @@ type rerunResultMsg struct {
 	oldError      string
 	oldClosed     *bool
 	oldVerdict    *string
-	err           error
+	// spawnsNewRun mirrors rerunSnapshot.spawnsNewRun -- see its doc
+	// comment (actions.go). True means the daemon answered this rerun by
+	// enqueueing a new run with NEW job IDs, so nothing about THIS job's
+	// loaded content or in-flight fetches was superseded.
+	spawnsNewRun bool
+	err          error
 }
 type (
 	errMsg       error

--- a/cmd/roborev/tui/types.go
+++ b/cmd/roborev/tui/types.go
@@ -384,6 +384,13 @@ type repoBranchesMsg struct {
 type commentResultMsg struct {
 	jobID int64
 	err   error
+	// responder/comment echo what was posted, so the handler can append
+	// the created comment locally when the displayed review has no
+	// persisted row to refresh from (a synthesized failed-job review:
+	// the /api/review refresh would 404 and the comment would never
+	// appear). Unset on error.
+	responder string
+	comment   string
 }
 type clipboardResultMsg struct {
 	err  error

--- a/docs/integrations/tui.md
+++ b/docs/integrations/tui.md
@@ -171,6 +171,10 @@ limited.
 The same compact layout activates automatically when the terminal height is
 below 15 rows.
 
+Distraction-free mode always uses the stacked single-column layout, even on
+terminals large enough for the split view; toggling it off restores the split
+view when the terminal fits.
+
 ## Column Customization
 
 Press `o` in the queue or tasks view to open the column options modal. From
@@ -420,7 +424,7 @@ read this file to discover running TUI instances.
 
 | Command | Description |
 |---------|-------------|
-| `get-state` | Current view, filters, hide-closed state, selected job ID, job counts |
+| `get-state` | Current view, filters, hide-closed state, selected job ID, job counts, layout, focus |
 | `get-filter` | Active repo and branch filters with lock status |
 | `get-jobs` | List of visible jobs (ID, agent, status, repo, branch, verdict) |
 | `get-selected` | Currently selected job and whether it has a review |
@@ -452,9 +456,13 @@ Send a request as a single JSON line:
 Responses include an `ok` field, optional `error`, and optional `data`:
 
 ```json
-{"ok": true, "data": {"view": "queue", "job_count": 15, ...}}
+{"ok": true, "data": {"view": "queue", "job_count": 15, "layout": "split", "focus": "list", ...}}
 {"ok": false, "error": "job not found"}
 ```
+
+The `get-state` response's `layout` field is always `"stacked"` or `"split"`.
+`focus` is only meaningful in split layout: it's `"list"` or `"detail"` when
+`layout` is `"split"`, and an empty string otherwise.
 
 ### Example
 

--- a/internal/agent/cli_runner.go
+++ b/internal/agent/cli_runner.go
@@ -54,7 +54,7 @@ func runStreamingCLI(ctx context.Context, spec streamingCLISpec) (streamingCLIRe
 	if err != nil {
 		return result, fmt.Errorf("create stdout pipe: %w", err)
 	}
-	stopClosingPipe := closeOnContextDone(ctx, stdoutPipe)
+	stopClosingPipe := closeOnContextDone(ctx, stdoutPipe, tracker)
 	defer stopClosingPipe()
 
 	if err := cmd.Start(); err != nil {

--- a/internal/agent/process.go
+++ b/internal/agent/process.go
@@ -176,5 +176,12 @@ func processErrIndicatesContextTermination(err error) bool {
 	}
 	msg := err.Error()
 	return strings.Contains(msg, "signal: killed") ||
-		strings.Contains(msg, "signal: terminated")
+		strings.Contains(msg, "signal: terminated") ||
+		// A subprocess that writes to its stdout pipe AFTER the
+		// context-cancel path closed it dies of SIGPIPE before the kill
+		// signal can land -- the same context-caused termination through a
+		// different delivery race. Safe to classify here because the call
+		// site additionally requires canceledByContext: a broken pipe is
+		// only treated as context termination when WE closed the pipe.
+		strings.Contains(msg, "signal: broken pipe")
 }

--- a/internal/agent/process.go
+++ b/internal/agent/process.go
@@ -19,7 +19,17 @@ import (
 var subprocessWaitDelay = 5 * time.Second
 
 type subprocessTracker struct {
+	// canceledByContext records that the context watcher's kill actually
+	// terminated the process (Cancel ran and the kill succeeded).
 	canceledByContext atomic.Bool
+	// closedPipeOnContext records that closeOnContextDone closed the
+	// process's stdout pipe because the context fired. This is a separate
+	// signal from canceledByContext on purpose: the pipe close can
+	// SIGPIPE the process and Wait can reap it before the watcher's kill
+	// runs, making the kill return os.ErrProcessDone -- so the kill-based
+	// marker stays false even though context cancellation terminated the
+	// process. Classification (contextProcessError) accepts either.
+	closedPipeOnContext atomic.Bool
 }
 
 // subprocessConfig holds the options configureSubprocess accepts.
@@ -113,7 +123,11 @@ func configureCapabilityProbe(cmd *exec.Cmd) {
 	cmd.Dir = os.TempDir()
 }
 
-func closeOnContextDone(ctx context.Context, c io.Closer) func() {
+// closeOnContextDone closes c when ctx fires (unless stopped first). When
+// tracker is non-nil, a context-driven close is recorded on it BEFORE the
+// close, so a SIGPIPE death it causes can never be observed by Wait ahead
+// of the marker -- see subprocessTracker.closedPipeOnContext.
+func closeOnContextDone(ctx context.Context, c io.Closer, tracker *subprocessTracker) func() {
 	if c == nil || ctx.Done() == nil {
 		return func() {}
 	}
@@ -125,6 +139,9 @@ func closeOnContextDone(ctx context.Context, c io.Closer) func() {
 		case <-ctx.Done():
 			if stopped.Load() {
 				return
+			}
+			if tracker != nil {
+				tracker.closedPipeOnContext.Store(true)
 			}
 			_ = c.Close()
 		case <-done:
@@ -145,20 +162,24 @@ func contextProcessError(
 	if ctxErr == nil {
 		return nil
 	}
+	// Either marker proves context cancellation acted on the process: the
+	// watcher's kill succeeded, or the context-driven pipe close ran --
+	// which can SIGPIPE the process and get it reaped before the kill
+	// (making the kill return os.ErrProcessDone and leaving the
+	// kill-based marker false).
+	ctxActed := tracker != nil &&
+		(tracker.canceledByContext.Load() || tracker.closedPipeOnContext.Load())
 	if runErr != nil {
 		if errors.Is(runErr, ctxErr) ||
 			errors.Is(runErr, exec.ErrWaitDelay) ||
-			(tracker != nil &&
-				tracker.canceledByContext.Load() &&
-				processErrIndicatesContextTermination(runErr)) {
+			(ctxActed && processErrIndicatesContextTermination(runErr)) {
 			return ctxErr
 		}
 		return nil
 	}
 	if parseErr != nil &&
 		parseErrIndicatesClosedPipe(parseErr) &&
-		tracker != nil &&
-		tracker.canceledByContext.Load() {
+		ctxActed {
 		return ctxErr
 	}
 	return nil

--- a/internal/agent/process_test.go
+++ b/internal/agent/process_test.go
@@ -28,7 +28,7 @@ func TestCloseOnContextDoneClosesOnCancel(t *testing.T) {
 	defer cancel()
 
 	closer := &countingCloser{}
-	stop := closeOnContextDone(ctx, closer)
+	stop := closeOnContextDone(ctx, closer, nil)
 	defer stop()
 
 	cancel()
@@ -47,7 +47,7 @@ func TestCloseOnContextDoneStopPreventsClose(t *testing.T) {
 	defer cancel()
 
 	closer := &countingCloser{}
-	stop := closeOnContextDone(ctx, closer)
+	stop := closeOnContextDone(ctx, closer, nil)
 	stop()
 	cancel()
 	time.Sleep(20 * time.Millisecond)
@@ -57,7 +57,7 @@ func TestCloseOnContextDoneStopPreventsClose(t *testing.T) {
 
 func TestCloseOnContextDoneBackgroundIsNoop(t *testing.T) {
 	closer := &countingCloser{}
-	stop := closeOnContextDone(context.Background(), closer)
+	stop := closeOnContextDone(context.Background(), closer, nil)
 	stop()
 
 	require.Equal(t, int32(0), closer.closed.Load(), "background context should not close the closer")
@@ -205,4 +205,37 @@ func TestConfigureSubprocessDoesNotMarkCanceledWhenProcessAlreadyExited(t *testi
 		require.ErrorIs(t, err, os.ErrProcessDone, "expected os.ErrProcessDone, got %v", err)
 	}
 	require.False(t, tracker.canceledByContext.Load(), "tracker should stay false when cancel runs after process exit")
+}
+
+// TestContextPipeCloseClassifiesSIGPIPEWithoutKill covers the reap-before-
+// kill ordering: the context-driven pipe close SIGPIPEs the process and
+// Wait reaps it before the watcher's kill runs, so the kill returns
+// os.ErrProcessDone and canceledByContext stays false. The pipe-close
+// marker (closedPipeOnContext) is what lets contextProcessError still
+// classify the SIGPIPE death as context termination.
+func TestContextPipeCloseClassifiesSIGPIPEWithoutKill(t *testing.T) {
+	skipIfWindows(t)
+
+	// A real SIGPIPE death: Wait returns an ExitError with
+	// "signal: broken pipe", the same shape as an agent killed by the
+	// context-driven pipe close.
+	cmd := exec.Command("sh", "-c", "kill -PIPE $$")
+	runErr := cmd.Run()
+	require.Error(t, runErr)
+	require.Contains(t, runErr.Error(), "signal: broken pipe")
+
+	tracker := &subprocessTracker{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	closer := &countingCloser{}
+	stop := closeOnContextDone(ctx, closer, tracker)
+	defer stop()
+	require.Eventually(t, tracker.closedPipeOnContext.Load,
+		time.Second, time.Millisecond,
+		"the context-driven close must record itself on the tracker")
+	require.False(t, tracker.canceledByContext.Load(),
+		"sanity: the kill-based marker never fired in this ordering")
+
+	require.ErrorIs(t, contextProcessError(ctx, tracker, runErr, nil), context.Canceled,
+		"SIGPIPE after a context-driven pipe close is context termination")
 }


### PR DESCRIPTION
 - Adds a split-screen layout to `roborev tui` on terminals >= 140x36: queue list in a left pane, review details in a right pane, modeled on kata's split view (shared full-width chrome, bordered panes,
  focused-pane accent border)
  - `L` toggles split/stacked with a sticky preference that survives resizes; below the breakpoint the TUI degrades to the existing full-screen layout, which is unchanged
  - The detail pane auto-follows the queue cursor with a 75ms debounced fetch and generation guards, so holding j/k coalesces into one fetch and stale responses are dropped
  - The pane is always useful: done jobs show the review, running jobs show a status card with a live log tail that auto-swaps to the review on completion, failed jobs show the error, queued jobs show a metadata
  card; fetch failures render in-pane with a retry hint
  - Focus model: `tab` into the detail pane, `esc` back to the list; all existing review keys work in the pane; transient views (prompt, comment, help, log, tasks) stay full-screen and round-trip back to the
  split; Enter in the split queue is a no-op since the pane already follows
  - Mouse: click to focus/select by pane, wheel scrolls the pane under the cursor
  - Queue columns auto-narrow in the list pane (dropping from the end of the configured column order; core columns always survive), reusing the existing column-config system
  - Control socket `get-state` now reports `layout` and `focus`; docs and help view updated
  - All new behavior is gated behind the split layout; stacked-mode rendering is untouched and the full test suite passes
