### PR TITLE
Calibrate the security review prompt: settled non-findings, precision posture, comparative pass

### DIFF
--- a/internal/prompt/templates/default_security.md.gotmpl
+++ b/internal/prompt/templates/default_security.md.gotmpl
@@ -2,7 +2,9 @@ You are a security code reviewer with an exploitability burden of proof. Review 
 
 Report an issue only when the changed code affects a real trust boundary, security decision, secret-bearing path, privileged operation, or externally/user-controlled input path. The finding does not need a turnkey exploit, but it must identify a realistic attacker capability, the weakened boundary or control, and the concrete asset or privilege at risk.
 
-Prefer no finding over generic hardening advice, local-only paranoia, or best-practice commentary without a changed security outcome.
+Prefer no finding over generic hardening advice, local-only paranoia, or best-practice commentary without a changed security outcome. Better to miss a theoretical issue than to flood the report: each finding should be one a security engineer would confidently raise.
+
+Before flagging, check how the codebase already handles the same class of operation: a new deviation from an established secure pattern is a strong finding; code consistent with that pattern usually is not.
 
 The categories below are examples of high-value security issues, not a checklist to exhaust. Do not produce one finding per category. Focus on:
 
@@ -27,6 +29,12 @@ Only report vulnerabilities with a plausible exploit path visible in the diff. D
 - CI permission concerns unless untrusted code or input can influence the privileged workflow
 - Do not report environment-variable exposure or environment hardening concerns unless the reviewed code newly exposes env vars across a trust boundary, such as returning them in an HTTP response, writing them to user-visible logs, embedding them in generated artifacts, sending them to third-party services, or making them readable by less-privileged users
 - Process environment variables being readable by local code, child processes, same-user tooling, or same-user OS inspection. Assume local same-user access is not an attacker boundary by itself. A finding must involve a weaker actor gaining access they did not already have
+- Denial of service, resource exhaustion, or rate-limiting concerns
+- Unsanitized input written to logs (log spoofing); logging is a finding only when it exposes secrets or PII
+- Regex injection or regex-based denial of service
+- Memory-safety claims in memory-safe languages
+- Findings confined to test-only files or fixtures
+- Untrusted content flowing into an AI prompt, unless the resulting model output can trigger a privileged action the content's author could not already perform
 
 For each finding, provide:
 - Severity, using these definitions:

--- a/internal/prompt/testdata/golden/security_review.golden
+++ b/internal/prompt/testdata/golden/security_review.golden
@@ -2,7 +2,9 @@ You are a security code reviewer with an exploitability burden of proof. Review 
 
 Report an issue only when the changed code affects a real trust boundary, security decision, secret-bearing path, privileged operation, or externally/user-controlled input path. The finding does not need a turnkey exploit, but it must identify a realistic attacker capability, the weakened boundary or control, and the concrete asset or privilege at risk.
 
-Prefer no finding over generic hardening advice, local-only paranoia, or best-practice commentary without a changed security outcome.
+Prefer no finding over generic hardening advice, local-only paranoia, or best-practice commentary without a changed security outcome. Better to miss a theoretical issue than to flood the report: each finding should be one a security engineer would confidently raise.
+
+Before flagging, check how the codebase already handles the same class of operation: a new deviation from an established secure pattern is a strong finding; code consistent with that pattern usually is not.
 
 The categories below are examples of high-value security issues, not a checklist to exhaust. Do not produce one finding per category. Focus on:
 
@@ -27,6 +29,12 @@ Only report vulnerabilities with a plausible exploit path visible in the diff. D
 - CI permission concerns unless untrusted code or input can influence the privileged workflow
 - Do not report environment-variable exposure or environment hardening concerns unless the reviewed code newly exposes env vars across a trust boundary, such as returning them in an HTTP response, writing them to user-visible logs, embedding them in generated artifacts, sending them to third-party services, or making them readable by less-privileged users
 - Process environment variables being readable by local code, child processes, same-user tooling, or same-user OS inspection. Assume local same-user access is not an attacker boundary by itself. A finding must involve a weaker actor gaining access they did not already have
+- Denial of service, resource exhaustion, or rate-limiting concerns
+- Unsanitized input written to logs (log spoofing); logging is a finding only when it exposes secrets or PII
+- Regex injection or regex-based denial of service
+- Memory-safety claims in memory-safe languages
+- Findings confined to test-only files or fixtures
+- Untrusted content flowing into an AI prompt, unless the resulting model output can trigger a privileged action the content's author could not already perform
 
 For each finding, provide:
 - Severity, using these definitions:


### PR DESCRIPTION
## Summary

- Add settled non-findings to the security review prompt's do-not-report list: denial of service and resource exhaustion, log spoofing (logging remains a finding when it exposes secrets or PII), regex injection and regex-based DoS, memory-safety claims in memory-safe languages, findings confined to test-only files, and untrusted content reaching an AI prompt unless the model's output can trigger a privileged action the content's author could not already perform.
- State the precision posture explicitly — better to miss a theoretical issue than flood the report; each finding should be one a security engineer would confidently raise.
- Add a comparative pass: judge changed code against the codebase's established secure pattern for the same class of operation. A new deviation from that pattern is a strong finding; consistency with it usually is not.
- Motivation: these are the noise classes repos keep suppressing one-by-one in per-repo `review_guidelines` — kit's history records the CI panel repeatedly flagging the same safe.directory pattern until a guideline shut it down, and roborev's own guidelines devote a page to excluding local-only trust-model findings. Adjudications that generalize belong in the default prompt; genuinely repo-specific trust models stay in `.roborev.toml`.
- Scope note: the dedicated `security` review type has almost no usage history (two jobs ever recorded), so this calibrates against security-flavored noise observed in general/design reviews. The existing exploitability-burden-of-proof structure, attacker/boundary verification questions, and severity definitions are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sup>generated by a clanker</sup>
