### PR TITLE
feat(reasoning): add exact effort tiers

### DIFF
--- a/cmd/roborev/analyze.go
+++ b/cmd/roborev/analyze.go
@@ -175,7 +175,7 @@ To fix an existing analysis job, use: roborev fix <job_id>
 
 	cmd.Flags().StringVar(&agentName, "agent", "", "agent to use for analysis (default: from config)")
 	cmd.Flags().StringVar(&model, "model", "", "model for analysis agent")
-	cmd.Flags().StringVar(&reasoning, "reasoning", "", "reasoning level: fast, standard, medium, thorough, or maximum")
+	cmd.Flags().StringVar(&reasoning, "reasoning", "", "reasoning level: legacy presets fast, standard, thorough, maximum; exact tiers low, medium, high, xhigh, max")
 	cmd.Flags().BoolVar(&wait, "wait", false, "wait for job to complete and show result")
 	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "suppress output (just enqueue)")
 	cmd.Flags().BoolVar(&listTypes, "list", false, "list available analysis types")

--- a/cmd/roborev/ci.go
+++ b/cmd/roborev/ci.go
@@ -117,7 +117,7 @@ Flags override config values. When run inside GitHub ` +
 	cmd.Flags().StringVar(&reviewTypes, "review-types", "",
 		"comma-separated review types (overrides config)")
 	cmd.Flags().StringVar(&reasoning, "reasoning", "",
-		"reasoning level: fast, standard, medium, thorough, or maximum")
+		"reasoning level: legacy presets fast, standard, thorough, maximum; exact tiers low, medium, high, xhigh, max")
 	cmd.Flags().StringVar(&minSeverity, "min-severity", "",
 		"minimum severity filter: critical, high, medium, low")
 	cmd.Flags().StringVar(&synthesisAgent, "synthesis-agent", "",

--- a/cmd/roborev/ci_test.go
+++ b/cmd/roborev/ci_test.go
@@ -1307,6 +1307,12 @@ func TestResolveCIReasoning(t *testing.T) {
 	t.Run("explicit flag wins", func(t *testing.T) {
 		got, err := config.ResolveCIReasoning("high", nil, nil)
 		require.NoError(t, err)
+		assert.Equal(t, "high", got)
+	})
+
+	t.Run("legacy explicit flag is unchanged", func(t *testing.T) {
+		got, err := config.ResolveCIReasoning("thorough", nil, nil)
+		require.NoError(t, err)
 		assert.Equal(t, "thorough", got)
 	})
 

--- a/cmd/roborev/fix.go
+++ b/cmd/roborev/fix.go
@@ -206,7 +206,7 @@ Examples:
 
 	cmd.Flags().StringVar(&agentName, "agent", "", "agent to use for fixes (default: from config)")
 	cmd.Flags().StringVar(&model, "model", "", "model for agent")
-	cmd.Flags().StringVar(&reasoning, "reasoning", "", "reasoning level: fast, standard, medium, thorough, or maximum")
+	cmd.Flags().StringVar(&reasoning, "reasoning", "", "reasoning level: legacy presets fast, standard, thorough, maximum; exact tiers low, medium, high, xhigh, max")
 	cmd.Flags().StringVar(&minSeverity, "min-severity", "", "minimum finding severity to address: critical, high, medium, or low")
 	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "suppress progress output")
 	cmd.Flags().BoolVar(&open, "open", false, "deprecated: open is now the default behavior")

--- a/cmd/roborev/insights.go
+++ b/cmd/roborev/insights.go
@@ -76,7 +76,7 @@ Examples:
 	cmd.Flags().StringVar(&since, "since", "30d", "time window for reviews (e.g., 7d, 30d, 90d)")
 	cmd.Flags().StringVar(&agentName, "agent", "", "agent to use for analysis (default: from config)")
 	cmd.Flags().StringVar(&model, "model", "", "model for agent")
-	cmd.Flags().StringVar(&reasoning, "reasoning", "", "reasoning level: fast, standard, or thorough")
+	cmd.Flags().StringVar(&reasoning, "reasoning", "", "reasoning level: legacy presets fast, standard, thorough, maximum; exact tiers low, medium, high, xhigh, max")
 	cmd.Flags().BoolVar(&wait, "wait", true, "wait for completion and display result")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output job info as JSON")
 	registerAgentCompletion(cmd)

--- a/cmd/roborev/quickstart_guide.md
+++ b/cmd/roborev/quickstart_guide.md
@@ -115,5 +115,5 @@ default_agent = "codex"
 default_model = "gpt-5-codex"
 ```
 
-For per-workflow routing and reasoning levels (fast / standard / thorough), see
+For per-workflow routing and legacy or exact reasoning levels, see
 https://roborev.io/configuration/.

--- a/cmd/roborev/refine.go
+++ b/cmd/roborev/refine.go
@@ -138,7 +138,7 @@ Use --all-branches to discover and refine all branches with failed reviews.`,
 
 	cmd.Flags().StringVar(&opts.agentName, "agent", "", "agent to use for addressing findings (default: from config)")
 	cmd.Flags().StringVar(&opts.model, "model", "", "model for agent (format varies: opencode uses provider/model, others use model name)")
-	cmd.Flags().StringVar(&opts.reasoning, "reasoning", "", "reasoning level: fast, standard (default), medium, thorough, or maximum")
+	cmd.Flags().StringVar(&opts.reasoning, "reasoning", "", "reasoning level: legacy presets fast, standard (default), thorough, maximum; exact tiers low, medium, high, xhigh, max")
 	cmd.Flags().StringVar(&opts.minSeverity, "min-severity", "", "minimum finding severity to address: critical, high, medium, or low")
 	cmd.Flags().BoolVar(&fast, "fast", false, "shorthand for --reasoning fast")
 	cmd.Flags().IntVar(&opts.maxIterations, "max-iterations", 10, "maximum refinement iterations")

--- a/cmd/roborev/review.go
+++ b/cmd/roborev/review.go
@@ -413,7 +413,7 @@ Examples:
 	cmd.Flags().StringVar(&sha, "sha", "HEAD", "commit SHA to review (used when no positional args)")
 	cmd.Flags().StringVar(&agent, "agent", "", "agent to use (codex, claude-code, gemini, copilot, opencode, cursor, kiro, kilo, droid, pi, grok)")
 	cmd.Flags().StringVar(&model, "model", "", "model for agent (format varies: opencode uses provider/model, others use model name)")
-	cmd.Flags().StringVar(&reasoning, "reasoning", "", "reasoning level: fast, standard, medium, thorough (default), or maximum")
+	cmd.Flags().StringVar(&reasoning, "reasoning", "", "reasoning level: legacy presets fast, standard, thorough (default), maximum; exact tiers low, medium, high, xhigh, max")
 	cmd.Flags().BoolVar(&fast, "fast", false, "shorthand for --reasoning fast")
 	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "suppress informational output and the usage block; runtime errors are still printed")
 	cmd.Flags().BoolVar(&dirty, "dirty", false, "review uncommitted changes instead of a commit")

--- a/cmd/roborev/run.go
+++ b/cmd/roborev/run.go
@@ -90,7 +90,7 @@ Examples:
 
 	cmd.Flags().StringVar(&agentName, "agent", "", "agent to use (default: from config)")
 	cmd.Flags().StringVar(&model, "model", "", "model for agent (format varies: opencode uses provider/model, others use model name)")
-	cmd.Flags().StringVar(&reasoning, "reasoning", "", "reasoning level: fast, standard, medium, thorough (default), or maximum")
+	cmd.Flags().StringVar(&reasoning, "reasoning", "", "reasoning level: legacy presets fast, standard, thorough (default), maximum; exact tiers low, medium, high, xhigh, max")
 	cmd.Flags().BoolVar(&wait, "wait", false, "wait for job to complete and show result")
 	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "suppress output (just enqueue)")
 	cmd.Flags().BoolVar(&noContext, "no-context", false, "don't include repository context in prompt")

--- a/docs/advanced/custom-tasks.md
+++ b/docs/advanced/custom-tasks.md
@@ -103,7 +103,7 @@ cat review-checklist.txt | roborev run --wait
 |------|-------------|
 | `--wait` | Wait for task to complete and show result |
 | `--agent` | Agent to use (default: from config) |
-| `--reasoning` | Reasoning level: `fast`, `standard`, or `thorough` |
+| `--reasoning` | Legacy or exact reasoning level; see [Reasoning Levels](/configuration/#reasoning-levels) |
 | `--no-context` | Don't include repository context in prompt |
 | `--agentic` | Enable agentic mode (allow file edits and commands) |
 | `--yolo` | Alias for `--agentic` |

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -337,8 +337,9 @@ grok --no-auto-update --output-format streaming-json --always-approve \
   --prompt-file <path>
 ```
 
-Reasoning mapping: `maximum` → `max`, `thorough` → `high`, `medium` → `medium`,
-`fast` → `low`. Standard leaves Grok's default effort.
+Legacy reasoning mapping: `maximum` → `max`, `thorough` → `high`, `fast` →
+`low`. Standard leaves Grok's default effort. Exact `low`, `medium`, `high`,
+`xhigh`, and `max` values pass through unchanged.
 
 Session resume uses Grok's `--resume` flag when a session ID is available (same
 `SessionAgent` path as Claude/Codex).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,9 @@ All notable changes to roborev, grouped by minor release.
 
 **New features**
 
+- Reasoning accepts exact `low`, `medium`, `high`, `xhigh`, and `max` values and
+    forwards them unchanged to agents that support each tier. The legacy `fast`,
+    `standard`, `thorough`, and `maximum` mappings remain unchanged.
 - Pi agents accept global `[agent.pi] launch_args`, passed as tokenized
     arguments to every Pi invocation before roborev-managed workflow and safety
     options. This allows isolated classifier jobs to load extension-defined

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,7 +11,7 @@ All notable changes to roborev, grouped by minor release.
 
 - Reasoning accepts exact `low`, `medium`, `high`, `xhigh`, and `max` values and
     forwards them unchanged to agents that support each tier. The legacy `fast`,
-    `standard`, `thorough`, and `maximum` mappings remain unchanged.
+    `standard`, `thorough`, and `maximum` presets remain compatible.
 - Pi agents accept global `[agent.pi] launch_args`, passed as tokenized
     arguments to every Pi invocation before roborev-managed workflow and safety
     options. This allows isolated classifier jobs to load extension-defined
@@ -30,6 +30,9 @@ All notable changes to roborev, grouped by minor release.
 - Daemon restarts now stop new job claims and wait indefinitely for running
     reviews and worker finalization instead of force-killing the daemon after a
     short graceful-shutdown window.
+- The Codex `maximum` preset now requests literal `max` for explicit GPT-5.6
+    `sol`, `terra`, and `luna` models. Older, default, and unknown models retain
+    the compatible `xhigh` mapping, while exact `xhigh` remains distinct.
 
 ______________________________________________________________________
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -86,7 +86,7 @@ roborev review --branch --panel none          # Force single-agent review
 | `--agent <name>` | Use a specific agent for review: a built-in (`codex`, `claude-code`, `gemini`, `copilot`, `opencode`, `cursor`, `kiro`, `kilo`, `droid`, `pi`, `grok`) or a configured ACP agent |
 | `-m, --model <model>` | Model to use (format varies by agent) |
 | `--type <type>` | Review type (`security`, `design`, `lookahead`); changes system prompt |
-| `--reasoning <level>` | Set reasoning depth (`maximum`/`thorough`/`standard`/`fast`) |
+| `--reasoning <level>` | Set a legacy or exact reasoning level; see [Reasoning Levels](/configuration/#reasoning-levels) |
 | `--fast` | Shorthand for `--reasoning fast` |
 | `--min-severity <level>` | Only report findings at or above this severity (`low`/`medium`/`high`/`critical`) |
 | `--panel <name or none>` | Run a named review panel. Use `none` to bypass configured defaults |
@@ -651,7 +651,7 @@ roborev ci review --comment                  # Post results as PR/MR comment
 | `--pr <number>` | PR number / GitLab MR IID (default: `GITHUB_EVENT_PATH` or `CI_MERGE_REQUEST_IID`) |
 | `--agent <names>` | Agents to use (comma-separated, default: auto-detect) |
 | `--review-types <types>` | Review types to run (comma-separated: `security`, `design`, `lookahead`, `default`) |
-| `--reasoning <level>` | Reasoning depth (`thorough`/`standard`/`fast`) |
+| `--reasoning <level>` | Legacy (`fast`/`standard`/`thorough`/`maximum`) or exact (`low`/`medium`/`high`/`xhigh`/`max`) reasoning |
 | `--min-severity <level>` | Minimum severity to report (`low`/`medium`/`high`/`critical`) |
 | `--upsert-comments` | Update the previous roborev comment instead of adding one (overrides `[ci] upsert_comments`) |
 | `--synthesis-agent <name>` | Agent for combining multi-job results |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -86,8 +86,8 @@ roborev review --branch --panel none          # Force single-agent review
 | `--agent <name>` | Use a specific agent for review: a built-in (`codex`, `claude-code`, `gemini`, `copilot`, `opencode`, `cursor`, `kiro`, `kilo`, `droid`, `pi`, `grok`) or a configured ACP agent |
 | `-m, --model <model>` | Model to use (format varies by agent) |
 | `--type <type>` | Review type (`security`, `design`, `lookahead`); changes system prompt |
-| `--reasoning <level>` | Set a legacy or exact reasoning level; see [Reasoning Levels](/configuration/#reasoning-levels) |
-| `--fast` | Shorthand for `--reasoning fast` |
+| `--reasoning <level>` | Set a reasoning level; prefer exact `low`/`medium`/`high`/`xhigh`/`max`, while legacy presets remain supported. See [Reasoning Levels](/configuration/#reasoning-levels) |
+| `--fast` | Legacy shorthand for `--reasoning fast` |
 | `--min-severity <level>` | Only report findings at or above this severity (`low`/`medium`/`high`/`critical`) |
 | `--panel <name or none>` | Run a named review panel. Use `none` to bypass configured defaults |
 | `--local` | Run review locally without the daemon (streams output to console) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1416,13 +1416,18 @@ The legacy values keep their established per-agent behavior:
 | `fast` | `low` | `low` | `low` | `low` | `minimal` | `low` |
 | `standard` | default | default | default | default | default | `medium` |
 | `thorough` | `high` | `high` | `high` | `high` | `high` | `high` |
-| `maximum` | `xhigh` | `max` | `max` | `high` | `high` | `high` |
+| `maximum` | GPT-5.6 `sol`/`terra`/`luna`: `max`; otherwise `xhigh` | `max` | `max` | `high` | `high` | `high` |
 
 Native support is agent-specific. Codex, Claude, Grok, and Pi accept all five
 exact values. Droid accepts `low`, `medium`, and `high`. Kilo passes exact
 values through as model variants, so availability depends on the selected
 provider and model. Agents without a reasoning flag ignore the level while
 workflow-specific agent and model routing still uses its exact name.
+
+For Codex, the legacy `maximum` preset requests literal `max` only when the
+selected model is explicitly `gpt-5.6-sol`, `gpt-5.6-terra`, or `gpt-5.6-luna`.
+Older, default, and unknown models keep the compatible `xhigh` mapping. Use the
+exact `xhigh` value to request `xhigh` on every Codex model, including GPT-5.6.
 
 Set per-command with `--reasoning`, or per-repo in `.roborev.toml`:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,7 +94,8 @@ review_context_count = 5   # Recent reviews to include as context
 display_name = "backend"   # Custom name shown in TUI (optional)
 excluded_branches = ["wip", "scratch"]  # Branches to skip reviews on
 
-# Reasoning levels: thorough, standard, fast
+# Legacy levels: fast, standard, thorough, maximum
+# Exact agent efforts: low, medium, high, xhigh, max
 review_reasoning = "thorough"  # For code reviews (default: thorough)
 refine_reasoning = "standard"  # For refine command (default: standard)
 
@@ -135,8 +136,8 @@ max_chars = 50000
 | `post_commit_review` | string | Post-commit hook behavior: `"commit"` (default) or `"branch"` |
 | `hook_timeout_seconds` | int | Override the post-commit hook request timeout for this repo, in seconds. Useful for large repos where the daemon's enqueue git calls are slow. Read filesystem-only from this checkout's `.roborev.toml` (a linked worktree without its own file does not inherit the main checkout's value). Zero or negative values inherit the global / platform default |
 | `auto_close_passing_reviews` | bool | Automatically close reviews that pass with no findings |
-| `review_reasoning` | string | Reasoning level for reviews: thorough, standard, fast |
-| `refine_reasoning` | string | Reasoning level for refine: thorough, standard, fast |
+| `review_reasoning` | string | Reasoning level for reviews. See [Reasoning Levels](#reasoning-levels) |
+| `refine_reasoning` | string | Reasoning level for refine. See [Reasoning Levels](#reasoning-levels) |
 | `review_min_severity` | string | Minimum severity for reviews: `critical`, `high`, `medium`, or `low`. Cascades: CLI flag > repo config > global config |
 | `fix_min_severity` | string | Minimum severity for `fix`: `critical`, `high`, `medium`, or `low` |
 | `refine_min_severity` | string | Minimum severity for `refine`: `critical`, `high`, `medium`, or `low` |
@@ -381,7 +382,11 @@ reasoning level:
 
 - `{workflow}_model_{level}` or `{workflow}_agent_{level}`
 - `workflow` is `review`, `refine`, `fix`, `security`, or `design`
-- `level` is `thorough`, `standard`, or `fast`
+- `level` is a legacy or exact value from [Reasoning Levels](#reasoning-levels)
+
+For compatibility, exact `low`, `high`, `xhigh`, and `max` routing falls back to
+the corresponding `fast`, `thorough`, or `maximum` key when an exact key is not
+configured.
 
 The fallback hierarchy for each workflow is:
 
@@ -1360,7 +1365,7 @@ to a design-review job or marks it skipped accordingly.
 |--------|------|---------|-------------|
 | `classify_agent` | string | `claude-code` | Agent for the routing classifier. Must implement structured-output (`SchemaAgent`) capability |
 | `classify_model` | string | agent default | Model for the classifier agent |
-| `classify_reasoning` | string | `fast` | Reasoning level: `fast`, `standard`, `medium`, `thorough`, or `maximum` |
+| `classify_reasoning` | string | `fast` | Legacy or exact value from [Reasoning Levels](#reasoning-levels) |
 | `classify_backup_agent` | string | - | Fallback classifier agent on quota exhaustion or failure |
 | `classify_backup_model` | string | - | Fallback classifier model |
 
@@ -1399,24 +1404,32 @@ when the feature is disabled across all repos.
 
 ## Reasoning Levels
 
-Reasoning levels control how deeply the AI analyzes code.
+Reasoning levels control how deeply the AI analyzes code. The exact values
+`low`, `medium`, `high`, `xhigh`, and `max` request the same-named native effort
+from agents that support it. An unsupported exact tier is left unset rather than
+collapsed into a different tier.
 
-| Level | Description | Best For |
-|-------|-------------|----------|
-| `maximum` | Deepest analysis; maps to Codex `xhigh` reasoning | Complex reviews requiring maximum depth |
-| `thorough` | Deep analysis with extended thinking | Code reviews (default) |
-| `standard` | Balanced analysis | Refine command (default) |
-| `fast` | Quick responses | Rapid feedback |
+The legacy values keep their established per-agent behavior:
 
-`maximum` is accepted as `max` or `xhigh` on the command line. For agents
-without an xhigh equivalent (Droid, Kilo, Pi), it maps to their highest
-available level (same as thorough).
+| Legacy value | Codex | Claude | Grok | Droid | Kilo | Pi |
+|--------------|-------|--------|------|-------|------|----|
+| `fast` | `low` | `low` | `low` | `low` | `minimal` | `low` |
+| `standard` | default | default | default | default | default | `medium` |
+| `thorough` | `high` | `high` | `high` | `high` | `high` | `high` |
+| `maximum` | `xhigh` | `max` | `max` | `high` | `high` | `high` |
+
+Native support is agent-specific. Codex, Claude, Grok, and Pi accept all five
+exact values. Droid accepts `low`, `medium`, and `high`. Kilo passes exact
+values through as model variants, so availability depends on the selected
+provider and model. Agents without a reasoning flag ignore the level while
+workflow-specific agent and model routing still uses its exact name.
 
 Set per-command with `--reasoning`, or per-repo in `.roborev.toml`:
 
 ```bash
 roborev review --reasoning fast      # Quick review
 roborev refine --reasoning thorough  # Careful fixes
+roborev review --reasoning xhigh     # Exact native xhigh effort
 ```
 
 ## Authentication

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -388,6 +388,17 @@ For compatibility, exact `low`, `high`, `xhigh`, and `max` routing falls back to
 the corresponding `fast`, `thorough`, or `maximum` key when an exact key is not
 configured.
 
+Agent and model keys fall back independently. Use the same naming family for
+both halves of a level-specific route: keep an existing legacy pair together, or
+migrate both keys to exact names. For example, do not combine `review_agent_low`
+with `review_model_fast`; the model fallback could pass the legacy route's model
+to the exact route's agent. Prefer this form for new configuration:
+
+```toml
+review_agent_low = "codex"
+review_model_low = "gpt-5.6-terra"
+```
+
 The fallback hierarchy for each workflow is:
 
 - **CLI flag** > **repo `{workflow}_agent_{level}`** > **repo
@@ -1407,7 +1418,19 @@ when the feature is disabled across all repos.
 Reasoning levels control how deeply the AI analyzes code. The exact values
 `low`, `medium`, `high`, `xhigh`, and `max` request the same-named native effort
 from agents that support it. An unsupported exact tier is left unset rather than
-collapsed into a different tier.
+collapsed into a different tier. Prefer exact values for new CLI invocations and
+configuration. The legacy presets remain accepted for compatibility.
+
+Use this table when moving from legacy presets to exact tiers. These are the
+closest matches in intent, not universal aliases: legacy presets retain their
+agent-specific behavior.
+
+| Legacy preset | Preferred exact tier | Difference to consider |
+|---------------|----------------------|------------------------|
+| `fast` | `low` | Kilo's legacy preset uses `minimal`; exact `low` requests `low` |
+| `standard` | `medium` | Legacy `standard` usually leaves the agent's default unchanged; exact `medium` requests `medium` |
+| `thorough` | `high` | Current reasoning-capable agents map the legacy preset to `high` |
+| `maximum` | `xhigh` or `max` | The legacy ceiling varies by agent and Codex model; choose the exact tier deliberately |
 
 The legacy values keep their established per-agent behavior:
 
@@ -1432,10 +1455,14 @@ exact `xhigh` value to request `xhigh` on every Codex model, including GPT-5.6.
 Set per-command with `--reasoning`, or per-repo in `.roborev.toml`:
 
 ```bash
-roborev review --reasoning fast      # Quick review
-roborev refine --reasoning thorough  # Careful fixes
-roborev review --reasoning xhigh     # Exact native xhigh effort
+roborev review --reasoning low    # Exact native low effort
+roborev refine --reasoning high   # Exact native high effort
+roborev review --reasoning xhigh  # Exact native xhigh effort
 ```
+
+The legacy `--reasoning fast`, `standard`, `thorough`, and `maximum` values and
+the `--fast` shorthand continue to work. Avoid mixing legacy and exact suffixes
+between matching agent and model configuration keys.
 
 ## Authentication
 

--- a/docs/guides/assisted-refactoring.md
+++ b/docs/guides/assisted-refactoring.md
@@ -313,7 +313,7 @@ max_prompt_size = 204800
 |------|-------------|
 | `--agent <name>` | Agent to use for analysis (default: from config) |
 | `--model <model>` | Model for analysis agent |
-| `--reasoning <level>` | Reasoning depth: `fast`, `standard`, or `thorough` |
+| `--reasoning <level>` | Legacy or exact reasoning level; see [Reasoning Levels](/configuration/#reasoning-levels) |
 | `--branch [name]` | Analyze files changed on branch (optionally specify branch name with `--branch=name`) |
 | `--base <branch>` | Base branch for `--branch` comparison (default: auto-detect) |
 | `--wait` | Wait for job to complete and show result |
@@ -332,7 +332,7 @@ max_prompt_size = 204800
 |------|-------------|
 | `--agent <name>` | Agent to use for fixes (default: from config) |
 | `--model <model>` | Model for fix agent |
-| `--reasoning <level>` | Reasoning depth: `fast`, `standard`, or `thorough` |
+| `--reasoning <level>` | Legacy or exact reasoning level; see [Reasoning Levels](/configuration/#reasoning-levels) |
 | `--quiet` | Suppress agent output |
 | `--open` | Fix all open reviews on the current branch (default when no job IDs given) |
 | `--batch` | Concatenate multiple reviews into a single agent prompt instead of fixing one at a time |

--- a/docs/guides/auto-fixing.md
+++ b/docs/guides/auto-fixing.md
@@ -97,7 +97,7 @@ those values directly with Git's `--author` and `--trailer` options. See
 | `--model <model>` | Model for agent |
 | `--max-iterations <n>` | Maximum fix iterations (default: 10) |
 | `--quiet` | Show elapsed time instead of agent output |
-| `--reasoning <level>` | Reasoning depth: fast, standard, thorough |
+| `--reasoning <level>` | Legacy or exact reasoning level; see [Reasoning Levels](/configuration/#reasoning-levels) |
 | `--fast` | Shorthand for `--reasoning fast` |
 | `--since <commit>` | Refine commits since a specific commit |
 | `--branch <name>` | Validate the current branch before refining (guardrail, does not switch branches) |

--- a/docs/integrations/github.md
+++ b/docs/integrations/github.md
@@ -699,7 +699,7 @@ panel = "ci"                         # run named [review.panels.ci] for this rep
 # Or omit panel and use the compatible matrix:
 # agents = ["gemini"]
 # review_types = ["security", "default"]
-reasoning = "standard"               # override reasoning level (thorough, standard, fast)
+reasoning = "standard"               # override legacy or exact reasoning level
 ```
 
 Per-repo overrides take priority over the global `[ci]` config. Any field not
@@ -712,7 +712,7 @@ set, it takes priority over the matrix fields for that repo.
 | `agents` | array | global `agents` | Agents for CI reviews of this repo |
 | `review_types` | array | global `review_types` | Review types for CI reviews of this repo |
 | `reviews` | table | global `reviews` | Granular agent-to-review-type map (overrides `agents` and `review_types`; empty table disables reviews) |
-| `reasoning` | string | `"thorough"` | Reasoning level: `thorough`, `standard`, or `fast` |
+| `reasoning` | string | `"thorough"` | Legacy or exact reasoning level; see [Reasoning Levels](/configuration/#reasoning-levels) |
 | `min_severity` | string | `"low"` | Minimum severity to include: `low`, `medium`, `high`, or `critical` |
 | `upsert_comments` | bool | global `upsert_comments` | Override global comment upsert setting for this repo |
 | `include_costs` | bool | global `include_costs` | Include token cost estimates in PR comment footers for this repo |

--- a/docs/integrations/gitlab.md
+++ b/docs/integrations/gitlab.md
@@ -381,7 +381,7 @@ Subgroup paths are supported: `--gl-repo group/subgroup/project`.
 | `--upsert-comments` | Update the previous roborev note instead of adding one (overrides `[ci] upsert_comments`) |
 | `--agent <names>` | Agents to use (comma-separated, default: auto-detect) |
 | `--review-types <types>` | Review types to run (`security`, `design`, `lookahead`, `default`) |
-| `--reasoning <level>` | Reasoning depth (`thorough`/`standard`/`fast`) |
+| `--reasoning <level>` | Legacy or exact reasoning level; see [Reasoning Levels](/configuration/#reasoning-levels) |
 | `--min-severity <level>` | Minimum severity to report (`low`/`medium`/`high`/`critical`) |
 | `--synthesis-agent <name>` | Agent for combining multi-job results |
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -24,24 +24,50 @@ const (
 	ReasoningStandard ReasoningLevel = "standard"
 	// ReasoningFast uses minimal reasoning for quick responses
 	ReasoningFast ReasoningLevel = "fast"
+	// ReasoningLow requests the agent's native low effort.
+	ReasoningLow ReasoningLevel = "low"
+	// ReasoningHigh requests the agent's native high effort.
+	ReasoningHigh ReasoningLevel = "high"
+	// ReasoningXHigh requests the agent's native xhigh effort.
+	ReasoningXHigh ReasoningLevel = "xhigh"
+	// ReasoningMax requests the agent's native max effort.
+	ReasoningMax ReasoningLevel = "max"
 )
 
 // ReasoningLevels returns the canonical reasoning level names.
 func ReasoningLevels() []string {
-	return []string{string(ReasoningFast), string(ReasoningStandard), string(ReasoningMedium), string(ReasoningThorough), string(ReasoningMaximum)}
+	return []string{
+		string(ReasoningFast),
+		string(ReasoningStandard),
+		string(ReasoningThorough),
+		string(ReasoningMaximum),
+		string(ReasoningLow),
+		string(ReasoningMedium),
+		string(ReasoningHigh),
+		string(ReasoningXHigh),
+		string(ReasoningMax),
+	}
 }
 
 // ParseReasoningLevel converts a string to ReasoningLevel, defaulting to standard
 func ParseReasoningLevel(s string) ReasoningLevel {
 	switch s {
-	case "maximum", "max", "xhigh":
+	case "maximum":
 		return ReasoningMaximum
-	case "thorough", "high":
+	case "thorough":
 		return ReasoningThorough
+	case "high":
+		return ReasoningHigh
 	case "medium":
 		return ReasoningMedium
-	case "fast", "low":
+	case "fast":
 		return ReasoningFast
+	case "low":
+		return ReasoningLow
+	case "xhigh":
+		return ReasoningXHigh
+	case "max":
+		return ReasoningMax
 	case "standard", "":
 		return ReasoningStandard
 	default:

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -14,7 +14,7 @@ import (
 type ReasoningLevel string
 
 const (
-	// ReasoningMaximum uses the highest available reasoning (e.g., codex xhigh, claude max)
+	// ReasoningMaximum uses the highest compatible reasoning for the selected model.
 	ReasoningMaximum ReasoningLevel = "maximum"
 	// ReasoningThorough uses deep reasoning for thorough analysis (slower)
 	ReasoningThorough ReasoningLevel = "thorough"

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -167,25 +167,63 @@ func TestParseReasoningLevel(t *testing.T) {
 
 func TestCodexReasoningEffortMapping(t *testing.T) {
 	tests := []struct {
+		name  string
+		model string
 		level ReasoningLevel
 		want  string
 	}{
-		{ReasoningMaximum, "xhigh"},
-		{ReasoningThorough, "high"},
-		{ReasoningFast, "low"},
-		{ReasoningStandard, ""},
-		{ReasoningLow, "low"},
-		{ReasoningMedium, "medium"},
-		{ReasoningHigh, "high"},
-		{ReasoningXHigh, "xhigh"},
-		{ReasoningMax, "max"},
+		{"maximum without explicit model", "", ReasoningMaximum, "xhigh"},
+		{"maximum with older model", "gpt-5.5", ReasoningMaximum, "xhigh"},
+		{"maximum with unknown model", "custom-model", ReasoningMaximum, "xhigh"},
+		{"maximum with unknown GPT-5.6 variant", "gpt-5.6-preview", ReasoningMaximum, "xhigh"},
+		{"maximum with GPT-5.6 sol", "gpt-5.6-sol", ReasoningMaximum, "max"},
+		{"maximum with GPT-5.6 terra", "gpt-5.6-terra", ReasoningMaximum, "max"},
+		{"maximum with GPT-5.6 luna", "gpt-5.6-luna", ReasoningMaximum, "max"},
+		{"explicit xhigh with GPT-5.6", "gpt-5.6-luna", ReasoningXHigh, "xhigh"},
+		{"thorough", "", ReasoningThorough, "high"},
+		{"fast", "", ReasoningFast, "low"},
+		{"standard", "", ReasoningStandard, ""},
+		{"exact low", "", ReasoningLow, "low"},
+		{"exact medium", "", ReasoningMedium, "medium"},
+		{"exact high", "", ReasoningHigh, "high"},
+		{"exact xhigh", "", ReasoningXHigh, "xhigh"},
+		{"exact max", "", ReasoningMax, "max"},
 	}
 
 	for _, tt := range tests {
-		a := NewCodexAgent("").WithReasoning(tt.level)
-		codex, ok := a.(*CodexAgent)
-		require.True(t, ok, "expected CodexAgent, got %T", a)
-		assert.Equal(t, tt.want, codex.codexReasoningEffort(), "codexReasoningEffort(%q)", tt.level)
+		t.Run(tt.name, func(t *testing.T) {
+			a := NewCodexAgent("").WithModel(tt.model).WithReasoning(tt.level)
+			codex, ok := a.(*CodexAgent)
+			require.True(t, ok, "expected CodexAgent, got %T", a)
+			assert.Equal(t, tt.want, codex.codexReasoningEffort())
+		})
+	}
+}
+
+func TestCodexBuildArgsGPT56MaximumReasoning(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent Agent
+	}{
+		{
+			name: "model then reasoning",
+			agent: NewCodexAgent("").
+				WithModel("gpt-5.6-luna").
+				WithReasoning(ReasoningMaximum),
+		},
+		{
+			name: "reasoning then model",
+			agent: NewCodexAgent("").
+				WithReasoning(ReasoningMaximum).
+				WithModel("gpt-5.6-luna"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Contains(t, tt.agent.CommandLine(), "-m gpt-5.6-luna")
+			assert.Contains(t, tt.agent.CommandLine(), `-c model_reasoning_effort="max"`)
+		})
 	}
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -148,12 +148,12 @@ func TestParseReasoningLevel(t *testing.T) {
 		want  ReasoningLevel
 	}{
 		{"maximum", ReasoningMaximum},
-		{"max", ReasoningMaximum},
-		{"xhigh", ReasoningMaximum},
+		{"max", ReasoningMax},
+		{"xhigh", ReasoningXHigh},
 		{"thorough", ReasoningThorough},
-		{"high", ReasoningThorough},
+		{"high", ReasoningHigh},
 		{"fast", ReasoningFast},
-		{"low", ReasoningFast},
+		{"low", ReasoningLow},
 		{"medium", ReasoningMedium},
 		{"standard", ReasoningStandard},
 		{"", ReasoningStandard},
@@ -174,6 +174,11 @@ func TestCodexReasoningEffortMapping(t *testing.T) {
 		{ReasoningThorough, "high"},
 		{ReasoningFast, "low"},
 		{ReasoningStandard, ""},
+		{ReasoningLow, "low"},
+		{ReasoningMedium, "medium"},
+		{ReasoningHigh, "high"},
+		{ReasoningXHigh, "xhigh"},
+		{ReasoningMax, "max"},
 	}
 
 	for _, tt := range tests {
@@ -194,6 +199,10 @@ func TestClaudeEffortMapping(t *testing.T) {
 		{ReasoningMedium, "medium"},
 		{ReasoningFast, "low"},
 		{ReasoningStandard, ""},
+		{ReasoningLow, "low"},
+		{ReasoningHigh, "high"},
+		{ReasoningXHigh, "xhigh"},
+		{ReasoningMax, "max"},
 	}
 
 	for _, tt := range tests {
@@ -201,6 +210,95 @@ func TestClaudeEffortMapping(t *testing.T) {
 		claude, ok := a.(*ClaudeAgent)
 		require.True(t, ok, "expected ClaudeAgent, got %T", a)
 		assert.Equal(t, tt.want, claude.claudeEffort(), "claudeEffort(%q)", tt.level)
+	}
+}
+
+func TestOtherReasoningEffortMappings(t *testing.T) {
+	type effortCase struct {
+		level ReasoningLevel
+		want  string
+	}
+	tests := []struct {
+		name      string
+		mapEffort func(ReasoningLevel) string
+		levels    []effortCase
+	}{
+		{
+			name: "grok",
+			mapEffort: func(level ReasoningLevel) string {
+				return NewGrokAgent("").WithReasoning(level).(*GrokAgent).grokReasoningEffort()
+			},
+			levels: []effortCase{
+				{ReasoningMaximum, "max"},
+				{ReasoningThorough, "high"},
+				{ReasoningFast, "low"},
+				{ReasoningStandard, ""},
+				{ReasoningLow, "low"},
+				{ReasoningMedium, "medium"},
+				{ReasoningHigh, "high"},
+				{ReasoningXHigh, "xhigh"},
+				{ReasoningMax, "max"},
+			},
+		},
+		{
+			name: "droid",
+			mapEffort: func(level ReasoningLevel) string {
+				return NewDroidAgent("").WithReasoning(level).(*DroidAgent).droidReasoningEffort()
+			},
+			levels: []effortCase{
+				{ReasoningMaximum, "high"},
+				{ReasoningThorough, "high"},
+				{ReasoningFast, "low"},
+				{ReasoningStandard, ""},
+				{ReasoningLow, "low"},
+				{ReasoningMedium, "medium"},
+				{ReasoningHigh, "high"},
+				{ReasoningXHigh, ""},
+				{ReasoningMax, ""},
+			},
+		},
+		{
+			name: "kilo",
+			mapEffort: func(level ReasoningLevel) string {
+				return NewKiloAgent("").WithReasoning(level).(*KiloAgent).kiloVariant()
+			},
+			levels: []effortCase{
+				{ReasoningMaximum, "high"},
+				{ReasoningThorough, "high"},
+				{ReasoningFast, "minimal"},
+				{ReasoningStandard, ""},
+				{ReasoningLow, "low"},
+				{ReasoningMedium, "medium"},
+				{ReasoningHigh, "high"},
+				{ReasoningXHigh, "xhigh"},
+				{ReasoningMax, "max"},
+			},
+		},
+		{
+			name: "pi",
+			mapEffort: func(level ReasoningLevel) string {
+				return NewPiAgent("").WithReasoning(level).(*PiAgent).thinkingLevel()
+			},
+			levels: []effortCase{
+				{ReasoningMaximum, "high"},
+				{ReasoningThorough, "high"},
+				{ReasoningFast, "low"},
+				{ReasoningStandard, "medium"},
+				{ReasoningLow, "low"},
+				{ReasoningMedium, "medium"},
+				{ReasoningHigh, "high"},
+				{ReasoningXHigh, "xhigh"},
+				{ReasoningMax, "max"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, level := range tt.levels {
+				assert.Equal(t, level.want, tt.mapEffort(level.level), "effort for %q", level.level)
+			}
+		})
 	}
 }
 

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -89,13 +89,15 @@ func (a *ClaudeAgent) WithSessionID(sessionID string) Agent {
 // claudeEffort maps ReasoningLevel to Claude Code's --effort flag values
 func (a *ClaudeAgent) claudeEffort() string {
 	switch a.Reasoning {
-	case ReasoningMaximum:
+	case ReasoningMaximum, ReasoningMax:
 		return "max"
-	case ReasoningThorough:
+	case ReasoningXHigh:
+		return "xhigh"
+	case ReasoningThorough, ReasoningHigh:
 		return "high"
 	case ReasoningMedium:
 		return "medium"
-	case ReasoningFast:
+	case ReasoningFast, ReasoningLow:
 		return "low"
 	default:
 		return "" // use claude default (standard = no override)

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -123,12 +123,16 @@ func WithCodexUserConfigIgnored(a Agent, ignored bool) Agent {
 // codexReasoningEffort maps ReasoningLevel to codex-specific effort values
 func (a *CodexAgent) codexReasoningEffort() string {
 	switch a.Reasoning {
-	case ReasoningMaximum:
+	case ReasoningMaximum, ReasoningXHigh:
 		return "xhigh"
-	case ReasoningThorough:
+	case ReasoningThorough, ReasoningHigh:
 		return "high"
-	case ReasoningFast:
+	case ReasoningMedium:
+		return "medium"
+	case ReasoningFast, ReasoningLow:
 		return "low"
+	case ReasoningMax:
+		return "max"
 	default:
 		return "" // use codex default
 	}

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -123,7 +123,12 @@ func WithCodexUserConfigIgnored(a Agent, ignored bool) Agent {
 // codexReasoningEffort maps ReasoningLevel to codex-specific effort values
 func (a *CodexAgent) codexReasoningEffort() string {
 	switch a.Reasoning {
-	case ReasoningMaximum, ReasoningXHigh:
+	case ReasoningMaximum:
+		if codexModelSupportsMaxReasoning(a.Model) {
+			return "max"
+		}
+		return "xhigh"
+	case ReasoningXHigh:
 		return "xhigh"
 	case ReasoningThorough, ReasoningHigh:
 		return "high"
@@ -135,6 +140,15 @@ func (a *CodexAgent) codexReasoningEffort() string {
 		return "max"
 	default:
 		return "" // use codex default
+	}
+}
+
+func codexModelSupportsMaxReasoning(model string) bool {
+	switch model {
+	case "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/agent/droid.go
+++ b/internal/agent/droid.go
@@ -58,9 +58,11 @@ func (a *DroidAgent) WithModel(model string) Agent {
 // droidReasoningEffort maps ReasoningLevel to droid-specific effort values
 func (a *DroidAgent) droidReasoningEffort() string {
 	switch a.Reasoning {
-	case ReasoningMaximum, ReasoningThorough:
+	case ReasoningMaximum, ReasoningThorough, ReasoningHigh:
 		return "high"
-	case ReasoningFast:
+	case ReasoningMedium:
+		return "medium"
+	case ReasoningFast, ReasoningLow:
 		return "low"
 	default:
 		return "" // use droid default

--- a/internal/agent/grok.go
+++ b/internal/agent/grok.go
@@ -253,13 +253,15 @@ func (a *GrokAgent) WithSessionID(sessionID string) Agent {
 // values (none/minimal/low/medium/high/xhigh/max). Standard leaves Grok's default.
 func (a *GrokAgent) grokReasoningEffort() string {
 	switch a.Reasoning {
-	case ReasoningMaximum:
+	case ReasoningMaximum, ReasoningMax:
 		return "max"
-	case ReasoningThorough:
+	case ReasoningXHigh:
+		return "xhigh"
+	case ReasoningThorough, ReasoningHigh:
 		return "high"
 	case ReasoningMedium:
 		return "medium"
-	case ReasoningFast:
+	case ReasoningFast, ReasoningLow:
 		return "low"
 	default:
 		return ""

--- a/internal/agent/kilo.go
+++ b/internal/agent/kilo.go
@@ -80,6 +80,16 @@ func (a *KiloAgent) kiloVariant() string {
 		return "high"
 	case ReasoningFast:
 		return "minimal"
+	case ReasoningLow:
+		return "low"
+	case ReasoningMedium:
+		return "medium"
+	case ReasoningHigh:
+		return "high"
+	case ReasoningXHigh:
+		return "xhigh"
+	case ReasoningMax:
+		return "max"
 	default:
 		return "" // use kilo default
 	}

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -129,10 +129,14 @@ func (a *PiAgent) buildArgs(sessionPath string) []string {
 
 func (a *PiAgent) thinkingLevel() string {
 	switch a.Reasoning {
-	case ReasoningMaximum, ReasoningThorough:
+	case ReasoningMaximum, ReasoningThorough, ReasoningHigh:
 		return "high"
-	case ReasoningFast:
+	case ReasoningFast, ReasoningLow:
 		return "low"
+	case ReasoningXHigh:
+		return "xhigh"
+	case ReasoningMax:
+		return "max"
 	default: // Standard
 		return "medium"
 	}

--- a/internal/config/analyze.go
+++ b/internal/config/analyze.go
@@ -13,7 +13,7 @@ import (
 type AnalyzeConfig struct {
 	Agent     string `toml:"agent" comment:"Agent override for this analysis type."`
 	Model     string `toml:"model" comment:"Model override for this analysis type."`
-	Reasoning string `toml:"reasoning" comment:"Reasoning level for this analysis type: fast, standard, medium, thorough, or maximum."`
+	Reasoning string `toml:"reasoning" comment:"Reasoning level for this analysis type. Legacy: fast, standard, thorough, maximum. Exact: low, medium, high, xhigh, max."`
 }
 
 // ResolveAnalyzeConfig resolves the agent/model/reasoning that should be sent

--- a/internal/config/ci.go
+++ b/internal/config/ci.go
@@ -463,7 +463,7 @@ type RepoCIConfig struct {
 	Panel string `toml:"panel" comment:"Named [review.panels.X] panel for CI."`
 
 	// Reasoning overrides the reasoning level for CI reviews.
-	Reasoning string `toml:"reasoning" comment:"Override the CI reasoning level for this repo: fast, standard, medium, thorough, or maximum."`
+	Reasoning string `toml:"reasoning" comment:"Override the CI reasoning level for this repo. Legacy: fast, standard, thorough, maximum. Exact: low, medium, high, xhigh, max."`
 
 	// MinSeverity overrides the minimum severity filter for CI synthesis.
 	MinSeverity string `toml:"min_severity" comment:"Override the minimum CI severity included in synthesized output."`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -126,9 +126,9 @@ type Config struct {
 	JobTimeoutMinutes          int    `toml:"job_timeout_minutes"`
 	HookTimeoutSeconds         int    `toml:"hook_timeout_seconds" comment:"Post-commit hook request timeout in seconds. 0 or negative uses the platform default (3 on most systems, 30 on Windows where git subprocess spawns are slow)."`
 	AgentQuotaCooldown         string `toml:"agent_quota_cooldown" comment:"Maximum daemon-wide cooldown after an agent quota error, as a Go duration such as 30m."`
-	ReviewReasoning            string `toml:"review_reasoning" comment:"Default reasoning level for reviews: fast, standard, medium, thorough, or maximum."`
-	RefineReasoning            string `toml:"refine_reasoning" comment:"Default reasoning level for refine: fast, standard, medium, thorough, or maximum."`
-	FixReasoning               string `toml:"fix_reasoning" comment:"Default reasoning level for fix: fast, standard, medium, thorough, or maximum."`
+	ReviewReasoning            string `toml:"review_reasoning" comment:"Default reasoning for reviews. Legacy: fast, standard, thorough, maximum. Exact: low, medium, high, xhigh, max."`
+	RefineReasoning            string `toml:"refine_reasoning" comment:"Default reasoning for refine. Legacy: fast, standard, thorough, maximum. Exact: low, medium, high, xhigh, max."`
+	FixReasoning               string `toml:"fix_reasoning" comment:"Default reasoning for fix. Legacy: fast, standard, thorough, maximum. Exact: low, medium, high, xhigh, max."`
 
 	// Analysis-type-specific agent/model configuration
 	Analyze map[string]AnalyzeConfig `toml:"analyze"`
@@ -136,69 +136,109 @@ type Config struct {
 	// Workflow-specific agent/model configuration
 	ReviewAgent           string `toml:"review_agent"`
 	ReviewAgentFast       string `toml:"review_agent_fast"`
+	ReviewAgentLow        string `toml:"review_agent_low"`
 	ReviewAgentStandard   string `toml:"review_agent_standard"`
 	ReviewAgentMedium     string `toml:"review_agent_medium"`
 	ReviewAgentThorough   string `toml:"review_agent_thorough"`
+	ReviewAgentHigh       string `toml:"review_agent_high"`
+	ReviewAgentXHigh      string `toml:"review_agent_xhigh"`
 	ReviewAgentMaximum    string `toml:"review_agent_maximum"`
+	ReviewAgentMax        string `toml:"review_agent_max"`
 	RefineAgent           string `toml:"refine_agent"`
 	RefineAgentFast       string `toml:"refine_agent_fast"`
+	RefineAgentLow        string `toml:"refine_agent_low"`
 	RefineAgentStandard   string `toml:"refine_agent_standard"`
 	RefineAgentMedium     string `toml:"refine_agent_medium"`
 	RefineAgentThorough   string `toml:"refine_agent_thorough"`
+	RefineAgentHigh       string `toml:"refine_agent_high"`
+	RefineAgentXHigh      string `toml:"refine_agent_xhigh"`
 	RefineAgentMaximum    string `toml:"refine_agent_maximum"`
+	RefineAgentMax        string `toml:"refine_agent_max"`
 	ReviewModel           string `toml:"review_model"`
 	ReviewModelFast       string `toml:"review_model_fast"`
+	ReviewModelLow        string `toml:"review_model_low"`
 	ReviewModelStandard   string `toml:"review_model_standard"`
 	ReviewModelMedium     string `toml:"review_model_medium"`
 	ReviewModelThorough   string `toml:"review_model_thorough"`
+	ReviewModelHigh       string `toml:"review_model_high"`
+	ReviewModelXHigh      string `toml:"review_model_xhigh"`
 	ReviewModelMaximum    string `toml:"review_model_maximum"`
+	ReviewModelMax        string `toml:"review_model_max"`
 	RefineModel           string `toml:"refine_model"`
 	RefineModelFast       string `toml:"refine_model_fast"`
+	RefineModelLow        string `toml:"refine_model_low"`
 	RefineModelStandard   string `toml:"refine_model_standard"`
 	RefineModelMedium     string `toml:"refine_model_medium"`
 	RefineModelThorough   string `toml:"refine_model_thorough"`
+	RefineModelHigh       string `toml:"refine_model_high"`
+	RefineModelXHigh      string `toml:"refine_model_xhigh"`
 	RefineModelMaximum    string `toml:"refine_model_maximum"`
+	RefineModelMax        string `toml:"refine_model_max"`
 	FixAgent              string `toml:"fix_agent"`
 	FixAgentFast          string `toml:"fix_agent_fast"`
+	FixAgentLow           string `toml:"fix_agent_low"`
 	FixAgentStandard      string `toml:"fix_agent_standard"`
 	FixAgentMedium        string `toml:"fix_agent_medium"`
 	FixAgentThorough      string `toml:"fix_agent_thorough"`
+	FixAgentHigh          string `toml:"fix_agent_high"`
+	FixAgentXHigh         string `toml:"fix_agent_xhigh"`
 	FixAgentMaximum       string `toml:"fix_agent_maximum"`
+	FixAgentMax           string `toml:"fix_agent_max"`
 	FixModel              string `toml:"fix_model"`
 	FixModelFast          string `toml:"fix_model_fast"`
+	FixModelLow           string `toml:"fix_model_low"`
 	FixModelStandard      string `toml:"fix_model_standard"`
 	FixModelMedium        string `toml:"fix_model_medium"`
 	FixModelThorough      string `toml:"fix_model_thorough"`
+	FixModelHigh          string `toml:"fix_model_high"`
+	FixModelXHigh         string `toml:"fix_model_xhigh"`
 	FixModelMaximum       string `toml:"fix_model_maximum"`
+	FixModelMax           string `toml:"fix_model_max"`
 	SecurityAgent         string `toml:"security_agent"`
 	SecurityAgentFast     string `toml:"security_agent_fast"`
+	SecurityAgentLow      string `toml:"security_agent_low"`
 	SecurityAgentStandard string `toml:"security_agent_standard"`
 	SecurityAgentMedium   string `toml:"security_agent_medium"`
 	SecurityAgentThorough string `toml:"security_agent_thorough"`
+	SecurityAgentHigh     string `toml:"security_agent_high"`
+	SecurityAgentXHigh    string `toml:"security_agent_xhigh"`
 	SecurityAgentMaximum  string `toml:"security_agent_maximum"`
+	SecurityAgentMax      string `toml:"security_agent_max"`
 	SecurityModel         string `toml:"security_model"`
 	SecurityModelFast     string `toml:"security_model_fast"`
+	SecurityModelLow      string `toml:"security_model_low"`
 	SecurityModelStandard string `toml:"security_model_standard"`
 	SecurityModelMedium   string `toml:"security_model_medium"`
 	SecurityModelThorough string `toml:"security_model_thorough"`
+	SecurityModelHigh     string `toml:"security_model_high"`
+	SecurityModelXHigh    string `toml:"security_model_xhigh"`
 	SecurityModelMaximum  string `toml:"security_model_maximum"`
+	SecurityModelMax      string `toml:"security_model_max"`
 	DesignAgent           string `toml:"design_agent"`
 	DesignAgentFast       string `toml:"design_agent_fast"`
+	DesignAgentLow        string `toml:"design_agent_low"`
 	DesignAgentStandard   string `toml:"design_agent_standard"`
 	DesignAgentMedium     string `toml:"design_agent_medium"`
 	DesignAgentThorough   string `toml:"design_agent_thorough"`
+	DesignAgentHigh       string `toml:"design_agent_high"`
+	DesignAgentXHigh      string `toml:"design_agent_xhigh"`
 	DesignAgentMaximum    string `toml:"design_agent_maximum"`
+	DesignAgentMax        string `toml:"design_agent_max"`
 	DesignModel           string `toml:"design_model"`
 	DesignModelFast       string `toml:"design_model_fast"`
+	DesignModelLow        string `toml:"design_model_low"`
 	DesignModelStandard   string `toml:"design_model_standard"`
 	DesignModelMedium     string `toml:"design_model_medium"`
 	DesignModelThorough   string `toml:"design_model_thorough"`
+	DesignModelHigh       string `toml:"design_model_high"`
+	DesignModelXHigh      string `toml:"design_model_xhigh"`
 	DesignModelMaximum    string `toml:"design_model_maximum"`
+	DesignModelMax        string `toml:"design_model_max"`
 
 	// Classify workflow (routing classifier for auto design review)
 	ClassifyAgent       string `toml:"classify_agent" comment:"Agent for the design-review routing classifier. Must implement SchemaAgent capability."`
 	ClassifyModel       string `toml:"classify_model" comment:"Model for the classifier agent. Empty = agent default."`
-	ClassifyReasoning   string `toml:"classify_reasoning" comment:"Reasoning level for the classifier: fast, standard, medium, thorough, or maximum."`
+	ClassifyReasoning   string `toml:"classify_reasoning" comment:"Reasoning for the classifier. Legacy: fast, standard, thorough, maximum. Exact: low, medium, high, xhigh, max."`
 	ClassifyBackupAgent string `toml:"classify_backup_agent" comment:"Fallback classifier agent on quota exhaustion / failure."`
 	ClassifyBackupModel string `toml:"classify_backup_model" comment:"Fallback classifier model."`
 
@@ -440,9 +480,9 @@ type RepoConfig struct {
 	ExcludedBranches                []string `toml:"excluded_branches" comment:"Branches that should be skipped for automatic review in this repo."`
 	ExcludedCommitPatterns          []string `toml:"excluded_commit_patterns" comment:"Commit message substrings that should skip review for this repo."`
 	DisplayName                     string   `toml:"display_name" comment:"Display name shown for this repo in the TUI and output."`
-	ReviewReasoning                 string   `toml:"review_reasoning" comment:"Reasoning level for reviews in this repo: fast, standard, medium, thorough, or maximum."`
-	RefineReasoning                 string   `toml:"refine_reasoning" comment:"Reasoning level for refine in this repo: fast, standard, medium, thorough, or maximum."`
-	FixReasoning                    string   `toml:"fix_reasoning" comment:"Reasoning level for fix in this repo: fast, standard, medium, thorough, or maximum."`
+	ReviewReasoning                 string   `toml:"review_reasoning" comment:"Reasoning for reviews in this repo. Legacy: fast, standard, thorough, maximum. Exact: low, medium, high, xhigh, max."`
+	RefineReasoning                 string   `toml:"refine_reasoning" comment:"Reasoning for refine in this repo. Legacy: fast, standard, thorough, maximum. Exact: low, medium, high, xhigh, max."`
+	FixReasoning                    string   `toml:"fix_reasoning" comment:"Reasoning for fix in this repo. Legacy: fast, standard, thorough, maximum. Exact: low, medium, high, xhigh, max."`
 	FixMinSeverity                  string   `toml:"fix_min_severity" comment:"Minimum severity for fix in this repo: critical, high, medium, or low."`     // Minimum severity for fix: critical, high, medium, low
 	RefineMinSeverity               string   `toml:"refine_min_severity" comment:"Minimum severity for refine in this repo: critical, high, medium, low."`  // Minimum severity for refine: critical, high, medium, low
 	ReviewMinSeverity               string   `toml:"review_min_severity" comment:"Minimum severity for reviews in this repo: critical, high, medium, low."` // Minimum severity for review: critical, high, medium, low
@@ -469,64 +509,104 @@ type RepoConfig struct {
 	// Workflow-specific agent/model configuration
 	ReviewAgent           string `toml:"review_agent" comment:"Agent override for standard review in this repo."`
 	ReviewAgentFast       string `toml:"review_agent_fast" comment:"Agent override for fast review in this repo."`
+	ReviewAgentLow        string `toml:"review_agent_low" comment:"Agent override for low review in this repo."`
 	ReviewAgentStandard   string `toml:"review_agent_standard" comment:"Agent override for standard review in this repo."`
 	ReviewAgentMedium     string `toml:"review_agent_medium" comment:"Agent override for medium review in this repo."`
 	ReviewAgentThorough   string `toml:"review_agent_thorough" comment:"Agent override for thorough review in this repo."`
+	ReviewAgentHigh       string `toml:"review_agent_high" comment:"Agent override for high review in this repo."`
+	ReviewAgentXHigh      string `toml:"review_agent_xhigh" comment:"Agent override for xhigh review in this repo."`
 	ReviewAgentMaximum    string `toml:"review_agent_maximum" comment:"Agent override for maximum review in this repo."`
+	ReviewAgentMax        string `toml:"review_agent_max" comment:"Agent override for max review in this repo."`
 	RefineAgent           string `toml:"refine_agent" comment:"Agent override for refine in this repo."`
 	RefineAgentFast       string `toml:"refine_agent_fast" comment:"Agent override for fast refine in this repo."`
+	RefineAgentLow        string `toml:"refine_agent_low" comment:"Agent override for low refine in this repo."`
 	RefineAgentStandard   string `toml:"refine_agent_standard" comment:"Agent override for standard refine in this repo."`
 	RefineAgentMedium     string `toml:"refine_agent_medium" comment:"Agent override for medium refine in this repo."`
 	RefineAgentThorough   string `toml:"refine_agent_thorough" comment:"Agent override for thorough refine in this repo."`
+	RefineAgentHigh       string `toml:"refine_agent_high" comment:"Agent override for high refine in this repo."`
+	RefineAgentXHigh      string `toml:"refine_agent_xhigh" comment:"Agent override for xhigh refine in this repo."`
 	RefineAgentMaximum    string `toml:"refine_agent_maximum" comment:"Agent override for maximum refine in this repo."`
+	RefineAgentMax        string `toml:"refine_agent_max" comment:"Agent override for max refine in this repo."`
 	ReviewModel           string `toml:"review_model" comment:"Model override for standard review in this repo."`
 	ReviewModelFast       string `toml:"review_model_fast" comment:"Model override for fast review in this repo."`
+	ReviewModelLow        string `toml:"review_model_low" comment:"Model override for low review in this repo."`
 	ReviewModelStandard   string `toml:"review_model_standard" comment:"Model override for standard review in this repo."`
 	ReviewModelMedium     string `toml:"review_model_medium" comment:"Model override for medium review in this repo."`
 	ReviewModelThorough   string `toml:"review_model_thorough" comment:"Model override for thorough review in this repo."`
+	ReviewModelHigh       string `toml:"review_model_high" comment:"Model override for high review in this repo."`
+	ReviewModelXHigh      string `toml:"review_model_xhigh" comment:"Model override for xhigh review in this repo."`
 	ReviewModelMaximum    string `toml:"review_model_maximum" comment:"Model override for maximum review in this repo."`
+	ReviewModelMax        string `toml:"review_model_max" comment:"Model override for max review in this repo."`
 	RefineModel           string `toml:"refine_model" comment:"Model override for standard refine in this repo."`
 	RefineModelFast       string `toml:"refine_model_fast" comment:"Model override for fast refine in this repo."`
+	RefineModelLow        string `toml:"refine_model_low" comment:"Model override for low refine in this repo."`
 	RefineModelStandard   string `toml:"refine_model_standard" comment:"Model override for standard refine in this repo."`
 	RefineModelMedium     string `toml:"refine_model_medium" comment:"Model override for medium refine in this repo."`
 	RefineModelThorough   string `toml:"refine_model_thorough" comment:"Model override for thorough refine in this repo."`
+	RefineModelHigh       string `toml:"refine_model_high" comment:"Model override for high refine in this repo."`
+	RefineModelXHigh      string `toml:"refine_model_xhigh" comment:"Model override for xhigh refine in this repo."`
 	RefineModelMaximum    string `toml:"refine_model_maximum" comment:"Model override for maximum refine in this repo."`
+	RefineModelMax        string `toml:"refine_model_max" comment:"Model override for max refine in this repo."`
 	FixAgent              string `toml:"fix_agent" comment:"Agent override for fix in this repo."`
 	FixAgentFast          string `toml:"fix_agent_fast" comment:"Agent override for fast fix in this repo."`
+	FixAgentLow           string `toml:"fix_agent_low" comment:"Agent override for low fix in this repo."`
 	FixAgentStandard      string `toml:"fix_agent_standard" comment:"Agent override for standard fix in this repo."`
 	FixAgentMedium        string `toml:"fix_agent_medium" comment:"Agent override for medium fix in this repo."`
 	FixAgentThorough      string `toml:"fix_agent_thorough" comment:"Agent override for thorough fix in this repo."`
+	FixAgentHigh          string `toml:"fix_agent_high" comment:"Agent override for high fix in this repo."`
+	FixAgentXHigh         string `toml:"fix_agent_xhigh" comment:"Agent override for xhigh fix in this repo."`
 	FixAgentMaximum       string `toml:"fix_agent_maximum" comment:"Agent override for maximum fix in this repo."`
+	FixAgentMax           string `toml:"fix_agent_max" comment:"Agent override for max fix in this repo."`
 	FixModel              string `toml:"fix_model" comment:"Model override for standard fix in this repo."`
 	FixModelFast          string `toml:"fix_model_fast" comment:"Model override for fast fix in this repo."`
+	FixModelLow           string `toml:"fix_model_low" comment:"Model override for low fix in this repo."`
 	FixModelStandard      string `toml:"fix_model_standard" comment:"Model override for standard fix in this repo."`
 	FixModelMedium        string `toml:"fix_model_medium" comment:"Model override for medium fix in this repo."`
 	FixModelThorough      string `toml:"fix_model_thorough" comment:"Model override for thorough fix in this repo."`
+	FixModelHigh          string `toml:"fix_model_high" comment:"Model override for high fix in this repo."`
+	FixModelXHigh         string `toml:"fix_model_xhigh" comment:"Model override for xhigh fix in this repo."`
 	FixModelMaximum       string `toml:"fix_model_maximum" comment:"Model override for maximum fix in this repo."`
+	FixModelMax           string `toml:"fix_model_max" comment:"Model override for max fix in this repo."`
 	SecurityAgent         string `toml:"security_agent" comment:"Agent override for security review in this repo."`
 	SecurityAgentFast     string `toml:"security_agent_fast" comment:"Agent override for fast security review in this repo."`
+	SecurityAgentLow      string `toml:"security_agent_low" comment:"Agent override for low security review in this repo."`
 	SecurityAgentStandard string `toml:"security_agent_standard" comment:"Agent override for standard security review in this repo."`
 	SecurityAgentMedium   string `toml:"security_agent_medium" comment:"Agent override for medium security review in this repo."`
 	SecurityAgentThorough string `toml:"security_agent_thorough" comment:"Agent override for thorough security review in this repo."`
+	SecurityAgentHigh     string `toml:"security_agent_high" comment:"Agent override for high security review in this repo."`
+	SecurityAgentXHigh    string `toml:"security_agent_xhigh" comment:"Agent override for xhigh security review in this repo."`
 	SecurityAgentMaximum  string `toml:"security_agent_maximum" comment:"Agent override for maximum security review in this repo."`
+	SecurityAgentMax      string `toml:"security_agent_max" comment:"Agent override for max security review in this repo."`
 	SecurityModel         string `toml:"security_model" comment:"Model override for standard security review in this repo."`
 	SecurityModelFast     string `toml:"security_model_fast" comment:"Model override for fast security review in this repo."`
+	SecurityModelLow      string `toml:"security_model_low" comment:"Model override for low security review in this repo."`
 	SecurityModelStandard string `toml:"security_model_standard" comment:"Model override for standard security review in this repo."`
 	SecurityModelMedium   string `toml:"security_model_medium" comment:"Model override for medium security review in this repo."`
 	SecurityModelThorough string `toml:"security_model_thorough" comment:"Model override for thorough security review in this repo."`
+	SecurityModelHigh     string `toml:"security_model_high" comment:"Model override for high security review in this repo."`
+	SecurityModelXHigh    string `toml:"security_model_xhigh" comment:"Model override for xhigh security review in this repo."`
 	SecurityModelMaximum  string `toml:"security_model_maximum" comment:"Model override for maximum security review in this repo."`
+	SecurityModelMax      string `toml:"security_model_max" comment:"Model override for max security review in this repo."`
 	DesignAgent           string `toml:"design_agent" comment:"Agent override for design review in this repo."`
 	DesignAgentFast       string `toml:"design_agent_fast" comment:"Agent override for fast design review in this repo."`
+	DesignAgentLow        string `toml:"design_agent_low" comment:"Agent override for low design review in this repo."`
 	DesignAgentStandard   string `toml:"design_agent_standard" comment:"Agent override for standard design review in this repo."`
 	DesignAgentMedium     string `toml:"design_agent_medium" comment:"Agent override for medium design review in this repo."`
 	DesignAgentThorough   string `toml:"design_agent_thorough" comment:"Agent override for thorough design review in this repo."`
+	DesignAgentHigh       string `toml:"design_agent_high" comment:"Agent override for high design review in this repo."`
+	DesignAgentXHigh      string `toml:"design_agent_xhigh" comment:"Agent override for xhigh design review in this repo."`
 	DesignAgentMaximum    string `toml:"design_agent_maximum" comment:"Agent override for maximum design review in this repo."`
+	DesignAgentMax        string `toml:"design_agent_max" comment:"Agent override for max design review in this repo."`
 	DesignModel           string `toml:"design_model" comment:"Model override for standard design review in this repo."`
 	DesignModelFast       string `toml:"design_model_fast" comment:"Model override for fast design review in this repo."`
+	DesignModelLow        string `toml:"design_model_low" comment:"Model override for low design review in this repo."`
 	DesignModelStandard   string `toml:"design_model_standard" comment:"Model override for standard design review in this repo."`
 	DesignModelMedium     string `toml:"design_model_medium" comment:"Model override for medium design review in this repo."`
 	DesignModelThorough   string `toml:"design_model_thorough" comment:"Model override for thorough design review in this repo."`
+	DesignModelHigh       string `toml:"design_model_high" comment:"Model override for high design review in this repo."`
+	DesignModelXHigh      string `toml:"design_model_xhigh" comment:"Model override for xhigh design review in this repo."`
 	DesignModelMaximum    string `toml:"design_model_maximum" comment:"Model override for maximum design review in this repo."`
+	DesignModelMax        string `toml:"design_model_max" comment:"Model override for max design review in this repo."`
 
 	// Classify workflow (per-repo overrides)
 	ClassifyAgent       string `toml:"classify_agent" comment:"Override classifier agent for this repo."`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2105,6 +2105,18 @@ func TestResolveAgentForWorkflow(t *testing.T) {
 		{"medium global level-specific", "", nil, &Config{ReviewAgentMedium: "claude"}, "review", "medium", "claude"},
 		{"medium falls back to workflow", "", M{"review_agent": "claude"}, nil, "review", "medium", "claude"},
 		{"medium falls back to generic", "", M{"agent": "claude"}, nil, "review", "medium", "claude"},
+
+		// Exact native levels
+		{"low repo level-specific", "", M{"review_agent_low": "claude"}, nil, "review", "low", "claude"},
+		{"low global level-specific", "", nil, &Config{ReviewAgentLow: "claude"}, "review", "low", "claude"},
+		{"high repo level-specific", "", M{"review_agent_high": "claude"}, nil, "review", "high", "claude"},
+		{"xhigh global level-specific", "", nil, &Config{ReviewAgentXHigh: "claude"}, "review", "xhigh", "claude"},
+		{"max repo level-specific", "", M{"review_agent_max": "claude"}, nil, "review", "max", "claude"},
+		{"low falls back to legacy fast key", "", M{"review_agent_fast": "claude"}, nil, "review", "low", "claude"},
+		{"high falls back to legacy thorough key", "", nil, &Config{ReviewAgentThorough: "claude"}, "review", "high", "claude"},
+		{"xhigh falls back to legacy maximum key", "", M{"review_agent_maximum": "claude"}, nil, "review", "xhigh", "claude"},
+		{"max falls back to legacy maximum key", "", nil, &Config{ReviewAgentMaximum: "claude"}, "review", "max", "claude"},
+		{"exact key overrides legacy fallback", "", M{"review_agent_low": "droid", "review_agent_fast": "claude"}, nil, "review", "low", "droid"},
 	}
 
 	for _, tt := range tests {
@@ -2398,6 +2410,13 @@ func TestResolveModelForWorkflow(t *testing.T) {
 		{"design level-specific model", "", M{"design_model": "gpt-4", "design_model_fast": "claude-3"}, nil, "design", "fast", "claude-3"},
 		{"design falls back to generic model", "", M{"model": "gpt-4"}, nil, "design", "fast", "gpt-4"},
 		{"design isolated from review model", "", M{"review_model": "gpt-4"}, nil, "design", "fast", ""},
+
+		// Exact native levels
+		{"low repo level-specific", "", M{"review_model_low": "gpt-low"}, nil, "review", "low", "gpt-low"},
+		{"high global level-specific", "", nil, &Config{ReviewModelHigh: "gpt-high"}, "review", "high", "gpt-high"},
+		{"xhigh repo level-specific", "", M{"review_model_xhigh": "gpt-xhigh"}, nil, "review", "xhigh", "gpt-xhigh"},
+		{"max global level-specific", "", nil, &Config{ReviewModelMax: "gpt-max"}, "review", "max", "gpt-max"},
+		{"xhigh falls back to legacy maximum key", "", M{"review_model_maximum": "legacy-model"}, nil, "review", "xhigh", "legacy-model"},
 	}
 
 	for _, tt := range tests {
@@ -2773,6 +2792,41 @@ discord_webhook_url = "https://discord.com/api/webhooks/123/token"
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	assert.Equal(t, "https://discord.com/api/webhooks/123/token", cfg.CI.DiscordWebhookURL)
+}
+
+func TestNormalizeReasoning(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "legacy fast", input: "fast", want: "fast"},
+		{name: "legacy standard", input: "standard", want: "standard"},
+		{name: "legacy thorough", input: "thorough", want: "thorough"},
+		{name: "legacy maximum", input: "maximum", want: "maximum"},
+		{name: "exact low", input: "low", want: "low"},
+		{name: "exact medium", input: "medium", want: "medium"},
+		{name: "exact high", input: "high", want: "high"},
+		{name: "exact xhigh", input: "xhigh", want: "xhigh"},
+		{name: "exact max", input: "max", want: "max"},
+		{name: "normalizes case and space", input: "  XHIGH  ", want: "xhigh"},
+		{name: "empty", input: "", want: ""},
+		{name: "unknown", input: "ultra", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeReasoning(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Empty(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestNormalizeMinSeverity(t *testing.T) {

--- a/internal/config/workflow.go
+++ b/internal/config/workflow.go
@@ -77,7 +77,7 @@ func WorkflowForReviewType(reviewType string) string {
 }
 
 // NormalizeReasoning validates and normalizes a reasoning level string.
-// Returns the canonical form (maximum, thorough, medium, standard, fast) or an error if invalid.
+// Returns the canonical legacy or exact effort name, or an error if invalid.
 // Returns empty string (no error) for empty input.
 func NormalizeReasoning(value string) (string, error) {
 	normalized := strings.ToLower(strings.TrimSpace(value))
@@ -86,16 +86,16 @@ func NormalizeReasoning(value string) (string, error) {
 	}
 
 	switch normalized {
-	case "maximum", "max", "xhigh":
+	case "maximum":
 		return "maximum", nil
-	case "thorough", "high":
+	case "thorough":
 		return "thorough", nil
-	case "medium":
-		return "medium", nil
 	case "standard":
 		return "standard", nil
-	case "fast", "low":
+	case "fast":
 		return "fast", nil
+	case "low", "medium", "high", "xhigh", "max":
+		return normalized, nil
 	default:
 		return "", fmt.Errorf("invalid reasoning level: %q", value)
 	}
@@ -774,18 +774,42 @@ func workflowFieldKey(workflow, level string, isAgent bool) string {
 // globalWorkflowField switch statements with a single, tag-driven lookup that
 // automatically supports new workflows/levels when fields are added.
 func lookupWorkflowField(v reflect.Value, workflow, level string, isAgent bool) string {
-	key := workflowFieldKey(workflow, level, isAgent)
+	levels := []string{level}
+	if legacy := legacyReasoningFallback(level); legacy != "" {
+		levels = append(levels, legacy)
+	}
+
 	t := v.Type()
-	for i := 0; i < t.NumField(); i++ {
-		tag := t.Field(i).Tag.Get("toml")
-		if tag == "" {
-			continue
-		}
-		if strings.Split(tag, ",")[0] == key {
-			return strings.TrimSpace(v.Field(i).String())
+	for _, candidate := range levels {
+		key := workflowFieldKey(workflow, candidate, isAgent)
+		for i := 0; i < t.NumField(); i++ {
+			tag := t.Field(i).Tag.Get("toml")
+			if tag == "" {
+				continue
+			}
+			if strings.Split(tag, ",")[0] == key {
+				if value := strings.TrimSpace(v.Field(i).String()); value != "" {
+					return value
+				}
+			}
 		}
 	}
 	return ""
+}
+
+// legacyReasoningFallback preserves level-specific routing for values that
+// were accepted as aliases before exact native efforts were introduced.
+func legacyReasoningFallback(level string) string {
+	switch level {
+	case "low":
+		return "fast"
+	case "high":
+		return "thorough"
+	case "xhigh", "max":
+		return "maximum"
+	default:
+		return ""
+	}
 }
 
 func repoWorkflowField(r *RepoConfig, workflow, level string, isAgent bool) string {

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -18,7 +18,7 @@ type EnqueueRequest struct {
 	Model        string   `json:"model,omitempty"`         // Model to use (for opencode: provider/model format)
 	DiffContent  string   `json:"diff_content,omitempty"`  // Pre-captured diff for dirty reviews
 	DirtyFiles   []string `json:"dirty_files,omitempty"`   // Unfiltered dirty file names for prompt metadata
-	Reasoning    string   `json:"reasoning,omitempty"`     // Reasoning level: thorough, standard, fast
+	Reasoning    string   `json:"reasoning,omitempty"`     // Legacy or exact reasoning level
 	ReviewType   string   `json:"review_type,omitempty"`   // Review type (e.g., "security") — changes system prompt
 	CustomPrompt string   `json:"custom_prompt,omitempty"` // Custom prompt for ad-hoc agent work
 	Agentic      bool     `json:"agentic,omitempty"`       // Enable agentic mode (allow file edits)

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -78,7 +78,7 @@ type ReviewJob struct {
 	Provider          string     `json:"provider,omitempty"`           // Effective provider for this run (e.g., anthropic, openai)
 	RequestedModel    string     `json:"requested_model,omitempty"`    // Explicitly requested model; empty means reevaluate on rerun
 	RequestedProvider string     `json:"requested_provider,omitempty"` // Explicitly requested provider; empty means reevaluate on rerun
-	Reasoning         string     `json:"reasoning,omitempty"`          // thorough, standard, fast (default: thorough)
+	Reasoning         string     `json:"reasoning,omitempty"`          // Legacy or exact reasoning level (default: thorough)
 	JobType           string     `json:"job_type"`                     // one of the JobType* constants above
 	Status            JobStatus  `json:"status"`
 	EnqueuedAt        time.Time  `json:"enqueued_at"`


### PR DESCRIPTION
Roborev's legacy reasoning values are presets whose per-agent mappings predate native effort tiers. Users who need a harness-native tier currently lose that distinction because values such as `low`, `high`, `xhigh`, and `max` normalize into legacy presets.

This adds exact `low`, `medium`, `high`, `xhigh`, and `max` identities across CLI and config resolution, persisted jobs, and agent adapters while leaving `fast`, `standard`, `thorough`, and `maximum` behavior unchanged. Exact workflow agent/model keys fall back independently to their matching legacy preset keys when no exact override exists, so existing configuration routing remains effective. New configuration should prefer exact names and use the same naming family for matching agent and model keys.

Agents receive an exact tier only where they support it. Unsupported tiers remain unset instead of being collapsed into another effort, and `maximum` keeps its existing agent-specific behavior even where it differs from `xhigh`.

CLI help labels legacy presets separately from exact tiers. The configuration guide includes a migration table, warns against mixing legacy and exact route suffixes, and documents intentional per-agent gaps. The main review points are reasoning parsing and normalization, workflow fallback lookup, and the adapter mapping tables.
