### PR TITLE
fix(codex): map GPT-5.6 maximum to max

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,7 +11,7 @@ All notable changes to roborev, grouped by minor release.
 
 - Reasoning accepts exact `low`, `medium`, `high`, `xhigh`, and `max` values and
     forwards them unchanged to agents that support each tier. The legacy `fast`,
-    `standard`, `thorough`, and `maximum` mappings remain unchanged.
+    `standard`, `thorough`, and `maximum` presets remain compatible.
 - Pi agents accept global `[agent.pi] launch_args`, passed as tokenized
     arguments to every Pi invocation before roborev-managed workflow and safety
     options. This allows isolated classifier jobs to load extension-defined
@@ -30,6 +30,9 @@ All notable changes to roborev, grouped by minor release.
 - Daemon restarts now stop new job claims and wait indefinitely for running
     reviews and worker finalization instead of force-killing the daemon after a
     short graceful-shutdown window.
+- The Codex `maximum` preset now requests literal `max` for explicit GPT-5.6
+    `sol`, `terra`, and `luna` models. Older, default, and unknown models retain
+    the compatible `xhigh` mapping, while exact `xhigh` remains distinct.
 
 ______________________________________________________________________
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1416,13 +1416,18 @@ The legacy values keep their established per-agent behavior:
 | `fast` | `low` | `low` | `low` | `low` | `minimal` | `low` |
 | `standard` | default | default | default | default | default | `medium` |
 | `thorough` | `high` | `high` | `high` | `high` | `high` | `high` |
-| `maximum` | `xhigh` | `max` | `max` | `high` | `high` | `high` |
+| `maximum` | GPT-5.6 `sol`/`terra`/`luna`: `max`; otherwise `xhigh` | `max` | `max` | `high` | `high` | `high` |
 
 Native support is agent-specific. Codex, Claude, Grok, and Pi accept all five
 exact values. Droid accepts `low`, `medium`, and `high`. Kilo passes exact
 values through as model variants, so availability depends on the selected
 provider and model. Agents without a reasoning flag ignore the level while
 workflow-specific agent and model routing still uses its exact name.
+
+For Codex, the legacy `maximum` preset requests literal `max` only when the
+selected model is explicitly `gpt-5.6-sol`, `gpt-5.6-terra`, or `gpt-5.6-luna`.
+Older, default, and unknown models keep the compatible `xhigh` mapping. Use the
+exact `xhigh` value to request `xhigh` on every Codex model, including GPT-5.6.
 
 Set per-command with `--reasoning`, or per-repo in `.roborev.toml`:
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -14,7 +14,7 @@ import (
 type ReasoningLevel string
 
 const (
-	// ReasoningMaximum uses the highest available reasoning (e.g., codex xhigh, claude max)
+	// ReasoningMaximum uses the highest compatible reasoning for the selected model.
 	ReasoningMaximum ReasoningLevel = "maximum"
 	// ReasoningThorough uses deep reasoning for thorough analysis (slower)
 	ReasoningThorough ReasoningLevel = "thorough"

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -167,25 +167,63 @@ func TestParseReasoningLevel(t *testing.T) {
 
 func TestCodexReasoningEffortMapping(t *testing.T) {
 	tests := []struct {
+		name  string
+		model string
 		level ReasoningLevel
 		want  string
 	}{
-		{ReasoningMaximum, "xhigh"},
-		{ReasoningThorough, "high"},
-		{ReasoningFast, "low"},
-		{ReasoningStandard, ""},
-		{ReasoningLow, "low"},
-		{ReasoningMedium, "medium"},
-		{ReasoningHigh, "high"},
-		{ReasoningXHigh, "xhigh"},
-		{ReasoningMax, "max"},
+		{"maximum without explicit model", "", ReasoningMaximum, "xhigh"},
+		{"maximum with older model", "gpt-5.5", ReasoningMaximum, "xhigh"},
+		{"maximum with unknown model", "custom-model", ReasoningMaximum, "xhigh"},
+		{"maximum with unknown GPT-5.6 variant", "gpt-5.6-preview", ReasoningMaximum, "xhigh"},
+		{"maximum with GPT-5.6 sol", "gpt-5.6-sol", ReasoningMaximum, "max"},
+		{"maximum with GPT-5.6 terra", "gpt-5.6-terra", ReasoningMaximum, "max"},
+		{"maximum with GPT-5.6 luna", "gpt-5.6-luna", ReasoningMaximum, "max"},
+		{"explicit xhigh with GPT-5.6", "gpt-5.6-luna", ReasoningXHigh, "xhigh"},
+		{"thorough", "", ReasoningThorough, "high"},
+		{"fast", "", ReasoningFast, "low"},
+		{"standard", "", ReasoningStandard, ""},
+		{"exact low", "", ReasoningLow, "low"},
+		{"exact medium", "", ReasoningMedium, "medium"},
+		{"exact high", "", ReasoningHigh, "high"},
+		{"exact xhigh", "", ReasoningXHigh, "xhigh"},
+		{"exact max", "", ReasoningMax, "max"},
 	}
 
 	for _, tt := range tests {
-		a := NewCodexAgent("").WithReasoning(tt.level)
-		codex, ok := a.(*CodexAgent)
-		require.True(t, ok, "expected CodexAgent, got %T", a)
-		assert.Equal(t, tt.want, codex.codexReasoningEffort(), "codexReasoningEffort(%q)", tt.level)
+		t.Run(tt.name, func(t *testing.T) {
+			a := NewCodexAgent("").WithModel(tt.model).WithReasoning(tt.level)
+			codex, ok := a.(*CodexAgent)
+			require.True(t, ok, "expected CodexAgent, got %T", a)
+			assert.Equal(t, tt.want, codex.codexReasoningEffort())
+		})
+	}
+}
+
+func TestCodexBuildArgsGPT56MaximumReasoning(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent Agent
+	}{
+		{
+			name: "model then reasoning",
+			agent: NewCodexAgent("").
+				WithModel("gpt-5.6-luna").
+				WithReasoning(ReasoningMaximum),
+		},
+		{
+			name: "reasoning then model",
+			agent: NewCodexAgent("").
+				WithReasoning(ReasoningMaximum).
+				WithModel("gpt-5.6-luna"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Contains(t, tt.agent.CommandLine(), "-m gpt-5.6-luna")
+			assert.Contains(t, tt.agent.CommandLine(), `-c model_reasoning_effort="max"`)
+		})
 	}
 }
 

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -123,7 +123,12 @@ func WithCodexUserConfigIgnored(a Agent, ignored bool) Agent {
 // codexReasoningEffort maps ReasoningLevel to codex-specific effort values
 func (a *CodexAgent) codexReasoningEffort() string {
 	switch a.Reasoning {
-	case ReasoningMaximum, ReasoningXHigh:
+	case ReasoningMaximum:
+		if codexModelSupportsMaxReasoning(a.Model) {
+			return "max"
+		}
+		return "xhigh"
+	case ReasoningXHigh:
 		return "xhigh"
 	case ReasoningThorough, ReasoningHigh:
 		return "high"
@@ -135,6 +140,15 @@ func (a *CodexAgent) codexReasoningEffort() string {
 		return "max"
 	default:
 		return "" // use codex default
+	}
+}
+
+func codexModelSupportsMaxReasoning(model string) bool {
+	switch model {
+	case "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna":
+		return true
+	default:
+		return false
 	}
 }
 


### PR DESCRIPTION
Stacked on #1042, which introduces distinct exact `xhigh` and `max` reasoning tiers.

RoboRev's legacy `maximum` preset should request the highest compatible effort. GPT-5.6 `sol`, `terra`, and `luna` distinguish `xhigh` from `max`, so this maps `maximum` to literal `max` for those explicit model aliases while retaining `xhigh` for older, default, and unknown Codex models. Exact `xhigh` remains a literal `xhigh` request on every model.

The model allowlist is deliberately conservative: new or custom model IDs keep the backward-compatible ceiling until their `max` support is known.