### PR TITLE
Bump Go to 1.26.6 [SECURITY]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.6'
           cache: ${{ contains(fromJSON('["ubuntu-latest","ubuntu-24.04","ubuntu-22.04"]'), matrix.os) && github.repository == 'kenn-io/roborev' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'false' || 'true' }}
 
       - name: Build
@@ -142,7 +142,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.6'
           cache: ${{ github.repository == 'kenn-io/roborev' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'false' || 'true' }}
 
       - name: Test with coverage
@@ -179,7 +179,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.6'
           cache: ${{ github.repository == 'kenn-io/roborev' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'false' || 'true' }}
 
       - name: Run integration tests
@@ -197,7 +197,7 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         if: needs.go-changes.outputs.changed == 'true'
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.6'
           cache: ${{ github.repository == 'kenn-io/roborev' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'false' || 'true' }}
 
       - name: Resolve pinned golangci-lint version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.6'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7.2.3

--- a/.github/workflows/windows-migration.yml
+++ b/.github/workflows/windows-migration.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.6'
           cache: 'true'
 
       - name: Download v0.56 Windows release binary

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <img alt="roborev" src="https://roborev.io/assets/static/logo-with-text-light.svg">
 </picture>
 
-[![Go](https://img.shields.io/badge/Go-1.21+-00ADD8?logo=go&logoColor=white)](https://go.dev/)
+[![Go](https://img.shields.io/badge/Go-1.26.6+-00ADD8?logo=go&logoColor=white)](https://go.dev/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Docs](https://img.shields.io/badge/Docs-roborev.io-blue)](https://roborev.io)
 

--- a/docs/screenshots/Dockerfile
+++ b/docs/screenshots/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.6-alpine AS builder
 
 WORKDIR /src
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.kenn.io/roborev
 
-go 1.26.3
+go 1.26.6
 
 require (
 	charm.land/bubbletea/v2 v2.0.7

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.kenn.io/roborev
 
-go 1.26.6
+go 1.26.3
 
 require (
 	charm.land/bubbletea/v2 v2.0.7


### PR DESCRIPTION
## Summary

- Move development, CI, release, and screenshot builds to Go 1.26.6.
- Close exposure to the sumdb verification bypass and module-cache attacks fixed in the [Go 1.26.6 security release](https://freenode.net/article/go-1-26-6-and-1-25-13-fix-sumdb-bypass-and-module-cache-attacks).
- Advertise Go 1.26.6 as the minimum supported toolchain without changing application code or dependencies.
