### PR TITLE
Require Go 1.26.6 in go.mod [SECURITY]

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,12 +21,19 @@
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
+          goPinned = pkgs.go_1_26.overrideAttrs (_: rec {
+            version = "1.26.6";
+            src = pkgs.fetchurl {
+              url = "https://go.dev/dl/go${version}.src.tar.gz";
+              hash = "sha256-oHIcVMaIkBRI13rZs+x+p8R0cwdV/4kTgukuy5P/LLE=";
+            };
+          });
+          buildGoModule = pkgs.buildGoModule.override { go = goPinned; };
         in
         {
-          default = pkgs.buildGoModule {
+          default = buildGoModule {
             pname = "roborev";
             version = "0.64.0";
-            go = pkgs.go_1_26;
 
             src = ./.;
 
@@ -66,11 +73,18 @@
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
+          goPinned = pkgs.go_1_26.overrideAttrs (_: rec {
+            version = "1.26.6";
+            src = pkgs.fetchurl {
+              url = "https://go.dev/dl/go${version}.src.tar.gz";
+              hash = "sha256-oHIcVMaIkBRI13rZs+x+p8R0cwdV/4kTgukuy5P/LLE=";
+            };
+          });
         in
         {
           default = pkgs.mkShell {
             buildInputs = with pkgs; [
-              go_1_26
+              goPinned
               gopls
               gotools
             ];

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.kenn.io/roborev
 
-go 1.26.3
+go 1.26.6
 
 require (
 	charm.land/bubbletea/v2 v2.0.7


### PR DESCRIPTION
## Summary

- Raise the module requirement from Go 1.26.3 to Go 1.26.6 now that CI and release workflows bootstrap the patched toolchain.
- Pin Roborev's Nix package and development shell to Go 1.26.6 while nixpkgs catches up, without exporting an overlay or changing `flake.lock`.
- Complete the response to the sumdb verification bypass and module-cache attacks fixed in the [Go 1.26.6 security release](https://freenode.net/article/go-1-26-6-and-1-25-13-fix-sumdb-bypass-and-module-cache-attacks).
- Leave application code and dependency versions unchanged.
