### PR TITLE
Keep branch reviews in the invoking linked worktree

### DIFF
--- a/cmd/roborev/review.go
+++ b/cmd/roborev/review.go
@@ -106,7 +106,7 @@ Examples:
 			}
 
 			// Get repo root
-			root, err := gitrepo.Root(ctx, repoPath)
+			root, err := git.GetRepoRoot(repoPath)
 			if err != nil {
 				if quiet {
 					return nil // Not a repo - silent exit for hooks

--- a/cmd/roborev/review_test.go
+++ b/cmd/roborev/review_test.go
@@ -49,7 +49,9 @@ func setupTestEnvironment(
 }
 
 type capturedEnqueue struct {
+	RepoPath  string `json:"repo_path"`
 	GitRef    string `json:"git_ref"`
+	Branch    string `json:"branch"`
 	Reasoning string `json:"reasoning"`
 }
 
@@ -458,6 +460,36 @@ func TestReviewBranchFlag(t *testing.T) {
 		req := <-reqCh
 		assert.Contains(t, req.GitRef, mainSHA)
 		assert.True(t, strings.HasSuffix(req.GitRef, "..HEAD"))
+	})
+
+	t.Run("branch review stays in the invoked linked worktree", func(t *testing.T) {
+		repo, mux := setupTestEnvironment(t)
+		reqCh := mockEnqueue(t, mux)
+
+		mainSHA := repo.CommitFile("base.txt", "base", "initial")
+		other := filepath.Join(t.TempDir(), "other")
+		target := filepath.Join(t.TempDir(), "target")
+		otherParent, err := filepath.EvalSymlinks(filepath.Dir(other))
+		require.NoError(t, err)
+		otherRoot := filepath.Join(otherParent, filepath.Base(other))
+		targetParent, err := filepath.EvalSymlinks(filepath.Dir(target))
+		require.NoError(t, err)
+		targetRoot := filepath.Join(targetParent, filepath.Base(target))
+		repo.Run("worktree", "add", "-b", "other", otherRoot)
+		repo.Run("worktree", "add", "-b", "feature", targetRoot)
+		runGitForCommit(t, targetRoot, "commit", "--allow-empty", "-m", "feature commit")
+
+		// A shared core.worktree value can point Git's reported top level at a
+		// sibling even though target's .git file and HEAD identify target.
+		repo.Run("config", "--file", filepath.Join(repo.Dir, ".git", "config"), "core.worktree", otherRoot)
+
+		_, _, err = executeReviewCmd("--repo", targetRoot, "--branch", "--quiet")
+		require.NoError(t, err)
+
+		req := <-reqCh
+		assert.Equal(t, targetRoot, req.RepoPath)
+		assert.Equal(t, "feature", req.Branch)
+		assert.Equal(t, mainSHA+"..HEAD", req.GitRef)
 	})
 
 	t.Run("branch review uses branch base before url upstream", func(t *testing.T) {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1035,6 +1035,18 @@ func isFullObjectID(ref string) bool {
 
 // GetRepoRoot returns the root directory of the git repository
 func GetRepoRoot(path string) (string, error) {
+	// A linked worktree has a .git file that names its worktree-specific
+	// administrative directory. Prefer that local binding over
+	// --show-toplevel: a shared core.worktree setting can make Git report a
+	// sibling checkout even while HEAD and --git-dir still belong to the
+	// worktree containing path.
+	if root, found, err := linkedWorktreeRoot(path); found {
+		if err != nil {
+			return "", err
+		}
+		return root, nil
+	}
+
 	cmd := newGitCmd("rev-parse", "--show-toplevel")
 	cmd.Dir = path
 
@@ -1046,6 +1058,54 @@ func GetRepoRoot(path string) (string, error) {
 	// Git on Windows can return MSYS-style paths (/c/Users/...) or forward-slash paths (C:/...).
 	// Convert to native Windows paths for consistency with Go's filepath.
 	return normalizeMSYSPath(string(out)), nil
+}
+
+func linkedWorktreeRoot(path string) (string, bool, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", false, nil
+	}
+	if info, statErr := os.Stat(abs); statErr == nil && !info.IsDir() {
+		abs = filepath.Dir(abs)
+	}
+
+	for dir := abs; ; dir = filepath.Dir(dir) {
+		marker := filepath.Join(dir, ".git")
+		info, err := os.Lstat(marker)
+		if err == nil && info.Mode().IsRegular() {
+			data, readErr := os.ReadFile(marker)
+			if readErr != nil {
+				return "", true, fmt.Errorf("read linked worktree marker: %w", readErr)
+			}
+			gitDir, found := strings.CutPrefix(strings.TrimSpace(string(data)), "gitdir:")
+			if !found {
+				return "", true, fmt.Errorf("invalid linked worktree marker %s", marker)
+			}
+			gitDir = strings.TrimSpace(gitDir)
+			if !filepath.IsAbs(gitDir) {
+				gitDir = filepath.Join(dir, gitDir)
+			}
+
+			resolved, resolveErr := ResolveGitDir(path)
+			if resolveErr != nil {
+				return "", true, resolveErr
+			}
+			if cleanEvalPath(gitDir) != cleanEvalPath(resolved) {
+				return "", true, fmt.Errorf("linked worktree marker does not match git directory")
+			}
+			return cleanEvalPath(dir), true, nil
+		}
+		if err == nil {
+			return "", false, nil
+		}
+		if !os.IsNotExist(err) {
+			return "", true, fmt.Errorf("inspect git marker: %w", err)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false, nil
+		}
+	}
 }
 
 // ValidateWorktreeForRepo checks that worktreePath is a git checkout


### PR DESCRIPTION
## Summary

- Bind `roborev review --branch` to the linked worktree that contains the invocation instead of trusting a shared `core.worktree` top-level path.
- Verify the local `.git` marker against the worktree-specific Git directory before selecting the repository, branch, and commit range.
- Prevent workspace tooling or stale shared Git configuration from silently enqueueing a review for a sibling checkout.