### PR TITLE
ci: fix Go version and Linux race filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.6'
           cache: ${{ github.repository == 'kenn-io/roborev' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'false' || 'true' }}
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
@@ -100,7 +100,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.6'
           cache: ${{ github.repository == 'kenn-io/roborev' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'false' || 'true' }}
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
@@ -158,7 +158,7 @@ jobs:
           # The daemon package is large enough to exceed Go's package timeout
           # under the race detector, so dedicated jobs shard it below.
           go list ./... |
-            rg -v '^go\.kenn\.io/roborev/internal/daemon$' |
+            grep -v '^go\.kenn\.io/roborev/internal/daemon$' |
             xargs go test -json -timeout 30m -race -shuffle=on -tags integration 2>&1 |
             tee "test-results/${{ matrix.os }}-test.jsonl"
 


### PR DESCRIPTION
The first CI run after the native web application merge failed before exercising
the new API and web checks. Those jobs used Go 1.26.4 while the module requires
Go 1.26.6. The Linux race job also assumed ripgrep on the project's
self-hosted runner, so it exited before filtering the package list.

This updates the API and web jobs to the required toolchain and uses the
runner's standard `grep` utility for the race shard. Application and release
packaging code remain unchanged; this only restores CI coverage.
