### PR TITLE
ci: make browser tests deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
         run: bun run web:test
 
       - name: Install browser test runtime
-        run: bunx playwright install --with-deps chromium
+        run: bun run --cwd web playwright install --with-deps chromium
 
       - name: Test embedded browser application
         run: bun run web:test:e2e

--- a/bun.lock
+++ b/bun.lock
@@ -2,7 +2,11 @@
   "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
-    "": {},
+    "": {
+      "devDependencies": {
+        "playwright": "1.61.1",
+      },
+    },
     "packages/roborev-ui": {
       "name": "@kenn-io/roborev-ui",
       "version": "0.1.0",

--- a/internal/testutil/webfixture/seed.go
+++ b/internal/testutil/webfixture/seed.go
@@ -294,6 +294,11 @@ func fixtureJobs() []fixtureJob {
 		jobs = append(jobs, job)
 	}
 
+	// Browser tests rerun this failed job through the production API. Keep the
+	// fixture independent of external agent commands installed on the host.
+	jobs[FailedJobID-1].agent = "test"
+	jobs[FailedJobID-1].model = ""
+
 	pricedVerdict := true
 	jobs[44].status = storage.JobStatusDone
 	jobs[44].verdict = &pricedVerdict

--- a/internal/testutil/webfixture/seed_test.go
+++ b/internal/testutil/webfixture/seed_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -82,6 +83,22 @@ func TestSeedRejectsExistingData(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "reviews.db")
 	require.NoError(t, Seed(path))
 	require.ErrorContains(t, Seed(path), "already contains fixture data")
+}
+
+func TestSeedRerunnableJobUsesBuiltInAgent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "reviews.db")
+	require.NoError(t, Seed(path))
+
+	db, err := storage.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	job, err := db.GetJobByID(FailedJobID)
+	require.NoError(t, err)
+	fixtureAgent, err := agent.Get(job.Agent)
+	require.NoError(t, err)
+	_, commandBacked := fixtureAgent.(agent.CommandAgent)
+	assert.False(t, commandBacked, "rerun fixture must not require an installed agent command")
 }
 
 func scalarInt(t *testing.T, db *sql.DB, query string) int {

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
     "web:test:e2e": "bun run --cwd web test:e2e",
     "web:build": "bun run --cwd web build",
     "web:generate": "bun run --cwd web generate"
+  },
+  "devDependencies": {
+    "playwright": "1.61.1"
   }
 }


### PR DESCRIPTION
Browser CI now uses the repository's locked Playwright 1.61.1 for browser installation and test execution. The root workspace dependency also makes the existing main-pinned pull-request workflow resolve the same version, so this fix can bootstrap through the current CI security boundary.

The local-session rerun fixture now uses Roborev's built-in test agent. This keeps the browser mutation test independent of external agent commands installed on a developer machine or CI runner.

The pull-request dispatcher remains pinned to `main`, preserving the managed-runner isolation model.
