### PR TITLE
fix(release): preserve pinned Go version

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -175,46 +175,19 @@ update_nix_flake() {
         ORIGINAL_REF=$(git -C "$REPO_ROOT" rev-parse HEAD)
 
     echo "Updating flake.nix version to $VERSION..."
-    sed -i.bak "s/version = \"[^\"]*\"/version = \"$VERSION\"/" "$FLAKE_FILE"
+    sed -i.bak \
+        "/pname = \"roborev\";/,/version = \"[^\"]*\";/ s/version = \"[^\"]*\"/version = \"$VERSION\"/" \
+        "$FLAKE_FILE"
     rm -f "$FLAKE_FILE.bak"
 
-    # Check if vendorHash needs updating (only if go.mod changed since last release)
+    # Recompute vendorHash and verify the updated flake.
     if command -v nix &> /dev/null; then
         echo "Checking if vendorHash needs updating..."
-
-        # Temporarily set vendorHash to empty to get the correct hash
-        local OLD_HASH=$(grep 'vendorHash = "' "$FLAKE_FILE" | sed 's/.*vendorHash = "\([^"]*\)".*/\1/')
-        sed -i.bak 's/vendorHash = "[^"]*"/vendorHash = ""/' "$FLAKE_FILE"
-
-        # Try to build and capture the expected hash
-        echo "Running nix build to compute vendorHash (this may take a moment)..."
-        local NIX_OUTPUT
-        if NIX_OUTPUT=$(nix build "$REPO_ROOT" 2>&1); then
-            # Build succeeded with empty hash - dependencies might be empty or cached
-            echo "Build succeeded, keeping existing vendorHash"
-            sed -i.bak "s|vendorHash = \"\"|vendorHash = \"$OLD_HASH\"|" "$FLAKE_FILE"
-        else
-            # Extract the expected hash from the error message
-            local NEW_HASH=$(echo "$NIX_OUTPUT" | grep -o 'sha256-[A-Za-z0-9+/=]*' | tail -1)
-            if [ -n "$NEW_HASH" ]; then
-                echo "Updating vendorHash to $NEW_HASH"
-                sed -i.bak "s|vendorHash = \"\"|vendorHash = \"$NEW_HASH\"|" "$FLAKE_FILE"
-            else
-                echo "Warning: Could not determine new vendorHash, restoring old value"
-                sed -i.bak "s|vendorHash = \"\"|vendorHash = \"$OLD_HASH\"|" "$FLAKE_FILE"
-            fi
-        fi
-        rm -f "$FLAKE_FILE.bak"
-
-        # Verify the build works
-        echo "Verifying nix build..."
-        if ! nix build "$REPO_ROOT" 2>/dev/null; then
-            echo "Error: nix build failed after updating flake.nix"
-            echo "Please fix flake.nix manually and try again"
+        if ! "$SCRIPT_DIR/update-nix-vendor-hash.sh" "$REPO_ROOT"; then
+            echo "Error: failed to update and verify flake.nix"
             git -C "$REPO_ROOT" checkout -- flake.nix
             exit 1
         fi
-        echo "Nix build successful!"
     else
         echo "Warning: nix not installed, cannot verify vendorHash"
         echo "If go.mod changed, you may need to update vendorHash manually"

--- a/scripts/release_test.go
+++ b/scripts/release_test.go
@@ -1,0 +1,106 @@
+package scripts
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReleaseUpdatesOnlyPackageVersionBeforeNixBuild(t *testing.T) {
+	repo := t.TempDir()
+	scriptsDir := filepath.Join(repo, "scripts")
+	fakeBin := filepath.Join(repo, "fake-bin")
+	remote := filepath.Join(repo, "origin.git")
+	require.NoError(t, os.MkdirAll(scriptsDir, 0o755))
+	require.NoError(t, os.MkdirAll(fakeBin, 0o755))
+
+	installReleaseFixture(t, scriptsDir)
+	writeExecutable(t, filepath.Join(fakeBin, "nix"), `#!/usr/bin/env bash
+set -e
+
+flake="$PWD/flake.nix"
+fake_hash="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+expected_hash="sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB="
+
+if ! grep -q 'version = "1.26.6";' "$flake"; then
+    echo "Go toolchain version changed unexpectedly" >&2
+    exit 1
+fi
+
+if grep -q "$fake_hash" "$flake"; then
+    echo "specified: $fake_hash" >&2
+    echo "got: $expected_hash" >&2
+    exit 1
+fi
+
+grep -q "$expected_hash" "$flake"
+`)
+	writeExecutable(t, filepath.Join(fakeBin, "gh"), `#!/usr/bin/env bash
+if [[ "$1 $2" == "pr list" ]]; then
+    exit 0
+fi
+echo "https://example.invalid/pull/1"
+`)
+
+	git(t, repo, "init", "-b", "main")
+	git(t, repo, "config", "user.name", "Release Test")
+	git(t, repo, "config", "user.email", "release-test@example.invalid")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "release fixture")
+	git(t, repo, "tag", "v0.64.0")
+	git(t, repo, "init", "--bare", remote)
+	git(t, repo, "remote", "add", "origin", remote)
+
+	cmd := exec.Command("bash", bashPath(t, filepath.Join(scriptsDir, "release.sh")), "0.65.0")
+	cmd.Dir = repo
+	cmd.Env = append(os.Environ(), "PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	cmd.Stdin = strings.NewReader("n\n")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	updatedFlake := gitOutput(t, repo, "show", "release/v0.65.0-nix-update:flake.nix")
+	assert := assert.New(t)
+	assert.Contains(string(output), "Release cancelled.")
+	assert.Contains(updatedFlake, `version = "1.26.6";`)
+	assert.Contains(updatedFlake, `version = "0.65.0";`)
+	assert.Contains(updatedFlake, `vendorHash = "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";`)
+}
+
+func installReleaseFixture(t *testing.T, scriptsDir string) {
+	t.Helper()
+
+	for _, name := range []string{"release.sh", "update-nix-vendor-hash.sh"} {
+		script := readShellScript(t, name)
+		require.NoError(t, os.WriteFile(filepath.Join(scriptsDir, name), script, 0o755))
+	}
+
+	writeExecutable(t, filepath.Join(scriptsDir, "changelog.sh"), `#!/usr/bin/env bash
+echo "Synthetic changelog"
+`)
+
+	flake := `{
+  outputs = { self }: {
+    goPinned = {
+      version = "1.26.6";
+      url = "https://go.dev/dl/go${version}.src.tar.gz";
+    };
+    packages.default = {
+      pname = "roborev";
+      version = "0.64.0";
+      vendorHash = "sha256-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC=";
+    };
+  };
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(filepath.Dir(scriptsDir), "flake.nix"), []byte(flake), 0o644))
+}
+
+func writeExecutable(t *testing.T, path, contents string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o755))
+}


### PR DESCRIPTION
Release preparation could replace the pinned Go toolchain version with the
roborev release number. Nix then tried to download a nonexistent Go release,
and the fallback parser mistook Nix's placeholder hash for the dependency
vendor hash.

The release workflow now limits the version bump to the roborev package and
uses the existing Nix vendor-hash updater for hash discovery and build
verification. A temporary-repository regression test exercises the release
preparation flow without publishing a tag or contacting GitHub.

This change is limited to release preparation. It does not change the pinned Go
version or the release artifact workflow.
