### PR TITLE
docs: introduce the 0.65.0 browser UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ background, reviews every commit as agents write code, and surfaces
 issues in seconds -- before they compound. Pull code reviews into
 your agentic loop while context is fresh.
 
-![roborev TUI](https://roborev.io/assets/generated/tui-hero.svg)
+![Roborev browser application](https://roborev.io/assets/generated/web-ui.png)
 
 ## How It Works
 
@@ -78,8 +78,10 @@ You can also choose the exact binary path with
   Reviews are orchestrated on your machine using the coding agents
   you already have configured.
 - **Interactive TUI** - Real-time review queue with vim-style navigation.
+  Large terminals show the queue and selected review in a split-screen layout.
 - **Native Browser UI** - Browse, filter, inspect, comment on, close, cancel,
-  and rerun reviews from the application embedded in the local daemon.
+  and rerun reviews from the application embedded in the local daemon, then
+  explore cost, latency, reliability, and outcomes in Analytics.
 - **Review Verification** - `roborev compact` verifies findings against
   current code, filters false positives, and consolidates related issues
   into a single review.
@@ -153,7 +155,7 @@ curl -fsSL https://roborev.io/install.sh | bash
 
 **Homebrew (macOS / Linux):**
 ```bash
-brew install roborev-dev/tap/roborev
+brew install kenn-io/tap/roborev
 ```
 
 **Windows (PowerShell):**

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ are ignored local outputs.
 
 - `docs-assets`: curated static media, including logos, favicons, Open Graph
   images, diagrams, agent icons, and manually captured integration images.
-- `docs-generated-assets`: generated CLI and TUI screenshots.
+- `docs-generated-assets`: generated browser UI, CLI, and TUI screenshots.
 
 Docs pages should reference media through:
 

--- a/docs/assets/hydrate-assets.sh
+++ b/docs/assets/hydrate-assets.sh
@@ -41,6 +41,7 @@ static_assets=(
 )
 
 generated_assets=(
+  "web-ui.png"
   "tui-hero.svg"
   "tui-queue.svg"
   "tui-review.svg"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,24 +5,39 @@ description: Release history for roborev
 
 All notable changes to roborev, grouped by minor release.
 
-## Unreleased
+## 0.65.0
+
+<small>2026-08-16</small>
 
 **New features**
 
-- Reasoning accepts exact `low`, `medium`, `high`, `xhigh`, and `max` values and
-    forwards them unchanged to agents that support each tier. The legacy `fast`,
-    `standard`, `thorough`, and `maximum` presets remain compatible.
 - Roborev now embeds an authenticated native browser review workspace on a
     separate daemon listener. `roborev ui [job-id]` opens the job list or a
     review deep link with filtering, sorting, panel detail, Markdown output,
     comments, logs, prompts, keyboard controls, and review/job mutations. Local
     use bootstraps automatically; remote HTTPS deployments exchange a token for
-    a browser session without exposing the private CLI listener.
+    a browser session without exposing the private CLI listener. Analytics
+    reports review volume, outcomes, errors, latency, agent attempts, estimated
+    cost, and pricing coverage. See [Browser UI](/web-ui/).
+- The TUI automatically shows a kata-style split-screen review workspace on
+    terminals at least 140 columns by 36 rows. The queue drives a live detail
+    pane for completed, running, failed, and queued jobs; `L` toggles layouts,
+    and smaller terminals fall back to the existing stacked view. See
+    [Split-Screen Review](/integrations/tui/#split-screen-review).
+- Reasoning accepts exact `low`, `medium`, `high`, `xhigh`, and `max` values and
+    forwards them unchanged to agents that support each tier. The legacy `fast`,
+    `standard`, `thorough`, and `maximum` presets remain compatible. See
+    [Reasoning Levels](/configuration/#reasoning-levels).
 - Pi agents accept global `[agent.pi] launch_args`, passed as tokenized
     arguments to every Pi invocation before roborev-managed workflow and safety
     options. This allows isolated classifier jobs to load extension-defined
     model providers explicitly while retaining `--no-extensions` discovery
-    isolation.
+    isolation. See [Pi Classifier Options](/configuration/#pi-classifier-options).
+- `roborev export ci-costs` exports job-level costs for eligible CI attempts,
+    including terminal retries that panel summaries cannot retain. Stable
+    cursors, overlapping-window refreshes, null-versus-zero pricing, and a
+    legacy backfill mode support incremental downstream accounting. See
+    [Exporting CI Costs](/commands/#exporting-ci-costs).
 
 **Improvements**
 
@@ -35,6 +50,25 @@ All notable changes to roborev, grouped by minor release.
     repository, worktree, branch, and expiry, while the TUI shows a contextual
     snooze badge for an exactly filtered checkout. See
     [Snoozing Reminders](/agent-hook/#snoozing-reminders).
+- Daemon restarts stop new claims and wait for active reviews, hooks, and final
+    sync to finish before starting the replacement process. The CLI reports the
+    wait instead of force-killing work after a fixed timeout.
+- `roborev review --branch` now resolves the repository and range from the
+    linked worktree that invoked it, preventing shared or stale Git
+    configuration from redirecting the review to a sibling checkout. See
+    [Git Worktrees](/guides/repository-management/#git-worktrees).
+- Agent Hook installation and runtime handling now use kit's shared coding-agent
+    profiles. One workflow supports Claude Code, Codex, Copilot CLI, Cursor,
+    Factory Droid, Gemini CLI, Hermes, and Qwen, while Roborev retains its Grok
+    integration. Existing Codex, Claude, and Droid registrations can be upgraded
+    in place. See [Agent Hook](/agent-hook/).
+- The Homebrew tap now discovers official Roborev releases and owns formula
+    updates, removing duplicate publisher logic and the cross-repository release
+    credential. See
+    [Homebrew installation](/installation/#homebrew-macos-linux).
+- Development, CI, release, and screenshot builds now require Go 1.26.6. Go,
+    JavaScript, documentation, and GitHub Actions dependencies were refreshed,
+    including fixes for known Go toolchain and `go-git` vulnerabilities.
 
 **Bug fixes**
 
@@ -44,12 +78,30 @@ All notable changes to roborev, grouped by minor release.
     rerun jobs. Session expiry and logout now close active browser streams.
 - Persisted job output is shown only when its log belongs to the current
     attempt, so a failed rerun cannot fall back to an older attempt's output.
-- Daemon restarts now stop new job claims and wait indefinitely for running
-    reviews and worker finalization instead of force-killing the daemon after a
-    short graceful-shutdown window.
+- Daemon discovery now preserves sandbox permission failures instead of treating
+    an unreachable loopback or Unix socket as proof that no daemon exists.
+    Clients can use the daemon's private Unix-socket fallback without starting a
+    competing process. See [Daemon & Hooks](/commands/#daemon-hooks).
+- Fresh agent sessions now receive a short, bounded agentsview usage-indexing
+    retry before Roborev falls back to job-log token data, reducing permanently
+    missing cost estimates. See [Token Usage](/commands/#token-usage).
 - The Codex `maximum` preset now requests literal `max` for explicit GPT-5.6
     `sol`, `terra`, and `luna` models. Older, default, and unknown models retain
     the compatible `xhigh` mapping, while exact `xhigh` remains distinct.
+
+**Acknowledgements**
+
+- Thanks to [Wes McKinney](https://github.com/wesm) for the native browser
+    application, job-level CI cost export, linked-worktree review fix,
+    usage-indexing retry, and release updates.
+- Thanks to [Graham Wheeler](https://github.com/gramster) for the TUI
+    split-screen review workspace.
+- Thanks to [Phillip Cloud](https://github.com/cpcloud) for exact
+    reasoning-effort tiers across supported agents.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for unified
+    Agent Hook profiles, sandbox-safe daemon discovery, visible snooze status,
+    graceful daemon restarts, Pi launch arguments, and the Go 1.26.6 security
+    upgrade.
 
 ______________________________________________________________________
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -213,7 +213,14 @@ branches before builds:
 
 - `docs-assets` contains curated static media such as logos, favicons, diagrams,
     Open Graph images, and integration screenshots.
-- `docs-generated-assets` contains generated CLI and TUI screenshots.
+- `docs-generated-assets` contains generated browser, CLI, and TUI screenshots.
+
+The screenshot pipeline reads the normal review database only through a
+read-only SQLite connection, extracts completed clean reviews from the canonical
+public Roborev repository, sanitizes copied content, and runs the branch binary
+against that reduced database inside Docker. See the
+[screenshot pipeline guide](https://github.com/kenn-io/roborev/blob/main/docs/screenshots/README.md)
+for the capture and asset publication workflow.
 
 Install the docs toolchain and build the site:
 

--- a/docs/guides/repository-management.md
+++ b/docs/guides/repository-management.md
@@ -145,6 +145,9 @@ When running commands from a worktree:
     active worktree branch
 - `roborev fix --open` filters to reviews reachable from the current worktree's
     HEAD
+- `roborev review --branch` resolves the repository root, branch, and commit
+    range from the linked worktree that invoked it, even if shared Git
+    configuration points at a sibling checkout
 - `refine` correctly finds and addresses reviews for commits in any worktree
 
 ### Detached HEAD worktrees

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,9 +28,31 @@ coding agent so the write -> review -> fix loop runs hands-off.
 
 [Set up automation ->](automation/post-commit-reviews.md)
 
+## Browser UI
+
+Run `roborev ui` to open the native browser application. Browse and filter the
+live review queue, inspect review output, prompts, and logs, manage jobs and
+comments, or switch to Analytics to explore cost, latency, reliability, and
+review outcomes. The application runs from the local daemon and uses the same
+SQLite history as the CLI and terminal UI.
+
 <figure class="hero-shot" data-lightbox>
-  <img src="/assets/generated/tui-hero.svg" alt="roborev TUI queue view" loading="eager">
+  <img src="/assets/generated/web-ui.png" alt="Roborev browser application showing the review queue and an open review" loading="eager">
 </figure>
+
+[Explore the browser UI ->](web-ui.md)
+
+## Terminal UI
+
+Prefer to stay in the terminal? `roborev tui` provides the same live review
+ledger with vim-style navigation. On a large terminal, its split-screen layout
+keeps the queue and selected review visible together.
+
+<figure class="hero-shot" data-lightbox>
+  <img src="/assets/generated/tui-hero.svg" alt="Roborev TUI split-screen review view" loading="lazy">
+</figure>
+
+[Explore the terminal UI ->](integrations/tui.md)
 
 <div class="agent-matrix">
   <a href="/agents/"><img src="/assets/static/agents/codex.svg" alt="Codex" data-agent="codex" width="1604" height="719" /></a>
@@ -57,6 +79,7 @@ Then from within your git repositories:
 roborev init          # Install post-commit hook
 # do some work, generate commits
 roborev tui           # Browse reviews in the terminal UI
+roborev ui            # Or browse reviews in the native browser UI
 ```
 
 For Windows, see the

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -50,6 +50,10 @@ brew install roborev
 This also works on Linux with
 [Linuxbrew](https://docs.brew.sh/Homebrew-on-Linux).
 
+The `kenn-io/tap` repository watches official Roborev releases and manages
+formula updates from their published checksums. Roborev release jobs do not need
+a cross-repository credential to update the formula.
+
 ## Linux Packages: DEB and RPM
 
 Starting with 0.57.0, GitHub releases include `.deb` and `.rpm` packages for
@@ -89,15 +93,17 @@ need the browser application.
 
 ## Build from Source
 
+Building Roborev requires Go 1.26.6 or newer. The embedded browser application
+also requires Bun 1.3.14.
+
 ```bash
 git clone https://github.com/kenn-io/roborev
 cd roborev
 make install
 ```
 
-The `make install` target requires Bun 1.3.14, builds and validates the browser
-application, and embeds it alongside version information (for example,
-`v0.7.0-5-gabcdef`).
+The `make install` target builds and validates the browser application and
+embeds it alongside version information (for example, `v0.7.0-5-gabcdef`).
 
 For quick iteration during development:
 

--- a/docs/integrations/tui.md
+++ b/docs/integrations/tui.md
@@ -60,6 +60,7 @@ branch.
 | `f` | Open filter (repo/branch tree) |
 | `b` | Open filter with branches expanded |
 | `h` | Toggle hide closed/failed/canceled |
+| `L` | Toggle split-screen or stacked layout |
 | `D` | Toggle distraction-free mode |
 | `P` | Pause or resume queue processing |
 | `g` | Jump to top of queue |
@@ -72,6 +73,30 @@ Panel reviews appear as one synthesis parent row by default. The parent row
 shows live progress while member reviewers run and a compact member summary
 after completion. Expand the row to inspect individual member jobs. Close,
 cancel, rerun, or fix the panel from the parent row, not from a member row.
+
+## Split-Screen Review
+
+At 140 columns by 36 rows or larger, the TUI automatically places the queue in a
+left pane and the selected job in a right detail pane. Moving through the queue
+updates the detail pane after a short debounce, so holding `j` or `k` does not
+issue a request for every intermediate row.
+
+The detail pane adapts to job state: completed jobs show the rendered review,
+running jobs show a live log tail, failed jobs show the error, and queued jobs
+show their metadata. When a running job finishes, its log is replaced by the
+review automatically.
+
+Press `Tab` to focus the detail pane and `Esc` to return to the queue. Review
+actions and scrolling work in the focused detail pane. `Enter` is intentionally
+a no-op while the split queue is focused because the detail already follows the
+selection. Mouse clicks focus either pane, and the wheel scrolls the pane below
+the pointer.
+
+Press `L` to lock the stacked or split preference for the TUI session. A split
+preference falls back to stacked when the terminal is too small and returns when
+it grows again. Prompt, comment, help, log, and task screens remain full-screen.
+The queue also drops lower-priority columns as needed to preserve the most
+useful fields in its narrower pane.
 
 ## Queue Pause
 

--- a/docs/screenshots/Dockerfile
+++ b/docs/screenshots/Dockerfile
@@ -1,3 +1,18 @@
+FROM oven/bun:1.3.14-alpine AS web-builder
+
+RUN apk add --no-cache git
+
+WORKDIR /src
+
+COPY package.json bun.lock ./
+COPY web/package.json web/package.json
+COPY packages/roborev-ui/package.json packages/roborev-ui/package.json
+RUN bun install --frozen-lockfile
+
+COPY web web
+COPY packages packages
+RUN bun run web:build
+
 FROM golang:1.26.6-alpine AS builder
 
 WORKDIR /src
@@ -8,15 +23,18 @@ RUN go mod download
 
 # Copy source and build
 COPY . .
+COPY --from=web-builder /src/web/dist ./internal/web/dist
 ARG VERSION=dev
-RUN go build \
+RUN CGO_ENABLED=0 go build \
     -ldflags="-X go.kenn.io/roborev/internal/version.Version=${VERSION}" \
     -o /roborev ./cmd/roborev
 
-FROM alpine:3.19
+FROM node:22-bookworm
 
 # Install dependencies for freeze + tmux screenshots
-RUN apk add --no-cache ca-certificates git bash tmux
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates git tmux wget && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install freeze for SVG screenshots (detect architecture)
 RUN ARCH=$(uname -m) && \
@@ -28,6 +46,11 @@ RUN ARCH=$(uname -m) && \
 
 COPY --from=builder /roborev /usr/local/bin/roborev
 
+WORKDIR /screenshots
+COPY docs/screenshots/package.json docs/screenshots/package-lock.json ./
+RUN npm ci && npx playwright install --with-deps chromium
+COPY docs/screenshots/ ./
+
 # Create config pointing to local daemon
 RUN mkdir -p /root/.roborev && \
     echo 'server_addr = "127.0.0.1:7373"' > /root/.roborev/config.toml
@@ -36,4 +59,4 @@ RUN mkdir -p /root/.roborev && \
 RUN printf '#!/bin/sh\ncat > /dev/null\n' > /usr/local/bin/xclip && \
     chmod +x /usr/local/bin/xclip
 
-WORKDIR /screenshots
+ENTRYPOINT ["/bin/bash"]

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -1,0 +1,42 @@
+# Documentation Screenshot Pipeline
+
+The Dockerized screenshot pipeline creates the terminal and browser images used
+by the documentation site. It follows the same shape as the AgentsView docs
+pipeline: prepare a reduced database on the host, build the release application
+in Docker, and drive the UI at fixed dimensions.
+
+## Safety
+
+The source database is opened read-only. The extractor accepts only the
+canonical public `github.com/kenn-io/roborev` repository, copies completed
+commit reviews, rewrites local paths and credential-shaped strings, and applies
+the private terms file at `$KENN_PRIVATE_TERMS_FILE` or
+`~/.config/kenn/private-terms.txt` when present. The daemon and browser run only
+inside Docker against the reduced copy.
+
+## Generate Screenshots
+
+From the repository root:
+
+```bash
+make docs-screenshots
+```
+
+Set `ROBOREV_DOCS_SOURCE_DB` to use a source other than
+`~/.roborev/reviews.db`. The output is written to the ignored
+`docs/assets/generated/` directory.
+
+Terminal captures use tmux and Freeze. The browser capture uses Playwright with
+a 1440 x 900 dark-mode Chromium viewport. The browser test opens the newest
+visible failing review so the image shows both the review queue and its detail
+drawer.
+
+To replace the local orphan asset branch after inspecting every generated
+image:
+
+```bash
+bash docs/screenshots/update-generated-assets-branch.sh --skip-generate
+```
+
+Add `--push` only when the updated `docs-generated-assets` branch is ready to
+publish.

--- a/docs/screenshots/generate-screenshots.sh
+++ b/docs/screenshots/generate-screenshots.sh
@@ -45,14 +45,15 @@ if [[ -z "${ROBOREV_DATA_DIR:-}" ]]; then
     exit 1
 fi
 roborev config set advanced.tasks_enabled false --global
+roborev config set web.listen "127.0.0.1:7374" --global
 # Hide noisy columns so screenshots match the default-ish view. This must be
 # explicit: any "config set" rewrites the file with the hide-nothing sentinel
 # (hidden_columns = ['_']), which would otherwise unhide the default-hidden
 # Session / Req Model / Req Provider columns.
 roborev config set hidden_columns "session_id,requested_model,requested_provider" --global
 
-# --- Start tmux session (tall for hero, resized later) ---
-tmux -f /dev/null new-session -d -s "$SESSION" -x 120 -y 50
+# --- Start tmux session (large enough for the split-screen hero) ---
+tmux -f /dev/null new-session -d -s "$SESSION" -x 160 -y 50
 tmux set-option -g default-terminal "tmux-256color"
 tmux set-option -ga terminal-overrides ",*:Tc"
 tmux send-keys -t "$SESSION" "export COLORTERM=truecolor" Enter
@@ -174,8 +175,18 @@ wait_until "NAME"
 sleep 0.5
 capture "cli-repo-list"
 
+# =====================
+# Browser Screenshot
+# =====================
+echo "==> Browser screenshot"
+
+ROBOREV_SCREENSHOT_ORIGIN="http://127.0.0.1:7374" \
+SCREENSHOT_DIR="$OUTPUT_DIR" \
+npx playwright test --config /screenshots/playwright.config.ts --reporter=list
+CAPTURED=$((CAPTURED + 1))
+
 # Cleanup
 tmux kill-session -t "$SESSION" 2>/dev/null || true
 
 echo ""
-echo "Done! Generated $CAPTURED SVG files in $OUTPUT_DIR"
+echo "Done! Generated $CAPTURED screenshot files in $OUTPUT_DIR"

--- a/docs/screenshots/package-lock.json
+++ b/docs/screenshots/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "roborev-docs-screenshots",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "roborev-docs-screenshots",
+      "devDependencies": {
+        "@playwright/test": "1.61.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/docs/screenshots/package.json
+++ b/docs/screenshots/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "roborev-docs-screenshots",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@playwright/test": "1.61.1"
+  }
+}

--- a/docs/screenshots/playwright.config.ts
+++ b/docs/screenshots/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "@playwright/test";
+
+const baseURL = process.env.ROBOREV_SCREENSHOT_ORIGIN;
+if (!baseURL) {
+  throw new Error("ROBOREV_SCREENSHOT_ORIGIN is required");
+}
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 60_000,
+  retries: 0,
+  workers: 1,
+  use: {
+    baseURL,
+    viewport: { width: 1440, height: 900 },
+    colorScheme: "dark",
+    timezoneId: "America/Chicago",
+  },
+  projects: [
+    {
+      name: "screenshots",
+      use: { browserName: "chromium" },
+    },
+  ],
+});

--- a/docs/screenshots/prepare-demo-db.sh
+++ b/docs/screenshots/prepare-demo-db.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Prepare an isolated demo database from real roborev reviews of public repos.
+# Prepare an isolated demo database from real reviews of the public Roborev repo.
 
 set -euo pipefail
 
@@ -34,7 +34,7 @@ import sqlite3
 import subprocess
 import sys
 
-allowed_repos = ("roborev", "kata", "msgvault", "agentsview")
+allowed_repos = ("roborev",)
 canonical_repos = {name: f"github.com/kenn-io/{name}" for name in allowed_repos}
 review_statuses = ("done",)
 limit = int(os.environ.get("ROBOREV_DOCS_REVIEW_LIMIT", "1000"))
@@ -42,6 +42,19 @@ source_db = os.environ["SOURCE_DB"]
 dest_db = os.environ["DEST_DB"]
 home = str(pathlib.Path.home())
 home_name = pathlib.Path.home().name
+private_terms_path = pathlib.Path(
+    os.environ.get(
+        "KENN_PRIVATE_TERMS_FILE",
+        pathlib.Path.home() / ".config" / "kenn" / "private-terms.txt",
+    )
+)
+private_terms = []
+if private_terms_path.is_file():
+    private_terms = [
+        line.strip()
+        for line in private_terms_path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
 
 windows_user_path_re = re.compile(
     r"(?i)\b[A-Z]:[\\/]+Users(?:[\\/]+[A-Za-z0-9._-]+(?:[\\/][^\s\"'`)>\]]*)?)?"
@@ -214,6 +227,8 @@ def sanitize_text(value):
     )
     for pattern in secret_patterns:
         sanitized = pattern.sub(lambda m: m.group(1) + m.group(2) + "[REDACTED]" if m.lastindex == 2 else "[REDACTED]", sanitized)
+    for term in private_terms:
+        sanitized = re.sub(re.escape(term), "[REDACTED]", sanitized, flags=re.IGNORECASE)
     return sanitized
 
 
@@ -369,6 +384,7 @@ def validate_sanitized():
         re.compile(r"AKIA[0-9A-Z]{16}"),
         re.compile(r"(?i)\b(api[_-]?key|secret|password)\b\s*[:=]\s*(?!\[REDACTED\])[^\s,\"')]+"),
     ]
+    private_patterns.extend(re.compile(re.escape(term), re.IGNORECASE) for term in private_terms)
     private_patterns = [p for p in private_patterns if p is not None]
     tables = dst.execute(
         "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
@@ -407,10 +423,6 @@ dst.commit()
 
 copied_failures = sum(1 for row in selected_jobs if review_is_failing(row))
 copied_passes = len(selected_jobs) - copied_failures
-missing_repos = [name for name in allowed_repos if name not in {row["name"] for row in repo_rows}]
-if missing_repos:
-    print("Warning: source database did not contain repos: " + ", ".join(missing_repos), file=sys.stderr)
-
 print("Demo database created successfully")
 print(f"Repos: {len(repo_rows)}")
 print(f"Commits: {len(commit_ids)}")

--- a/docs/screenshots/screenshot-all.sh
+++ b/docs/screenshots/screenshot-all.sh
@@ -12,7 +12,7 @@ usage() {
     cat <<EOF
 Usage: $(basename "$0") [OPTIONS]
 
-Generate roborev SVG screenshots using freeze + tmux.
+Generate Roborev CLI, TUI, and browser screenshots in Docker.
 
 Options:
   --repo PATH     Path to roborev source repo (default: current repo)
@@ -54,7 +54,7 @@ REPO="$REPO_RESOLVED"
 
 echo ""
 echo "=========================================="
-echo "  roborev SVG Screenshot Generator"
+echo "  roborev Documentation Screenshot Generator"
 echo "=========================================="
 echo ""
 
@@ -81,9 +81,8 @@ fi
 # --- Step 3: Generate screenshots ---
 mkdir -p "$OUTPUT_DIR"
 
-echo "==> Generating SVG screenshots..."
+echo "==> Generating documentation screenshots..."
 docker run --rm \
-    -v "$SCRIPT_DIR:/screenshots" \
     -v "$DEMO_DATA_DIR:/data" \
     -v "$OUTPUT_DIR:/output" \
     -v "$REPO:/repos/roborev:ro" \

--- a/docs/screenshots/tests/review-selection.spec.ts
+++ b/docs/screenshots/tests/review-selection.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "@playwright/test";
+
+import { findFirstFailingJob } from "./review-selection";
+
+test("loads additional pages until a failing job appears", async ({ page }) => {
+  await page.setContent(`
+    <section aria-label="Review jobs">
+      <div class="job-row"><span class="verdict-pass">Pass</span></div>
+      <button type="button">Load more</button>
+    </section>
+    <script>
+      let loadedPages = 0;
+      document.querySelector("button").addEventListener("click", () => {
+        loadedPages += 1;
+        document.querySelector("section").insertAdjacentHTML(
+          "afterbegin",
+          loadedPages === 2
+            ? '<div class="job-row"><span class="verdict-fail">Fail</span></div>'
+            : '<div class="job-row"><span class="verdict-pass">Pass</span></div>',
+        );
+        if (loadedPages === 2) document.querySelector("button").remove();
+      });
+    </script>
+  `);
+
+  const failingJob = await findFirstFailingJob(page);
+
+  await expect(failingJob).toContainText("Fail");
+  await expect(page.locator(".job-row")).toHaveCount(3);
+});

--- a/docs/screenshots/tests/review-selection.ts
+++ b/docs/screenshots/tests/review-selection.ts
@@ -1,0 +1,25 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+export async function findFirstFailingJob(page: Page): Promise<Locator> {
+  const jobRows = page.locator(".job-row");
+  const failingJob = page.locator(".job-row", {
+    has: page.locator(".verdict-fail"),
+  });
+  const loadMore = page.getByRole("button", {
+    name: "Load more",
+    exact: true,
+  });
+
+  await expect(jobRows.first()).toBeVisible();
+  while ((await failingJob.count()) === 0) {
+    if (!(await loadMore.isVisible())) {
+      throw new Error("No failing review is available for the screenshot");
+    }
+    const loadedCount = await jobRows.count();
+    await loadMore.click();
+    await expect.poll(() => jobRows.count()).toBeGreaterThan(loadedCount);
+  }
+
+  await expect(failingJob.first()).toBeVisible();
+  return failingJob.first();
+}

--- a/docs/screenshots/tests/screenshots.spec.ts
+++ b/docs/screenshots/tests/screenshots.spec.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "@playwright/test";
 import { join } from "node:path";
 
+import { findFirstFailingJob } from "./review-selection";
+
 const outputDir = process.env.SCREENSHOT_DIR ?? "/output";
 
 test("review workspace with an open finding", async ({ page }) => {
@@ -8,11 +10,8 @@ test("review workspace with an open finding", async ({ page }) => {
 
   const jobs = page.getByRole("region", { name: "Review jobs" });
   await expect(jobs).toBeVisible();
-  const failingJob = page.locator(".job-row", {
-    has: page.locator(".verdict-fail"),
-  });
-  await expect(failingJob.first()).toBeVisible();
-  await failingJob.first().click();
+  const failingJob = await findFirstFailingJob(page);
+  await failingJob.click();
 
   await expect(
     page.getByRole("region", { name: "Review details" }),

--- a/docs/screenshots/tests/screenshots.spec.ts
+++ b/docs/screenshots/tests/screenshots.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+import { join } from "node:path";
+
+const outputDir = process.env.SCREENSHOT_DIR ?? "/output";
+
+test("review workspace with an open finding", async ({ page }) => {
+  await page.goto("/reviews");
+
+  const jobs = page.getByRole("region", { name: "Review jobs" });
+  await expect(jobs).toBeVisible();
+  const failingJob = page.locator(".job-row", {
+    has: page.locator(".verdict-fail"),
+  });
+  await expect(failingJob.first()).toBeVisible();
+  await failingJob.first().click();
+
+  await expect(
+    page.getByRole("region", { name: "Review details" }),
+  ).toBeVisible();
+  await expect(page.locator(".review-content")).toBeVisible();
+  await page.waitForTimeout(750);
+
+  await page.screenshot({
+    path: join(outputDir, "web-ui.png"),
+    type: "png",
+    animations: "disabled",
+  });
+});

--- a/docs/screenshots/update-generated-assets-branch.sh
+++ b/docs/screenshots/update-generated-assets-branch.sh
@@ -11,6 +11,7 @@ push=false
 generate=true
 
 expected_assets=(
+  "web-ui.png"
   "tui-hero.svg"
   "tui-queue.svg"
   "tui-review.svg"

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -7,6 +7,10 @@ Roborev includes a browser application in its release packages. It is served by
 the same daemon that owns the review queue and SQLite database, on a separate
 browser-only listener.
 
+<figure class="hero-shot" data-lightbox>
+  <img src="/assets/generated/web-ui.png" alt="Roborev browser application showing the review queue and an open review" loading="eager">
+</figure>
+
 ## Open the Application
 
 For normal local use, install a Roborev release and run:
@@ -39,6 +43,46 @@ The Go module source archive does not contain the generated application assets.
 An installation made with `go install` still provides the CLI and terminal UI,
 but the native browser application requires a release package or a source build
 made with `make build`.
+
+## Reviews Workspace
+
+The Reviews workspace follows the daemon's queue in real time. Use the
+repository and branch picker, status filter, ref search, and closed-review
+toggle to narrow the list. Columns can be sorted after all matching rows are
+loaded. Panel reviews appear as a synthesis row that can be expanded to show its
+individual reviewers.
+
+Select a row to open its detail drawer without leaving the queue. The drawer
+provides:
+
+- rendered review output and existing comments;
+- the persisted agent log and the exact stored prompt;
+- close or reopen, rerun, and eligible cancellation actions; and
+- review-output copying and a comment form.
+
+Available actions depend on both the job and the browser session. For example, a
+running review can be canceled but has no completed output to close, while
+remote sessions have the narrower mutation policy described under
+[Browser Sessions](#browser-sessions).
+
+The most common keyboard controls are:
+
+| Key | Action |
+|-----|--------|
+| `j` / `k` | Move down or up through the queue |
+| `Enter` | Open the selected review |
+| `Left` / `Right` | Collapse or expand a review panel |
+| `/` | Focus ref search |
+| `a` | Close or reopen the open review |
+| `c` | Focus its comment field |
+| `l` / `p` | Show its log or prompt |
+| `y` | Copy its review output |
+| `Esc` | Close the detail drawer |
+| `?` | Show all keyboard shortcuts |
+
+Review deep links and Analytics filters are stored in the URL. They can be
+bookmarked on one daemon, but numeric job IDs and local data are not portable to
+a different daemon.
 
 ## Analytics
 

--- a/scripts/hydrate_assets_test.go
+++ b/scripts/hydrate_assets_test.go
@@ -109,6 +109,25 @@ func TestAssetPublishersRejectUnexpectedFiles(t *testing.T) {
 	}
 }
 
+func TestGeneratedAssetPublisherRequiresBrowserScreenshot(t *testing.T) {
+	tempDir := t.TempDir()
+	repo := filepath.Join(tempDir, "repo")
+	sourceDir := filepath.Join(tempDir, "source")
+	require.NoError(t, os.MkdirAll(repo, 0o755))
+	git(t, repo, "init")
+	writeGeneratedAssets(t, sourceDir, "asset")
+	require.NoError(t, os.Remove(filepath.Join(sourceDir, "web-ui.png")))
+
+	scriptPath := installAssetScript(t, repo, filepath.Join("docs", "screenshots", "update-generated-assets-branch.sh"))
+	cmd := exec.Command("bash", bashPath(t, scriptPath), "--source", bashPath(t, sourceDir))
+	cmd.Dir = repo
+	output, err := cmd.CombinedOutput()
+
+	require.Error(t, err, string(output))
+	assert.Contains(t, string(output), "web-ui.png")
+	assert.Contains(t, string(output), "missing expected asset")
+}
+
 func installAssetScript(t *testing.T, repo, scriptRel string) string {
 	t.Helper()
 	script := readShellScript(t, filepath.Join("..", scriptRel))
@@ -153,6 +172,7 @@ func writeStaticAssets(t *testing.T, dir, content string) {
 func writeGeneratedAssets(t *testing.T, dir, content string) {
 	t.Helper()
 	files := []string{
+		"web-ui.png",
 		"tui-hero.svg",
 		"tui-queue.svg",
 		"tui-review.svg",

--- a/scripts/prepare_demo_db_test.go
+++ b/scripts/prepare_demo_db_test.go
@@ -14,7 +14,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-var docsScreenshotRepos = []string{"roborev", "kata", "msgvault", "agentsview"}
+var docsScreenshotRepos = []string{"roborev"}
 
 func TestPrepareDemoDBUsesCanonicalRepoIdentity(t *testing.T) {
 	tempDir := t.TempDir()
@@ -139,6 +139,24 @@ High: REAL_PUBLIC_REVIEW_FINDING from /Users/Alice/roborev with api_key=abc123'
 	assert.NotContains(t, text, "REAL_PUBLIC_RESPONSE")
 	assert.NotContains(t, text, "TASK_LOCAL_SECRET")
 	assert.NotContains(t, text, "DIRTY_LOCAL_SECRET")
+}
+
+func TestPrepareDemoDBRedactsConfiguredPrivateTerms(t *testing.T) {
+	tempDir := t.TempDir()
+	sourceDB := filepath.Join(tempDir, "source.db")
+	db := createScreenshotSourceDB(t, sourceDB)
+	defer db.Close()
+
+	insertScreenshotRepo(t, db, 1, "/public/roborev", "roborev", "git@github.com:kenn-io/roborev.git")
+	insertScreenshotReview(t, db, 1, 1, "PRIVATE_SCREENSHOT_MARKER", 0)
+
+	termsFile := filepath.Join(tempDir, "private-terms.txt")
+	require.NoError(t, os.WriteFile(termsFile, []byte("# local screenshot denylist\nprivate_screenshot_marker\n"), 0o600))
+	demoDB := runPrepareDemoDBWithTerms(t, tempDir, sourceDB, termsFile)
+	text := readScreenshotDemoText(t, demoDB)
+
+	assert.NotContains(t, strings.ToLower(text), "private_screenshot_marker")
+	assert.Contains(t, text, "[REDACTED]")
 }
 
 func TestPrepareDemoDBSelectsOnlyCompletedJobsWithReviewVerdicts(t *testing.T) {
@@ -385,6 +403,11 @@ func insertScreenshotJobWithoutReview(t *testing.T, db *sql.DB, repoID, jobID in
 
 func runPrepareDemoDB(t *testing.T, tempDir, sourceDB string) string {
 	t.Helper()
+	return runPrepareDemoDBWithTerms(t, tempDir, sourceDB, "")
+}
+
+func runPrepareDemoDBWithTerms(t *testing.T, tempDir, sourceDB, termsFile string) string {
+	t.Helper()
 
 	script := readShellScript(t, filepath.Join("..", "docs", "screenshots", "prepare-demo-db.sh"))
 	scriptPath := filepath.Join(tempDir, "prepare-demo-db.sh")
@@ -393,13 +416,16 @@ func runPrepareDemoDB(t *testing.T, tempDir, sourceDB string) string {
 	homeDir := filepath.Join(tempDir, "maintainer-home")
 	require.NoError(t, os.MkdirAll(homeDir, 0o755))
 
+	environment := "export TMPDIR=" + shellQuote(bashPath(t, tempDir)) +
+		" ROBOREV_DOCS_SOURCE_DB=" + shellQuote(bashPath(t, sourceDB)) +
+		" HOME=" + shellQuote(bashPath(t, homeDir))
+	if termsFile != "" {
+		environment += " KENN_PRIVATE_TERMS_FILE=" + shellQuote(bashPath(t, termsFile))
+	}
 	cmd := exec.Command(
 		"bash",
 		"-lc",
-		"export TMPDIR="+shellQuote(bashPath(t, tempDir))+
-			" ROBOREV_DOCS_SOURCE_DB="+shellQuote(bashPath(t, sourceDB))+
-			" HOME="+shellQuote(bashPath(t, homeDir))+
-			"; exec "+shellQuote(bashPath(t, scriptPath)),
+		environment+"; exec "+shellQuote(bashPath(t, scriptPath)),
 	)
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))


### PR DESCRIPTION
Roborev 0.65.0 adds a second primary review interface and several operator-facing behaviors, but the release documentation still led with the previous terminal UI and did not tell the complete release story.

This makes the native browser application the primary visual on the README and documentation home page, expands the browser and TUI workflow guides, and completes the 0.65.0 changelog with contributor acknowledgements. It also corrects the Homebrew tap path and source-build requirements.

![Roborev browser application showing the review queue and an open review](https://raw.githubusercontent.com/kenn-io/roborev/docs-generated-assets/web-ui.png)

The browser image is reproducible rather than hand-edited. The Dockerized capture builds the branch application and drives it at a fixed viewport with Playwright. Its reduced database is limited to completed reviews from the canonical public Roborev repository and sanitizes local paths, credential-shaped values, and configured private terms before the daemon starts.

This PR documents existing 0.65.0 behavior. It does not change the daemon, browser application, or review lifecycle; the executable changes are limited to documentation asset generation and its regression coverage.
