### PR TITLE
Fix streamed Grok text wrapping in TUI logs

### DIFF
--- a/cmd/roborev/tui/fetch.go
+++ b/cmd/roborev/tui/fetch.go
@@ -1050,8 +1050,10 @@ func (m model) fetchJobLog(jobID int64) tea.Cmd {
 			isIncremental = false
 		}
 
-		// No new data — return early with current state
-		if newOffset == offset && isIncremental {
+		// No new data while streaming — return early with current state.
+		// A terminal poll must still finish the persistent formatter so any
+		// buffered response text is emitted even when the body is empty.
+		if newOffset == offset && isIncremental && hasMore {
 			return logOutputMsg{
 				hasMore:   hasMore,
 				newOffset: newOffset,
@@ -1165,8 +1167,10 @@ func (m model) fetchPaneLog(jobID int64) tea.Cmd {
 			isIncremental = false
 		}
 
-		// No new data — return early with current state
-		if newOffset == offset && isIncremental {
+		// No new data while streaming — return early with current state.
+		// A terminal poll must still finish the persistent formatter so any
+		// buffered response text is emitted even when the body is empty.
+		if newOffset == offset && isIncremental && hasMore {
 			return paneLogOutputMsg{
 				jobID:     jobID,
 				hasMore:   hasMore,
@@ -1191,9 +1195,11 @@ func (m model) fetchPaneLog(jobID int64) tea.Cmd {
 			)
 		}
 
-		if err := streamfmt.RenderLogWith(
-			resp.Body, renderFmtr, &buf,
-		); err != nil {
+		renderLog := streamfmt.RenderLogWith
+		if hasMore {
+			renderLog = streamfmt.RenderLogChunkWith
+		}
+		if err := renderLog(resp.Body, renderFmtr, &buf); err != nil {
 			return paneLogOutputMsg{jobID: jobID, err: err, seq: seq}
 		}
 

--- a/cmd/roborev/tui/fetch.go
+++ b/cmd/roborev/tui/fetch.go
@@ -1075,9 +1075,11 @@ func (m model) fetchJobLog(jobID int64) tea.Cmd {
 			)
 		}
 
-		if err := streamfmt.RenderLogWith(
-			resp.Body, renderFmtr, &buf,
-		); err != nil {
+		renderLog := streamfmt.RenderLogWith
+		if hasMore {
+			renderLog = streamfmt.RenderLogChunkWith
+		}
+		if err := renderLog(resp.Body, renderFmtr, &buf); err != nil {
 			return logOutputMsg{err: err, seq: seq}
 		}
 

--- a/cmd/roborev/tui/review_log_test.go
+++ b/cmd/roborev/tui/review_log_test.go
@@ -2,10 +2,12 @@ package tui
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/mattn/go-runewidth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -135,6 +137,112 @@ func TestTUILogLoadingGuard(t *testing.T) {
 
 	assert.Nil(t, cmd)
 	assert.True(t, m2.logLoading)
+}
+
+func TestTUILogFetchWrapsChunkedGrokTextAtPaneWidth(t *testing.T) {
+	// If adjacent Grok response chunks are rendered as separate messages,
+	// wide TUI log panes show one token per row and hide most of the review.
+	const response = "This commit is an empty live fire probe."
+	events := strings.Join([]string{
+		`{"type":"text","data":"This"}`,
+		`{"type":"text","data":" commit"}`,
+		`{"type":"text","data":" is an"}`,
+		`{"type":"text","data":" empty live"}`,
+		`{"type":"text","data":" fire probe."}`,
+		`{"type":"end","stopReason":"EndTurn"}`,
+	}, "\n") + "\n"
+
+	tests := []struct {
+		name      string
+		width     int
+		wantLines int
+	}{
+		{name: "wide pane", width: 80, wantLines: 1},
+		{name: "narrow pane", width: 18, wantLines: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			_, m := mockServerModel(t, func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("X-Job-Status", "done")
+				_, _ = fmt.Fprint(w, events)
+			})
+			m.currentView = viewLog
+			m.logJobID = 42
+			m.width = tt.width
+			m.height = 24
+
+			msg, ok := m.fetchJobLog(42)().(logOutputMsg)
+			require.True(t, ok)
+			require.NoError(t, msg.err)
+			require.NotNil(t, msg.fmtr)
+			assert.Equal(tt.width, msg.fmtr.Width())
+
+			var lines []string
+			for _, line := range msg.lines {
+				plain := strings.TrimSpace(streamfmt.StripANSI(line.text))
+				if plain == "" {
+					continue
+				}
+				lines = append(lines, plain)
+				assert.LessOrEqual(runewidth.StringWidth(plain), tt.width)
+			}
+
+			assert.Equal(response, strings.Join(lines, " "))
+			assert.Len(lines, tt.wantLines)
+		})
+	}
+}
+
+func TestTUILogFetchKeepsGrokTextChunksTogetherAcrossPolls(t *testing.T) {
+	// If a live-log poll finalizes Grok text before the response event ends,
+	// users still get one short row per poll after the job completes.
+	const response = "This commit is an empty live fire probe."
+	_, m := mockServerModel(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("offset") {
+		case "0":
+			w.Header().Set("X-Job-Status", "running")
+			w.Header().Set("X-Log-Offset", "40")
+			_, _ = fmt.Fprint(w, strings.Join([]string{
+				`{"type":"text","data":"This"}`,
+				`{"type":"text","data":" commit"}`,
+			}, "\n")+"\n")
+		case "40":
+			w.Header().Set("X-Job-Status", "done")
+			w.Header().Set("X-Log-Offset", "100")
+			_, _ = fmt.Fprint(w, strings.Join([]string{
+				`{"type":"text","data":" is an empty"}`,
+				`{"type":"text","data":" live fire probe."}`,
+				`{"type":"end","stopReason":"EndTurn"}`,
+			}, "\n")+"\n")
+		default:
+			http.Error(w, "unexpected offset", http.StatusBadRequest)
+		}
+	})
+	m.currentView = viewLog
+	m.logJobID = 42
+	m.width = 80
+	m.height = 24
+
+	first, ok := m.fetchJobLog(42)().(logOutputMsg)
+	require.True(t, ok)
+	require.NoError(t, first.err)
+	m, _ = updateModel(t, m, first)
+
+	second, ok := m.fetchJobLog(42)().(logOutputMsg)
+	require.True(t, ok)
+	require.NoError(t, second.err)
+	m, _ = updateModel(t, m, second)
+
+	var lines []string
+	for _, line := range m.logLines {
+		plain := strings.TrimSpace(streamfmt.StripANSI(line.text))
+		if plain != "" {
+			lines = append(lines, plain)
+		}
+	}
+	assert.Equal(t, []string{response}, lines)
 }
 
 func TestTUILogErrorDroppedOutsideLogView(t *testing.T) {

--- a/cmd/roborev/tui/review_log_test.go
+++ b/cmd/roborev/tui/review_log_test.go
@@ -245,6 +245,104 @@ func TestTUILogFetchKeepsGrokTextChunksTogetherAcrossPolls(t *testing.T) {
 	assert.Equal(t, []string{response}, lines)
 }
 
+func TestTUILogFetchFlushesBufferedGrokTextAfterEmptyFinalPoll(t *testing.T) {
+	// If the terminal poll carries no new bytes, an early return can stop the
+	// poll chain without flushing Grok text buffered by the running poll.
+	assert := assert.New(t)
+	require := require.New(t)
+	const response = "This response spans polls."
+	_, m := mockServerModel(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("offset") {
+		case "0":
+			w.Header().Set("X-Job-Status", "running")
+			w.Header().Set("X-Log-Offset", "40")
+			_, _ = fmt.Fprint(w, strings.Join([]string{
+				`{"type":"text","data":"This response"}`,
+				`{"type":"text","data":" spans polls."}`,
+			}, "\n")+"\n")
+		case "40":
+			w.Header().Set("X-Job-Status", "done")
+			w.Header().Set("X-Log-Offset", "40")
+		default:
+			http.Error(w, "unexpected offset", http.StatusBadRequest)
+		}
+	})
+	m.currentView = viewLog
+	m.logJobID = 42
+	m.width = 80
+	m.height = 24
+
+	first, ok := m.fetchJobLog(42)().(logOutputMsg)
+	require.True(ok)
+	require.NoError(first.err)
+	m, _ = updateModel(t, m, first)
+	require.Empty(m.logLines)
+	require.True(m.logStreaming)
+
+	second, ok := m.fetchJobLog(42)().(logOutputMsg)
+	require.True(ok)
+	require.NoError(second.err)
+	m, _ = updateModel(t, m, second)
+
+	var lines []string
+	for _, line := range m.logLines {
+		plain := strings.TrimSpace(streamfmt.StripANSI(line.text))
+		if plain != "" {
+			lines = append(lines, plain)
+		}
+	}
+	assert.Equal([]string{response}, lines)
+}
+
+func TestTUIPaneLogFetchKeepsGrokTextChunksTogetherAcrossPolls(t *testing.T) {
+	// If each running split-pane poll finalizes its formatter, one Grok
+	// response is rendered as several poll-sized rows instead of one message.
+	assert := assert.New(t)
+	require := require.New(t)
+	const response = "This response spans polls."
+	_, m := mockServerModel(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("offset") {
+		case "0":
+			w.Header().Set("X-Job-Status", "running")
+			w.Header().Set("X-Log-Offset", "40")
+			_, _ = fmt.Fprintln(w, `{"type":"text","data":"This response"}`)
+		case "40":
+			w.Header().Set("X-Job-Status", "running")
+			w.Header().Set("X-Log-Offset", "80")
+			_, _ = fmt.Fprintln(w, `{"type":"text","data":" spans polls."}`)
+		case "80":
+			w.Header().Set("X-Job-Status", "done")
+			w.Header().Set("X-Log-Offset", "100")
+			_, _ = fmt.Fprintln(w, `{"type":"end","stopReason":"EndTurn"}`)
+		default:
+			http.Error(w, "unexpected offset", http.StatusBadRequest)
+		}
+	})
+	m.currentView = viewQueue
+	m.layout = layoutSplit
+	m.width = 150
+	m.height = 40
+	m.selectedJobID = 42
+	m.paneLogJobID = 42
+	m.paneLogStreaming = true
+
+	for range 3 {
+		msg, ok := m.fetchPaneLog(42)().(paneLogOutputMsg)
+		require.True(ok)
+		require.NoError(msg.err)
+		m, _ = updateModel(t, m, msg)
+	}
+
+	var lines []string
+	for _, line := range m.paneLogLines {
+		plain := strings.TrimSpace(streamfmt.StripANSI(line.text))
+		if plain != "" {
+			lines = append(lines, plain)
+		}
+	}
+	assert.Equal([]string{response}, lines)
+}
+
 func TestTUILogErrorDroppedOutsideLogView(t *testing.T) {
 	m := newModel(localhostEndpoint, withExternalIODisabled())
 	m.currentView = viewQueue

--- a/internal/streamfmt/grok_test.go
+++ b/internal/streamfmt/grok_test.go
@@ -13,6 +13,7 @@ func TestFormatter_GrokRendering(t *testing.T) {
 	t.Run("text data", func(t *testing.T) {
 		fix := newFixture(true)
 		fix.writeLine(`{"type":"text","data":"Hello review"}`)
+		fix.writeLine(`{"type":"end","stopReason":"EndTurn"}`)
 		fix.assertContains(t, "Hello review")
 	})
 

--- a/internal/streamfmt/streamfmt.go
+++ b/internal/streamfmt/streamfmt.go
@@ -69,6 +69,7 @@ type Formatter struct {
 	// tool_call_update events (which often omit toolName) can still render.
 	grokRenderedToolIDs map[string]struct{}
 	grokToolByID        map[string]grokToolInfo
+	grokText            strings.Builder
 }
 
 // grokToolInfo is metadata captured from a Grok tool_call for later updates.
@@ -196,6 +197,13 @@ func (f *Formatter) Write(p []byte) (int, error) {
 
 // Flush writes any remaining buffered content.
 func (f *Formatter) Flush() {
+	f.flushInput()
+	f.flushGrokText()
+}
+
+// flushInput processes a final unterminated input line without finalizing
+// provider state that may continue in a later incremental log chunk.
+func (f *Formatter) flushInput() {
 	if len(f.buf) > 0 {
 		line := string(f.buf)
 		f.buf = nil
@@ -358,8 +366,17 @@ func (f *Formatter) processLine(line string) {
 
 	var ev streamEvent
 	if err := json.Unmarshal([]byte(line), &ev); err != nil {
+		f.flushGrokText()
 		f.writeText(SanitizeControlKeepNewlines(line))
 		return
+	}
+
+	// Grok streaming-json text events are response chunks, not complete
+	// messages. Keep adjacent chunks together so markdown wrapping sees the
+	// response as one document. Any other event is a semantic boundary.
+	isGrokText := ev.Type == "text" && ev.Data != "" && ev.Part == nil
+	if !isGrokText {
+		f.flushGrokText()
 	}
 
 	switch ev.Type {
@@ -406,7 +423,7 @@ func (f *Formatter) processLine(line string) {
 			f.formatToolUse(ev.ToolName, ev.Parameters)
 		case ev.Type == "text" && ev.Data != "":
 			// Grok Build streaming-json assistant text.
-			f.writeText(SanitizeControlKeepNewlines(ev.Data))
+			f.grokText.WriteString(SanitizeControlKeepNewlines(ev.Data))
 		case ev.Type == "reasoning" && ev.Data != "":
 			// Some Grok builds may emit reasoning as type=reasoning.
 			text := strings.TrimSpace(sanitizeControl(ev.Data))
@@ -453,6 +470,15 @@ func (f *Formatter) processLine(line string) {
 	default:
 		// Suppress system, user, and other events
 	}
+}
+
+func (f *Formatter) flushGrokText() {
+	if f.grokText.Len() == 0 {
+		return
+	}
+	text := f.grokText.String()
+	f.grokText.Reset()
+	f.writeText(text)
 }
 
 func (f *Formatter) processGrokToolCall(ev streamEvent) {
@@ -1048,6 +1074,20 @@ func RenderLog(r io.Reader, w io.Writer, isTTY bool) error {
 func RenderLogWith(
 	r io.Reader, fmtr *Formatter, plainW io.Writer,
 ) error {
+	return renderLogWith(r, fmtr, plainW, true)
+}
+
+// RenderLogChunkWith renders an incremental log chunk while retaining
+// provider state that belongs to a response continued by a later chunk.
+func RenderLogChunkWith(
+	r io.Reader, fmtr *Formatter, plainW io.Writer,
+) error {
+	return renderLogWith(r, fmtr, plainW, false)
+}
+
+func renderLogWith(
+	r io.Reader, fmtr *Formatter, plainW io.Writer, final bool,
+) error {
 	br := bufio.NewReader(r)
 	for {
 		line, err := br.ReadString('\n')
@@ -1062,6 +1102,7 @@ func RenderLogWith(
 					return werr
 				}
 			} else {
+				fmtr.flushGrokText()
 				// Non-JSON lines: sanitize ANSI/control sequences
 				// to prevent terminal spoofing from agent stderr,
 				// then word-wrap to the formatter's width.
@@ -1080,6 +1121,7 @@ func RenderLogWith(
 
 			}
 		} else if err != io.EOF {
+			fmtr.flushGrokText()
 			// Preserve blank lines for spacing in rendered output.
 			if _, werr := fmt.Fprintln(plainW); werr != nil {
 				return werr
@@ -1093,7 +1135,14 @@ func RenderLogWith(
 		}
 	}
 
-	fmtr.Flush()
+	if final {
+		fmtr.Flush()
+	} else {
+		fmtr.flushInput()
+	}
+	if fmtr.writeErr != nil {
+		return fmtr.writeErr
+	}
 	return nil
 }
 


### PR DESCRIPTION
Grok Build emits assistant text as adjacent streaming chunks. The TUI treated each chunk as a complete Markdown document, which inserted a line break after every chunk and could reduce a wide log pane to one or a few words per row.

This change keeps adjacent Grok text together until a meaningful stream boundary and carries that buffered response across incremental polling in both the full-screen log and split detail pane. Running polls keep the formatter open; the terminal poll finalizes it even when the daemon has no new bytes to return.

The assembled response still goes through the existing width-aware Markdown renderer, so genuinely narrow panes continue to wrap normally. Non-Grok events and plain stderr remain response boundaries.
