### PR TITLE
Fail jobs promptly after agent process errors

### DIFF
--- a/internal/agent/cli_runner.go
+++ b/internal/agent/cli_runner.go
@@ -3,10 +3,88 @@ package agent
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
+	"sync"
+	"time"
 )
+
+const (
+	// Give os/exec a short output-drain window, then close descriptors inherited
+	// by descendants so they cannot keep an exited agent's stream open.
+	streamingCLIWaitDelay = 250 * time.Millisecond
+	// Bound unread stdout per agent so a stalled parser cannot exhaust daemon
+	// memory. The total stream remains unlimited when the parser keeps up.
+	streamingCLIMaxBufferedOutput = 1 << 20
+)
+
+var errStreamingCLIOutputBacklog = errors.New("agent stdout backlog exceeded 1 MiB limit")
+
+// streamingBuffer lets os/exec drain the process pipe without waiting for the
+// parser. That keeps WaitDelay focused on descriptors held by descendants.
+type streamingBuffer struct {
+	mu     sync.Mutex
+	ready  *sync.Cond
+	buf    bytes.Buffer
+	closed bool
+	err    error
+}
+
+func newStreamingBuffer() *streamingBuffer {
+	b := &streamingBuffer{}
+	b.ready = sync.NewCond(&b.mu)
+	return b
+}
+
+func (b *streamingBuffer) Read(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for b.buf.Len() == 0 && !b.closed {
+		b.ready.Wait()
+	}
+	if b.buf.Len() == 0 {
+		if b.err != nil {
+			return 0, b.err
+		}
+		return 0, io.EOF
+	}
+	return b.buf.Read(p)
+}
+
+func (b *streamingBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.closed {
+		return 0, io.ErrClosedPipe
+	}
+	if len(p) > streamingCLIMaxBufferedOutput-b.buf.Len() {
+		b.err = errStreamingCLIOutputBacklog
+		b.closed = true
+		b.ready.Broadcast()
+		return 0, b.err
+	}
+	n, err := b.buf.Write(p)
+	b.ready.Signal()
+	return n, err
+}
+
+func (b *streamingBuffer) Close() error {
+	b.mu.Lock()
+	b.closed = true
+	b.ready.Broadcast()
+	b.mu.Unlock()
+	return nil
+}
+
+func (b *streamingBuffer) Err() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.err
+}
 
 type streamingCLISpec struct {
 	Name          string
@@ -40,44 +118,56 @@ func runStreamingCLI(ctx context.Context, spec streamingCLISpec) (streamingCLIRe
 	}
 	cmd.Stdin = spec.Stdin
 	tracker := configureSubprocess(cmd)
+	cmd.WaitDelay = streamingCLIWaitDelay
 
 	sw := newSyncWriter(spec.Output)
 
 	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
 	if spec.StreamStderr && sw != nil {
 		cmd.Stderr = io.MultiWriter(&stderrBuf, sw)
-	} else {
-		cmd.Stderr = &stderrBuf
 	}
 
-	stdoutPipe, err := cmd.StdoutPipe()
-	if err != nil {
-		return result, fmt.Errorf("create stdout pipe: %w", err)
-	}
-	stopClosingPipe := closeOnContextDone(ctx, stdoutPipe, tracker)
+	stdout := newStreamingBuffer()
+	defer stdout.Close()
+	cmd.Stdout = stdout
+
+	stopClosingPipe := closeOnContextDone(ctx, stdout, tracker)
 	defer stopClosingPipe()
 
 	if err := cmd.Start(); err != nil {
 		return result, fmt.Errorf("start %s: %w", spec.Name, err)
 	}
 
-	reader := io.Reader(stdoutPipe)
+	var waitErr error
+	waitDone := make(chan struct{})
+	go func() {
+		waitErr = cmd.Wait()
+		_ = stdout.Close()
+		close(waitDone)
+	}()
+
+	reader := io.Reader(stdout)
 	var stdoutBuf bytes.Buffer
 	if spec.CaptureStdout {
-		reader = io.TeeReader(stdoutPipe, &stdoutBuf)
+		reader = io.TeeReader(stdout, &stdoutBuf)
 	}
 
 	result.Result, result.ParseErr = spec.Parse(reader, sw)
 
 	if spec.DrainStdout {
 		if spec.CaptureStdout {
-			_, _ = io.Copy(&stdoutBuf, stdoutPipe)
+			_, _ = io.Copy(&stdoutBuf, stdout)
 		} else {
-			_, _ = io.Copy(io.Discard, stdoutPipe)
+			_, _ = io.Copy(io.Discard, stdout)
 		}
 	}
 
-	result.WaitErr = cmd.Wait()
+	<-waitDone
+	result.WaitErr = waitErr
+	if stdoutErr := stdout.Err(); stdoutErr != nil {
+		result.WaitErr = stdoutErr
+	}
 	result.Stderr = stderrBuf.String()
 	result.Stdout = stdoutBuf.String()
 
@@ -88,6 +178,11 @@ func runStreamingCLI(ctx context.Context, spec streamingCLISpec) (streamingCLIRe
 		if ctxErr := contextProcessError(ctx, tracker, nil, result.ParseErr); ctxErr != nil {
 			return result, ctxErr
 		}
+	}
+	// A descendant-held descriptor is not an agent failure when the direct
+	// process exited successfully and all available output was consumed.
+	if errors.Is(result.WaitErr, exec.ErrWaitDelay) && cmd.ProcessState.Success() {
+		result.WaitErr = nil
 	}
 
 	return result, nil

--- a/internal/agent/cli_runner_test.go
+++ b/internal/agent/cli_runner_test.go
@@ -5,10 +5,85 @@ import (
 	"io"
 	"io/fs"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRunStreamingCLIPreservesOutputWhenParentExitsFirst(t *testing.T) {
+	skipIfWindows(t)
+
+	cmdPath := writeTempCommand(t, `#!/bin/sh
+case "$1" in *etxtbsy*) exit 0;; esac
+(sleep 3 2>/dev/null) &
+printf 'complete\n'
+exit 0
+`)
+	startedAt := time.Now()
+	result, err := runStreamingCLI(context.Background(), streamingCLISpec{
+		Name:    "test",
+		Command: cmdPath,
+		Parse: func(r io.Reader, sw *syncWriter) (string, error) {
+			time.Sleep(50 * time.Millisecond)
+			data, readErr := io.ReadAll(r)
+			return string(data), readErr
+		},
+	})
+
+	require.NoError(t, err)
+	require.NoError(t, result.WaitErr)
+	require.NoError(t, result.ParseErr)
+	assert.Equal(t, "complete\n", result.Result)
+	assert.Less(t, time.Since(startedAt), 1500*time.Millisecond,
+		"runner waited for a descendant-held stdout pipe")
+}
+
+func TestRunStreamingCLIPreservesOutputWhenParserIsSlow(t *testing.T) {
+	skipIfWindows(t)
+
+	cmdPath := writeTempCommand(t, `#!/bin/sh
+case "$1" in *etxtbsy*) exit 0;; esac
+dd if=/dev/zero bs=65536 count=1 2>/dev/null
+`)
+	result, err := runStreamingCLI(context.Background(), streamingCLISpec{
+		Name:    "test",
+		Command: cmdPath,
+		Parse: func(r io.Reader, sw *syncWriter) (string, error) {
+			time.Sleep(2 * streamingCLIWaitDelay)
+			data, readErr := io.ReadAll(r)
+			return string(data), readErr
+		},
+	})
+
+	require.NoError(t, err)
+	require.NoError(t, result.WaitErr)
+	require.NoError(t, result.ParseErr)
+	resultLen := len(result.Result)
+	assert.Equal(t, 65536, resultLen)
+}
+
+func TestRunStreamingCLIFailsWhenStdoutBacklogExceedsLimit(t *testing.T) {
+	skipIfWindows(t)
+
+	cmdPath := writeTempCommand(t, `#!/bin/sh
+case "$1" in *etxtbsy*) exit 0;; esac
+dd if=/dev/zero bs=2097152 count=1 2>/dev/null
+`)
+	result, err := runStreamingCLI(context.Background(), streamingCLISpec{
+		Name:    "test",
+		Command: cmdPath,
+		Parse: func(r io.Reader, sw *syncWriter) (string, error) {
+			time.Sleep(2 * streamingCLIWaitDelay)
+			data, readErr := io.ReadAll(r)
+			return string(data), readErr
+		},
+	})
+
+	require.NoError(t, err)
+	require.Error(t, result.WaitErr)
+	assert.ErrorContains(t, result.WaitErr, "stdout backlog exceeded 1 MiB limit")
+}
 
 func TestRunStreamingCLIPreservesWaitErrWhenContextCancelsAfterParse(t *testing.T) {
 	skipIfWindows(t)

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -345,16 +345,11 @@ func TestCodexReviewWithSessionResumePassesResumeArgs(t *testing.T) {
 func TestCodexReviewTimeoutClosesStdoutPipe(t *testing.T) {
 	skipIfWindows(t)
 
-	prevWaitDelay := subprocessWaitDelay
-	subprocessWaitDelay = 20 * time.Millisecond
-	t.Cleanup(func() {
-		subprocessWaitDelay = prevWaitDelay
-	})
-
 	cmdPath := writeTempCommand(t, `#!/bin/sh
 case "$*" in *--help*) echo "usage --sandbox"; exit 0;; esac
 (sleep 0.2) &
 printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"partial"}}'
+sleep 0.2
 exit 0
 `)
 

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -1870,6 +1870,49 @@ func TestProcessJob_OversizedFinalPromptFailsBeforeAnyAgent(t *testing.T) {
 	assert.Contains(t, updated.Error, "prompt exceeds size limit before agent submission")
 }
 
+func TestProcessJob_NonzeroAgentExitFailsPromptly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("synthetic agent uses a POSIX shell")
+	}
+	assert := assert.New(t)
+
+	commandPath := filepath.Join(t.TempDir(), "codex")
+	require.NoError(t, os.WriteFile(commandPath, []byte(`#!/bin/sh
+case "$1" in *etxtbsy*) exit 0;; esac
+case "$*" in *--help*) echo "usage --sandbox"; exit 0;; esac
+(sleep 3 2>/dev/null) &
+echo '{"type":"thread.started","thread_id":"synthetic"}'
+echo 'synthetic agent failure' >&2
+exit 17
+`), 0o755))
+
+	tc := newWorkerTestContext(t, 1)
+	cfg := config.DefaultConfig()
+	cfg.CodexCmd = commandPath
+	tc.reconfigurePool(cfg)
+	sha := testutil.GetHeadSHA(t, tc.TmpDir)
+	job := tc.createAndClaimJobWithAgent(t, sha, testWorkerID, "codex")
+	job = tc.exhaustRetries(t, job, testWorkerID, "codex")
+	_, eventCh := tc.Broadcaster.Subscribe("")
+
+	startedAt := time.Now()
+	tc.Pool.processJob(testWorkerID, job)
+	elapsed := time.Since(startedAt)
+
+	updated := tc.assertJobStatus(t, job.ID, storage.JobStatusFailed)
+	assert.Less(elapsed, 1500*time.Millisecond,
+		"job waited for a descendant-held stdout pipe after the agent exited")
+	assert.Contains(updated.Error, "exit status 17")
+	assert.NotContains(updated.Error, agentTimeoutErrorPrefix)
+
+	startedEvent, ok := waitForEvent(t, eventCh, time.Second)
+	require.True(t, ok, "expected review.started event")
+	assert.Equal("review.started", startedEvent.Type)
+	failedEvent, ok := waitForEvent(t, eventCh, time.Second)
+	require.True(t, ok, "expected review.failed event")
+	assert.Equal("review.failed", failedEvent.Type)
+}
+
 func TestFailOrRetryAgent_ContextWindowErrorFailsWithoutRetry(t *testing.T) {
 	tc := newWorkerTestContext(t, 1)
 	job := tc.createAndClaimJobWithAgent(t, "context-limit-test", testWorkerID, "codex")


### PR DESCRIPTION
An agent process can exit nonzero while one of its descendants still holds an output descriptor open. The streaming runner previously parsed stdout to end-of-file before waiting for the direct process, so the daemon worker could remain running until the job timeout even though the child exit status was already available.

The runner now waits for the direct process alongside stream parsing and lets `os/exec` own process-pipe draining. A small in-memory streaming buffer decouples that draining from parser speed, so `WaitDelay` can release descriptors held by descendants without truncating a successful result. Nonzero exits continue through the established retry and failed-job path, while explicit context cancellation remains canceled.

Unread stdout is capped at 1 MiB. A stalled parser paired with a runaway agent now fails with a clear error instead of growing daemon memory without limit. Parsers that keep up can still consume streams of any total size.

The behavioral regressions use a synthetic agent that exits 17 while a descendant retains stdout, a successful agent whose parser pauses beyond `WaitDelay`, and a 2 MiB producer that exceeds the unread backlog limit. They require prompt `failed` storage and event transitions for the nonzero exit, complete output for the successful exit, and an explicit overflow error for the runaway producer. The upstream agent failure itself remains outside roborev's scope.
