### PR TITLE
fix(streamfmt): assemble streamed Grok reasoning

### DIFF
--- a/internal/streamfmt/decoder_grok.go
+++ b/internal/streamfmt/decoder_grok.go
@@ -8,8 +8,17 @@ import (
 type grokDecoder struct {
 	renderedToolIDs map[string]struct{}
 	toolByID        map[string]grokToolInfo
-	text            strings.Builder
+	chunkKind       grokChunkKind
+	chunks          strings.Builder
 }
+
+type grokChunkKind uint8
+
+const (
+	grokChunkNone grokChunkKind = iota
+	grokChunkText
+	grokChunkReasoning
+)
 
 type grokToolInfo struct {
 	name  string
@@ -43,17 +52,16 @@ func (d *grokDecoder) Decode(line string) []Event {
 		)
 	}
 
-	if streamEvent.Type == "text" && streamEvent.Data != "" {
-		d.text.WriteString(streamEvent.Data)
-		return nil
+	switch {
+	case streamEvent.Type == "text" && streamEvent.Data != "":
+		return d.appendChunk(grokChunkText, streamEvent.Data)
+	case (streamEvent.Type == "thought" ||
+		streamEvent.Type == "reasoning") && streamEvent.Data != "":
+		return d.appendChunk(grokChunkReasoning, streamEvent.Data)
 	}
 
 	events := d.flushBoundary()
 	switch streamEvent.Type {
-	case "thought", "reasoning":
-		if text := strings.TrimSpace(streamEvent.Data); text != "" {
-			events = append(events, Event{Kind: EventReasoning, Text: text})
-		}
 	case "tool_call":
 		if event, ok := d.decodeToolCall(streamEvent); ok {
 			events = append(events, event)
@@ -81,24 +89,38 @@ func (d *grokDecoder) Decode(line string) []Event {
 }
 
 func (d *grokDecoder) Flush() []Event {
-	if d.text.Len() == 0 {
+	if d.chunks.Len() == 0 {
+		d.chunkKind = grokChunkNone
 		return nil
 	}
-	text := d.text.String()
-	d.text.Reset()
-	return []Event{{Kind: EventText, Text: text}}
+	kind := EventText
+	if d.chunkKind == grokChunkReasoning {
+		kind = EventReasoningBlock
+	}
+	text := d.chunks.String()
+	d.chunks.Reset()
+	d.chunkKind = grokChunkNone
+	return []Event{{Kind: kind, Text: text}}
+}
+
+func (d *grokDecoder) appendChunk(
+	kind grokChunkKind, text string,
+) []Event {
+	var events []Event
+	if d.chunkKind != grokChunkNone && d.chunkKind != kind {
+		events = d.flushBoundary()
+	}
+	d.chunkKind = kind
+	d.chunks.WriteString(text)
+	return events
 }
 
 func (d *grokDecoder) flushBoundary() []Event {
-	if d.text.Len() == 0 {
+	events := d.Flush()
+	if len(events) == 0 {
 		return nil
 	}
-	text := d.text.String()
-	d.text.Reset()
-	return []Event{
-		{Kind: EventText, Text: text},
-		{Kind: EventBoundary},
-	}
+	return append(events, Event{Kind: EventBoundary})
 }
 
 func (d *grokDecoder) decodeToolCall(

--- a/internal/streamfmt/event.go
+++ b/internal/streamfmt/event.go
@@ -7,6 +7,7 @@ const (
 	EventBoundary EventKind = iota
 	EventText
 	EventReasoning
+	EventReasoningBlock
 	EventTool
 	EventLiteral
 )

--- a/internal/streamfmt/grok_test.go
+++ b/internal/streamfmt/grok_test.go
@@ -22,6 +22,7 @@ func TestFormatter_GrokRendering(t *testing.T) {
 	t.Run("thought as reasoning", func(t *testing.T) {
 		fix := newFixture(true, "grok")
 		fix.writeLine(`{"type":"thought","data":"considering the diff"}`)
+		fix.writeLine(`{"type":"end"}`)
 		fix.assertContains(t, "considering the diff")
 	})
 
@@ -187,6 +188,88 @@ func TestGrokDecoderKeepsAdjacentTextAcrossIncrementalChunks(t *testing.T) {
 	plain := StripANSI(out.String())
 	assert.Contains(t, plain, "adjacent text")
 	assert.NotContains(t, plain, "**")
+}
+
+// If Grok thought frames are rendered independently, token-sized provider
+// chunks consume one terminal row each instead of wrapping as prose.
+func TestGrokThoughtChunksRenderAsWrappedProse(t *testing.T) {
+	tests := []struct {
+		name  string
+		width int
+		want  []string
+	}{
+		{
+			name:  "wide",
+			width: 80,
+			want:  []string{"This synthetic reasoning flows as normal prose."},
+		},
+		{
+			name:  "narrow",
+			width: 24,
+			want: []string{
+				"This synthetic",
+				"reasoning flows as",
+				"normal prose.",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			fmtr := NewWithWidth(
+				&out, tt.width, GlamourStyle(), DecoderForAgent("grok"),
+			)
+
+			require.NoError(t, RenderLogChunkWith(
+				strings.NewReader(strings.Join([]string{
+					`{"type":"thought","data":"This synthetic"}`,
+					`{"type":"thought","data":" reasoning flows"}`,
+				}, "\n")+"\n"),
+				fmtr,
+			))
+			assert.Empty(t, out.String())
+			require.NoError(t, RenderLogWith(
+				strings.NewReader(strings.Join([]string{
+					`{"type":"thought","data":" as normal prose."}`,
+					`{"type":"end"}`,
+				}, "\n")+"\n"),
+				fmtr,
+			))
+
+			plain := strings.TrimSuffix(StripANSI(out.String()), "\n")
+			assert.Equal(t, tt.want, strings.Split(plain, "\n"))
+		})
+	}
+}
+
+// If Grok thought assembly normalizes whitespace, intentional paragraphs and
+// structured blocks collapse into one line.
+func TestGrokThoughtChunksPreserveStructuredLineBreaks(t *testing.T) {
+	var out bytes.Buffer
+	fmtr := NewWithWidth(
+		&out, 80, GlamourStyle(), DecoderForAgent("grok"),
+	)
+	input := strings.Join([]string{
+		`{"type":"thought","data":"Inspection notes:\n\n"}`,
+		`{"type":"thought","data":"- branch A\n- branch B\n\n"}`,
+		"{\"type\":\"thought\",\"data\":\"```text\\nstatus: ok\\n```\"}",
+		`{"type":"end"}`,
+	}, "\n") + "\n"
+
+	require.NoError(t, RenderLogWith(strings.NewReader(input), fmtr))
+
+	assert.Equal(t, strings.Join([]string{
+		"Inspection notes:",
+		"",
+		"- branch A",
+		"- branch B",
+		"",
+		"```text",
+		"status: ok",
+		"```",
+		"",
+	}, "\n"), StripANSI(out.String()))
 }
 
 func TestDecodeClaudeMessage_RejectsString(t *testing.T) {

--- a/internal/streamfmt/renderer_stream.go
+++ b/internal/streamfmt/renderer_stream.go
@@ -59,6 +59,8 @@ func (r *Renderer) Render(events []Event) {
 			r.writeText(event.Text)
 		case EventReasoning:
 			r.writeReasoning(event.Text)
+		case EventReasoningBlock:
+			r.writeReasoningBlock(event.Text)
 		case EventTool:
 			r.writeTool(event.Name, event.Arg)
 		case EventLiteral:
@@ -155,6 +157,30 @@ func (r *Renderer) writeReasoning(text string) {
 	r.lastWasTool = false
 	r.hasOutput = true
 	r.writef("%s\n", sfReasoningStyle.Render(text))
+}
+
+func (r *Renderer) writeReasoningBlock(text string) {
+	text = strings.TrimSpace(SanitizeControlKeepNewlines(text))
+	if text == "" {
+		return
+	}
+	if r.lastWasTool && r.hasOutput {
+		r.writef("\n")
+	}
+	r.lastWasTool = false
+	r.hasOutput = true
+
+	lines := strings.Split(text, "\n")
+	if r.width > 0 {
+		lines = WrapText(text, r.width)
+	}
+	for _, line := range lines {
+		if line == "" {
+			r.writef("\n")
+			continue
+		}
+		r.writef("%s\n", sfReasoningStyle.Render(line))
+	}
 }
 
 func (r *Renderer) writeTool(name, arg string) {


### PR DESCRIPTION
Live Grok logs rendered each chain-of-thought fragment as its own terminal row. The provider adapter and daemon preserved the raw events correctly, but the Grok stream decoder treated every `thought` frame as a complete one-line reasoning summary. The existing chunk assembly covered `text` events only.

This change accumulates adjacent Grok `thought` and `reasoning` frames until a semantic event boundary, then renders the completed reasoning block at the pane width. Explicit paragraphs and structured line breaks remain intact. Compact summaries from other providers and tool events keep their existing behavior.
