### PR TITLE
fix(agent): pass large Antigravity prompts on stdin and allow pwd

### DIFF
--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -182,17 +182,21 @@ npm install -g @google/gemini-cli
 
 Antigravity runs in print mode — the prompt is passed via `--prompt` on `agy` >=
 1.1.1 and piped over stdin with a bare `--print` on older versions (roborev
-probes `agy --version` to pick the contract). Review jobs get `--sandbox`;
-agentic jobs get `--dangerously-skip-permissions`.
+probes `agy --version` to pick the contract). Review jobs omit both `--sandbox`
+and `--dangerously-skip-permissions`; agentic jobs use
+`--dangerously-skip-permissions`. Omitting `--sandbox` is intentional because
+agy's print-mode sandbox can deny the read-only workspace probes that reviews
+need.
 
 Since
 [agy 1.1.3](https://github.com/google-antigravity/antigravity-cli/releases/tag/1.1.3),
 print mode soft-denies tool calls that would need a permission confirmation
-instead of silently auto-approving them. Sandboxed review jobs hit this on the
-model's first tool call — typically a file read or a terminal command: agy exits
-cleanly having produced no review, and roborev fails the job (retrying, then
-failing over to a configured backup agent when one is available). To unblock
-reviews, add allow-rules to `~/.gemini/antigravity-cli/settings.json`:
+instead of silently auto-approving them. Reviews can hit this on the model's
+first tool call — typically a file read or a terminal command: agy exits cleanly
+having produced no review, and roborev fails the job (retrying, then failing
+over to a configured backup agent when one is available). Before each
+non-agentic review, roborev automatically merges the required allow-rules into
+`~/.gemini/antigravity-cli/settings.json`:
 
 ```json
 {
@@ -200,17 +204,22 @@ reviews, add allow-rules to `~/.gemini/antigravity-cli/settings.json`:
     "allow": [
       "read_file(*)",
       "command(pwd)",
-      "command(ls)"
+      "command(wc)",
+      "command(ls)",
+      "command(cat)",
+      "command(head)",
+      "command(tail)",
+      "command(stat)",
+      "command(file)"
     ]
   }
 }
 ```
 
-`read_file(*)` is the rule that matters: agy's native read tools (view file,
-search, list directory) do the real work of a review once file reads are
-allowed. The `command` rules only keep a stray `pwd` or `ls` from aborting the
-run — under `--sandbox`, shell commands are confined to agy's scratch directory
-anyway.
+Roborev preserves existing settings and allow entries, appending only missing
+rules. `read_file(*)` is the rule that matters: agy's native read tools (view
+file, search, list directory) do the real work of a review once file reads are
+allowed. The `command` rules keep inspect commands from aborting the run.
 
 These rules are global to every agy session, and command targets are prefix
 matchers (see the
@@ -218,10 +227,16 @@ matchers (see the
 treat any `command(...)` rule as broad shell authority rather than a read-only
 grant. The same global scope applies to `read_file(*)`, which auto-approves
 reads of any path on the system — narrow its target to your source roots if that
-is broader than you want. If a review still aborts on a `command` denial, allow
-that specific command; avoid `command(*)`, and do not add `unsandboxed(*)` — it
-lifts the sandbox confinement for every agy use. Agentic jobs are unaffected:
+is broader than you want. Review jobs run without agy's OS-level `--sandbox`, so
+these command permissions are not confined to agy's scratch directory. Avoid
+`command(*)` and `unsandboxed(*)`, which broaden permission scope further.
+Agentic jobs are unaffected by this merge because
 `--dangerously-skip-permissions` auto-approves all tools.
+
+Roborev does not currently provide an opt-out for the automatic settings merge
+when using `agy`. To avoid Antigravity's global settings and unsandboxed review
+path, pin the legacy CLI with `gemini_cmd = "gemini"` in your config, or choose
+another agent.
 
 Antigravity does not currently accept a `--model` flag, so an explicit `--model`
 returns an error whenever the Gemini agent resolves to `agy` — even when the

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-git/go-git/v5 v5.19.2
 	github.com/go-playground/validator/v10 v10.30.3
+	github.com/gofrs/flock v0.13.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v90 v90.0.0
 	github.com/google/uuid v1.6.0
@@ -73,7 +74,6 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
-	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -20,7 +20,17 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	os.Exit(testenv.RunIsolatedMain(m))
+	dir, err := os.MkdirTemp("", "roborev-agy-settings-*")
+	if err == nil {
+		antigravitySettingsPathForTest = func() string {
+			return filepath.Join(dir, ".gemini", "antigravity-cli", "settings.json")
+		}
+	}
+	code := testenv.RunIsolatedMain(m)
+	if dir != "" {
+		_ = os.RemoveAll(dir)
+	}
+	os.Exit(code)
 }
 
 func TestAgentRegistry(t *testing.T) {

--- a/internal/agent/antigravity_settings.go
+++ b/internal/agent/antigravity_settings.go
@@ -1,0 +1,284 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gofrs/flock"
+)
+
+// Official agy settings path. There is no documented --settings flag or env
+// override that headless print-mode honors; permissions are read from
+// ~/.gemini/antigravity-cli/settings.json.
+// See https://antigravity.google/docs/cli/permissions/
+func defaultAntigravitySettingsPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".gemini", "antigravity-cli", "settings.json")
+}
+
+// antigravitySettingsPathForTest, when set, redirects settings writes away
+// from the developer's real ~/.gemini tree (agent tests do not isolate HOME).
+var antigravitySettingsPathForTest func() string
+
+func antigravitySettingsPath() string {
+	if antigravitySettingsPathForTest != nil {
+		return antigravitySettingsPathForTest()
+	}
+	return defaultAntigravitySettingsPath()
+}
+
+// Inspect commands reviews run (pwd/wc/ls/...) must be allowlisted. In
+// headless print mode, unconfigured command() actions default to Ask and
+// are soft-denied or hard-fail with "permission check failed for command".
+var antigravityReviewAllowPermissions = []string{
+	"read_file(*)",
+	"command(pwd)",
+	"command(wc)",
+	"command(ls)",
+	"command(cat)",
+	"command(head)",
+	"command(tail)",
+	"command(stat)",
+	"command(file)",
+}
+
+var antigravitySettingsGate = make(chan struct{}, 1)
+
+const antigravitySettingsLockRetryDelay = 10 * time.Millisecond
+
+// ensureAntigravityReviewPermissions merges the allow-rules non-agentic
+// reviews need into settings.json. Existing keys and allow entries are
+// preserved; only missing allow strings are appended. Invalid JSON is
+// left untouched.
+func ensureAntigravityReviewPermissions(ctx context.Context, settingsPath string) (err error) {
+	if settingsPath == "" {
+		return nil
+	}
+
+	select {
+	case antigravitySettingsGate <- struct{}{}:
+		defer func() { <-antigravitySettingsGate }()
+	case <-ctx.Done():
+		return fmt.Errorf("acquire settings lock: %w", ctx.Err())
+	}
+
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		return fmt.Errorf("prepare %s: %w", settingsPath, err)
+	}
+	lockPath := settingsPath + ".lock"
+	lock := flock.New(lockPath, flock.SetPermissions(0o600))
+	locked, err := lock.TryLockContext(ctx, antigravitySettingsLockRetryDelay)
+	if err != nil {
+		_ = lock.Close()
+		return fmt.Errorf("lock %s: %w", lockPath, err)
+	}
+	if !locked {
+		_ = lock.Close()
+		return fmt.Errorf("lock %s: %w", lockPath, ctx.Err())
+	}
+	defer func() {
+		if unlockErr := lock.Unlock(); unlockErr != nil {
+			err = errors.Join(err, fmt.Errorf("unlock %s: %w", lockPath, unlockErr))
+		}
+		if closeErr := lock.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close %s: %w", lockPath, closeErr))
+		}
+	}()
+
+	doc := map[string]any{}
+	raw, err := os.ReadFile(settingsPath)
+	switch {
+	case err == nil:
+		if trimmed := trimSpaceBytes(raw); len(trimmed) > 0 {
+			decoder := json.NewDecoder(bytes.NewReader(raw))
+			decoder.UseNumber()
+			if err := decoder.Decode(&doc); err != nil {
+				return fmt.Errorf("parse %s: %w", settingsPath, err)
+			}
+			if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+				if err == nil {
+					err = errors.New("multiple JSON values")
+				}
+				return fmt.Errorf("parse %s: %w", settingsPath, err)
+			}
+			if doc == nil {
+				doc = map[string]any{}
+			}
+		}
+	case os.IsNotExist(err):
+		// create below
+	default:
+		return fmt.Errorf("read %s: %w", settingsPath, err)
+	}
+
+	permissions, err := settingsObject(doc, "permissions")
+	if err != nil {
+		return fmt.Errorf("%s: %w", settingsPath, err)
+	}
+	doc["permissions"] = permissions
+
+	allow, changed, err := mergeAllowList(permissions["allow"], antigravityReviewAllowPermissions)
+	if err != nil {
+		return fmt.Errorf("%s permissions.allow: %w", settingsPath, err)
+	}
+	if !changed && fileExists(settingsPath) {
+		return nil
+	}
+	permissions["allow"] = allow
+
+	if err := writeSettingsJSON(settingsPath, doc); err != nil {
+		return fmt.Errorf("write %s: %w", settingsPath, err)
+	}
+	return nil
+}
+
+func ensureAntigravityReviewSettings(ctx context.Context) error {
+	path := antigravitySettingsPath()
+	if path == "" {
+		log.Printf("antigravity: skipping settings merge; cannot resolve home directory")
+		return nil
+	}
+	if err := ensureAntigravityReviewPermissions(ctx, path); err != nil {
+		log.Printf("antigravity: could not merge review permissions into %s: %v", path, err)
+		return err
+	}
+	return nil
+}
+
+func settingsObject(doc map[string]any, key string) (map[string]any, error) {
+	raw, ok := doc[key]
+	if !ok || raw == nil {
+		return map[string]any{}, nil
+	}
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s is not a JSON object", key)
+	}
+	return obj, nil
+}
+
+func mergeAllowList(existing any, needed []string) (allow []any, changed bool, err error) {
+	switch v := existing.(type) {
+	case nil:
+		allow = nil
+	case []any:
+		allow = append([]any(nil), v...)
+	default:
+		return nil, false, fmt.Errorf("not a JSON array")
+	}
+
+	have := make(map[string]struct{}, len(allow))
+	for _, item := range allow {
+		s, ok := item.(string)
+		if !ok {
+			continue
+		}
+		have[s] = struct{}{}
+	}
+	for _, rule := range needed {
+		if _, ok := have[rule]; ok {
+			continue
+		}
+		allow = append(allow, rule)
+		have[rule] = struct{}{}
+		changed = true
+	}
+	if existing == nil {
+		changed = true
+	}
+	return allow, changed, nil
+}
+
+func writeSettingsJSON(path string, doc map[string]any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	target, mode, err := settingsWriteTarget(path)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(target), "."+filepath.Base(target)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, target); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+func settingsWriteTarget(path string) (string, os.FileMode, error) {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return path, 0o644, nil
+	}
+	if err != nil {
+		return "", 0, err
+	}
+	target := path
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, err = filepath.EvalSymlinks(path)
+		if err != nil {
+			return "", 0, fmt.Errorf("resolve %s: %w", path, err)
+		}
+	}
+	info, err = os.Stat(target)
+	if os.IsNotExist(err) {
+		return target, 0o644, nil
+	}
+	if err != nil {
+		return "", 0, err
+	}
+	return target, info.Mode().Perm(), nil
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func trimSpaceBytes(b []byte) []byte {
+	i, j := 0, len(b)
+	for i < j && (b[i] == ' ' || b[i] == '\n' || b[i] == '\r' || b[i] == '\t') {
+		i++
+	}
+	for j > i && (b[j-1] == ' ' || b[j-1] == '\n' || b[j-1] == '\r' || b[j-1] == '\t') {
+		j--
+	}
+	return b[i:j]
+}

--- a/internal/agent/antigravity_settings_test.go
+++ b/internal/agent/antigravity_settings_test.go
@@ -1,0 +1,228 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/gofrs/flock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureAntigravityReviewPermissionsCreatesFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+
+	require.NoError(t, ensureAntigravityReviewPermissions(context.Background(), path))
+
+	assertSettingsAllow(t, path, antigravityReviewAllowPermissions...)
+}
+
+func TestEnsureAntigravityReviewPermissionsHandlesNullRoot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	require.NoError(t, os.WriteFile(path, []byte("null\n"), 0o644))
+
+	require.NoError(t, ensureAntigravityReviewPermissions(context.Background(), path))
+	assertSettingsAllow(t, path, antigravityReviewAllowPermissions...)
+}
+
+func TestEnsureAntigravityReviewPermissionsPreservesLargeNumbers(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{
+  "large": 9007199254740993,
+  "permissions": {"allow": []}
+}
+`), 0o644))
+
+	require.NoError(t, ensureAntigravityReviewPermissions(context.Background(), path))
+
+	assert.Contains(t, string(readRaw(t, path)), `"large": 9007199254740993`)
+}
+
+func TestEnsureAntigravityReviewPermissionsPreservesSymlinkAndMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink and permission semantics differ on Windows")
+	}
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.json")
+	path := filepath.Join(dir, "settings.json")
+	writeSettings(t, target, map[string]any{
+		"permissions": map[string]any{"allow": []any{}},
+	})
+	require.NoError(t, os.Chmod(target, 0o600))
+	require.NoError(t, os.Symlink(target, path))
+
+	require.NoError(t, ensureAntigravityReviewPermissions(context.Background(), path))
+
+	linkInfo, err := os.Lstat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.ModeSymlink, linkInfo.Mode()&os.ModeSymlink)
+	targetInfo, err := os.Stat(target)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), targetInfo.Mode().Perm())
+	assertSettingsAllow(t, target, antigravityReviewAllowPermissions...)
+}
+
+func TestEnsureAntigravityReviewPermissionsWaitsForConcurrentWriter(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	writeSettings(t, path, map[string]any{
+		"permissions": map[string]any{"allow": []any{}},
+	})
+
+	lock := flock.New(path+".lock", flock.SetPermissions(0o600))
+	require.NoError(t, lock.Lock())
+	t.Cleanup(func() {
+		_ = lock.Unlock()
+		require.NoError(t, lock.Close())
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- ensureAntigravityReviewPermissions(context.Background(), path)
+	}()
+
+	completed := false
+	select {
+	case err := <-done:
+		completed = true
+		require.NoError(t, err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	require.False(t, completed)
+
+	require.NoError(t, lock.Unlock())
+	require.NoError(t, <-done)
+	assertSettingsAllow(t, path, antigravityReviewAllowPermissions...)
+}
+
+func TestEnsureAntigravityReviewPermissionsMergesAllow(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "settings.json")
+	writeSettings(t, path, map[string]any{
+		"model": "gemini-3.1-pro-preview",
+		"permissions": map[string]any{
+			"allow": []any{"command(git)", "read_file(*)"},
+			"deny":  []any{"command(rm -rf)"},
+			"ask":   []any{"command(*)"},
+		},
+		"enableTerminalSandbox": true,
+	})
+
+	require.NoError(t, ensureAntigravityReviewPermissions(context.Background(), path))
+
+	doc := readSettings(t, path)
+	assert.Equal(t, "gemini-3.1-pro-preview", doc["model"])
+	assert.Equal(t, true, doc["enableTerminalSandbox"])
+
+	permissions := doc["permissions"].(map[string]any)
+	assert.Equal(t, []any{"command(rm -rf)"}, permissions["deny"])
+	assert.Equal(t, []any{"command(*)"}, permissions["ask"])
+
+	allow := asStrings(t, permissions["allow"])
+	assert.Equal(t, "command(git)", allow[0], "existing allow entries stay first")
+	assert.Contains(t, allow, "read_file(*)")
+	assert.Equal(t, 1, countStrings(allow, "read_file(*)"), "do not duplicate existing allows")
+	for _, rule := range antigravityReviewAllowPermissions {
+		assert.Contains(t, allow, rule)
+	}
+}
+
+func TestEnsureAntigravityReviewPermissionsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	require.NoError(t, ensureAntigravityReviewPermissions(context.Background(), path))
+	first := readRaw(t, path)
+
+	require.NoError(t, ensureAntigravityReviewPermissions(context.Background(), path))
+	second := readRaw(t, path)
+	assert.Equal(t, first, second)
+}
+
+func TestEnsureAntigravityReviewPermissionsDoesNotClobberInvalidJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	require.NoError(t, os.WriteFile(path, []byte("{not-json"), 0o644))
+
+	err := ensureAntigravityReviewPermissions(context.Background(), path)
+	require.Error(t, err)
+	assert.Equal(t, "{not-json", string(readRaw(t, path)))
+}
+
+func TestEnsureAntigravityReviewPermissionsRejectsNonObjectPermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	writeSettings(t, path, map[string]any{"permissions": "always-proceed"})
+
+	err := ensureAntigravityReviewPermissions(context.Background(), path)
+	require.Error(t, err)
+	doc := readSettings(t, path)
+	assert.Equal(t, "always-proceed", doc["permissions"])
+}
+
+func TestEnsureAntigravityReviewPermissionsEmptyPathIsNoop(t *testing.T) {
+	require.NoError(t, ensureAntigravityReviewPermissions(context.Background(), ""))
+}
+
+func TestAntigravityReviewAllowPermissionsCoverProdFailures(t *testing.T) {
+	assert.Contains(t, antigravityReviewAllowPermissions, "read_file(*)")
+	for _, cmd := range []string{"pwd", "wc", "ls", "cat", "head", "tail", "stat", "file"} {
+		assert.Contains(t, antigravityReviewAllowPermissions, "command("+cmd+")")
+	}
+}
+
+func writeSettings(t *testing.T, path string, doc map[string]any) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	data, err := json.MarshalIndent(doc, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, append(data, '\n'), 0o644))
+}
+
+func readSettings(t *testing.T, path string) map[string]any {
+	t.Helper()
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(readRaw(t, path), &doc))
+	return doc
+}
+
+func readRaw(t *testing.T, path string) []byte {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return raw
+}
+
+func assertSettingsAllow(t *testing.T, path string, want ...string) {
+	t.Helper()
+	doc := readSettings(t, path)
+	permissions, ok := doc["permissions"].(map[string]any)
+	require.True(t, ok)
+	allow := asStrings(t, permissions["allow"])
+	for _, rule := range want {
+		assert.Contains(t, allow, rule)
+	}
+}
+
+func asStrings(t *testing.T, raw any) []string {
+	t.Helper()
+	items, ok := raw.([]any)
+	require.True(t, ok)
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		s, ok := item.(string)
+		require.True(t, ok)
+		out = append(out, s)
+	}
+	return out
+}
+
+func countStrings(items []string, want string) int {
+	n := 0
+	for _, item := range items {
+		if item == want {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -178,9 +178,10 @@ func (a *GeminiAgent) buildAntigravityArgs(agenticMode bool) []string {
 
 	if agenticMode {
 		args = append(args, "--dangerously-skip-permissions")
-	} else {
-		args = append(args, "--sandbox")
 	}
+	// Non-agentic print-mode reviews omit --sandbox: agy's sandbox permission
+	// gate rejects `pwd` (and similar read-only workspace probes) in headless
+	// print mode. Reviews still do not get --dangerously-skip-permissions.
 
 	return args
 }
@@ -238,23 +239,40 @@ const (
 )
 
 func (a *GeminiAgent) runAntigravity(ctx context.Context, repoPath, prompt string, args []string, output io.Writer) (string, string, error) {
+	// Headless print mode soft-denies tools that need a confirmation. Merge
+	// read_file(*) and inspect command() allows into the official settings
+	// file before launch so reviews emit output. Agentic runs already pass
+	// --dangerously-skip-permissions and do not need this.
+	if !a.Agentic {
+		if err := ensureAntigravityReviewSettings(ctx); err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return "", "", ctxErr
+			}
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return "", "", err
+	}
+
 	// Choose the prompt-carrying flag by agy version: >= 1.1.1 takes the prompt
-	// as the value of --prompt (stdin is ignored); older agy reads it from
-	// stdin with a bare --print. A bare --print on new agy would swallow the
-	// following --print-timeout token as the prompt, so the two forms must not
-	// be mixed.
+	// as the value of --prompt (stdin is ignored when a prompt flag is present);
+	// older agy reads it from stdin with a bare --print. A bare --print on new
+	// agy would swallow the following --print-timeout token as the prompt, so
+	// the two forms must not be mixed.
+	//
+	// Exception: when the prompt exceeds the platform argv cap, omit every
+	// prompt flag (--prompt/--print/-p). New agy still reads a non-TTY stdin
+	// as the prompt if no prompt flag is passed (antigravity-cli#582).
 	trimmedPrompt := strings.TrimRight(prompt, "\n")
 	var finalArgs []string
 	var stdin io.Reader
 	if antigravityPromptViaFlag(ctx, a.Command) {
-		// This contract carries the prompt in argv (agy has no stdin/file
-		// prompt input here), so bound its length to fail with a clear error
-		// rather than an opaque exec failure. The ceiling is platform-specific
-		// (see antigravityMaxPromptArgLen).
 		if size, limit := antigravityPromptArgSize(trimmedPrompt), antigravityMaxPromptArgLen(); size > limit {
-			return "", "", fmt.Errorf("prompt too large for antigravity argv (size %d, max %d on %s)", size, limit, runtime.GOOS)
+			finalArgs = append([]string(nil), args...)
+			stdin = strings.NewReader(trimmedPrompt + "\n")
+		} else {
+			finalArgs = append(append([]string(nil), args...), "--prompt", trimmedPrompt)
 		}
-		finalArgs = append(append([]string(nil), args...), "--prompt", trimmedPrompt)
 	} else {
 		finalArgs = append([]string{"--print"}, args...)
 		stdin = strings.NewReader(trimmedPrompt + "\n")
@@ -361,12 +379,13 @@ func utf16CodeUnits(s string) int {
 }
 
 // antigravityMaxPromptArgLen is the ceiling for antigravityPromptArgSize when
-// the prompt is passed in argv, the only channel agy print mode offers. The
-// limits differ sharply by OS: Windows caps the whole command line at 32767
-// UTF-16 units, Linux caps a single argument at MAX_ARG_STRLEN (128 KiB), and
-// macOS only bounds total argv+env (~1 MiB). The default prompt cap (200 KiB)
-// exceeds the Linux and Windows ceilings, so a large diff fails with a clear
-// error instead of an opaque one.
+// the prompt is passed in argv. Prompts larger than this are delivered on
+// stdin without a --prompt/--print/-p flag: new agy still reads non-TTY stdin
+// when no prompt flag is present (antigravity-cli#582). The limits differ
+// sharply by OS: Windows caps the whole command line at 32767 UTF-16 units,
+// Linux caps a single argument at MAX_ARG_STRLEN (128 KiB), and macOS only
+// bounds total argv+env (~1 MiB). The default prompt cap (200 KiB) exceeds
+// the Linux and Windows ceilings.
 func antigravityMaxPromptArgLen() int {
 	switch runtime.GOOS {
 	case "windows":

--- a/internal/agent/gemini_test.go
+++ b/internal/agent/gemini_test.go
@@ -8,7 +8,9 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/gofrs/flock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -93,27 +95,29 @@ func TestGeminiAntigravityBuildArgs(t *testing.T) {
 	tests := []struct {
 		name         string
 		agentic      bool
-		wantFlag     string
+		wantFlags    []string
 		unwantedArgs []string
 	}{
 		{
-			name:     "ReviewMode",
-			agentic:  false,
-			wantFlag: "--sandbox",
+			name:    "ReviewMode",
+			agentic: false,
+			// Print-mode reviews omit --sandbox so `pwd` is not gated, and
+			// still omit --dangerously-skip-permissions (agentic-only).
 			unwantedArgs: []string{
 				"--output-format",
 				"--approval-mode",
 				"-m",
 				"--dangerously-skip-permissions",
+				"--sandbox",
 				// A bare --print would swallow --print-timeout as the
 				// prompt; the prompt is passed via --prompt at run time.
 				"--print",
 			},
 		},
 		{
-			name:     "AgenticMode",
-			agentic:  true,
-			wantFlag: "--dangerously-skip-permissions",
+			name:      "AgenticMode",
+			agentic:   true,
+			wantFlags: []string{"--dangerously-skip-permissions"},
 			unwantedArgs: []string{
 				"--output-format",
 				"--approval-mode",
@@ -130,12 +134,108 @@ func TestGeminiAntigravityBuildArgs(t *testing.T) {
 			args := a.buildArgs(tc.agentic)
 
 			assertFlagValue(t, args, "--print-timeout", "30m")
-			assert.Contains(t, args, tc.wantFlag)
+			for _, flag := range tc.wantFlags {
+				assert.Contains(t, args, flag)
+			}
 			for _, unwanted := range tc.unwantedArgs {
 				assert.NotContains(t, args, unwanted)
 			}
 		})
 	}
+}
+
+func TestGeminiAntigravityReviewMergesSettingsAndOmitsYolo(t *testing.T) {
+	skipIfWindows(t)
+
+	settingsPath := filepath.Join(t.TempDir(), "settings.json")
+	writeSettings(t, settingsPath, map[string]any{
+		"model": "keep-me",
+		"permissions": map[string]any{
+			"allow": []any{"command(git)"},
+			"deny":  []any{"command(rm -rf)"},
+		},
+	})
+	prev := antigravitySettingsPathForTest
+	antigravitySettingsPathForTest = func() string { return settingsPath }
+	t.Cleanup(func() { antigravitySettingsPathForTest = prev })
+
+	scriptPath := writeTempCommand(t, `#!/bin/sh
+if [ "$1" = "--version" ]; then echo "1.1.1"; exit 0; fi
+printf '%s\n' "$@" > "$ARGS_FILE"
+echo "Review after settings merge"
+`)
+	argsFile := filepath.Join(t.TempDir(), "args")
+	t.Setenv("ARGS_FILE", argsFile)
+	a := NewGeminiAgent(scriptPath)
+	a.Command = filepath.Join(filepath.Dir(scriptPath), "agy")
+	require.NoError(t, os.Rename(scriptPath, a.Command))
+
+	res, err := a.Review(context.Background(), t.TempDir(), "sha", "prompt", &bytes.Buffer{})
+	require.NoError(t, err)
+	assert.Equal(t, "Review after settings merge", res)
+
+	assertSettingsAllow(t, settingsPath, "read_file(*)", "command(wc)", "command(pwd)", "command(git)")
+	doc := readSettings(t, settingsPath)
+	assert.Equal(t, "keep-me", doc["model"])
+	permissions := doc["permissions"].(map[string]any)
+	assert.Equal(t, []any{"command(rm -rf)"}, permissions["deny"])
+
+	argsBytes, readErr := os.ReadFile(argsFile)
+	require.NoError(t, readErr)
+	argsOut := string(argsBytes)
+	assert.NotContains(t, argsOut, "--sandbox\n")
+	assert.NotContains(t, argsOut, "--dangerously-skip-permissions\n")
+}
+
+func TestGeminiAntigravityReviewStopsWhenSettingsLockCanceled(t *testing.T) {
+	skipIfWindows(t)
+
+	settingsPath := filepath.Join(t.TempDir(), "settings.json")
+	writeSettings(t, settingsPath, map[string]any{
+		"permissions": map[string]any{"allow": []any{}},
+	})
+	prev := antigravitySettingsPathForTest
+	antigravitySettingsPathForTest = func() string { return settingsPath }
+	t.Cleanup(func() { antigravitySettingsPathForTest = prev })
+
+	lock := flock.New(settingsPath+".lock", flock.SetPermissions(0o600))
+	require.NoError(t, lock.Lock())
+	t.Cleanup(func() {
+		_ = lock.Unlock()
+		require.NoError(t, lock.Close())
+	})
+
+	invokedPath := filepath.Join(t.TempDir(), "invoked")
+	t.Setenv("INVOKED_PATH", invokedPath)
+	scriptPath := writeTempCommand(t, `#!/bin/sh
+case "$1" in *etxtbsy*) exit 0;; esac
+touch "$INVOKED_PATH"
+exit 0
+`)
+	commandPath := filepath.Join(filepath.Dir(scriptPath), "agy")
+	require.NoError(t, os.Rename(scriptPath, commandPath))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, err := NewGeminiAgent(commandPath).Review(ctx, t.TempDir(), "sha", "prompt", &bytes.Buffer{})
+		done <- err
+	}()
+
+	var reviewErr error
+	require.Eventually(t, func() bool {
+		select {
+		case reviewErr = <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	require.ErrorIs(t, reviewErr, context.DeadlineExceeded)
+
+	_, err := os.Stat(invokedPath)
+	assert.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestGeminiDetectsAntigravityCommandNames(t *testing.T) {
@@ -340,6 +440,8 @@ echo "No issues found."
 	argsOut := string(argsBytes)
 	assert.Contains(t, argsOut, "--prompt\nprompt\n")
 	assert.NotContains(t, argsOut, "--print\n")
+	assert.NotContains(t, argsOut, "--sandbox\n")
+	assert.NotContains(t, argsOut, "--dangerously-skip-permissions\n")
 }
 
 func TestGeminiAntigravityLegacyStdinContract(t *testing.T) {
@@ -471,20 +573,42 @@ func TestUTF16CodeUnits(t *testing.T) {
 func TestGeminiAntigravityPromptTooLargeForArgv(t *testing.T) {
 	skipIfWindows(t)
 
-	// New-contract (flag) path bounds the argv-passed prompt with a clear error.
+	// Overflowing the platform argv cap must not error. New agy (>= 1.1.1)
+	// still reads the prompt from non-TTY stdin when no --prompt/--print/-p
+	// flag is passed (google-antigravity/antigravity-cli#582).
 	scriptPath := writeTempCommand(t, `#!/bin/sh
 if [ "$1" = "--version" ]; then echo "1.1.1"; exit 0; fi
-echo "should not run the review"
+cat > "$STDIN_FILE"
+printf '%s\n' "$@" > "$ARGS_FILE"
+echo "Large prompt review output"
+echo "No issues found."
 `)
+	stdinFile := filepath.Join(t.TempDir(), "stdin")
+	argsFile := filepath.Join(t.TempDir(), "args")
+	t.Setenv("STDIN_FILE", stdinFile)
+	t.Setenv("ARGS_FILE", argsFile)
 	a := NewGeminiAgent(scriptPath)
 	a.Command = filepath.Join(filepath.Dir(scriptPath), "agy")
 	require.NoError(t, os.Rename(scriptPath, a.Command))
 
 	big := strings.Repeat("x", antigravityMaxPromptArgLen()+1)
-	_, err := a.Review(context.Background(), t.TempDir(), "sha", big, &bytes.Buffer{})
+	res, err := a.Review(context.Background(), t.TempDir(), "sha", big, &bytes.Buffer{})
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "too large for antigravity argv")
+	require.NoError(t, err)
+	assert.Equal(t, "Large prompt review output\nNo issues found.", res)
+
+	stdinBytes, readErr := os.ReadFile(stdinFile)
+	require.NoError(t, readErr)
+	assert.Equal(t, big+"\n", string(stdinBytes))
+
+	argsBytes, readErr := os.ReadFile(argsFile)
+	require.NoError(t, readErr)
+	argsOut := string(argsBytes)
+	assert.Contains(t, argsOut, "--print-timeout\n")
+	assert.NotContains(t, argsOut, "--prompt\n")
+	assert.NotContains(t, argsOut, "--print\n")
+	assert.NotContains(t, argsOut, "-p\n")
+	assert.NotContains(t, argsOut, "--sandbox\n")
 }
 
 func TestGeminiAntigravityVersionProbeFailureDefaultsToPromptFlag(t *testing.T) {

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -666,12 +666,9 @@ func (wp *WorkerPool) worker(id int) {
 		}
 
 		// Try to claim a job
-		job, err := wp.db.ClaimJob(workerID)
+		job, err := wp.db.ClaimJobContext(wp.stopCtx, workerID)
 		if err != nil {
-			log.Printf("[%s] Error claiming job: %v", workerID, err)
-			if wp.errorLog != nil {
-				wp.errorLog.LogError("worker", fmt.Sprintf("claim job: %v", err), 0)
-			}
+			wp.noteClaimError(workerID, err)
 			select {
 			case <-wp.stopCh:
 				log.Printf("[%s] Shutting down", workerID)
@@ -711,6 +708,21 @@ func reviewTypeTag(rt string) string {
 		return ""
 	}
 	return rt + " "
+}
+
+// noteClaimError records a ClaimJob failure. SQLITE_BUSY / "database is
+// locked" is lock contention: retry/backoff already happened inside
+// ClaimJob, so do not spam the daemon error log. Empty-queue is silent
+// (nil job, nil error). Real claim failures stay errors.
+func (wp *WorkerPool) noteClaimError(workerID string, err error) {
+	if storage.IsSQLiteBusy(err) {
+		log.Printf("[%s] Claim job deferred (database busy): %v", workerID, err)
+		return
+	}
+	log.Printf("[%s] Error claiming job: %v", workerID, err)
+	if wp.errorLog != nil {
+		wp.errorLog.LogError("worker", fmt.Sprintf("claim job: %v", err), 0)
+	}
 }
 
 func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {

--- a/internal/daemon/worker_claim_test.go
+++ b/internal/daemon/worker_claim_test.go
@@ -1,0 +1,39 @@
+package daemon
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/storage"
+)
+
+func TestNoteClaimErrorSkipsBusy(t *testing.T) {
+	el, _ := createTestErrorLog(t)
+	wp := &WorkerPool{errorLog: el}
+
+	wp.noteClaimError("worker-1", errors.New("database is locked (5) (SQLITE_BUSY)"))
+	assert.Empty(t, el.Recent(), "SQLITE_BUSY must not spam the daemon error log")
+
+	wp.noteClaimError("worker-1", errors.New("disk I/O error"))
+	recent := el.Recent()
+	require.Len(t, recent, 1)
+	assert.Equal(t, "error", recent[0].Level)
+	assert.Equal(t, "worker", recent[0].Component)
+	assert.Contains(t, recent[0].Message, "claim job:")
+	assert.Contains(t, recent[0].Message, "disk I/O error")
+}
+
+func TestNoteClaimErrorNilErrorLogBusy(t *testing.T) {
+	wp := &WorkerPool{}
+	// Must not panic when errorLog is unset (production Start can omit it).
+	wp.noteClaimError("worker-1", errors.New("database is locked"))
+	wp.noteClaimError("worker-1", errors.New("boom"))
+}
+
+func TestIsSQLiteBusyMatchesClaimErrors(t *testing.T) {
+	assert.True(t, storage.IsSQLiteBusy(errors.New("database is locked (5) (SQLITE_BUSY)")))
+	assert.False(t, storage.IsSQLiteBusy(errors.New("disk I/O error")))
+}

--- a/internal/storage/db_job_test.go
+++ b/internal/storage/db_job_test.go
@@ -1,7 +1,9 @@
 package storage
 
 import (
+	"context"
 	"database/sql"
+	"sync"
 	"testing"
 	"time"
 
@@ -93,6 +95,103 @@ func TestClaimJobPersistsPreciseAttemptStart(t *testing.T) {
 	).Scan(&startedAt))
 
 	assert.Regexp(t, `\.\d{9}Z$`, startedAt)
+}
+
+func TestClaimJobRollsBackWhenHydrationFails(t *testing.T) {
+	env := setupJobEnv(t, "/tmp/claim-hydration-rollback", "claim-hydration-rollback")
+	_, err := env.db.Exec(`UPDATE review_jobs SET panel_member_index = ? WHERE id = ?`, "invalid", env.job.ID)
+	require.NoError(t, err)
+
+	claimed, err := env.db.ClaimJob("worker-hydration-rollback")
+	require.Error(t, err)
+	assert.Nil(t, claimed)
+
+	var status string
+	require.NoError(t, env.db.QueryRow(`SELECT status FROM review_jobs WHERE id = ?`, env.job.ID).Scan(&status))
+	assert.Equal(t, string(JobStatusQueued), status)
+}
+
+func TestClaimJobCancellationBeforeCommitRollsBack(t *testing.T) {
+	env := setupJobEnv(t, "/tmp/claim-cancel-before-commit", "claim-cancel-before-commit")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	commitStarted := make(chan struct{})
+	releaseCommit := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseCommit) })
+	}
+	previousHook := claimJobBeforeCommitForTest
+	claimJobBeforeCommitForTest = func() {
+		close(commitStarted)
+		<-releaseCommit
+	}
+	t.Cleanup(func() {
+		release()
+		claimJobBeforeCommitForTest = previousHook
+	})
+
+	resultCh := make(chan struct {
+		job *ReviewJob
+		err error
+	}, 1)
+	go func() {
+		job, err := env.db.ClaimJobContext(ctx, "worker-cancel-before-commit")
+		resultCh <- struct {
+			job *ReviewJob
+			err error
+		}{job: job, err: err}
+	}()
+
+	<-commitStarted
+	cancel()
+	release()
+	result := <-resultCh
+
+	require.ErrorIs(t, result.err, context.Canceled)
+	assert.Nil(t, result.job)
+	var status string
+	require.NoError(t, env.db.QueryRow(
+		`SELECT status FROM review_jobs WHERE id = ?`, env.job.ID,
+	).Scan(&status))
+	assert.Equal(t, string(JobStatusQueued), status)
+}
+
+func TestClaimJobRetriesAfterBusyTransactionTimeout(t *testing.T) {
+	env := setupJobEnv(t, "/tmp/claim-busy-retry", "claim-busy-retry")
+	lockConn, err := env.db.Conn(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, lockConn.Close()) })
+	_, err = lockConn.ExecContext(t.Context(), "BEGIN IMMEDIATE")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	resultCh := make(chan struct {
+		job *ReviewJob
+		err error
+	}, 1)
+	go func() {
+		job, err := env.db.ClaimJobContext(ctx, "worker-busy-retry")
+		resultCh <- struct {
+			job *ReviewJob
+			err error
+		}{job: job, err: err}
+	}()
+
+	time.Sleep(claimJobBusyAttemptTimeout + 100*time.Millisecond)
+	var status string
+	require.NoError(t, env.db.QueryRow(
+		`SELECT status FROM review_jobs WHERE id = ?`, env.job.ID,
+	).Scan(&status))
+	assert.Equal(t, string(JobStatusQueued), status)
+	_, err = lockConn.ExecContext(t.Context(), "COMMIT")
+	require.NoError(t, err)
+	result := <-resultCh
+
+	require.NoError(t, result.err)
+	require.NotNil(t, result.job)
+	assert.Equal(t, env.job.ID, result.job.ID)
 }
 
 func TestJobFailure(t *testing.T) {

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -496,11 +496,61 @@ func (db *DB) enqueuePanelRunTx(ctx context.Context, exec execer, members []Enqu
 	return memberJobs, synthJob, nil
 }
 
+// claimJobBusyAttempts / claimJobBusyAttemptTimeout / claimJobBusyBackoff
+// keep each SQLite claim attempt below the 30s busy_timeout while leaving
+// enough room for all attempts and backoffs inside claimJobRetryWindow.
+const (
+	claimJobBusyAttempts       = 4
+	claimJobBusyAttemptTimeout = 7 * time.Second
+	claimJobBusyBackoff        = 50 * time.Millisecond
+	claimJobRetryWindow        = 30 * time.Second
+)
+
+// claimJobBeforeCommitForTest coordinates cancellation-boundary coverage.
+var claimJobBeforeCommitForTest func()
+
 // ClaimJob atomically claims the next queued job for a worker.
 // Jobs whose retry_not_before is in the future are skipped so the retry
 // backoff applies regardless of which worker happened to fail the prior
 // attempt.
 func (db *DB) ClaimJob(workerID string) (*ReviewJob, error) {
+	return db.ClaimJobContext(context.Background(), workerID)
+}
+
+// ClaimJobContext is ClaimJob with caller-controlled cancellation. The
+// caller's context and the claim retry window both bound the operation. The
+// retry boundary owns a fresh connection and BEGIN IMMEDIATE transaction so
+// an interrupted SQLite statement cannot be retried on an invalid transaction.
+func (db *DB) ClaimJobContext(ctx context.Context, workerID string) (*ReviewJob, error) {
+	deadline := time.Now().Add(claimJobRetryWindow)
+	operationCtx, cancelOperation := context.WithDeadline(ctx, deadline)
+	defer cancelOperation()
+
+	return retryOnSQLiteBusy(operationCtx, claimJobBusyAttempts, claimJobBusyAttemptTimeout, claimJobBusyBackoff, nil, func(attemptCtx context.Context) (*ReviewJob, error) {
+		return db.claimJobAttempt(attemptCtx, operationCtx, workerID)
+	})
+}
+
+func (db *DB) claimJobAttempt(
+	ctx context.Context, commitCtx context.Context, workerID string,
+) (*ReviewJob, error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return nil, err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			if _, err := conn.ExecContext(context.Background(), "ROLLBACK"); err != nil {
+				log.Printf("jobs ClaimJob: rollback failed: %v", err)
+			}
+		}
+	}()
+
 	now := time.Now()
 	nowStr := preciseTimestampAt(now)
 	// retry_not_before is stored UTC + fixed-width nano (see
@@ -510,7 +560,7 @@ func (db *DB) ClaimJob(workerID string) (*ReviewJob, error) {
 
 	// Atomically claim a job by updating it in a single statement
 	// This prevents race conditions where two workers select the same job
-	result, err := db.Exec(`
+	result, err := conn.ExecContext(ctx, `
 		UPDATE review_jobs
 		SET status = 'running', worker_id = ?, started_at = ?, updated_at = ?
 		WHERE id = (
@@ -542,7 +592,7 @@ func (db *DB) ClaimJob(workerID string) (*ReviewJob, error) {
 	// Now fetch the job we just claimed
 	var job ReviewJob
 	var fields reviewJobScanFields
-	err = db.QueryRow(`
+	err = conn.QueryRowContext(ctx, `
 		SELECT j.id, j.repo_id, j.commit_id, j.git_ref, j.branch, j.ci_base_branch, j.session_id, j.agent, j.model, j.provider, j.requested_model, j.requested_provider, j.reasoning, j.status, j.enqueued_at,
 		       r.root_path, r.name, c.subject, j.diff_content, j.dirty_files, j.prompt, COALESCE(j.agentic, 0), COALESCE(j.prompt_prebuilt, 0), j.job_type, j.review_type,
 		       j.output_prefix, j.patch_id, j.parent_job_id, COALESCE(j.worktree_path, ''), j.command_line, COALESCE(j.min_severity, ''), COALESCE(j.backup_agent, ''), COALESCE(j.backup_model, ''),
@@ -565,6 +615,13 @@ func (db *DB) ClaimJob(workerID string) (*ReviewJob, error) {
 	job.WorkerID = workerID
 	job.StartedAt = &now
 	job.StartedAtRaw = nowStr
+	if claimJobBeforeCommitForTest != nil {
+		claimJobBeforeCommitForTest()
+	}
+	if _, err := conn.ExecContext(commitCtx, "COMMIT"); err != nil {
+		return nil, err
+	}
+	committed = true
 	return &job, nil
 }
 

--- a/internal/storage/sqlite_busy.go
+++ b/internal/storage/sqlite_busy.go
@@ -1,0 +1,102 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	sqlite "modernc.org/sqlite"
+)
+
+// SQLite result codes for lock contention. Named locally so we do not
+// depend on modernc.org/sqlite/lib constants.
+const (
+	sqliteBusy   = 5 // SQLITE_BUSY
+	sqliteLocked = 6 // SQLITE_LOCKED
+)
+
+var errSQLiteBusyAttemptTimeout = errors.New("sqlite busy attempt timed out")
+
+// IsSQLiteBusy reports whether err is lock contention (SQLITE_BUSY /
+// SQLITE_LOCKED), including the "database is locked (5) (SQLITE_BUSY)"
+// text modernc.org/sqlite emits after busy_timeout elapses.
+func IsSQLiteBusy(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, errSQLiteBusyAttemptTimeout) {
+		return true
+	}
+	if se, ok := errors.AsType[*sqlite.Error](err); ok {
+		switch se.Code() {
+		case sqliteBusy, sqliteLocked:
+			return true
+		}
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "database is locked") ||
+		strings.Contains(msg, "sqlite_busy") ||
+		strings.Contains(msg, "sqlite_locked")
+}
+
+func retryOnSQLiteBusy[T any](
+	ctx context.Context,
+	attempts int,
+	attemptTimeout time.Duration,
+	backoff time.Duration,
+	sleep func(context.Context, time.Duration) error,
+	fn func(context.Context) (T, error),
+) (T, error) {
+	var zero T
+	if attempts < 1 {
+		attempts = 1
+	}
+	if sleep == nil {
+		sleep = waitForSQLiteBusyRetry
+	}
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		if err := ctx.Err(); err != nil {
+			return zero, err
+		}
+		attemptCtx := ctx
+		cancel := func() {}
+		if attemptTimeout > 0 {
+			attemptCtx, cancel = context.WithTimeout(ctx, attemptTimeout)
+		}
+		v, err := fn(attemptCtx)
+		attemptTimedOut := errors.Is(attemptCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil
+		cancel()
+		if err == nil {
+			return v, nil
+		}
+		if attemptTimedOut && !IsSQLiteBusy(err) {
+			err = errors.Join(errSQLiteBusyAttemptTimeout, err)
+		}
+		if !IsSQLiteBusy(err) && !attemptTimedOut {
+			return v, err
+		}
+		if err := ctx.Err(); err != nil {
+			return zero, err
+		}
+		lastErr = err
+		if i+1 < attempts {
+			if err := sleep(ctx, backoff<<i); err != nil {
+				return zero, err
+			}
+		}
+	}
+	return zero, lastErr
+}
+
+func waitForSQLiteBusyRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/storage/sqlite_busy_test.go
+++ b/internal/storage/sqlite_busy_test.go
@@ -1,0 +1,142 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsSQLiteBusy(t *testing.T) {
+	assert.False(t, IsSQLiteBusy(nil))
+	assert.False(t, IsSQLiteBusy(errors.New("disk I/O error")))
+	assert.False(t, IsSQLiteBusy(errors.New("no such table: review_jobs")))
+	assert.True(t, IsSQLiteBusy(errors.New("database is locked (5) (SQLITE_BUSY)")))
+	assert.True(t, IsSQLiteBusy(fmt.Errorf("claim job: %w", errors.New("SQLITE_BUSY"))))
+	assert.True(t, IsSQLiteBusy(errors.New("database is locked")))
+	assert.True(t, IsSQLiteBusy(errors.New("SQLITE_LOCKED")))
+}
+
+func TestIsSQLiteBusyRealError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "busy.db")
+	dsn := path + "?_pragma=journal_mode(DELETE)&_pragma=busy_timeout(0)"
+
+	holder, err := sql.Open("sqlite", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = holder.Close() })
+	_, err = holder.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY); INSERT INTO t (id) VALUES (1)`)
+	require.NoError(t, err)
+	tx, err := holder.Begin()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback() })
+	_, err = tx.Exec(`UPDATE t SET id = 1`)
+	require.NoError(t, err)
+
+	contender, err := sql.Open("sqlite", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = contender.Close() })
+	_, err = contender.Exec(`UPDATE t SET id = 2`)
+	require.Error(t, err)
+	assert.True(t, IsSQLiteBusy(err), "got %v", err)
+}
+
+func TestRetryOnSQLiteBusySucceedsAfterContention(t *testing.T) {
+	n := 0
+	var sleeps []time.Duration
+	job, err := retryOnSQLiteBusy(context.Background(), 4, 0, 50*time.Millisecond, func(_ context.Context, d time.Duration) error {
+		sleeps = append(sleeps, d)
+		return nil
+	}, func(context.Context) (*ReviewJob, error) {
+		n++
+		if n < 3 {
+			return nil, errors.New("database is locked (5) (SQLITE_BUSY)")
+		}
+		return &ReviewJob{ID: 7}, nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, job)
+	assert.Equal(t, int64(7), job.ID)
+	assert.Equal(t, 3, n)
+	assert.Equal(t, []time.Duration{50 * time.Millisecond, 100 * time.Millisecond}, sleeps)
+}
+
+func TestRetryOnSQLiteBusyDoesNotRetryPermanentErrors(t *testing.T) {
+	n := 0
+	sleepCalls := 0
+	_, err := retryOnSQLiteBusy(context.Background(), 4, 0, time.Millisecond, func(context.Context, time.Duration) error {
+		sleepCalls++
+		return nil
+	}, func(context.Context) (*ReviewJob, error) {
+		n++
+		return nil, errors.New("disk I/O error")
+	})
+	require.EqualError(t, err, "disk I/O error")
+	assert.Equal(t, 1, n)
+	assert.Equal(t, 0, sleepCalls)
+}
+
+func TestRetryOnSQLiteBusyGivesUp(t *testing.T) {
+	n := 0
+	_, err := retryOnSQLiteBusy(context.Background(), 3, 0, time.Millisecond, func(context.Context, time.Duration) error { return nil }, func(context.Context) (*ReviewJob, error) {
+		n++
+		return nil, errors.New("database is locked (5) (SQLITE_BUSY)")
+	})
+	require.Error(t, err)
+	assert.True(t, IsSQLiteBusy(err))
+	assert.Equal(t, 3, n)
+}
+
+func TestRetryOnSQLiteBusyNilIsSuccess(t *testing.T) {
+	job, err := retryOnSQLiteBusy(context.Background(), 4, 0, time.Millisecond, nil, func(context.Context) (*ReviewJob, error) {
+		return nil, nil
+	})
+	require.NoError(t, err)
+	assert.Nil(t, job)
+}
+
+func TestRetryOnSQLiteBusyReturnsSuccessAfterAttemptDeadline(t *testing.T) {
+	calls := 0
+	job, err := retryOnSQLiteBusy(context.Background(), 4, 5*time.Millisecond, 0, nil, func(ctx context.Context) (*ReviewJob, error) {
+		calls++
+		<-ctx.Done()
+		return &ReviewJob{ID: 7}, nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, job)
+	assert.Equal(t, int64(7), job.ID)
+	assert.Equal(t, 1, calls)
+}
+
+func TestRetryOnSQLiteBusyStopsWhenContextIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	_, err := retryOnSQLiteBusy(ctx, 4, 0, time.Hour, nil, func(context.Context) (*ReviewJob, error) {
+		calls++
+		cancel()
+		return nil, errors.New("database is locked (5) (SQLITE_BUSY)")
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, calls)
+}
+
+func TestRetryOnSQLiteBusyUsesEachAttemptBudget(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	calls := 0
+
+	_, err := retryOnSQLiteBusy(ctx, 4, 10*time.Millisecond, 0, nil, func(attemptCtx context.Context) (*ReviewJob, error) {
+		calls++
+		<-attemptCtx.Done()
+		return nil, attemptCtx.Err()
+	})
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.True(t, IsSQLiteBusy(err))
+	assert.Equal(t, 4, calls)
+}


### PR DESCRIPTION
Deliver Antigravity prompts that exceed the platform argv cap on stdin with no --prompt/--print/-p flag (agy >= 1.1.1 still reads non-TTY stdin when no prompt flag is present). Small prompts keep --prompt. Drop --sandbox for non-agentic print-mode reviews so pwd is not permission-gated. Reviews still do not get --dangerously-skip-permissions.