### PR TITLE
Surface why the browser UI is unavailable and verify release assets

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -63,8 +63,25 @@ jobs:
           if [ -z "$TAG" ]; then
             TAG="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)"
           fi
-          echo "Verifying release $TAG"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          # sed consumes all of sort's output, avoiding SIGPIPE under
+          # pipefail.
+          version_at_least() {
+            [ "$(printf '%s\n' "$2" "$1" | sort -V | sed -n '1p')" = "$2" ]
+          }
+          # The browser UI (and its embedded-distribution marker) first
+          # shipped in v0.65.0; earlier releases legitimately contain no web
+          # assets. The web_assets field in `version --json` exists since
+          # v0.66.0.
+          web_checks=false
+          web_assets_field=false
+          if version_at_least "$TAG" "v0.65.0"; then web_checks=true; fi
+          if version_at_least "$TAG" "v0.66.0"; then web_assets_field=true; fi
+          echo "Verifying release $TAG (web checks: $web_checks)"
+          {
+            echo "tag=$TAG"
+            echo "web_checks=$web_checks"
+            echo "web_assets_field=$web_assets_field"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Download release assets
         env:
@@ -102,37 +119,31 @@ jobs:
           exit "$failed"
 
       - name: Verify embedded web assets
-        env:
-          TAG: ${{ steps.resolve.outputs.tag }}
+        # Both web asset steps share this gate; resolve computes it once so
+        # they can never disagree about which releases predate the web UI.
+        if: steps.resolve.outputs.web_checks == 'true'
         run: |
           set -euo pipefail
-          # The browser UI (and its embedded-distribution marker) first
-          # shipped in v0.65.0; earlier releases legitimately contain no
-          # web assets. sed consumes all of sort's output, avoiding SIGPIPE
-          # under pipefail.
-          FIRST_WEB_TAG="v0.65.0"
-          lowest="$(printf '%s\n' "$FIRST_WEB_TAG" "$TAG" | sort -V | sed -n '1p')"
-          if [ "$lowest" != "$FIRST_WEB_TAG" ]; then
-            echo "::notice::skipping embedded web asset checks: $TAG predates the browser UI ($FIRST_WEB_TAG)"
-            exit 0
-          fi
           if ! command -v rpm2cpio >/dev/null 2>&1 || ! command -v cpio >/dev/null 2>&1; then
             sudo apt-get update -q
             sudo apt-get install -qy rpm cpio
           fi
+          # Extract outside assets/ so the extraction dirs can never match
+          # a later glob over the downloaded assets.
+          mkdir extracted
           cd assets
           failed=0
           # Windows releases ship a .zip and a .tar.gz with the same stem, so
           # the extraction dir must be derived from the full asset name.
           for asset in *.tar.gz *.zip *.deb *.rpm; do
             [ -e "$asset" ] || continue
-            dir="extract-$asset"
+            dir="../extracted/$asset"
             mkdir "$dir"
             case "$asset" in
               *.tar.gz) tar -xzf "$asset" -C "$dir" ;;
               *.zip) unzip -q "$asset" -d "$dir" ;;
               *.deb) dpkg-deb -x "$asset" "$dir" ;;
-              *.rpm) (cd "$dir" && rpm2cpio "../$asset" | cpio -idm --quiet) ;;
+              *.rpm) rpm2cpio "$asset" | (cd "$dir" && cpio -idm --quiet) ;;
             esac
             binary="$(find "$dir" -type f \( -name roborev -o -name roborev.exe \) -print -quit)"
             if [ ! -f "$binary" ]; then
@@ -157,23 +168,24 @@ jobs:
           exit "$failed"
 
       - name: Verify runtime web asset report
+        if: steps.resolve.outputs.web_checks == 'true'
         env:
           TAG: ${{ steps.resolve.outputs.tag }}
+          WEB_ASSETS_FIELD: ${{ steps.resolve.outputs.web_assets_field }}
         run: |
           set -euo pipefail
-          FIRST_WEB_TAG="v0.65.0"
-          lowest="$(printf '%s\n' "$FIRST_WEB_TAG" "$TAG" | sort -V | sed -n '1p')"
-          if [ "$lowest" != "$FIRST_WEB_TAG" ]; then
-            echo "::notice::skipping runtime web asset check: $TAG predates the browser UI ($FIRST_WEB_TAG)"
-            exit 0
-          fi
-          cd assets
           version="${TAG#v}"
-          binary="extract-roborev_${version}_linux_amd64.tar.gz/roborev"
+          binary="extracted/roborev_${version}_linux_amd64.tar.gz/roborev"
           if [ ! -f "$binary" ]; then
             echo "::error::expected linux_amd64 binary not found at $binary; update this workflow if the archive naming changed"
             exit 1
           fi
           "$binary" version --json | tee version.json
-          # web_assets exists since v0.66; require it to be true when present.
-          jq -e '(.web_assets == null) or (.web_assets == true)' version.json >/dev/null
+          if [ "$WEB_ASSETS_FIELD" = "true" ]; then
+            # The web_assets field is part of the version --json contract
+            # since v0.66.0; a missing field is a regression, not tolerance.
+            jq -e '.web_assets == true' version.json >/dev/null
+          else
+            # v0.65.x predates the field; only reject an explicit false.
+            jq -e '(.web_assets == null) or (.web_assets == true)' version.json >/dev/null
+          fi

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -44,11 +44,22 @@ jobs:
           INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          TAG="${INPUT_TAG:-${EVENT_TAG:-}}"
-          case "$TAG" in
+          if [ -n "${INPUT_TAG:-}" ]; then
+            case "$INPUT_TAG" in
+              v[0-9]*) ;;
+              *)
+                echo "::error::tag input '$INPUT_TAG' does not look like a release tag (expected vMAJOR.MINOR.PATCH)"
+                exit 1
+                ;;
+            esac
+          fi
+          # head_branch is only a tag for tag-push runs; ignore other shapes.
+          EVENT="${EVENT_TAG:-}"
+          case "$EVENT" in
             v[0-9]*) ;;
-            *) TAG="" ;;
+            *) EVENT="" ;;
           esac
+          TAG="${INPUT_TAG:-$EVENT}"
           if [ -z "$TAG" ]; then
             TAG="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)"
           fi
@@ -111,7 +122,7 @@ jobs:
               *.deb) dpkg-deb -x "$asset" "$dir" ;;
               *.rpm) (cd "$dir" && rpm2cpio "../$asset" | cpio -idm --quiet) ;;
             esac
-            binary="$(find "$dir" -type f \( -name roborev -o -name roborev.exe \) | head -n 1)"
+            binary="$(find "$dir" -type f \( -name roborev -o -name roborev.exe \) -print -quit)"
             if [ ! -f "$binary" ]; then
               echo "FAIL $asset: no roborev binary in archive"
               failed=1

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -102,8 +102,20 @@ jobs:
           exit "$failed"
 
       - name: Verify embedded web assets
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
         run: |
           set -euo pipefail
+          # The browser UI (and its embedded-distribution marker) first
+          # shipped in v0.65.0; earlier releases legitimately contain no
+          # web assets. sed consumes all of sort's output, avoiding SIGPIPE
+          # under pipefail.
+          FIRST_WEB_TAG="v0.65.0"
+          lowest="$(printf '%s\n' "$FIRST_WEB_TAG" "$TAG" | sort -V | sed -n '1p')"
+          if [ "$lowest" != "$FIRST_WEB_TAG" ]; then
+            echo "::notice::skipping embedded web asset checks: $TAG predates the browser UI ($FIRST_WEB_TAG)"
+            exit 0
+          fi
           if ! command -v rpm2cpio >/dev/null 2>&1 || ! command -v cpio >/dev/null 2>&1; then
             sudo apt-get update -q
             sudo apt-get install -qy rpm cpio
@@ -149,6 +161,12 @@ jobs:
           TAG: ${{ steps.resolve.outputs.tag }}
         run: |
           set -euo pipefail
+          FIRST_WEB_TAG="v0.65.0"
+          lowest="$(printf '%s\n' "$FIRST_WEB_TAG" "$TAG" | sort -V | sed -n '1p')"
+          if [ "$lowest" != "$FIRST_WEB_TAG" ]; then
+            echo "::notice::skipping runtime web asset check: $TAG predates the browser UI ($FIRST_WEB_TAG)"
+            exit 0
+          fi
           cd assets
           version="${TAG#v}"
           binary="extract-roborev_${version}_linux_amd64.tar.gz/roborev"

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -70,12 +70,13 @@ jobs:
           }
           # The browser UI (and its embedded-distribution marker) first
           # shipped in v0.65.0; earlier releases legitimately contain no web
-          # assets. The web_assets field in `version --json` exists since
-          # v0.66.0.
+          # assets. The web_assets field in `version --json` exists in every
+          # release after v0.65.0, so v0.65.1 is the first tag that can
+          # carry it.
           web_checks=false
           web_assets_field=false
           if version_at_least "$TAG" "v0.65.0"; then web_checks=true; fi
-          if version_at_least "$TAG" "v0.66.0"; then web_assets_field=true; fi
+          if version_at_least "$TAG" "v0.65.1"; then web_assets_field=true; fi
           echo "Verifying release $TAG (web checks: $web_checks)"
           {
             echo "tag=$TAG"
@@ -184,9 +185,9 @@ jobs:
           "$binary" version --json | tee version.json
           if [ "$WEB_ASSETS_FIELD" = "true" ]; then
             # The web_assets field is part of the version --json contract
-            # since v0.66.0; a missing field is a regression, not tolerance.
+            # after v0.65.0; a missing field is a regression, not tolerance.
             jq -e '.web_assets == true' version.json >/dev/null
           else
-            # v0.65.x predates the field; only reject an explicit false.
+            # v0.65.0 predates the field; only reject an explicit false.
             jq -e '(.web_assets == null) or (.web_assets == true)' version.json >/dev/null
           fi

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -48,13 +48,15 @@ jobs:
           set -euo pipefail
           mkdir assets
           gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir assets \
-            --pattern '*.tar.gz' --pattern '*.zip' --pattern 'SHA256SUMS'
+            --pattern '*.tar.gz' --pattern '*.zip' \
+            --pattern '*.deb' --pattern '*.rpm' \
+            --pattern 'SHA256SUMS'
 
       - name: Verify checksums
         run: |
           set -euo pipefail
           cd assets
-          for asset in *.tar.gz *.zip; do
+          for asset in *.tar.gz *.zip *.deb *.rpm; do
             [ -e "$asset" ] || continue
             grep " $asset\$" SHA256SUMS | sha256sum -c -
           done
@@ -62,18 +64,25 @@ jobs:
       - name: Verify embedded web assets
         run: |
           set -euo pipefail
+          if ! command -v rpm2cpio >/dev/null 2>&1 || ! command -v cpio >/dev/null 2>&1; then
+            sudo apt-get update -q
+            sudo apt-get install -qy rpm cpio
+          fi
           cd assets
           failed=0
-          for asset in *.tar.gz *.zip; do
+          # Windows releases ship a .zip and a .tar.gz with the same stem, so
+          # the extraction dir must be derived from the full asset name.
+          for asset in *.tar.gz *.zip *.deb *.rpm; do
             [ -e "$asset" ] || continue
-            dir="${asset%.zip}"; dir="${dir%.tar.gz}"
+            dir="extract-$asset"
             mkdir "$dir"
             case "$asset" in
               *.tar.gz) tar -xzf "$asset" -C "$dir" ;;
               *.zip) unzip -q "$asset" -d "$dir" ;;
+              *.deb) dpkg-deb -x "$asset" "$dir" ;;
+              *.rpm) (cd "$dir" && rpm2cpio "../$asset" | cpio -idm --quiet) ;;
             esac
-            binary="$dir/roborev"
-            [ -f "$binary" ] || binary="$dir/roborev.exe"
+            binary="$(find "$dir" -type f \( -name roborev -o -name roborev.exe \) | head -n 1)"
             if [ ! -f "$binary" ]; then
               echo "FAIL $asset: no roborev binary in archive"
               failed=1
@@ -82,8 +91,10 @@ jobs:
             # The production index.html duplicates the marker string that
             # internal/web/assets.go compiles in, so a binary that embeds
             # the web distribution contains it at least twice; a binary
-            # built without web assets contains it exactly once.
-            occurrences="$(grep -aob 'roborev-web-distribution' "$binary" | wc -l)"
+            # built without web assets contains it at most once. grep exits
+            # non-zero on zero matches, so keep pipefail from aborting the
+            # loop before the FAIL diagnostic is emitted.
+            occurrences="$(grep -aob 'roborev-web-distribution' "$binary" | wc -l || true)"
             if [ "$occurrences" -lt 2 ]; then
               echo "FAIL $asset: binary does not embed the production web assets"
               failed=1
@@ -100,10 +111,10 @@ jobs:
           set -euo pipefail
           cd assets
           version="${TAG#v}"
-          binary="roborev_${version}_linux_amd64/roborev"
+          binary="extract-roborev_${version}_linux_amd64.tar.gz/roborev"
           if [ ! -f "$binary" ]; then
-            echo "linux_amd64 binary not found; skipping runtime check"
-            exit 0
+            echo "::error::expected linux_amd64 binary not found at $binary; update this workflow if the archive naming changed"
+            exit 1
           fi
           "$binary" version --json | tee version.json
           # web_assets exists since v0.66; require it to be true when present.

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -96,6 +96,11 @@ jobs:
             --pattern 'SHA256SUMS'
 
       - name: Verify required assets are present
+        # Older releases legitimately shipped other artifact sets (v0.57.0
+        # had no Windows tar.gz, early releases no deb/rpm), so the matrix
+        # below is only asserted from the same v0.65.0 floor as the web
+        # checks; older tags still get checksum verification.
+        if: steps.resolve.outputs.web_checks == 'true'
         env:
           TAG: ${{ steps.resolve.outputs.tag }}
         run: |

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -1,0 +1,110 @@
+name: Verify release assets
+
+# Release assets can be replaced after publication (for example by a
+# rebuild bot) without firing any webhook event, so a scheduled re-check of
+# the latest release is the only way to catch a swap like the one that
+# shipped v0.65.0 binaries without the embedded web UI (#1081).
+on:
+  release:
+    types:
+      - published
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to verify (default: latest release)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Resolve release tag
+        id: resolve
+        env:
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          TAG="${INPUT_TAG:-${EVENT_TAG:-}}"
+          if [ -z "$TAG" ]; then
+            TAG="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)"
+          fi
+          echo "Verifying release $TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Download release assets
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir assets
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir assets \
+            --pattern '*.tar.gz' --pattern '*.zip' --pattern 'SHA256SUMS'
+
+      - name: Verify checksums
+        run: |
+          set -euo pipefail
+          cd assets
+          for asset in *.tar.gz *.zip; do
+            [ -e "$asset" ] || continue
+            grep " $asset\$" SHA256SUMS | sha256sum -c -
+          done
+
+      - name: Verify embedded web assets
+        run: |
+          set -euo pipefail
+          cd assets
+          failed=0
+          for asset in *.tar.gz *.zip; do
+            [ -e "$asset" ] || continue
+            dir="${asset%.zip}"; dir="${dir%.tar.gz}"
+            mkdir "$dir"
+            case "$asset" in
+              *.tar.gz) tar -xzf "$asset" -C "$dir" ;;
+              *.zip) unzip -q "$asset" -d "$dir" ;;
+            esac
+            binary="$dir/roborev"
+            [ -f "$binary" ] || binary="$dir/roborev.exe"
+            if [ ! -f "$binary" ]; then
+              echo "FAIL $asset: no roborev binary in archive"
+              failed=1
+              continue
+            fi
+            # The production index.html duplicates the marker string that
+            # internal/web/assets.go compiles in, so a binary that embeds
+            # the web distribution contains it at least twice; a binary
+            # built without web assets contains it exactly once.
+            occurrences="$(grep -aob 'roborev-web-distribution' "$binary" | wc -l)"
+            if [ "$occurrences" -lt 2 ]; then
+              echo "FAIL $asset: binary does not embed the production web assets"
+              failed=1
+              continue
+            fi
+            echo "ok $asset"
+          done
+          exit "$failed"
+
+      - name: Verify runtime web asset report
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          cd assets
+          version="${TAG#v}"
+          binary="roborev_${version}_linux_amd64/roborev"
+          if [ ! -f "$binary" ]; then
+            echo "linux_amd64 binary not found; skipping runtime check"
+            exit 0
+          fi
+          "$binary" version --json | tee version.json
+          # web_assets exists since v0.66; require it to be true when present.
+          jq -e '(.web_assets == null) or (.web_assets == true)' version.json >/dev/null

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -32,8 +32,6 @@ jobs:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    env:
-      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Resolve release tag
         id: resolve
@@ -42,6 +40,7 @@ jobs:
           # the tag name.
           EVENT_TAG: ${{ github.event.workflow_run.head_branch }}
           INPUT_TAG: ${{ inputs.tag }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           # head_branch is only a tag for tag-push runs; ignore other shapes.
@@ -56,13 +55,10 @@ jobs:
           fi
           # Validate whatever won: a tag of an unexpected shape would sort
           # below v0.65.0 and silently disable the web asset checks below.
-          case "$TAG" in
-            v[0-9]*) ;;
-            *)
-              echo "::error::resolved tag '$TAG' does not look like a release tag (expected vMAJOR.MINOR.PATCH)"
-              exit 1
-              ;;
-          esac
+          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::resolved tag '$TAG' does not look like a release tag (expected vMAJOR.MINOR.PATCH)"
+            exit 1
+          fi
           # sed consumes all of sort's output, avoiding SIGPIPE under
           # pipefail.
           version_at_least() {
@@ -85,8 +81,12 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Download release assets
+        # GH_TOKEN is scoped to the steps that call gh, not the job: later
+        # steps execute the downloaded (post-publication, hence swappable)
+        # binary and must hold no credential when they do.
         env:
           TAG: ${{ steps.resolve.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           mkdir assets

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -158,9 +158,14 @@ jobs:
         if: steps.resolve.outputs.web_checks == 'true'
         run: |
           set -euo pipefail
-          if ! command -v rpm2cpio >/dev/null 2>&1 || ! command -v cpio >/dev/null 2>&1; then
+          # bsdtar extracts rpm payloads directly and relative to -C.
+          # Ubuntu's rpm2cpio exits 1 on nfpm-built rpms while still
+          # emitting the full payload, and GNU cpio extracts the payload's
+          # absolute paths (/usr/bin/roborev) onto the real filesystem, so
+          # the classic rpm2cpio | cpio pipeline fails here both ways.
+          if ! command -v bsdtar >/dev/null 2>&1; then
             sudo apt-get update -q
-            sudo apt-get install -qy rpm cpio
+            sudo apt-get install -qy libarchive-tools
           fi
           # Extract outside assets/ so the extraction dirs can never match
           # a later glob over the downloaded assets.
@@ -177,10 +182,7 @@ jobs:
               *.tar.gz) tar -xzf "$asset" -C "$dir" ;;
               *.zip) unzip -q "$asset" -d "$dir" ;;
               *.deb) dpkg-deb -x "$asset" "$dir" ;;
-              # nfpm rpm payloads store absolute paths (/usr/bin/roborev);
-              # without --no-absolute-filenames cpio extracts onto the
-              # runner's real filesystem and dies with Permission denied.
-              *.rpm) rpm2cpio "$asset" | (cd "$dir" && cpio -idm --quiet --no-absolute-filenames) ;;
+              *.rpm) bsdtar -xf "$asset" -C "$dir" ;;
             esac
             binary="$(find "$dir" -type f \( -name roborev -o -name roborev.exe \) -print -quit)"
             if [ ! -f "$binary" ]; then

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -44,15 +44,6 @@ jobs:
           INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          if [ -n "${INPUT_TAG:-}" ]; then
-            case "$INPUT_TAG" in
-              v[0-9]*) ;;
-              *)
-                echo "::error::tag input '$INPUT_TAG' does not look like a release tag (expected vMAJOR.MINOR.PATCH)"
-                exit 1
-                ;;
-            esac
-          fi
           # head_branch is only a tag for tag-push runs; ignore other shapes.
           EVENT="${EVENT_TAG:-}"
           case "$EVENT" in
@@ -63,6 +54,15 @@ jobs:
           if [ -z "$TAG" ]; then
             TAG="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)"
           fi
+          # Validate whatever won: a tag of an unexpected shape would sort
+          # below v0.65.0 and silently disable the web asset checks below.
+          case "$TAG" in
+            v[0-9]*) ;;
+            *)
+              echo "::error::resolved tag '$TAG' does not look like a release tag (expected vMAJOR.MINOR.PATCH)"
+              exit 1
+              ;;
+          esac
           # sed consumes all of sort's output, avoiding SIGPIPE under
           # pipefail.
           version_at_least() {
@@ -154,10 +154,11 @@ jobs:
             # The production index.html duplicates the marker string that
             # internal/web/assets.go compiles in, so a binary that embeds
             # the web distribution contains it at least twice; a binary
-            # built without web assets contains it at most once. grep exits
-            # non-zero on zero matches, so keep pipefail from aborting the
-            # loop before the FAIL diagnostic is emitted.
-            occurrences="$(grep -aob 'roborev-web-distribution' "$binary" | wc -l || true)"
+            # built without web assets contains it at most once. grep -o
+            # prints one line per match (not per matching line), and the
+            # || true keeps pipefail from aborting the loop on zero matches
+            # before the FAIL diagnostic is emitted.
+            occurrences="$(grep -ao 'roborev-web-distribution' "$binary" | wc -l || true)"
             if [ "$occurrences" -lt 2 ]; then
               echo "FAIL $asset: binary does not embed the production web assets"
               failed=1

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -177,7 +177,10 @@ jobs:
               *.tar.gz) tar -xzf "$asset" -C "$dir" ;;
               *.zip) unzip -q "$asset" -d "$dir" ;;
               *.deb) dpkg-deb -x "$asset" "$dir" ;;
-              *.rpm) rpm2cpio "$asset" | (cd "$dir" && cpio -idm --quiet) ;;
+              # nfpm rpm payloads store absolute paths (/usr/bin/roborev);
+              # without --no-absolute-filenames cpio extracts onto the
+              # runner's real filesystem and dies with Permission denied.
+              *.rpm) rpm2cpio "$asset" | (cd "$dir" && cpio -idm --quiet --no-absolute-filenames) ;;
             esac
             binary="$(find "$dir" -type f \( -name roborev -o -name roborev.exe \) -print -quit)"
             if [ ! -f "$binary" ]; then

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -215,6 +215,13 @@ jobs:
             echo "::error::expected linux_amd64 binary not found at $binary; update this workflow if the archive naming changed"
             exit 1
           fi
+          # verify-web-assets shipped in v0.65.0 alongside the web UI and
+          # runs the same validation the daemon uses to gate the browser
+          # listener (stub detection, marker, Vite manifest, referenced
+          # bundles) — strictly stronger than the marker count above, and
+          # the only structural check available for v0.65.0 itself, which
+          # predates the web_assets version field.
+          "$binary" verify-web-assets
           "$binary" version --json | tee version.json
           if [ "$WEB_ASSETS_FIELD" = "true" ]; then
             # The web_assets field is part of the version --json contract

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -4,10 +4,17 @@ name: Verify release assets
 # rebuild bot) without firing any webhook event, so a scheduled re-check of
 # the latest release is the only way to catch a swap like the one that
 # shipped v0.65.0 binaries without the embedded web UI (#1081).
+#
+# The Release workflow creates the GitHub release before goreleaser uploads
+# the assets, so a `release: published` trigger would race the upload and
+# fail on every healthy release; trigger on the Release workflow finishing
+# instead.
 on:
-  release:
+  workflow_run:
+    workflows:
+      - Release
     types:
-      - published
+      - completed
   schedule:
     - cron: '17 6 * * *'
   workflow_dispatch:
@@ -22,6 +29,7 @@ permissions:
 
 jobs:
   verify:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -30,11 +38,17 @@ jobs:
       - name: Resolve release tag
         id: resolve
         env:
-          EVENT_TAG: ${{ github.event.release.tag_name }}
+          # For tag-push runs of the Release workflow, head_branch carries
+          # the tag name.
+          EVENT_TAG: ${{ github.event.workflow_run.head_branch }}
           INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
           TAG="${INPUT_TAG:-${EVENT_TAG:-}}"
+          case "$TAG" in
+            v[0-9]*) ;;
+            *) TAG="" ;;
+          esac
           if [ -z "$TAG" ]; then
             TAG="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)"
           fi
@@ -56,10 +70,15 @@ jobs:
         run: |
           set -euo pipefail
           cd assets
+          failed=0
           for asset in *.tar.gz *.zip *.deb *.rpm; do
             [ -e "$asset" ] || continue
-            grep " $asset\$" SHA256SUMS | sha256sum -c -
+            if ! grep " $asset\$" SHA256SUMS | sha256sum -c -; then
+              echo "FAIL $asset: checksum mismatch or not listed in SHA256SUMS"
+              failed=1
+            fi
           done
+          exit "$failed"
 
       - name: Verify embedded web assets
         run: |

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -83,7 +83,8 @@ jobs:
           # can also delete assets from the release.
           while read -r _ name; do
             if [ ! -e "$name" ]; then
-              echo "FAIL $name: listed in SHA256SUMS but missing from the release"
+              echo "FAIL $name: listed in SHA256SUMS but not in the downloaded set" \
+                "(deleted from the release, or not matched by the download patterns above)"
               failed=1
             fi
           done < SHA256SUMS

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -95,6 +95,34 @@ jobs:
             --pattern '*.deb' --pattern '*.rpm' \
             --pattern 'SHA256SUMS'
 
+      - name: Verify required assets are present
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          cd assets
+          version="${TAG#v}"
+          failed=0
+          # Independent of SHA256SUMS on purpose: a rebuild that drops a
+          # target regenerates the manifest too (#1081), so the manifest
+          # cannot define the expected inventory. Mirrors the goreleaser
+          # archive/nfpm matrix; update both together.
+          for target in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 windows_amd64 windows_arm64; do
+            case "$target" in
+              linux_*)   exts="tar.gz deb rpm" ;;
+              windows_*) exts="tar.gz zip" ;;
+              *)         exts="tar.gz" ;;
+            esac
+            for ext in $exts; do
+              name="roborev_${version}_${target}.${ext}"
+              if [ ! -e "$name" ]; then
+                echo "FAIL $name: required release asset missing"
+                failed=1
+              fi
+            done
+          done
+          exit "$failed"
+
       - name: Verify checksums
         run: |
           set -euo pipefail

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -71,6 +71,7 @@ jobs:
           set -euo pipefail
           cd assets
           failed=0
+          # Every downloaded asset must be listed with a matching hash.
           for asset in *.tar.gz *.zip *.deb *.rpm; do
             [ -e "$asset" ] || continue
             if ! grep " $asset\$" SHA256SUMS | sha256sum -c -; then
@@ -78,6 +79,14 @@ jobs:
               failed=1
             fi
           done
+          # Every listed asset must still be present: a post-publication swap
+          # can also delete assets from the release.
+          while read -r _ name; do
+            if [ ! -e "$name" ]; then
+              echo "FAIL $name: listed in SHA256SUMS but missing from the release"
+              failed=1
+            fi
+          done < SHA256SUMS
           exit "$failed"
 
       - name: Verify embedded web assets

--- a/cmd/roborev/daemon_cmd.go
+++ b/cmd/roborev/daemon_cmd.go
@@ -89,26 +89,42 @@ func daemonCmd() *cobra.Command {
 
 func writeDaemonLifecycleResult(message string) {
 	fmt.Println(message)
-	fmt.Printf("Web UI: %s\n", displayWebUIURL(discoverWebUIURL(daemonDiscover)))
+	fmt.Printf("Web UI: %s\n", displayWebUI(discoverWebUI(daemonDiscover)))
 }
 
-func discoverWebUIURL(discover func() (*daemon.RuntimeInfo, error)) string {
+// webUIStatus describes the daemon's browser UI: either a reachable URL, or
+// the daemon-published reason the listener is not running.
+type webUIStatus struct {
+	url            string
+	disabledReason string
+}
+
+func discoverWebUI(discover func() (*daemon.RuntimeInfo, error)) webUIStatus {
 	runtimeInfo, err := discover()
-	if err != nil || runtimeInfo == nil || runtimeInfo.WebOrigin == "" {
-		return ""
+	if err != nil || runtimeInfo == nil {
+		return webUIStatus{}
+	}
+	if runtimeInfo.WebOrigin == "" {
+		return webUIStatus{disabledReason: runtimeInfo.WebDisabledReason}
 	}
 	webURL, err := browserRootURL(runtimeInfo.WebOrigin, runtimeInfo.WebBasePath)
 	if err != nil {
-		return ""
+		return webUIStatus{}
 	}
-	return webURL
+	return webUIStatus{url: webURL}
 }
 
-func displayWebUIURL(webURL string) string {
-	if webURL == "" {
-		return "unavailable"
+func displayWebUI(status webUIStatus) string {
+	if status.url != "" {
+		return status.url
 	}
-	return webURL
+	switch status.disabledReason {
+	case daemon.WebDisabledReasonMissingAssets:
+		return "disabled (this build has no embedded web assets; reinstall from an official release)"
+	case daemon.WebDisabledReasonConfig:
+		return "disabled ([web] enabled = false)"
+	}
+	return "unavailable"
 }
 
 // daemonRunCmd runs the daemon in the foreground (used by "daemon start" internally)

--- a/cmd/roborev/daemon_cmd_test.go
+++ b/cmd/roborev/daemon_cmd_test.go
@@ -137,6 +137,39 @@ func TestDaemonRestartShowsUnavailableWhenBrowserIsDisabled(t *testing.T) {
 	assert.Equal(t, "Daemon restarted\nWeb UI: unavailable\n", output)
 }
 
+func TestDaemonRestartExplainsWebDisabledReason(t *testing.T) {
+	cases := []struct {
+		reason  string
+		display string
+	}{
+		{
+			reason:  daemon.WebDisabledReasonMissingAssets,
+			display: "disabled (this build has no embedded web assets; reinstall from an official release)",
+		},
+		{
+			reason:  daemon.WebDisabledReasonConfig,
+			display: "disabled ([web] enabled = false)",
+		},
+	}
+	for _, testCase := range cases {
+		withDaemonCommandDependencies(t,
+			func() error { return nil },
+			func() error { return nil },
+			func() (*daemon.RuntimeInfo, error) {
+				return &daemon.RuntimeInfo{WebDisabledReason: testCase.reason}, nil
+			},
+		)
+
+		output := captureStdout(t, func() {
+			cmd := daemonCmd()
+			cmd.SetArgs([]string{"restart"})
+			require.NoError(t, cmd.Execute())
+		})
+
+		assert.Equal(t, "Daemon restarted\nWeb UI: "+testCase.display+"\n", output)
+	}
+}
+
 func withDaemonCommandDependencies(
 	t *testing.T,
 	ensure func() error,

--- a/cmd/roborev/status.go
+++ b/cmd/roborev/status.go
@@ -24,12 +24,13 @@ var (
 )
 
 type statusJSONResult struct {
-	Running bool                  `json:"running"`
-	WebURL  string                `json:"web_url"`
-	Daemon  *storage.DaemonStatus `json:"daemon,omitempty"`
-	Health  *storage.HealthStatus `json:"health,omitempty"`
-	Jobs    []storage.ReviewJob   `json:"jobs,omitempty"`
-	Error   string                `json:"error,omitempty"`
+	Running           bool                  `json:"running"`
+	WebURL            string                `json:"web_url"`
+	WebDisabledReason string                `json:"web_disabled_reason,omitempty"`
+	Daemon            *storage.DaemonStatus `json:"daemon,omitempty"`
+	Health            *storage.HealthStatus `json:"health,omitempty"`
+	Jobs              []storage.ReviewJob   `json:"jobs,omitempty"`
+	Error             string                `json:"error,omitempty"`
 }
 
 func statusCmd() *cobra.Command {
@@ -39,7 +40,7 @@ func statusCmd() *cobra.Command {
 		Use:   "status",
 		Short: "Show daemon, browser UI, and queue status",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			webURL := ""
+			webStatus := webUIStatus{}
 			writeJSONResult := func(result statusJSONResult) error {
 				enc := json.NewEncoder(os.Stdout)
 				enc.SetIndent("", "  ")
@@ -48,13 +49,14 @@ func statusCmd() *cobra.Command {
 			writeStatusUnavailable := func(err error) error {
 				if jsonOutput {
 					return writeJSONResult(statusJSONResult{
-						Running: true,
-						WebURL:  webURL,
-						Error:   err.Error(),
+						Running:           true,
+						WebURL:            webStatus.url,
+						WebDisabledReason: webStatus.disabledReason,
+						Error:             err.Error(),
 					})
 				}
 				fmt.Println("Daemon: running")
-				fmt.Printf("Web UI: %s\n", displayWebUIURL(webURL))
+				fmt.Printf("Web UI: %s\n", displayWebUI(webStatus))
 				fmt.Printf("Status: unavailable: %v\n", err)
 				return nil
 			}
@@ -68,13 +70,14 @@ func statusCmd() *cobra.Command {
 					)
 					if jsonOutput {
 						return writeJSONResult(statusJSONResult{
-							Running: true,
-							WebURL:  webURL,
-							Error:   message,
+							Running:           true,
+							WebURL:            webStatus.url,
+							WebDisabledReason: webStatus.disabledReason,
+							Error:             message,
 						})
 					}
 					fmt.Println("Daemon: status unavailable")
-					fmt.Printf("Web UI: %s\n", displayWebUIURL(webURL))
+					fmt.Printf("Web UI: %s\n", displayWebUI(webStatus))
 					fmt.Println(message)
 					return nil
 				}
@@ -86,7 +89,7 @@ func statusCmd() *cobra.Command {
 				fmt.Println("Start with: roborev daemon start")
 				return nil
 			}
-			webURL = discoverWebUIURL(statusDiscover)
+			webStatus = discoverWebUI(statusDiscover)
 
 			ep := getDaemonEndpoint()
 			addr := ep.BaseURL()
@@ -136,11 +139,12 @@ func statusCmd() *cobra.Command {
 
 			if jsonOutput {
 				return writeJSONResult(statusJSONResult{
-					Running: true,
-					WebURL:  webURL,
-					Daemon:  &status,
-					Health:  health,
-					Jobs:    jobs,
+					Running:           true,
+					WebURL:            webStatus.url,
+					WebDisabledReason: webStatus.disabledReason,
+					Daemon:            &status,
+					Health:            health,
+					Jobs:              jobs,
 				})
 			}
 
@@ -153,7 +157,7 @@ func statusCmd() *cobra.Command {
 				daemonLine += fmt.Sprintf(" [%s]", status.Version)
 			}
 			fmt.Println(daemonLine)
-			fmt.Printf("Web UI: %s\n", displayWebUIURL(webURL))
+			fmt.Printf("Web UI: %s\n", displayWebUI(webStatus))
 			workersLine := fmt.Sprintf("Workers: %d/%d active", status.ActiveWorkers, status.MaxWorkers)
 			if status.QueuePaused {
 				workersLine += " (paused)"

--- a/cmd/roborev/status_test.go
+++ b/cmd/roborev/status_test.go
@@ -72,6 +72,45 @@ func TestStatusCmdJSONIncludesEmptyWebUIURLWhenUnavailable(t *testing.T) {
 	assert.Empty(t, parsed["web_url"])
 }
 
+func TestStatusCmdExplainsWebDisabledReason(t *testing.T) {
+	md := NewMockDaemon(t, MockRefineHooks{})
+	defer md.Close()
+
+	withStatusWebRuntime(t, func() (*daemon.RuntimeInfo, error) {
+		return &daemon.RuntimeInfo{WebDisabledReason: daemon.WebDisabledReasonMissingAssets}, nil
+	})
+
+	output := captureStdout(t, func() {
+		require.NoError(t, statusCmd().Execute())
+	})
+
+	assert.Contains(t, output,
+		"Web UI: disabled (this build has no embedded web assets; reinstall from an official release)\n")
+}
+
+func TestStatusCmdJSONIncludesWebDisabledReason(t *testing.T) {
+	md := NewMockDaemon(t, MockRefineHooks{})
+	defer md.Close()
+
+	withStatusWebRuntime(t, func() (*daemon.RuntimeInfo, error) {
+		return &daemon.RuntimeInfo{WebDisabledReason: daemon.WebDisabledReasonConfig}, nil
+	})
+
+	output := captureStdout(t, func() {
+		cmd := statusCmd()
+		cmd.SetArgs([]string{"--json"})
+		require.NoError(t, cmd.Execute())
+	})
+
+	var parsed struct {
+		WebURL            string `json:"web_url"`
+		WebDisabledReason string `json:"web_disabled_reason"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed))
+	assert.Empty(t, parsed.WebURL)
+	assert.Equal(t, daemon.WebDisabledReasonConfig, parsed.WebDisabledReason)
+}
+
 func TestStatusCmdJSONIncludesWebUIURL(t *testing.T) {
 	md := NewMockDaemon(t, MockRefineHooks{})
 	defer md.Close()

--- a/cmd/roborev/ui_cmd.go
+++ b/cmd/roborev/ui_cmd.go
@@ -35,7 +35,7 @@ func uiCmd() *cobra.Command {
 				return fmt.Errorf("discover daemon: %w", err)
 			}
 			if runtimeInfo.WebOrigin == "" {
-				return fmt.Errorf("the daemon browser listener is disabled")
+				return webUIDisabledError(runtimeInfo.WebDisabledReason)
 			}
 			target, err := uiURL(runtimeInfo.WebOrigin, runtimeInfo.WebBasePath, args)
 			if err != nil {
@@ -47,6 +47,18 @@ func uiCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func webUIDisabledError(reason string) error {
+	switch reason {
+	case daemon.WebDisabledReasonMissingAssets:
+		return fmt.Errorf("this roborev build has no embedded web assets; " +
+			"reinstall from an official release (or build with 'make build'), then run 'roborev daemon restart'")
+	case daemon.WebDisabledReasonConfig:
+		return fmt.Errorf("the browser UI is disabled in config; " +
+			"set enabled = true under [web] and run 'roborev daemon restart'")
+	}
+	return fmt.Errorf("the daemon browser listener is disabled")
 }
 
 func ensureUIDaemon() error {

--- a/cmd/roborev/ui_cmd_test.go
+++ b/cmd/roborev/ui_cmd_test.go
@@ -82,6 +82,35 @@ func TestUICmdRequiresBrowserMetadata(t *testing.T) {
 	require.EqualError(t, err, "the daemon browser listener is disabled")
 }
 
+func TestUICmdExplainsPublishedDisabledReasons(t *testing.T) {
+	cases := []struct {
+		reason  string
+		message string
+	}{
+		{
+			reason: daemon.WebDisabledReasonMissingAssets,
+			message: "this roborev build has no embedded web assets; " +
+				"reinstall from an official release (or build with 'make build'), then run 'roborev daemon restart'",
+		},
+		{
+			reason: daemon.WebDisabledReasonConfig,
+			message: "the browser UI is disabled in config; " +
+				"set enabled = true under [web] and run 'roborev daemon restart'",
+		},
+	}
+	for _, testCase := range cases {
+		withUICommandDependencies(t,
+			func() error { return nil },
+			func() (*daemon.RuntimeInfo, error) {
+				return &daemon.RuntimeInfo{WebDisabledReason: testCase.reason}, nil
+			},
+			func(string) error { return nil },
+		)
+		cmd := uiCmd()
+		require.EqualError(t, cmd.Execute(), testCase.message)
+	}
+}
+
 func TestUICmdPreservesDiscoveryAccessDenial(t *testing.T) {
 	want := daemon.ErrDaemonAccessDenied
 	withUICommandDependencies(t,

--- a/cmd/roborev/version.go
+++ b/cmd/roborev/version.go
@@ -37,7 +37,7 @@ func versionCmd() *cobra.Command {
 
 			suffix := ""
 			if !embedded {
-				suffix = " (web assets missing; this build cannot serve the browser UI)"
+				suffix = " (no embedded web assets; the browser UI needs a release build or --web-dev-origin)"
 			}
 			_, err := fmt.Fprintf(cmd.OutOrStdout(), "roborev %s%s\n", version.Version, suffix)
 			return err

--- a/cmd/roborev/version.go
+++ b/cmd/roborev/version.go
@@ -7,7 +7,12 @@ import (
 	"github.com/spf13/cobra"
 
 	"go.kenn.io/roborev/internal/version"
+	webassets "go.kenn.io/roborev/internal/web"
 )
+
+// webAssetsEmbedded reports whether this binary embeds the production web
+// distribution. Var so tests can pin both outcomes.
+var webAssetsEmbedded = webassets.EmbeddedReleaseAvailable
 
 func versionCmd() *cobra.Command {
 	var jsonOutput bool
@@ -17,17 +22,24 @@ func versionCmd() *cobra.Command {
 		Short: "Show roborev version",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			embedded := webAssetsEmbedded()
 			if jsonOutput {
 				return json.NewEncoder(cmd.OutOrStdout()).Encode(struct {
-					Name    string `json:"name"`
-					Version string `json:"version"`
+					Name      string `json:"name"`
+					Version   string `json:"version"`
+					WebAssets bool   `json:"web_assets"`
 				}{
-					Name:    "roborev",
-					Version: version.Version,
+					Name:      "roborev",
+					Version:   version.Version,
+					WebAssets: embedded,
 				})
 			}
 
-			_, err := fmt.Fprintf(cmd.OutOrStdout(), "roborev %s\n", version.Version)
+			suffix := ""
+			if !embedded {
+				suffix = " (web assets missing; this build cannot serve the browser UI)"
+			}
+			_, err := fmt.Fprintf(cmd.OutOrStdout(), "roborev %s%s\n", version.Version, suffix)
 			return err
 		},
 	}

--- a/cmd/roborev/version.go
+++ b/cmd/roborev/version.go
@@ -37,7 +37,7 @@ func versionCmd() *cobra.Command {
 
 			suffix := ""
 			if !embedded {
-				suffix = " (no embedded web assets; the browser UI needs a release build or --web-dev-origin)"
+				suffix = " (no embedded web assets; reinstall from an official release or build with 'make build')"
 			}
 			_, err := fmt.Fprintf(cmd.OutOrStdout(), "roborev %s%s\n", version.Version, suffix)
 			return err

--- a/cmd/roborev/version_test.go
+++ b/cmd/roborev/version_test.go
@@ -12,7 +12,15 @@ import (
 	"go.kenn.io/roborev/internal/version"
 )
 
+func stubWebAssetsEmbedded(t *testing.T, embedded bool) {
+	t.Helper()
+	original := webAssetsEmbedded
+	webAssetsEmbedded = func() bool { return embedded }
+	t.Cleanup(func() { webAssetsEmbedded = original })
+}
+
 func TestVersionCmdHumanOutput(t *testing.T) {
+	stubWebAssetsEmbedded(t, true)
 	var output bytes.Buffer
 	cmd := versionCmd()
 	cmd.SetOut(&output)
@@ -21,19 +29,37 @@ func TestVersionCmdHumanOutput(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("roborev %s\n", version.Version), output.String())
 }
 
-func TestVersionCmdJSONOutput(t *testing.T) {
+func TestVersionCmdHumanOutputFlagsMissingWebAssets(t *testing.T) {
+	stubWebAssetsEmbedded(t, false)
 	var output bytes.Buffer
 	cmd := versionCmd()
 	cmd.SetOut(&output)
-	cmd.SetArgs([]string{"--json"})
 
 	require.NoError(t, cmd.Execute())
+	assert.Equal(t, fmt.Sprintf(
+		"roborev %s (web assets missing; this build cannot serve the browser UI)\n",
+		version.Version,
+	), output.String())
+}
 
-	var got struct {
-		Name    string `json:"name"`
-		Version string `json:"version"`
+func TestVersionCmdJSONOutput(t *testing.T) {
+	for _, embedded := range []bool{true, false} {
+		stubWebAssetsEmbedded(t, embedded)
+		var output bytes.Buffer
+		cmd := versionCmd()
+		cmd.SetOut(&output)
+		cmd.SetArgs([]string{"--json"})
+
+		require.NoError(t, cmd.Execute())
+
+		var got struct {
+			Name      string `json:"name"`
+			Version   string `json:"version"`
+			WebAssets bool   `json:"web_assets"`
+		}
+		require.NoError(t, json.Unmarshal(output.Bytes(), &got))
+		assert.Equal(t, "roborev", got.Name)
+		assert.Equal(t, version.Version, got.Version)
+		assert.Equal(t, embedded, got.WebAssets)
 	}
-	require.NoError(t, json.Unmarshal(output.Bytes(), &got))
-	assert.Equal(t, "roborev", got.Name)
-	assert.Equal(t, version.Version, got.Version)
 }

--- a/cmd/roborev/version_test.go
+++ b/cmd/roborev/version_test.go
@@ -37,7 +37,7 @@ func TestVersionCmdHumanOutputFlagsMissingWebAssets(t *testing.T) {
 
 	require.NoError(t, cmd.Execute())
 	assert.Equal(t, fmt.Sprintf(
-		"roborev %s (web assets missing; this build cannot serve the browser UI)\n",
+		"roborev %s (no embedded web assets; the browser UI needs a release build or --web-dev-origin)\n",
 		version.Version,
 	), output.String())
 }

--- a/cmd/roborev/version_test.go
+++ b/cmd/roborev/version_test.go
@@ -37,7 +37,7 @@ func TestVersionCmdHumanOutputFlagsMissingWebAssets(t *testing.T) {
 
 	require.NoError(t, cmd.Execute())
 	assert.Equal(t, fmt.Sprintf(
-		"roborev %s (no embedded web assets; the browser UI needs a release build or --web-dev-origin)\n",
+		"roborev %s (no embedded web assets; reinstall from an official release or build with 'make build')\n",
 		version.Version,
 	), output.String())
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -34,6 +34,11 @@ roborev version --json           # Show stable machine-readable version data
 
 ### Version JSON contract
 
+When the binary was built without the production web assets, the human-readable
+`roborev version` output appends
+`(web assets missing; this build cannot serve the browser UI)` to the version
+line.
+
 `roborev version --json` prints one JSON object and exits successfully without
 requiring a repository or a running daemon:
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -38,7 +38,7 @@ roborev version --json           # Show stable machine-readable version data
 requiring a repository or a running daemon:
 
 ```json
-{"name":"roborev","version":"v0.62.1"}
+{"name":"roborev","version":"v0.62.1","web_assets":true}
 ```
 
 The stable fields are:
@@ -47,6 +47,7 @@ The stable fields are:
 |-------|------|-------------|
 | `name` | string | Canonical tool name; always `roborev` |
 | `version` | string | Build version, using the release semantic version for release builds |
+| `web_assets` | bool | Whether this binary embeds the production web assets required to serve the [browser UI](/web-ui/) |
 
 Consumers should ignore additional fields so the contract can grow compatibly.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -32,12 +32,12 @@ roborev version                  # Show version
 roborev version --json           # Show stable machine-readable version data
 ```
 
-### Version JSON contract
-
 When the binary was built without the production web assets, the human-readable
 `roborev version` output appends
-`(no embedded web assets; the browser UI needs a release build or --web-dev-origin)`
+`(no embedded web assets; reinstall from an official release or build with 'make build')`
 to the version line.
+
+### Version JSON contract
 
 `roborev version --json` prints one JSON object and exits successfully without
 requiring a repository or a running daemon:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -36,8 +36,8 @@ roborev version --json           # Show stable machine-readable version data
 
 When the binary was built without the production web assets, the human-readable
 `roborev version` output appends
-`(web assets missing; this build cannot serve the browser UI)` to the version
-line.
+`(no embedded web assets; the browser UI needs a release build or --web-dev-origin)`
+to the version line.
 
 `roborev version --json` prints one JSON object and exits successfully without
 requiring a repository or a running daemon:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -852,13 +852,16 @@ roborev uninstall-hook           # Remove hook
 
 | Flag | Description |
 |------|-------------|
-| `--json` | Emit daemon, web UI, and queue status as JSON. Includes the canonical browser origin as `web_url`, active snoozes under `daemon.active_snoozes`, and the active daemon endpoint as `network`, `address`, and `port` fields alongside queue counters and version fields |
+| `--json` | Emit daemon, web UI, and queue status as JSON. Includes the canonical browser origin as `web_url` (with `web_disabled_reason` set to `config` or `missing-web-assets` when the browser listener is not running), active snoozes under `daemon.active_snoozes`, and the active daemon endpoint as `network`, `address`, and `port` fields alongside queue counters and version fields |
 | `--force` | Overwrite an existing post-commit hook with a fresh one |
 
 `roborev daemon start`, `roborev daemon restart`, and `roborev daemon status`
 print the canonical browser URL. If the running daemon has no browser listener,
-they print `Web UI: unavailable` instead of silently omitting the application.
-The older `roborev status` command remains an alias with identical output.
+they explain why when the daemon published a reason — `Web UI: disabled (this
+build has no embedded web assets; reinstall from an official release)` or
+`Web UI: disabled ([web] enabled = false)` — and print `Web UI: unavailable`
+otherwise, instead of silently omitting the application. The older
+`roborev status` command remains an alias with identical output.
 
 When Agent Hook reminders are snoozed, `roborev daemon status` lists every
 active scope with its repository, exact worktree, branch, and local expiry time.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -857,9 +857,9 @@ roborev uninstall-hook           # Remove hook
 
 `roborev daemon start`, `roborev daemon restart`, and `roborev daemon status`
 print the canonical browser URL. If the running daemon has no browser listener,
-they explain why when the daemon published a reason — `Web UI: disabled (this
-build has no embedded web assets; reinstall from an official release)` or
-`Web UI: disabled ([web] enabled = false)` — and print `Web UI: unavailable`
+they explain why when the daemon published a reason —
+`Web UI: disabled (this build has no embedded web assets; reinstall from an official release)`
+or `Web UI: disabled ([web] enabled = false)` — and print `Web UI: unavailable`
 otherwise, instead of silently omitting the application. The older
 `roborev status` command remains an alias with identical output.
 

--- a/internal/daemon/browser_server.go
+++ b/internal/daemon/browser_server.go
@@ -33,7 +33,10 @@ func (s *Server) startBrowserServer(web config.WebConfig) (*BrowserRuntimeInfo, 
 		return nil, err
 	}
 	if !endpoint.Enabled {
-		return &BrowserRuntimeInfo{DisabledReason: WebDisabledReasonConfig}, nil
+		// Unreachable: ResolveBrowserEndpoint only disables the endpoint for
+		// !web.Enabled, which is handled above. Fail loudly rather than
+		// publish a made-up disabled reason if that ever changes.
+		return nil, fmt.Errorf("browser endpoint disabled for an unknown reason")
 	}
 	fail := func(err error) (*BrowserRuntimeInfo, error) {
 		_ = endpoint.Listener.Close()

--- a/internal/daemon/browser_server.go
+++ b/internal/daemon/browser_server.go
@@ -18,11 +18,11 @@ var browserCapabilities = []string{"web-ui-v1", "web-session-v1", "analytics-v1"
 
 func (s *Server) startBrowserServer(web config.WebConfig) (*BrowserRuntimeInfo, error) {
 	if !web.Enabled {
-		return nil, nil
+		return &BrowserRuntimeInfo{DisabledReason: WebDisabledReasonConfig}, nil
 	}
 	if s.webDevOrigin == "" && !s.allowWebCompilationStub && !webassets.EmbeddedReleaseAvailable() {
-		log.Printf("Browser application disabled: this source build does not contain production web assets")
-		return nil, nil
+		log.Printf("Browser application disabled: this binary does not contain production web assets (reinstall from an official release, or build with 'make build')")
+		return &BrowserRuntimeInfo{DisabledReason: WebDisabledReasonMissingAssets}, nil
 	}
 	authToken, err := web.ResolveAuthToken()
 	if err != nil {
@@ -33,7 +33,7 @@ func (s *Server) startBrowserServer(web config.WebConfig) (*BrowserRuntimeInfo, 
 		return nil, err
 	}
 	if !endpoint.Enabled {
-		return nil, nil
+		return &BrowserRuntimeInfo{DisabledReason: WebDisabledReasonConfig}, nil
 	}
 	fail := func(err error) (*BrowserRuntimeInfo, error) {
 		_ = endpoint.Listener.Close()

--- a/internal/daemon/browser_server_test.go
+++ b/internal/daemon/browser_server_test.go
@@ -14,6 +14,7 @@ import (
 
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/testutil"
+	webassets "go.kenn.io/roborev/internal/web"
 )
 
 func TestBrowserServerStartsReadyAndKeepsShutdownPrivate(t *testing.T) {
@@ -106,11 +107,18 @@ func TestBrowserServerProxyAuthBootstrapsWithoutToken(t *testing.T) {
 }
 
 func TestBrowserServerSkipsCompilationStubOutsideDevelopment(t *testing.T) {
+	// Test builds embed the compilation stub, so without the stub override
+	// this is exactly the shipped-without-assets case.
+	if webassets.EmbeddedReleaseAvailable() {
+		t.Skip("production web assets are embedded in this build")
+	}
 	server, _, _ := newTestServer(t)
 	server.allowWebCompilationStub = false
 	runtime, err := server.startBrowserServer(config.DefaultConfig().Web)
 	require.NoError(t, err)
-	assert.Nil(t, runtime)
+	require.NotNil(t, runtime)
+	assert.Empty(t, runtime.Origin)
+	assert.Equal(t, WebDisabledReasonMissingAssets, runtime.DisabledReason)
 }
 
 func TestBrowserServerCannotStartAfterStop(t *testing.T) {
@@ -146,7 +154,9 @@ func TestBrowserServerDisabled(t *testing.T) {
 	server, _, _ := newTestServer(t)
 	runtime, err := server.startBrowserServer(config.WebConfig{Enabled: false})
 	require.NoError(t, err)
-	assert.Nil(t, runtime)
+	require.NotNil(t, runtime)
+	assert.Empty(t, runtime.Origin)
+	assert.Equal(t, WebDisabledReasonConfig, runtime.DisabledReason)
 }
 
 func TestBrowserDevelopmentOriginOption(t *testing.T) {
@@ -284,6 +294,7 @@ func TestServerDisabledBrowserOmitsRuntimeMetadata(t *testing.T) {
 	assert.Empty(t, runtime.WebAddress)
 	assert.Empty(t, runtime.WebOrigin)
 	assert.Empty(t, runtime.WebCapabilities)
+	assert.Equal(t, WebDisabledReasonConfig, runtime.WebDisabledReason)
 	stopTestServer(t, server, errCh)
 }
 

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -208,8 +208,9 @@ func WriteRuntime(primary DaemonEndpoint, alternate *DaemonEndpoint, version str
 		}
 	}
 	if browser != nil && browser.DisabledReason != "" {
-		if browser.Address != "" || browser.Origin != "" {
-			return fmt.Errorf("browser runtime cannot carry both an origin and a disabled reason")
+		if browser.Address != "" || browser.Origin != "" ||
+			browser.WebBasePath != "" || len(browser.Capabilities) > 0 {
+			return fmt.Errorf("browser runtime cannot carry both listener fields and a disabled reason")
 		}
 		rec.Metadata[runtimeWebDisabledReasonKey] = browser.DisabledReason
 	} else if browser != nil {

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -20,13 +20,24 @@ import (
 )
 
 const (
-	daemonServiceName          = "roborev"
-	runtimeAlternateNetworkKey = "alternate_network"
-	runtimeAlternateAddressKey = "alternate_address"
-	runtimeWebAddressKey       = "web_address"
-	runtimeWebOriginKey        = "web_origin"
-	runtimeWebBasePathKey      = "web_base_path"
-	runtimeWebCapabilitiesKey  = "web_capabilities"
+	daemonServiceName           = "roborev"
+	runtimeAlternateNetworkKey  = "alternate_network"
+	runtimeAlternateAddressKey  = "alternate_address"
+	runtimeWebAddressKey        = "web_address"
+	runtimeWebOriginKey         = "web_origin"
+	runtimeWebBasePathKey       = "web_base_path"
+	runtimeWebCapabilitiesKey   = "web_capabilities"
+	runtimeWebDisabledReasonKey = "web_disabled_reason"
+)
+
+// Reasons the daemon publishes when the browser listener is not running, so
+// CLI commands can tell users how to get the web UI back.
+const (
+	// WebDisabledReasonConfig means [web] enabled = false in the config.
+	WebDisabledReasonConfig = "config"
+	// WebDisabledReasonMissingAssets means this binary was built without the
+	// production web assets and cannot serve the browser application.
+	WebDisabledReasonMissingAssets = "missing-web-assets"
 )
 
 // ErrDaemonAccessDenied means a daemon runtime was found but local permissions
@@ -37,27 +48,31 @@ var probeRuntimeEndpoint = probeRuntimeRecord
 
 // RuntimeInfo stores daemon runtime state
 type RuntimeInfo struct {
-	PID              int      `json:"pid"`
-	Network          string   `json:"network,omitempty"`
-	Address          string   `json:"address"`
-	Service          string   `json:"service,omitempty"`
-	Version          string   `json:"version,omitempty"`
-	SourcePath       string   `json:"-"` // Path to the runtime file (not serialized, set by ListAllRuntimes)
-	AlternateNetwork string   `json:"-"`
-	AlternateAddress string   `json:"-"`
-	WebAddress       string   `json:"-"`
-	WebOrigin        string   `json:"-"`
-	WebBasePath      string   `json:"-"`
-	WebCapabilities  []string `json:"-"`
+	PID               int      `json:"pid"`
+	Network           string   `json:"network,omitempty"`
+	Address           string   `json:"address"`
+	Service           string   `json:"service,omitempty"`
+	Version           string   `json:"version,omitempty"`
+	SourcePath        string   `json:"-"` // Path to the runtime file (not serialized, set by ListAllRuntimes)
+	AlternateNetwork  string   `json:"-"`
+	AlternateAddress  string   `json:"-"`
+	WebAddress        string   `json:"-"`
+	WebOrigin         string   `json:"-"`
+	WebBasePath       string   `json:"-"`
+	WebCapabilities   []string `json:"-"`
+	WebDisabledReason string   `json:"-"`
 }
 
 // BrowserRuntimeInfo is the non-secret discovery information published for
-// the daemon's optional browser listener.
+// the daemon's optional browser listener. When the listener is not running,
+// DisabledReason carries the machine-readable cause and all other fields are
+// empty.
 type BrowserRuntimeInfo struct {
-	Address      string
-	Origin       string
-	WebBasePath  string
-	Capabilities []string
+	Address        string
+	Origin         string
+	WebBasePath    string
+	Capabilities   []string
+	DisabledReason string
 }
 
 // Endpoint returns a DaemonEndpoint for this runtime.
@@ -142,6 +157,10 @@ func runtimeInfoFromRecord(rec kitdaemon.RuntimeRecord) *RuntimeInfo {
 		WebOrigin:        rec.Metadata[runtimeWebOriginKey],
 		WebBasePath:      rec.Metadata[runtimeWebBasePathKey],
 	}
+	info.WebDisabledReason = rec.Metadata[runtimeWebDisabledReasonKey]
+	if info.WebOrigin != "" {
+		info.WebDisabledReason = ""
+	}
 	if raw := rec.Metadata[runtimeWebCapabilitiesKey]; raw != "" {
 		info.WebCapabilities = strings.Split(raw, ",")
 	}
@@ -188,7 +207,12 @@ func WriteRuntime(primary DaemonEndpoint, alternate *DaemonEndpoint, version str
 			rec.Metadata[runtimeAlternateAddressKey] = alternate.Address
 		}
 	}
-	if browser != nil {
+	if browser != nil && browser.DisabledReason != "" {
+		if browser.Address != "" || browser.Origin != "" {
+			return fmt.Errorf("browser runtime cannot carry both an origin and a disabled reason")
+		}
+		rec.Metadata[runtimeWebDisabledReasonKey] = browser.DisabledReason
+	} else if browser != nil {
 		if err := validateBrowserRuntime(*browser); err != nil {
 			return err
 		}

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -297,16 +297,19 @@ func TestRuntimeInfoRoundTripsWebDisabledReason(t *testing.T) {
 	}
 }
 
-func TestWriteRuntimeRejectsDisabledReasonWithOrigin(t *testing.T) {
+func TestWriteRuntimeRejectsDisabledReasonWithListenerFields(t *testing.T) {
 	testenv.SetDataDir(t)
-	err := WriteRuntime(
-		DaemonEndpoint{Network: "tcp", Address: defaultTestAddr}, nil, "test-version",
-		&BrowserRuntimeInfo{
-			Origin:         "http://127.0.0.1:7400",
-			DisabledReason: WebDisabledReasonMissingAssets,
-		},
-	)
-	require.ErrorContains(t, err, "disabled reason")
+	for _, browser := range []*BrowserRuntimeInfo{
+		{Origin: "http://127.0.0.1:7400", DisabledReason: WebDisabledReasonMissingAssets},
+		{Address: "127.0.0.1:7400", DisabledReason: WebDisabledReasonMissingAssets},
+		{WebBasePath: "/roborev-ci", DisabledReason: WebDisabledReasonMissingAssets},
+		{Capabilities: []string{"web-ui-v1"}, DisabledReason: WebDisabledReasonMissingAssets},
+	} {
+		err := WriteRuntime(
+			DaemonEndpoint{Network: "tcp", Address: defaultTestAddr}, nil, "test-version", browser,
+		)
+		require.ErrorContains(t, err, "disabled reason")
+	}
 }
 
 func TestRuntimeInfoIgnoresDisabledReasonAlongsideOrigin(t *testing.T) {

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -283,6 +283,46 @@ func TestWriteRuntimeRejectsInvalidBrowserCapabilities(t *testing.T) {
 	}
 }
 
+func TestRuntimeInfoRoundTripsWebDisabledReason(t *testing.T) {
+	testenv.SetDataDir(t)
+	for _, reason := range []string{WebDisabledReasonConfig, WebDisabledReasonMissingAssets} {
+		require.NoError(t, WriteRuntime(
+			DaemonEndpoint{Network: "tcp", Address: defaultTestAddr}, nil, "test-version",
+			&BrowserRuntimeInfo{DisabledReason: reason},
+		))
+		info, err := ReadRuntime()
+		require.NoError(t, err)
+		assert.Empty(t, info.WebOrigin)
+		assert.Equal(t, reason, info.WebDisabledReason)
+	}
+}
+
+func TestWriteRuntimeRejectsDisabledReasonWithOrigin(t *testing.T) {
+	testenv.SetDataDir(t)
+	err := WriteRuntime(
+		DaemonEndpoint{Network: "tcp", Address: defaultTestAddr}, nil, "test-version",
+		&BrowserRuntimeInfo{
+			Origin:         "http://127.0.0.1:7400",
+			DisabledReason: WebDisabledReasonMissingAssets,
+		},
+	)
+	require.ErrorContains(t, err, "disabled reason")
+}
+
+func TestRuntimeInfoIgnoresDisabledReasonAlongsideOrigin(t *testing.T) {
+	rec := kitdaemon.NewRuntimeRecord(
+		daemonServiceName, "test-version",
+		DaemonEndpoint{Network: "tcp", Address: defaultTestAddr}.kitEndpoint(),
+	)
+	rec.Metadata = map[string]string{
+		runtimeWebOriginKey:         "http://127.0.0.1:7400",
+		runtimeWebDisabledReasonKey: WebDisabledReasonMissingAssets,
+	}
+	info := runtimeInfoFromRecord(rec)
+	assert.Equal(t, "http://127.0.0.1:7400", info.WebOrigin)
+	assert.Empty(t, info.WebDisabledReason)
+}
+
 func TestKillDaemonCleansRuntimeForNonRoborevPIDWithoutShutdown(t *testing.T) {
 	testenv.SetDataDir(t)
 	// Verify that isLoopbackAddr correctly rejects non-loopback addresses,


### PR DESCRIPTION
## Summary

- The daemon now publishes a machine-readable `web_disabled_reason` in its runtime record when the browser listener is not running: `missing-web-assets` for binaries built without the production web distribution, `config` when `[web] enabled = false` (context: #1081, where replaced v0.65.0 release assets shipped without the embedded web UI and users only saw "Web UI: unavailable")
- `roborev status` and `roborev daemon restart` render the reason ("Web UI: disabled (this build has no embedded web assets; reinstall from an official release)") instead of the generic "unavailable"; `status --json` gains `web_disabled_reason`
- `roborev ui` explains the cause and the remediation instead of "the daemon browser listener is disabled"
- `roborev version` flags builds without web assets, and `version --json` adds a stable `web_assets` bool to the documented contract so release artifacts can be verified mechanically
- New `release-verify` workflow downloads the published release archives, validates them against SHA256SUMS, and asserts every binary embeds the production web distribution; it runs on release publication, on demand, and on a daily schedule against the latest release, since post-publication asset replacement fires no webhook event — validated against the current v0.65.0 assets, where the embed check fails as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)