### PR TITLE
Build and lint with Go 1.27

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '37 4 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: go
+            build-mode: manual
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+        with:
+          go-version: '1.27.0'
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  # v4.37.8
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Build Go
+        if: matrix.language == 'go'
+        run: go build ./...
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  # v4.37.8
+        with:
+          category: /language:${{ matrix.language }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 version: "2"
 run:
   tests: true
+  go: "1.27"
 linters:
   default: none
   enable:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <img alt="roborev" src="https://roborev.io/assets/static/logo-with-text-light.svg">
 </picture>
 
-[![Go](https://img.shields.io/badge/Go-1.26.6+-00ADD8?logo=go&logoColor=white)](https://go.dev/)
+[![Go](https://img.shields.io/badge/Go-1.27.0+-00ADD8?logo=go&logoColor=white)](https://go.dev/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Docs](https://img.shields.io/badge/Docs-roborev.io-blue)](https://roborev.io)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -93,7 +93,7 @@ need the browser application.
 
 ## Build from Source
 
-Building Roborev requires Go 1.26.6 or newer. The embedded browser application
+Building Roborev requires Go 1.27.0 or newer. The embedded browser application
 also requires Bun 1.3.14.
 
 ```bash

--- a/docs/screenshots/Dockerfile
+++ b/docs/screenshots/Dockerfile
@@ -13,7 +13,7 @@ COPY web web
 COPY packages packages
 RUN bun run web:build
 
-FROM golang:1.26.6-alpine AS builder
+FROM golang:1.27.0-alpine AS builder
 
 WORKDIR /src
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783224372,
-        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
+        "lastModified": 1787135253,
+        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,11 +21,11 @@
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-          goPinned = pkgs.go_1_26.overrideAttrs (_: rec {
-            version = "1.26.6";
+          goPinned = pkgs.go_1_27.overrideAttrs (_: rec {
+            version = "1.27.0";
             src = pkgs.fetchurl {
               url = "https://go.dev/dl/go${version}.src.tar.gz";
-              hash = "sha256-oHIcVMaIkBRI13rZs+x+p8R0cwdV/4kTgukuy5P/LLE=";
+              hash = "sha256-cAJAPXzERSnvbSb2mkSBgmM5Xq18FsBaWAiuBH6+sOU=";
             };
           });
           buildGoModule = pkgs.buildGoModule.override { go = goPinned; };
@@ -73,11 +73,11 @@
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-          goPinned = pkgs.go_1_26.overrideAttrs (_: rec {
-            version = "1.26.6";
+          goPinned = pkgs.go_1_27.overrideAttrs (_: rec {
+            version = "1.27.0";
             src = pkgs.fetchurl {
               url = "https://go.dev/dl/go${version}.src.tar.gz";
-              hash = "sha256-oHIcVMaIkBRI13rZs+x+p8R0cwdV/4kTgukuy5P/LLE=";
+              hash = "sha256-cAJAPXzERSnvbSb2mkSBgmM5Xq18FsBaWAiuBH6+sOU=";
             };
           });
         in

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.kenn.io/roborev
 
-go 1.26.6
+go 1.27.0
 
 require (
 	charm.land/bubbletea/v2 v2.0.8

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2970,13 +2970,13 @@ reasoning = "standard"
 
 func TestInstallationIDForOwner(t *testing.T) {
 	t.Run("map lookup", func(t *testing.T) {
-		ci := CIConfig{GitHubAppConfig: GitHubAppConfig{
+		ci := CIConfig{
 			GitHubAppInstallations: map[string]int64{
 				"wesm":        111111,
 				"roborev-dev": 222222,
 			},
 			GitHubAppInstallationID: 999999,
-		}}
+		}
 		if got := ci.InstallationIDForOwner("wesm"); got != 111111 {
 			assert.Condition(t, func() bool {
 				return false
@@ -2990,10 +2990,10 @@ func TestInstallationIDForOwner(t *testing.T) {
 	})
 
 	t.Run("falls back to singular", func(t *testing.T) {
-		ci := CIConfig{GitHubAppConfig: GitHubAppConfig{
+		ci := CIConfig{
 			GitHubAppInstallations:  map[string]int64{"wesm": 111111},
 			GitHubAppInstallationID: 999999,
-		}}
+		}
 		if got := ci.InstallationIDForOwner("unknown-org"); got != 999999 {
 			assert.Condition(t, func() bool {
 				return false
@@ -3011,10 +3011,10 @@ func TestInstallationIDForOwner(t *testing.T) {
 	})
 
 	t.Run("zero mapped value falls back to singular", func(t *testing.T) {
-		ci := CIConfig{GitHubAppConfig: GitHubAppConfig{
+		ci := CIConfig{
 			GitHubAppInstallations:  map[string]int64{"wesm": 0},
 			GitHubAppInstallationID: 999999,
-		}}
+		}
 		if got := ci.InstallationIDForOwner("wesm"); got != 999999 {
 			assert.Condition(t, func() bool {
 				return false
@@ -3023,9 +3023,9 @@ func TestInstallationIDForOwner(t *testing.T) {
 	})
 
 	t.Run("case-insensitive lookup after normalization", func(t *testing.T) {
-		ci := CIConfig{GitHubAppConfig: GitHubAppConfig{
+		ci := CIConfig{
 			GitHubAppInstallations: map[string]int64{"Wesm": 111111, "RoboRev-Dev": 222222},
-		}}
+		}
 		if err := ci.NormalizeInstallations(); err != nil {
 			require.Condition(t, func() bool {
 				return false
@@ -3051,9 +3051,9 @@ func TestInstallationIDForOwner(t *testing.T) {
 
 func TestNormalizeInstallations(t *testing.T) {
 	t.Run("lowercases keys", func(t *testing.T) {
-		ci := CIConfig{GitHubAppConfig: GitHubAppConfig{
+		ci := CIConfig{
 			GitHubAppInstallations: map[string]int64{"Wesm": 111111, "RoboRev-Dev": 222222},
-		}}
+		}
 		if err := ci.NormalizeInstallations(); err != nil {
 			require.Condition(t, func() bool {
 				return false
@@ -3086,9 +3086,9 @@ func TestNormalizeInstallations(t *testing.T) {
 	})
 
 	t.Run("case-colliding keys returns error", func(t *testing.T) {
-		ci := CIConfig{GitHubAppConfig: GitHubAppConfig{
+		ci := CIConfig{
 			GitHubAppInstallations: map[string]int64{"wesm": 111111, "Wesm": 222222},
-		}}
+		}
 		err := ci.NormalizeInstallations()
 		if err == nil {
 			require.Condition(t, func() bool {
@@ -3143,11 +3143,11 @@ RoboRev-Dev = 222222
 
 func TestGitHubAppConfigured_MultiInstall(t *testing.T) {
 	t.Run("configured with map only", func(t *testing.T) {
-		ci := CIConfig{GitHubAppConfig: GitHubAppConfig{
+		ci := CIConfig{
 			GitHubAppID:            12345,
 			GitHubAppPrivateKey:    "~/.roborev/app.pem",
 			GitHubAppInstallations: map[string]int64{"wesm": 111111},
-		}}
+		}
 		if !ci.GitHubAppConfigured() {
 			assert.Condition(t, func() bool {
 				return false
@@ -3156,11 +3156,11 @@ func TestGitHubAppConfigured_MultiInstall(t *testing.T) {
 	})
 
 	t.Run("configured with singular only", func(t *testing.T) {
-		ci := CIConfig{GitHubAppConfig: GitHubAppConfig{
+		ci := CIConfig{
 			GitHubAppID:             12345,
 			GitHubAppPrivateKey:     "~/.roborev/app.pem",
 			GitHubAppInstallationID: 111111,
-		}}
+		}
 		if !ci.GitHubAppConfigured() {
 			assert.Condition(t, func() bool {
 				return false
@@ -3169,10 +3169,10 @@ func TestGitHubAppConfigured_MultiInstall(t *testing.T) {
 	})
 
 	t.Run("not configured without any installation", func(t *testing.T) {
-		ci := CIConfig{GitHubAppConfig: GitHubAppConfig{
+		ci := CIConfig{
 			GitHubAppID:         12345,
 			GitHubAppPrivateKey: "~/.roborev/app.pem",
-		}}
+		}
 		if ci.GitHubAppConfigured() {
 			assert.Condition(t, func() bool {
 				return false
@@ -3181,10 +3181,10 @@ func TestGitHubAppConfigured_MultiInstall(t *testing.T) {
 	})
 
 	t.Run("not configured without private key", func(t *testing.T) {
-		ci := CIConfig{GitHubAppConfig: GitHubAppConfig{
+		ci := CIConfig{
 			GitHubAppID:             12345,
 			GitHubAppInstallationID: 111111,
-		}}
+		}
 		if ci.GitHubAppConfigured() {
 			assert.Condition(t, func() bool {
 				return false
@@ -3206,7 +3206,7 @@ func TestGitHubAppPrivateKeyResolved_TildeExpansion(t *testing.T) {
 	}
 
 	t.Run("inline PEM returned directly", func(t *testing.T) {
-		ci := CIConfig{GitHubAppConfig: GitHubAppConfig{GitHubAppPrivateKey: pemContent}}
+		ci := CIConfig{GitHubAppPrivateKey: pemContent}
 		got, err := ci.GitHubAppPrivateKeyResolved()
 		if err != nil {
 			require.Condition(t, func() bool {
@@ -3221,7 +3221,7 @@ func TestGitHubAppPrivateKeyResolved_TildeExpansion(t *testing.T) {
 	})
 
 	t.Run("absolute path reads file", func(t *testing.T) {
-		ci := CIConfig{GitHubAppConfig: GitHubAppConfig{GitHubAppPrivateKey: pemFile}}
+		ci := CIConfig{GitHubAppPrivateKey: pemFile}
 		got, err := ci.GitHubAppPrivateKeyResolved()
 		if err != nil {
 			require.Condition(t, func() bool {
@@ -3253,7 +3253,7 @@ func TestGitHubAppPrivateKeyResolved_TildeExpansion(t *testing.T) {
 			}, err)
 		}
 
-		ci := CIConfig{GitHubAppConfig: GitHubAppConfig{GitHubAppPrivateKey: "~/.roborev/test.pem"}}
+		ci := CIConfig{GitHubAppPrivateKey: "~/.roborev/test.pem"}
 		got, err := ci.GitHubAppPrivateKeyResolved()
 		if err != nil {
 			require.Condition(t, func() bool {
@@ -3268,7 +3268,7 @@ func TestGitHubAppPrivateKeyResolved_TildeExpansion(t *testing.T) {
 	})
 
 	t.Run("empty after expansion returns error", func(t *testing.T) {
-		ci := CIConfig{GitHubAppConfig: GitHubAppConfig{GitHubAppPrivateKey: ""}}
+		ci := CIConfig{GitHubAppPrivateKey: ""}
 		_, err := ci.GitHubAppPrivateKeyResolved()
 		if err == nil {
 			assert.Condition(t, func() bool {

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -2568,9 +2568,7 @@ func TestCIMemberFailoverUsesSnapshottedACPBackup(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(tc.TmpDir, ".roborev.toml"),
 		fmt.Appendf(nil, "[acp.goose]\ncommand = %q\n", liveCommand), 0o644))
 	snapshot, err := json.Marshal(ciPanelMemberConfig{
-		ResolvedMember: config.ResolvedMember{
-			Agent: "test", BackupAgent: "acp.goose", BackupModel: "backup-model",
-		},
+		Agent: "test", BackupAgent: "acp.goose", BackupModel: "backup-model",
 		ACP: config.ACPAgentConfigs{"goose": {Command: frozenCommand}},
 	})
 	require.NoError(t, err)

--- a/internal/github/comment.go
+++ b/internal/github/comment.go
@@ -28,9 +28,7 @@ func (c *Client) FindExistingComment(ctx context.Context, ghRepo string, prNumbe
 	opts := &googlegithub.IssueListCommentsOptions{
 		Sort:      ptr("created"),
 		Direction: ptr("asc"),
-		ListOptions: googlegithub.ListOptions{
-			PerPage: 100,
-		},
+		PerPage:   100,
 	}
 
 	var lastID int64

--- a/internal/github/pr_discussion.go
+++ b/internal/github/pr_discussion.go
@@ -39,9 +39,7 @@ func (c *Client) ListPRDiscussionComments(ctx context.Context, ghRepo string, pr
 	issueOpts := &googlegithub.IssueListCommentsOptions{
 		Sort:      ptr("created"),
 		Direction: ptr("asc"),
-		ListOptions: googlegithub.ListOptions{
-			PerPage: 100,
-		},
+		PerPage:   100,
 	}
 	for {
 		issueComments, resp, err := c.api.Issues.ListComments(ctx, owner, repo, prNumber, issueOpts)
@@ -91,9 +89,7 @@ func (c *Client) ListPRDiscussionComments(ctx context.Context, ghRepo string, pr
 	inlineOpts := &googlegithub.PullRequestListCommentsOptions{
 		Sort:      "created",
 		Direction: "asc",
-		ListOptions: googlegithub.ListOptions{
-			PerPage: 100,
-		},
+		PerPage:   100,
 	}
 	for {
 		inlineComments, resp, err := c.api.PullRequests.ListComments(ctx, owner, repo, prNumber, inlineOpts)
@@ -142,7 +138,7 @@ func (c *Client) ListTrustedRepoCollaborators(ctx context.Context, ghRepo string
 
 	opts := &googlegithub.ListCollaboratorsOptions{
 		Affiliation: "all",
-		ListOptions: googlegithub.ListOptions{PerPage: 100},
+		PerPage:     100,
 	}
 	trusted := make(map[string]struct{})
 	for {

--- a/internal/github/repo_ops.go
+++ b/internal/github/repo_ops.go
@@ -40,10 +40,8 @@ func (c *Client) ListOpenPullRequests(ctx context.Context, ghRepo string, limit 
 	}
 
 	opts := &googlegithub.PullRequestListOptions{
-		State: "open",
-		ListOptions: googlegithub.ListOptions{
-			PerPage: limit,
-		},
+		State:   "open",
+		PerPage: limit,
 	}
 
 	prs, _, err := c.api.PullRequests.List(ctx, owner, repo, opts)
@@ -260,10 +258,8 @@ func splitGitConfigEnv(baseEnv []string) ([]string, []gitConfigEntry) {
 
 func (c *Client) listOrgRepos(ctx context.Context, owner string, limit int) ([]string, error) {
 	opts := &googlegithub.RepositoryListByOrgOptions{
-		Type: "all",
-		ListOptions: googlegithub.ListOptions{
-			PerPage: min(limit, 100),
-		},
+		Type:    "all",
+		PerPage: min(limit, 100),
 	}
 	return c.collectRepos(ctx, limit, func() ([]*googlegithub.Repository, *googlegithub.Response, error) {
 		return c.api.Repositories.ListByOrg(ctx, owner, opts)
@@ -277,10 +273,8 @@ func (c *Client) listUserRepos(ctx context.Context, owner string, limit int) ([]
 	var repos []string
 
 	userOpts := &googlegithub.RepositoryListByUserOptions{
-		Type: "owner",
-		ListOptions: googlegithub.ListOptions{
-			PerPage: min(limit, 100),
-		},
+		Type:    "owner",
+		PerPage: min(limit, 100),
 	}
 	pageRepos, err := c.collectRepos(ctx, limit, func() ([]*googlegithub.Repository, *googlegithub.Response, error) {
 		return c.api.Repositories.ListByUser(ctx, owner, userOpts)
@@ -301,9 +295,7 @@ func (c *Client) listUserRepos(ctx context.Context, owner string, limit int) ([]
 	authOpts := &googlegithub.RepositoryListByAuthenticatedUserOptions{
 		Affiliation: "owner,collaborator",
 		Visibility:  "all",
-		ListOptions: googlegithub.ListOptions{
-			PerPage: min(limit, 100),
-		},
+		PerPage:     min(limit, 100),
 	}
 	for {
 		authPage, resp, err := c.api.Repositories.ListByAuthenticatedUser(ctx, authOpts)

--- a/internal/gitlab/comment.go
+++ b/internal/gitlab/comment.go
@@ -98,9 +98,7 @@ func (c *Client) eachMRNote(
 	opts := &gogitlab.ListMergeRequestNotesOptions{
 		OrderBy: ptr("created_at"),
 		Sort:    ptr("asc"),
-		ListOptions: gogitlab.ListOptions{
-			PerPage: 100,
-		},
+		PerPage: 100,
 	}
 
 	for {

--- a/scripts/release_test.go
+++ b/scripts/release_test.go
@@ -27,7 +27,7 @@ flake="$PWD/flake.nix"
 fake_hash="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 expected_hash="sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB="
 
-if ! grep -q 'version = "1.26.6";' "$flake"; then
+if ! grep -q 'version = "1.27.0";' "$flake"; then
     echo "Go toolchain version changed unexpectedly" >&2
     exit 1
 fi
@@ -66,7 +66,7 @@ echo "https://example.invalid/pull/1"
 	updatedFlake := gitOutput(t, repo, "show", "release/v0.65.0-nix-update:flake.nix")
 	assert := assert.New(t)
 	assert.Contains(string(output), "Release cancelled.")
-	assert.Contains(updatedFlake, `version = "1.26.6";`)
+	assert.Contains(updatedFlake, `version = "1.27.0";`)
 	assert.Contains(updatedFlake, `version = "0.65.0";`)
 	assert.Contains(updatedFlake, `vendorHash = "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";`)
 }
@@ -86,7 +86,7 @@ echo "Synthetic changelog"
 	flake := `{
   outputs = { self }: {
     goPinned = {
-      version = "1.26.6";
+      version = "1.27.0";
       url = "https://go.dev/dl/go${version}.src.tar.gz";
     };
     packages.default = {


### PR DESCRIPTION
#1085 established Go 1.27.0 and golangci-lint 2.13.1 in the reusable workflows
while the module remained on Go 1.26.6. This completes the migration by raising
the module and lint language targets to Go 1.27, updating screenshot and Nix
builds, and documenting Go 1.27.0 as the supported source-build version.

The Nix input advances to a revision that provides `go_1_27`, while the source
override keeps the toolchain on the official 1.27.0 checksum. The remaining
modernize changes use Go 1.27 syntax and embedded-field literal behavior; no
agentsview-specific protocol or application changes are included.

CodeQL moves from generated default setup to a repository-owned advanced
workflow. It preserves Actions, Go, and JavaScript/TypeScript analysis plus the
weekly schedule, and builds the Go database explicitly with Go 1.27.0.

Published binaries remain self-contained.

🤖 Generated with Codex

<sup>generated by a clanker</sup>
