### PR TITLE
Run CI on Go 1.27 and golangci-lint 2.13.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          go-version: '1.26.6'
+          go-version: '1.27.0'
           cache: ${{ github.repository == 'kenn-io/roborev' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'false' || 'true' }}
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
@@ -100,7 +100,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          go-version: '1.26.6'
+          go-version: '1.27.0'
           cache: ${{ github.repository == 'kenn-io/roborev' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'false' || 'true' }}
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
@@ -144,7 +144,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
-          go-version: '1.26.6'
+          go-version: '1.27.0'
           cache: ${{ contains(fromJSON('["ubuntu-latest","ubuntu-24.04","ubuntu-22.04"]'), matrix.os) && github.repository == 'kenn-io/roborev' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'false' || 'true' }}
 
       - name: Build
@@ -235,7 +235,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          go-version: '1.26.6'
+          go-version: '1.27.0'
           cache: ${{ github.repository == 'kenn-io/roborev' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'false' || 'true' }}
 
       - name: Test daemon with race detection
@@ -263,7 +263,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
-          go-version: '1.26.6'
+          go-version: '1.27.0'
           cache: ${{ github.repository == 'kenn-io/roborev' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'false' || 'true' }}
 
       - name: Test with coverage
@@ -302,7 +302,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
-          go-version: '1.26.6'
+          go-version: '1.27.0'
           cache: ${{ github.repository == 'kenn-io/roborev' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'false' || 'true' }}
 
       - name: Run integration tests
@@ -320,7 +320,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         if: needs.go-changes.outputs.changed == 'true'
         with:
-          go-version: '1.26.6'
+          go-version: '1.27.0'
           cache: ${{ github.repository == 'kenn-io/roborev' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'false' || 'true' }}
 
       - name: Resolve pinned golangci-lint version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
-          go-version: '1.26.6'
+          go-version: '1.27.0'
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
         with:

--- a/.github/workflows/windows-migration.yml
+++ b/.github/workflows/windows-migration.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
-          go-version: '1.26.6'
+          go-version: '1.27.0'
           cache: 'true'
 
       - name: Download v0.56 Windows release binary

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ CODEX_SKILL_EVAL_MODELS ?= gpt-5.6-sol
 # `make print-golangci-lint-version` (see .github/workflows/ci.yml), and
 # `make lint`/`make lint-ci` refuse to run unless the local binary matches.
 # A mismatched version can silently apply different formatting/fixes.
-GOLANGCI_LINT_VERSION := 2.12.2
+GOLANGCI_LINT_VERSION := 2.13.1
 
 # Keep the golangci-lint cache per-checkout. The default user-global cache
 # stores raw linter findings keyed by package content with absolute file

--- a/cmd/roborev/analyze.go
+++ b/cmd/roborev/analyze.go
@@ -1040,8 +1040,7 @@ func getBranchFiles(ctx context.Context, cmd *cobra.Command, repoRoot string, op
 		// already-pushed feature commits, contradicting "--branch analyzes
 		// all commits since trunk".
 		upstream, uerr := git.GetUpstream(repoRoot, targetRef)
-		var missing *git.UpstreamMissingError
-		if errors.As(uerr, &missing) {
+		if missing, ok := errors.AsType[*git.UpstreamMissingError](uerr); ok {
 			return nil, fmt.Errorf("%w (or pass --base <ref>)", missing)
 		}
 		if uerr != nil {

--- a/cmd/roborev/daemon_lifecycle.go
+++ b/cmd/roborev/daemon_lifecycle.go
@@ -195,8 +195,7 @@ func isTransportError(err error) bool {
 		return false
 	}
 	// Check if the underlying error is a net-level transport failure
-	var opErr *net.OpError
-	if errors.As(urlErr.Err, &opErr) {
+	if _, ok := errors.AsType[*net.OpError](urlErr.Err); ok {
 		return true
 	}
 	// Also catch net.Error (timeout interface) that isn't wrapped in OpError

--- a/cmd/roborev/fix.go
+++ b/cmd/roborev/fix.go
@@ -548,8 +548,7 @@ func runFixWithSeen(cmd *cobra.Command, jobIDs []int64, opts fixOptions, seen ma
 			// discovery mode — otherwise the re-query loop keeps
 			// invoking the exhausted agent until every queued job is
 			// burned through with the same error.
-			var lim *agentLimitError
-			if errors.As(err, &lim) {
+			if _, ok := errors.AsType[*agentLimitError](err); ok {
 				return err
 			}
 			// In discovery mode (seen != nil), log a warning and
@@ -989,8 +988,7 @@ func isConnectionError(err error) bool {
 	if err == nil {
 		return false
 	}
-	var urlErr *url.Error
-	if errors.As(err, &urlErr) {
+	if _, ok := errors.AsType[*url.Error](err); ok {
 		return true
 	}
 	var netErr net.Error
@@ -1160,8 +1158,7 @@ func fixSingleJob(cmd *cobra.Command, repoRoot string, jobID int64, opts fixOpti
 		// fixJobDirect already returns *agentLimitError for retry-path
 		// quota/session aborts; preserve it instead of re-classifying
 		// its user-facing message string.
-		var lim *agentLimitError
-		if errors.As(err, &lim) {
+		if _, ok := errors.AsType[*agentLimitError](err); ok {
 			return err
 		}
 		cls := opts.classify(agent.CanonicalName(currentAgent.Name()), err.Error())
@@ -1468,8 +1465,7 @@ func processFixBatch(ctx context.Context, cmd *cobra.Command, roots currentRepoR
 			tracker.Reset()
 			// Preserve a retry-path agentLimitError without
 			// re-classifying its user-facing message string.
-			var lim *agentLimitError
-			if errors.As(err, &lim) {
+			if _, ok := errors.AsType[*agentLimitError](err); ok {
 				return err
 			}
 			cls := opts.classify(agent.CanonicalName(currentAgent.Name()), err.Error())

--- a/cmd/roborev/helpers.go
+++ b/cmd/roborev/helpers.go
@@ -49,8 +49,7 @@ func silentExit(cmd *cobra.Command, code int) error {
 // points whose error may have originated in concurrent code that could
 // not safely mutate cmd itself.
 func silenceIfExit(cmd *cobra.Command, err error) error {
-	var exitErr *exitError
-	if errors.As(err, &exitErr) {
+	if _, ok := errors.AsType[*exitError](err); ok {
 		cmd.SilenceErrors = true
 	}
 	return err
@@ -80,8 +79,7 @@ func quietExit(cmd *cobra.Command, err error) error {
 		return nil
 	}
 	cmd.SilenceUsage = true
-	var exitErr *exitError
-	if errors.As(err, &exitErr) {
+	if _, ok := errors.AsType[*exitError](err); ok {
 		return err
 	}
 	return &exitError{code: 1, cause: err}

--- a/cmd/roborev/main.go
+++ b/cmd/roborev/main.go
@@ -90,8 +90,7 @@ func main() {
 	if err := rootCmd.Execute(); err != nil {
 		// exitError carries a specific exit code; the RunE that returned
 		// it has already silenced cobra's error printing via silentExit.
-		var exitErr *exitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[*exitError](err); ok {
 			os.Exit(exitErr.code)
 		}
 		// All other errors: cobra already printed them.

--- a/cmd/roborev/refine.go
+++ b/cmd/roborev/refine.go
@@ -291,8 +291,7 @@ func validateRefineContext(
 			// upstream/main in a fork). A branch tracking its own remote
 			// counterpart is not trunk — use GetDefaultBranch instead.
 			upstream, uerr := git.GetUpstream(repoPath, "HEAD")
-			var missing *git.UpstreamMissingError
-			if errors.As(uerr, &missing) {
+			if missing, ok := errors.AsType[*git.UpstreamMissingError](uerr); ok {
 				return "", "", "", "",
 					fmt.Errorf(
 						"%w (run 'git fetch' or pass --since)", missing,
@@ -1513,8 +1512,7 @@ func isInitializedRefineSubmodule(ctx context.Context, repoPath, path string) (b
 	cmd := refineGitCmd(ctx, "-C", submodulePath, "rev-parse", "--show-toplevel")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if _, ok := errors.AsType[*exec.ExitError](err); ok {
 			return false, nil
 		}
 		return false, fmt.Errorf(

--- a/cmd/roborev/review.go
+++ b/cmd/roborev/review.go
@@ -200,8 +200,7 @@ Examples:
 					// would skip already-pushed feature commits, contradicting
 					// "--branch reviews all commits since trunk".
 					upstream, uerr := git.GetUpstream(root, targetRef)
-					var missing *git.UpstreamMissingError
-					if errors.As(uerr, &missing) {
+					if missing, ok := errors.AsType[*git.UpstreamMissingError](uerr); ok {
 						return fmt.Errorf("%w (or pass --base <ref>)", missing)
 					}
 					if uerr != nil {

--- a/cmd/roborev/tui/actions.go
+++ b/cmd/roborev/tui/actions.go
@@ -434,8 +434,7 @@ func (m model) checkApplyCommitPatch(ctx context.Context, jobID int64, jobDetail
 
 	// Dry-run check — only trigger rebase on actual merge conflicts
 	if err := gitworktree.CheckPatch(ctx, targetDir, patch); err != nil {
-		var conflictErr *gitworktree.PatchConflictError
-		if errors.As(err, &conflictErr) {
+		if _, ok := errors.AsType[*gitworktree.PatchConflictError](err); ok {
 			return applyPatchResultMsg{jobID: jobID, rebase: true, err: err}
 		}
 		return applyPatchResultMsg{jobID: jobID, err: err}

--- a/cmd/roborev/tui/tui.go
+++ b/cmd/roborev/tui/tui.go
@@ -852,8 +852,7 @@ func isConnectionError(err error) bool {
 		return false
 	}
 	// Check for url.Error (wraps network errors from http.Client)
-	var urlErr *neturl.Error
-	if errors.As(err, &urlErr) {
+	if _, ok := errors.AsType[*neturl.Error](err); ok {
 		return true
 	}
 	// Check for net.Error (timeout, connection refused, etc.)

--- a/cmd/roborev/wait.go
+++ b/cmd/roborev/wait.go
@@ -294,8 +294,7 @@ func waitMultiple(
 				if r.err == nil {
 					continue
 				}
-				var exitErr *exitError
-				if !errors.As(r.err, &exitErr) {
+				if _, ok := errors.AsType[*exitError](r.err); !ok {
 					return r.err
 				}
 			}
@@ -308,8 +307,7 @@ func waitMultiple(
 
 // isExitCode reports whether err is an *exitError with the given code.
 func isExitCode(err error, code int) bool {
-	var e *exitError
-	if errors.As(err, &e) {
+	if e, ok := errors.AsType[*exitError](err); ok {
 		return e.code == code
 	}
 	return false

--- a/internal/agent/acp_client_terminal.go
+++ b/internal/agent/acp_client_terminal.go
@@ -189,15 +189,13 @@ func getTerminalExitStatus(processState *os.ProcessState) *acp.TerminalExitStatu
 	var signal *string
 
 	// Check if process was terminated by a signal
-	if exited := processState.Sys(); exited != nil {
-		// For Unix systems, check for signal termination
-		if ws, ok := exited.(syscall.WaitStatus); ok {
-			if ws.Signaled() {
-				signalName := ws.Signal().String()
-				signal = &signalName
-				// Per ACP spec, exitCode should be nil when terminated by signal
-				exitCode = nil
-			}
+	// For Unix systems, check for signal termination
+	if ws, ok := processState.Sys().(syscall.WaitStatus); ok {
+		if ws.Signaled() {
+			signalName := ws.Signal().String()
+			signal = &signalName
+			// Per ACP spec, exitCode should be nil when terminated by signal
+			exitCode = nil
 		}
 	}
 

--- a/internal/agent/process.go
+++ b/internal/agent/process.go
@@ -191,8 +191,7 @@ func parseErrIndicatesClosedPipe(err error) bool {
 }
 
 func processErrIndicatesContextTermination(err error) bool {
-	var exitErr *exec.ExitError
-	if !errors.As(err, &exitErr) {
+	if _, ok := errors.AsType[*exec.ExitError](err); !ok {
 		return false
 	}
 	msg := err.Error()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,8 +43,7 @@ func (e *ConfigParseError) Unwrap() error { return e.Err }
 // IsConfigParseError reports whether err (or any error in its chain)
 // is a ConfigParseError.
 func IsConfigParseError(err error) bool {
-	var pe *ConfigParseError
-	if errors.As(err, &pe) {
+	if _, ok := errors.AsType[*ConfigParseError](err); ok {
 		return true
 	}
 	var syntaxErr toml.ParseError
@@ -428,7 +427,7 @@ func walkAgentReferences(value reflect.Value, path string) error {
 	typeOfValue := value.Type()
 	for i := range value.NumField() {
 		fieldType := typeOfValue.Field(i)
-		tag := strings.Split(fieldType.Tag.Get("toml"), ",")[0]
+		tag, _, _ := strings.Cut(fieldType.Tag.Get("toml"), ",")
 		if tag == "" || tag == "-" {
 			continue
 		}

--- a/internal/config/config_test_helpers_test.go
+++ b/internal/config/config_test_helpers_test.go
@@ -55,8 +55,7 @@ func execGit(t *testing.T, dir string, args ...string) string {
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {
-		var exitError *exec.ExitError
-		if errors.As(err, &exitError) {
+		if exitError, ok := errors.AsType[*exec.ExitError](err); ok {
 			require.NoError(t, err, "git %v failed\nstderr: %s", args, exitError.Stderr)
 		}
 		require.NoError(t, err, "git %v failed", args)

--- a/internal/config/workflow.go
+++ b/internal/config/workflow.go
@@ -744,7 +744,7 @@ func workflowHasPrimaryConfigField(t reflect.Type, workflow string) bool {
 	modelPrefix := workflow + "_model"
 	for field := range t.Fields() {
 		tag := field.Tag.Get("toml")
-		key := strings.Split(tag, ",")[0]
+		key, _, _ := strings.Cut(tag, ",")
 		if key == agentPrefix || key == modelPrefix ||
 			strings.HasPrefix(key, agentPrefix+"_") ||
 			strings.HasPrefix(key, modelPrefix+"_") {

--- a/internal/daemon/browser_handler.go
+++ b/internal/daemon/browser_handler.go
@@ -413,8 +413,7 @@ func handleBrowserSession(w http.ResponseWriter, request *http.Request, policy B
 		}
 		credentials, err := sessions.Login(login.Token)
 		if err != nil {
-			var limited *WebLoginRateLimitError
-			if errors.As(err, &limited) {
+			if limited, ok := errors.AsType[*WebLoginRateLimitError](err); ok {
 				seconds := max(1, int((limited.RetryAfter+time.Second-1)/time.Second))
 				w.Header().Set("Retry-After", strconv.Itoa(seconds))
 				writeBrowserError(w, http.StatusTooManyRequests, "login_rate_limited")

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -1457,8 +1457,7 @@ func cloneRemoteMatches(path, ghRepo, rawBaseURL string) (bool, error) {
 	cfgCmd.Env = append(os.Environ(), "LC_ALL=C")
 	cfgOut, err := cfgCmd.CombinedOutput()
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			code := exitErr.ExitCode()
 			// Exit 1 = key not found in config.
 			if code == 1 {

--- a/internal/daemon/hooks.go
+++ b/internal/daemon/hooks.go
@@ -406,8 +406,7 @@ func redactWebhookURL(raw string) string {
 // error, preventing Go's HTTP client from leaking the raw URL
 // (including secret path segments) in log output.
 func redactURLError(err error) error {
-	var ue *neturl.Error
-	if errors.As(err, &ue) {
+	if ue, ok := errors.AsType[*neturl.Error](err); ok {
 		return ue.Err
 	}
 	return err

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -910,8 +910,7 @@ func resolveRerunModelProvider(job *storage.ReviewJob, cfg *config.Config) (stri
 func validateRerunAgent(repoPath string, agentName string, backupAgent string, cfg *config.Config) error {
 	_, err := agent.GetPreferredOrBackupWithConfig(repoPath, agentName, cfg, backupAgent)
 	if err != nil {
-		var unknownErr *agent.UnknownAgentError
-		if errors.As(err, &unknownErr) {
+		if _, ok := errors.AsType[*agent.UnknownAgentError](err); ok {
 			return fmt.Errorf("invalid agent: %w", err)
 		}
 		return fmt.Errorf("no agent available: %w", err)
@@ -2649,8 +2648,7 @@ func (s *Server) resolveSingleAgent(
 		repoCfg, agentName, in.cfg, resolution.BackupAgent,
 	)
 	if err != nil {
-		var unknownErr *agent.UnknownAgentError
-		if errors.As(err, &unknownErr) {
+		if _, ok := errors.AsType[*agent.UnknownAgentError](err); ok {
 			out, _ := rawJSONOutput(
 				http.StatusBadRequest,
 				ErrorResponse{Error: fmt.Sprintf("invalid agent: %v", err)},
@@ -3110,8 +3108,7 @@ func (s *Server) humaFixJob(
 	if resolved, err := agent.GetPreferredOrBackupWithConfig(
 		resolutionPath, agentName, cfg, resolution.BackupAgent,
 	); err != nil {
-		var unknownErr *agent.UnknownAgentError
-		if errors.As(err, &unknownErr) {
+		if _, ok := errors.AsType[*agent.UnknownAgentError](err); ok {
 			return rawJSONOutput(
 				http.StatusBadRequest,
 				ErrorResponse{Error: fmt.Sprintf("invalid agent: %v", err)},

--- a/internal/daemon/worktree_create.go
+++ b/internal/daemon/worktree_create.go
@@ -251,8 +251,7 @@ func gitOutput(ctx context.Context, repoPath string, args ...string) ([]byte, er
 }
 
 func isGitExitCode(err error, code int) bool {
-	var gitErr *gitcmd.GitError
-	if errors.As(err, &gitErr) {
+	if gitErr, ok := errors.AsType[*gitcmd.GitError](err); ok {
 		err = gitErr.Err
 	}
 	var exitErr *exec.ExitError

--- a/internal/kata/client.go
+++ b/internal/kata/client.go
@@ -72,8 +72,7 @@ func realRun(ctx context.Context, c *CLIClient, args []string, stdin io.Reader) 
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, fmt.Errorf("kata %s: %w", verb, ctxErr)
 		}
-		var ee *exec.ExitError
-		if errors.As(err, &ee) {
+		if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 			return nil, fmt.Errorf("kata %s: exit %d: %s", verb, ee.ExitCode(), strings.TrimSpace(string(ee.Stderr)))
 		}
 		return nil, fmt.Errorf("kata %s: %w", verb, err)

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -624,8 +624,7 @@ func isPgError(err error) (string, bool) {
 	if err == nil {
 		return "", false
 	}
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) {
+	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
 		return pgErr.Code, true
 	}
 	return "", false

--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -285,8 +285,7 @@ func shouldFallbackToTokenUse(err error) bool {
 }
 
 func handleSessionUsageError(err error) error {
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 		// agentsview usage exit codes: 2 = session not found,
 		// 3 = found but no token/cost data. Both mean "no usage",
 		// not an error.
@@ -304,8 +303,7 @@ func handleSessionUsageError(err error) error {
 }
 
 func handleTokenUseError(out []byte, err error) error {
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 		// Legacy token-use signalled not-found with exit 1 and empty
 		// stdout+stderr.
 		if exitErr.ExitCode() == 1 &&


### PR DESCRIPTION
Pull request checks execute reusable workflows from `main`, so #1084 cannot
select its own Go toolchain. The current Go 1.26 pin causes those jobs to fail
before the migration code is evaluated.

Run CI, Windows migration, and release jobs on Go 1.27.0 while leaving the
module at Go 1.26.6. Go 1.27 can build the current module, and golangci-lint
2.13.1 is pinned with its required mechanical modernization. Once this lands,
#1084 can use main-hosted workflows that support its raised module version.

<sup>generated by a clanker</sup>
