### PR TITLE
Update flake.nix for v0.66.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
         {
           default = buildGoModule {
             pname = "roborev";
-            version = "0.65.0";
+            version = "0.66.0";
 
             src = ./.;
 


### PR DESCRIPTION
Updates flake.nix version to 0.66.0 for the v0.66.0 release.